### PR TITLE
Add distributed key-value metadata sharing feature(draft)

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <nvToolsExt.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <torch/extension.h>
@@ -20,6 +21,11 @@
 #include "transfer.cuh"
 #include "transfer_ssd.h"
 #include "radix_tree.h"
+#include "local_radix_tree.h"
+#include "distributed_radix_tree.h"
+#include "redis_meta_channel.h"
+#include "block_meta.h"
+#include <deque>
 
 namespace py = pybind11;
 
@@ -102,6 +108,56 @@ void transfer_kv_blocks_remote(
       remote_kv_stride_in_bytes, block_size_in_bytes, total_layers, is_read,
       partition_block_type, round_robin, num_remote_blocks_per_file, use_mmap,
       num_threads_per_file, is_mla);
+}
+
+void shared_transfer_kv_blocks_remote_read_binding(
+    const py::list &file_nodeid_list,
+    const py::list &cfs_blocks_partition_list,
+    const py::list &cpu_blocks_partition_list,
+    const torch::Tensor &cpu_layer_id_list,
+    int64_t cpu_tensor_ptr,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cfs_layer_stride_in_bytes,
+    int64_t cfs_block_stride_in_bytes,
+    int64_t cfs_kv_stride_in_bytes,
+    int64_t block_size_in_bytes,
+    int64_t total_layers,
+    bool is_mla = false,
+    int num_threads_per_file = 8) {
+    
+    // 转换 file_nodeids
+    std::vector<std::uint64_t> file_nodeids;
+    for (const auto &file_nodeid : file_nodeid_list) {
+        file_nodeids.push_back(file_nodeid.cast<std::uint64_t>());
+    }
+    
+    // 转换 cfs_blocks_partition
+    std::vector<std::vector<int64_t>> cfs_blocks_partition;
+    for (const auto &block_list : cfs_blocks_partition_list) {
+        std::vector<int64_t> blocks;
+        for (const auto &block_id : block_list) {
+            blocks.push_back(block_id.cast<int64_t>());
+        }
+        cfs_blocks_partition.push_back(std::move(blocks));
+    }
+    
+    // 转换 cpu_blocks_partition
+    std::vector<std::vector<int64_t>> cpu_blocks_partition;
+    for (const auto &block_list : cpu_blocks_partition_list) {
+        std::vector<int64_t> blocks;
+        for (const auto &block_id : block_list) {
+            blocks.push_back(block_id.cast<int64_t>());
+        }
+        cpu_blocks_partition.push_back(std::move(blocks));
+    }
+    
+    // 调用 C++ 实现
+    flexkv::shared_transfer_kv_blocks_remote_read(
+        file_nodeids, cfs_blocks_partition, cpu_blocks_partition, cpu_layer_id_list,
+        cpu_tensor_ptr, cpu_layer_stride_in_bytes, cpu_kv_stride_in_bytes,
+        cfs_layer_stride_in_bytes, cfs_block_stride_in_bytes, cfs_kv_stride_in_bytes,
+        block_size_in_bytes, total_layers, is_mla, num_threads_per_file);
 }
 #endif
 
@@ -193,6 +249,23 @@ PYBIND11_MODULE(c_ext, m) {
   m.def("call_pcfs_write", &flexkv::call_pcfs_write,
         "Call Pcfs::write from C++", py::arg("file_nodeid"), py::arg("offset"),
         py::arg("buffer"), py::arg("size"), py::arg("thread_id"));
+  m.def("shared_transfer_kv_blocks_remote_read", 
+        &shared_transfer_kv_blocks_remote_read_binding,
+        "Shared transfer KV blocks from remote PCFS to CPU memory",
+        py::arg("file_nodeid_list"),
+        py::arg("cfs_blocks_partition_list"),
+        py::arg("cpu_blocks_partition_list"),
+        py::arg("cpu_layer_id_list"),
+        py::arg("cpu_tensor_ptr"),
+        py::arg("cpu_layer_stride_in_bytes"),
+        py::arg("cpu_kv_stride_in_bytes"),
+        py::arg("cfs_layer_stride_in_bytes"),
+        py::arg("cfs_block_stride_in_bytes"),
+        py::arg("cfs_kv_stride_in_bytes"),
+        py::arg("block_size_in_bytes"),
+        py::arg("total_layers"),
+        py::arg("is_mla") = false,
+        py::arg("num_threads_per_file") = 8);
 #endif
 
   py::class_<flexkv::CRadixTreeIndex>(m, "CRadixTreeIndex")
@@ -206,24 +279,117 @@ PYBIND11_MODULE(c_ext, m) {
       .def("insert", &flexkv::CRadixTreeIndex::insert, py::return_value_policy::reference,
           py::arg("physical_block_ids"), py::arg("block_hashes"), py::arg("num_blocks"),
           py::arg("num_insert_blocks"), py::arg("ready") = true, py::arg("node") = nullptr,
-          py::arg("num_matched_blocks") = -1, py::arg("last_node_matched_length") = -1)
-      .def("evict", &flexkv::CRadixTreeIndex::evict, py::arg("evicted_blocks"), py::arg("num_evicted"))
+          py::arg("num_matched_blocks") = -1, py::arg("last_node_matched_length") = -1,
+          py::call_guard<py::gil_scoped_release>())
+      .def("evict", &flexkv::CRadixTreeIndex::evict, py::arg("evicted_blocks"), py::arg("num_evicted"),
+           py::call_guard<py::gil_scoped_release>())
       .def("total_cached_blocks", &flexkv::CRadixTreeIndex::total_cached_blocks)
       .def("total_unready_blocks", &flexkv::CRadixTreeIndex::total_unready_blocks)
       .def("total_ready_blocks", &flexkv::CRadixTreeIndex::total_ready_blocks)
       .def("match_prefix", &flexkv::CRadixTreeIndex::match_prefix,
-           py::arg("block_hashes"), py::arg("num_blocks"), py::arg("update_cache_info"));
+           py::arg("block_hashes"), py::arg("num_blocks"), py::arg("update_cache_info"),
+           py::call_guard<py::gil_scoped_release>());
 
   py::class_<flexkv::CRadixNode>(m, "CRadixNode")
       .def(py::init<flexkv::CRadixTreeIndex *, bool, int>())
-      .def("size", &flexkv::CRadixNode::size);
+      .def(py::init<flexkv::CRadixTreeIndex *, bool, int, bool>())
+      .def("size", &flexkv::CRadixNode::size)
+      .def("has_block_node_ids", &flexkv::CRadixNode::has_block_node_ids);
 
   py::class_<flexkv::CMatchResult, std::shared_ptr<flexkv::CMatchResult>>(m, "CMatchResult")
       .def(py::init<int, int, int, flexkv::CRadixNode *, flexkv::CRadixNode *, std::vector<int64_t> *>())
       .def_readonly("last_ready_node", &flexkv::CMatchResult::last_ready_node)
       .def_readonly("last_node", &flexkv::CMatchResult::last_node)
       .def_readonly("physical_blocks", &flexkv::CMatchResult::physical_blocks)
+      .def_readonly("block_node_ids", &flexkv::CMatchResult::block_node_ids)
       .def_readonly("num_ready_matched_blocks", &flexkv::CMatchResult::num_ready_matched_blocks)
       .def_readonly("num_matched_blocks", &flexkv::CMatchResult::num_matched_blocks)
       .def_readonly("last_node_matched_length", &flexkv::CMatchResult::last_node_matched_length);
+
+  // BlockMeta binding
+  py::class_<flexkv::BlockMeta>(m, "BlockMeta")
+      .def(py::init<>())
+      .def_readwrite("ph", &flexkv::BlockMeta::ph)
+      .def_readwrite("pb", &flexkv::BlockMeta::pb)
+      .def_readwrite("nid", &flexkv::BlockMeta::nid)
+      .def_readwrite("hash", &flexkv::BlockMeta::hash)
+      .def_readwrite("lt", &flexkv::BlockMeta::lt)
+      .def_readwrite("state", &flexkv::BlockMeta::state);
+
+  // RedisMetaChannel binding
+  py::class_<flexkv::RedisMetaChannel>(m, "RedisMetaChannel")
+      .def(py::init<const std::string&, int, uint32_t, const std::string&, const std::string&>(),
+           py::arg("host"), py::arg("port"), py::arg("node_id"), py::arg("local_ip"), py::arg("blocks_key") = std::string("blocks"))
+      .def("connect", &flexkv::RedisMetaChannel::connect)
+      .def("get_node_id", &flexkv::RedisMetaChannel::get_node_id)
+      .def("get_local_ip", &flexkv::RedisMetaChannel::get_local_ip)
+      .def("make_block_key", &flexkv::RedisMetaChannel::make_block_key, py::arg("node_id"), py::arg("hash"))
+      .def("publish_one", [](flexkv::RedisMetaChannel &ch, const flexkv::BlockMeta &m){ ch.publish(m); })
+      .def("publish_batch", [](flexkv::RedisMetaChannel &ch, const std::vector<flexkv::BlockMeta> &metas, size_t batch_size){ ch.publish(metas, batch_size); }, py::arg("metas"), py::arg("batch_size")=100)
+      .def("load", [](flexkv::RedisMetaChannel &ch, size_t max_items){ std::vector<flexkv::BlockMeta> out; ch.load(out, max_items); return out; }, py::arg("max_items"))
+      .def("renew_node_leases", &flexkv::RedisMetaChannel::renew_node_leases, py::arg("node_id"), py::arg("new_lt"), py::arg("batch_size")=200)
+      .def("list_keys", [](flexkv::RedisMetaChannel &ch, const std::string &pattern){ std::vector<std::string> keys; ch.list_keys(pattern, keys); return keys; }, py::arg("pattern"))
+      .def("list_node_keys", [](flexkv::RedisMetaChannel &ch){ std::vector<std::string> keys; ch.list_node_keys(keys); return keys; })
+      .def("list_block_keys", [](flexkv::RedisMetaChannel &ch, uint32_t node_id){ std::vector<std::string> keys; ch.list_block_keys(node_id, keys); return keys; }, py::arg("node_id"))
+      .def("hmget_field_for_keys", [](flexkv::RedisMetaChannel &ch, const std::vector<std::string> &keys, const std::string &field){ std::vector<std::string> values; ch.hmget_field_for_keys(keys, field, values); return values; }, py::arg("keys"), py::arg("field"))
+      .def("hmget_two_fields_for_keys", [](flexkv::RedisMetaChannel &ch, const std::vector<std::string> &keys, const std::string &f1, const std::string &f2){ std::vector<std::pair<std::string,std::string>> out; ch.hmget_two_fields_for_keys(keys, f1, f2, out); return out; }, py::arg("keys"), py::arg("field1"), py::arg("field2"))
+      .def("load_metas_by_keys", [](flexkv::RedisMetaChannel &ch, const std::vector<std::string> &keys){ std::vector<flexkv::BlockMeta> out; ch.load_metas_by_keys(keys, out); return out; }, py::arg("keys"))
+      .def("update_block_state_batch", [](flexkv::RedisMetaChannel &ch, uint32_t node_id, const std::vector<int64_t> &hashes, flexkv::NodeState state, size_t batch_size){ std::deque<int64_t> dq(hashes.begin(), hashes.end()); ch.update_block_state_batch(node_id, &dq, state, batch_size); }, py::arg("node_id"), py::arg("hashes"), py::arg("state"), py::arg("batch_size")=200)
+      .def("delete_blockmeta_batch", [](flexkv::RedisMetaChannel &ch, uint32_t node_id, const std::vector<int64_t> &hashes, size_t batch_size){ std::deque<int64_t> dq(hashes.begin(), hashes.end()); ch.delete_blockmeta_batch(node_id, &dq, batch_size); }, py::arg("node_id"), py::arg("hashes"), py::arg("batch_size")=200);
+
+  // LocalRadixTree bindings (derived from CRadixTreeIndex)
+  py::class_<flexkv::LocalRadixTree, flexkv::CRadixTreeIndex>(m, "LocalRadixTree")
+      .def(py::init<int, int, uint32_t, uint32_t, uint32_t, uint32_t, size_t>(),
+           py::arg("tokens_per_block"),
+           py::arg("max_num_blocks") = 1000000,
+           py::arg("lease_ttl_ms") = 100000,
+           py::arg("renew_lease_ms") = 0,
+           py::arg("refresh_batch_size") = 256,
+           py::arg("idle_sleep_ms") = 10,
+           py::arg("lt_pool_initial_capacity") = 0)
+      .def("set_meta_channel", &flexkv::LocalRadixTree::set_meta_channel, py::arg("channel"))
+      .def("start", &flexkv::LocalRadixTree::start, py::arg("channel"))
+      .def("stop", &flexkv::LocalRadixTree::stop)
+      .def("insert_and_publish", &flexkv::LocalRadixTree::insert_and_publish, py::arg("node"))
+      // Mirror CRadixTreeIndex APIs explicitly on LocalRadixTree
+      .def("match_prefix", &flexkv::LocalRadixTree::match_prefix,
+           py::arg("block_hashes"), py::arg("num_blocks"), py::arg("update_cache_info") = true,
+           py::call_guard<py::gil_scoped_release>())
+      .def("total_unready_blocks", &flexkv::LocalRadixTree::total_unready_blocks)
+      .def("total_ready_blocks", &flexkv::LocalRadixTree::total_ready_blocks)
+      .def("total_cached_blocks", &flexkv::LocalRadixTree::total_cached_blocks)
+      .def("total_node_num", &flexkv::LocalRadixTree::total_node_num)
+      .def("reset", &flexkv::LocalRadixTree::reset)
+      .def("is_root", &flexkv::LocalRadixTree::is_root, py::arg("node"))
+      .def("remove_node", &flexkv::LocalRadixTree::remove_node, py::arg("node"))
+      .def("remove_leaf", &flexkv::LocalRadixTree::remove_leaf, py::arg("node"))
+      .def("add_node", &flexkv::LocalRadixTree::add_node, py::arg("node"))
+      .def("add_leaf", &flexkv::LocalRadixTree::add_leaf, py::arg("node"))
+      .def("lock", &flexkv::LocalRadixTree::lock, py::arg("node"))
+      .def("unlock", &flexkv::LocalRadixTree::unlock, py::arg("node"))
+      .def("is_empty", &flexkv::LocalRadixTree::is_empty)
+      .def("inc_node_count", &flexkv::LocalRadixTree::inc_node_count)
+      .def("dec_node_count", &flexkv::LocalRadixTree::dec_node_count)
+      .def("set_ready", &flexkv::LocalRadixTree::set_ready, py::arg("node"), py::arg("ready"), py::arg("ready_length") = -1);
+
+  // DistributedRadixTree bindings (remote reference tree manager)
+  py::class_<flexkv::DistributedRadixTree>(m, "DistributedRadixTree")
+      .def(py::init<int, int, uint32_t, size_t, size_t, uint32_t, uint32_t>(),
+           py::arg("tokens_per_block"),
+           py::arg("max_num_blocks"),
+           py::arg("node_id"),
+           py::arg("lt_pool_initial_capacity") = 0,
+           py::arg("refresh_batch_size") = 128,
+           py::arg("rebuild_interval_ms") = 1000,
+           py::arg("idle_sleep_ms") = 10)
+      .def("start", &flexkv::DistributedRadixTree::start, py::arg("channel"))
+      .def("stop", &flexkv::DistributedRadixTree::stop)
+      .def("remote_tree_refresh", &flexkv::DistributedRadixTree::remote_tree_refresh, py::return_value_policy::reference)
+      .def("match_prefix", &flexkv::DistributedRadixTree::match_prefix,
+           py::arg("block_hashes"), py::arg("num_blocks"), py::arg("update_cache_info") = true,
+           py::call_guard<py::gil_scoped_release>())
+      .def("lock", &flexkv::DistributedRadixTree::lock, py::arg("node"))
+      .def("unlock", &flexkv::DistributedRadixTree::unlock, py::arg("node"))
+      .def("is_empty", &flexkv::DistributedRadixTree::is_empty)
+      .def("set_ready", &flexkv::DistributedRadixTree::set_ready, py::arg("node"), py::arg("ready") = true, py::arg("ready_length") = -1);
 }

--- a/csrc/block_meta.h
+++ b/csrc/block_meta.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+#include "radix_tree.h" // for NodeState
+
+namespace flexkv {
+
+struct BlockMeta {
+  int64_t ph;        // previous block hash
+  int64_t pb;        // physical block id
+  uint32_t nid;      // node id
+  int64_t hash;      // current block hash
+  uint32_t lt;       // lease time
+  NodeState state;   // lease state
+};
+
+} // namespace flexkv
+
+

--- a/csrc/distributed_radix_tree.cpp
+++ b/csrc/distributed_radix_tree.cpp
@@ -1,0 +1,562 @@
+#include "distributed_radix_tree.h"
+#include "redis_meta_channel.h"
+
+#include <algorithm>
+#include <pthread.h>
+#include <unistd.h>
+#include <queue>
+#include <stack>
+#include <sys/time.h>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace flexkv {
+DistributedRadixTree::DistributedRadixTree(int tokens_per_block, int max_num_blocks,
+                  uint32_t nid, size_t lt_pool_initial_capacity,
+                  size_t refresh_batch_size, uint32_t rebuild_interval_ms, uint32_t idle_sleep_ms)
+  : channel(nullptr), node_id(nid), tokens_per_block(tokens_per_block), max_num_blocks(max_num_blocks),
+    lt_pool(lt_pool_initial_capacity) {
+  refresh_batch_size_ = refresh_batch_size;
+  rebuild_interval_ms_ = rebuild_interval_ms;
+  idle_sleep_ms_ = idle_sleep_ms;
+  old_index.store(nullptr, std::memory_order_relaxed);
+  c_index.store(nullptr, std::memory_order_relaxed);
+}
+
+DistributedRadixTree::~DistributedRadixTree() {
+  stop();
+}
+
+
+// Parse dotted-decimal IPv4 string to uint32_t in network byte order (big-endian).
+static inline bool ipv4_to_uint32(const std::string &ip, uint32_t &out) {
+  unsigned int a = 0, b = 0, c = 0, d = 0;
+  if (sscanf(ip.c_str(), "%u.%u.%u.%u", &a, &b, &c, &d) != 4) return false;
+  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
+  out = (uint32_t)((a << 24) | (b << 16) | (c << 8) | d);
+  return true;
+}
+
+// Compute absolute numeric distance between two IPv4 addresses represented as dotted-decimal.
+static inline uint32_t compute_ip_distance(const std::string &ip,
+                                           const std::string &self_ip) {
+  uint32_t x = 0, y = 0;
+  if (!ipv4_to_uint32(ip, x) || !ipv4_to_uint32(self_ip, y)) return UINT32_MAX;
+  return (x >= y) ? (x - y) : (y - x);
+}
+
+// DistributedRadixTree implementation moved here (remote behavior)
+class DistributedRadixTree; // forward decl not needed in cpp but harmless
+
+void* DistributedRadixTree::refresh_worker_trampoline(void* arg) {
+  auto* self = reinterpret_cast<DistributedRadixTree*>(arg);
+  self->refresh_worker();
+  return nullptr;
+}
+
+void DistributedRadixTree::start(RedisMetaChannel *ch) {
+  if (refresh_started) return;
+  channel = ch;
+  refresh_should_stop = false;
+  refresh_started = true;
+  pthread_create(&refresh_tid, nullptr, &DistributedRadixTree::refresh_worker_trampoline, this);
+}
+
+void DistributedRadixTree::stop() {
+  if (!refresh_started) return;
+  refresh_should_stop = true;
+  pthread_join(refresh_tid, nullptr);
+  refresh_started = false;
+}
+
+void DistributedRadixTree::refresh_worker() {
+  const size_t batch_size = refresh_batch_size_;
+  // periodically rebuild reference index from remote nodes
+  const uint32_t rebuild_interval_ms = rebuild_interval_ms_;
+  struct timeval tv_start; gettimeofday(&tv_start, nullptr);
+  uint64_t last_rebuild_ms = (uint64_t)tv_start.tv_sec * 1000 + (uint64_t)(tv_start.tv_usec / 1000);
+  while (!refresh_should_stop) {
+    std::vector<CRadixNode*> batch;
+    batch.reserve(batch_size);
+    CRadixNode* node = nullptr;
+    while (batch.size() < batch_size && renew_lease_queue.pop(node)) {
+      if (node != nullptr) batch.push_back(node);
+    }
+
+    if (!batch.empty() && channel != nullptr) {
+      refresh_nodes_lease_from_redis(batch);
+    }
+
+    // timed remote index refresh
+    struct timeval tv_now; gettimeofday(&tv_now, nullptr);
+    uint64_t now_ms = (uint64_t)tv_now.tv_sec * 1000 + (uint64_t)(tv_now.tv_usec / 1000);
+    if (now_ms - last_rebuild_ms >= rebuild_interval_ms) {
+      RefRadixTree* new_idx = remote_tree_refresh();
+      if (new_idx != nullptr) {
+        RefRadixTree* old_idx = c_index.exchange(new_idx, std::memory_order_acq_rel);
+        RefRadixTree* old_idx2 = old_index.exchange(old_idx, std::memory_order_acq_rel);
+        if (old_idx2 != nullptr) {
+          old_idx2->dec_ref_cnt();
+        }
+        last_rebuild_ms = now_ms;
+      }
+    }
+
+    if (batch.empty()) {
+      usleep(1000 * idle_sleep_ms_);
+    }
+  }
+}
+
+void DistributedRadixTree::refresh_nodes_lease_from_redis(const std::vector<CRadixNode*> &batch) {
+  std::vector<std::string> keys;
+  for (CRadixNode* n : batch) {
+    auto &hashes = n->get_block_hashes();
+    std::deque<uint32_t>* bnis = n->get_block_node_ids();
+    assert(bnis != nullptr);
+    assert(bnis->size() == hashes.size());
+    for (size_t i = 0; i < hashes.size(); ++i) {
+      keys.push_back(channel->make_block_key(bnis->at(i), (uint64_t)hashes[i]));
+    }
+  }
+
+  std::vector<std::pair<std::string, std::string>> lt_state;
+  channel->hmget_two_fields_for_keys(keys, "lt", "state", lt_state);
+
+  size_t idx = 0;
+  for (CRadixNode* n : batch) {
+    auto *lm = n->get_lease_meta();
+    if (lm == nullptr) continue;
+    auto &hashes = n->get_block_hashes();
+    uint32_t min_lt = UINT32_MAX;
+    for (size_t i = 0; i < hashes.size(); ++i, ++idx) {
+      if (idx >= lt_state.size()) break;
+      const std::string &lt_s = lt_state[idx].first;
+      const std::string &st_s = lt_state[idx].second;
+      if (lt_s.empty() || st_s.empty()) continue;
+      int st = std::stoi(st_s);
+      if (st == (int)NODE_STATE_NORMAL) {
+        uint32_t lt = (uint32_t)std::stoul(lt_s);
+        if (lt < min_lt) min_lt = lt;
+      }
+    }
+    if (min_lt != UINT32_MAX) {
+      lm->lease_time = min_lt;
+    }
+  }
+}
+
+struct NodeInfo { 
+  uint32_t nid;
+  uint32_t dst; 
+};
+
+RefRadixTree* DistributedRadixTree::remote_tree_refresh() {
+  if (channel == nullptr) return nullptr;
+  // 1) list node:* keys
+  std::vector<std::string> node_keys;
+  if (!channel->list_node_keys(node_keys)) return nullptr;
+  if (node_keys.empty()) return nullptr;
+
+  // Extract node ids from keys (format: node:<id>)
+
+  std::vector<NodeInfo> nodes;
+  nodes.reserve(node_keys.size());
+  std::vector<std::string> ips;
+  ips.reserve(node_keys.size());
+  // 2) fetch ip for each node
+  if (!channel->hmget_field_for_keys(node_keys, "ip", ips)) return nullptr;
+
+  // this node ip
+  std::string self_ip = channel->get_local_ip();
+
+  for (size_t i = 0; i < node_keys.size(); ++i) {
+    const std::string &k = node_keys[i];
+    if (k.size() <= 5) continue;
+    if (ips.size() <= i) continue;
+    // parse nid
+    uint32_t nid = (uint32_t)std::stoul(k.substr(5));
+    if (nid == node_id) continue; // skip self
+    std::string ip = ips[i];
+    uint32_t dst = compute_ip_distance(ip, self_ip);
+    nodes.push_back(NodeInfo{nid, dst});
+  }
+
+  // 3) sort by numeric distance ascending
+  std::sort(nodes.begin(), nodes.end(), [](const NodeInfo &a, const NodeInfo &b){ return a.dst < b.dst; });
+
+  // 4) iterate nodes and load their block metas
+  RefRadixTree* new_index = new RefRadixTree(tokens_per_block, max_num_blocks);
+  for (const auto &nfo : nodes) {
+    // list keys block:<nid>:*
+    std::vector<std::string> bkeys;
+    //std::string pat = std::string("block:") + std::to_string(nfo.nid) + ":*";
+    if (!channel->list_block_keys(nfo.nid, bkeys)) continue;
+    if (bkeys.empty()) continue;
+
+    std::vector<BlockMeta> metas;
+    channel->load_metas_by_keys(bkeys, metas);
+    if (metas.empty()) continue;
+    // Merge into new_index via DFS+merge helpers
+    if (!metas.empty()) {
+      std::unordered_map<int64_t, std::vector<BlockMeta*>> parent_to_children;
+      for (const auto& meta : metas) parent_to_children[meta.ph].push_back(&meta);
+      std::unordered_set<int64_t> processed_hashes;
+      std::vector<CRadixNode*> temp_root_children;
+      for (const auto& root_child_ptr : parent_to_children[0]) {
+        if (processed_hashes.find(root_child_ptr->hash) != processed_hashes.end()) continue;
+        CRadixNode* temp_root_child = dfs_build_subtree_from_meta(root_child_ptr, new_index, nullptr,
+                                   parent_to_children, processed_hashes, lt_pool, true);
+        temp_root_children.push_back(temp_root_child);
+      }
+      for (auto root_child : temp_root_children) {
+        if (root_child == nullptr) continue;
+        attach_and_merge_root_child(new_index, root_child, new_index->get_root(), lt_pool);
+      }
+    }
+  }
+  return new_index;
+}
+
+std::shared_ptr<CMatchResult> DistributedRadixTree::match_prefix(
+  torch::Tensor &block_hashes, int num_blocks, bool update_cache_info) {
+  RefRadixTree *idx = c_index.load(std::memory_order_acquire);
+  if (idx == nullptr) {
+    return std::make_shared<CMatchResult>(0, 0, 0, nullptr, nullptr, new std::vector<int64_t>());
+  }
+  RefCntGuard guard{idx};
+  return idx->match_prefix(block_hashes, num_blocks, update_cache_info);
+}
+
+void DistributedRadixTree::lock(CRadixNode *node) {
+  if (node == nullptr) return;
+  CRadixTreeIndex *owner = node->get_index();
+  if (owner != nullptr) {
+    owner->lock(node);
+    return;
+  }
+  RefRadixTree *idx = c_index.load(std::memory_order_acquire);
+  if (idx == nullptr) return;
+  RefCntGuard guard{idx};
+  idx->lock(node);
+}
+
+void DistributedRadixTree::unlock(CRadixNode *node) {
+  if (node == nullptr) return;
+  CRadixTreeIndex *owner = node->get_index();
+  if (owner != nullptr) {
+    owner->unlock(node);
+    return;
+  }
+  RefRadixTree *idx = c_index.load(std::memory_order_acquire);
+  if (idx == nullptr) return;
+  RefCntGuard guard{idx};
+  idx->unlock(node);
+}
+
+bool DistributedRadixTree::is_empty() {
+  RefRadixTree *idx = c_index.load(std::memory_order_acquire);
+  if (idx == nullptr) return true;
+  RefCntGuard guard{idx};
+  return idx->is_empty();
+}
+
+void DistributedRadixTree::set_ready(CRadixNode *node, bool ready, int ready_length) {
+  if (node == nullptr) return;
+  CRadixTreeIndex *owner = node->get_index();
+  if (owner != nullptr) {
+    owner->set_ready(node, ready, ready_length);
+    return;
+  }
+  RefRadixTree *idx = c_index.load(std::memory_order_acquire);
+  if (idx == nullptr) return;
+  RefCntGuard guard{idx};
+  idx->set_ready(node, ready, ready_length);
+}
+
+RefRadixTree::RefRadixTree(int tokens_per_block, int max_num_blocks)
+  : CRadixTreeIndex(tokens_per_block, max_num_blocks) {
+  ref_cnt.store(1);
+}
+
+RefRadixTree::~RefRadixTree() {
+  // No special cleanup beyond base class for now
+}
+
+void RefRadixTree::dec_ref_cnt() {
+  uint32_t prev = ref_cnt.fetch_sub(1, std::memory_order_acq_rel);
+  if (prev == 1) {
+    delete this;
+  }
+}
+
+void RefRadixTree::inc_ref_cnt() {
+  ref_cnt.fetch_add(1, std::memory_order_relaxed);
+}
+
+void RefRadixTree::lock(CRadixNode *node) {
+  inc_ref_cnt();
+  CRadixTreeIndex::lock(node);
+}
+
+void RefRadixTree::unlock(CRadixNode *node) {
+  CRadixTreeIndex::unlock(node);
+  dec_ref_cnt();
+}
+
+bool RefRadixTree::is_empty() {
+  return CRadixTreeIndex::is_empty();
+}
+
+void RefRadixTree::set_ready(CRadixNode *node, bool ready, int ready_length) {
+  CRadixTreeIndex::set_ready(node, ready, ready_length);
+}
+
+CRadixNode *RefRadixTree::insert(torch::Tensor &physical_block_ids,
+  torch::Tensor &block_hashes, int num_blocks, int num_insert_blocks,
+  bool ready, CRadixNode *node, int num_matched_blocks,
+  int last_node_matched_length) {
+  (void)physical_block_ids; (void)block_hashes; (void)num_blocks; (void)num_insert_blocks;
+  (void)ready; (void)node; (void)num_matched_blocks; (void)last_node_matched_length;
+  // we do nothing here, since the RefRadixTree is only used for reference and rebuild from remote nodes
+  return nullptr;
+}
+
+int RefRadixTree::evict(torch::Tensor &evicted_blocks, int num_evicted) {
+  (void)evicted_blocks; (void)num_evicted;
+  // we do nothing here, since the RefRadixTree is only used for reference and rebuild from remote nodes
+  return 0;
+}
+
+std::shared_ptr<CMatchResult> RefRadixTree::match_prefix(
+  torch::Tensor &block_hashes, int num_blocks, bool update_cache_info) {
+  // Increment ref count at entry and guarantee decrement on all exit paths
+  RefCntGuard guard{this};
+  auto current_node = root;
+  auto last_ready_node = root;
+  auto prefix_blocks_num = 0;
+  auto ready_prefix_blocks_num = 0;
+  auto last_node_matched_length = 0;
+  auto physical_blocks = new std::vector<int64_t>();
+  auto block_hashes_ptr = block_hashes.data_ptr<int64_t>();
+  HashType child_hash;
+
+  // now in ms
+  struct timeval now_tv; gettimeofday(&now_tv, nullptr);
+  uint64_t now_ms = (uint64_t)now_tv.tv_sec * 1000 + (uint64_t)(now_tv.tv_usec / 1000);
+
+  while (prefix_blocks_num < num_blocks) {
+    if (update_cache_info) {
+      current_node->update_time();
+    }
+
+    // Lease checks on current node before descending further
+    if (!is_root(current_node)) {
+      LeaseMeta* lm = current_node->get_lease_meta();
+      uint64_t lt = (lm != nullptr) ? (uint64_t)lm->lease_time : 0;
+      if (lt > 0) {
+        if ((int64_t)lt - (int64_t)now_ms <= 0) {
+          // expired: stop matching and return what we have so far
+          break;
+        }
+        if ((int64_t)lt - (int64_t)now_ms <= (int64_t)renew_threshold_ms_) {
+          renew_lease_queue.push(current_node);
+        }
+      }
+    }
+
+    child_hash = HashType(block_hashes_ptr[prefix_blocks_num + current_node->size()]);
+    if (current_node->lookup_child(child_hash)) {
+      if (current_node->is_ready()) {
+        last_ready_node = current_node;
+        ready_prefix_blocks_num += current_node->size();
+      }
+      prefix_blocks_num += current_node->size();
+      physical_blocks->insert(physical_blocks->end(), current_node->get_physical_blocks().begin(),
+        current_node->get_physical_blocks().end());
+      current_node = current_node->get_child(child_hash);
+    } else {
+      auto matched_length = 0;
+      if (is_root(current_node) == false) {
+        auto cmp_length = std::min(current_node->size(), num_blocks - prefix_blocks_num);
+        auto left = 0;
+        auto right = cmp_length;
+
+        while (left < right) {
+          auto mid = (left + right) / 2;
+          if (current_node->get_hash(mid) == HashType(block_hashes_ptr[prefix_blocks_num+mid])) {
+            left = mid + 1;
+          } else {
+            right = mid;
+          }
+        }
+        matched_length = left;
+        physical_blocks->insert(physical_blocks->end(), current_node->get_physical_blocks().begin(),
+          current_node->get_physical_blocks().begin() + matched_length);
+      } else {
+        matched_length = 0;
+      }
+
+      if (current_node->is_ready()) {
+        last_ready_node = current_node;
+        ready_prefix_blocks_num += matched_length;
+      }
+
+      last_node_matched_length = matched_length;
+      prefix_blocks_num += matched_length;
+      break;
+    }
+  }
+
+  return std::make_shared<CMatchResult>(prefix_blocks_num, ready_prefix_blocks_num, last_node_matched_length,
+    last_ready_node, current_node, physical_blocks);
+}
+
+// DFS function to build subtree from BlockMeta with chain compression
+CRadixNode* dfs_build_subtree_from_meta(const BlockMeta* current_meta,
+                                CRadixTreeIndex* index,
+                                CRadixNode* parent_node,
+                                const std::unordered_map<int64_t, std::vector<BlockMeta*>>& parent_to_children,
+                                std::unordered_set<int64_t>& processed_hashes,
+                                LeaseMetaMemPool& lt_pool,
+                                bool is_ready) {
+  if (current_meta == nullptr) return nullptr;
+  if (current_meta->state != NODE_STATE_NORMAL) return nullptr;
+  // we will add block_node_ids and lease_meta to the child node
+  if (processed_hashes.find(current_meta->hash) != processed_hashes.end()) {
+    return nullptr; // Already processed
+  }
+  
+  // Create a child node and try to compress a linear chain into it
+  auto* child_node = new CRadixNode(index, is_ready, 0, true);
+  if (child_node == nullptr) return nullptr;
+  LeaseMeta *lm = lt_pool.alloc();
+  if (lm == nullptr) return nullptr;
+  child_node->set_lease_meta(lm);
+  lm->state = NODE_STATE_NORMAL;
+  lm->lease_time = current_meta->lt;
+  if (parent_node != nullptr) {
+    child_node->set_parent(parent_node);
+    parent_node->set_child(static_cast<HashType>(current_meta->hash), child_node);
+  }
+
+  auto& cbh = child_node->get_block_hashes();
+  auto& cpb = child_node->get_physical_blocks();
+  auto& bni = child_node->get_block_node_ids();
+  if (bni == nullptr) return nullptr;
+
+  // Seed with the current meta
+  cbh.push_back(current_meta->hash);
+  cpb.push_back(current_meta->pb);
+  processed_hashes.insert(current_meta->hash);
+
+  // Track minimal lease time across merged chain
+  int64_t min_lease_time = current_meta->lt;
+  int64_t tail_hash = current_meta->hash;
+
+  // Compress along unique-child chains
+  while (true) {
+    auto next_it = parent_to_children.find(tail_hash);
+    if (next_it == parent_to_children.end()) break;
+    const auto& next_children = next_it->second;
+    if (next_children.size() != 1) break;
+    const BlockMeta* next_meta = next_children[0];
+
+    // Check if already processed
+    if (processed_hashes.find(next_meta->hash) != processed_hashes.end()) break;
+
+    // Append into the same CRadixNode
+    cbh.push_back(next_meta->hash);
+    cpb.push_back(next_meta->pb);
+    bni->push_back(next_meta->nid);
+    if (next_meta->lt < min_lease_time) min_lease_time = next_meta->lt;
+    processed_hashes.insert(next_meta->hash);
+
+    tail_hash = next_meta->hash;
+  }
+
+  child_node->set_lease_time(min_lease_time);
+
+  // Recurse from the final tail hash of this compressed chain
+  auto tail_children_it = parent_to_children.find(tail_hash);
+  if (tail_children_it != parent_to_children.end()) {
+    for (const auto& child_meta : tail_children_it->second) {
+      if (processed_hashes.find(child_meta->hash) == processed_hashes.end()) {
+        dfs_build_subtree_from_meta(child_meta, index, child_node, parent_to_children, processed_hashes, lt_pool, is_ready);
+      }
+    }
+  }
+  return child_node;
+}
+
+void attach_and_merge_root_child(CRadixTreeIndex* temp_tree, CRadixNode* root_child, 
+  CRadixNode* current_root, LeaseMetaMemPool& lt_pool) {
+  if (!temp_tree || !root_child || !current_root) return;
+
+  // 1) Merge block sequences: keep existing blocks in current_root, append only new blocks from root_child
+  auto &dst_hashes = current_root->get_block_hashes();
+  auto &src_hashes = root_child->get_block_hashes();
+  //impossible to merge an root_child with an empty block sequence
+  if (src_hashes.size() == 0) {
+    return;
+  }
+  CRadixNode* matched_root_child = root_child;
+  size_t dst_size = dst_hashes.size();
+  size_t src_size = src_hashes.size();
+  // try to match block_hashes within current_root
+  if (dst_size > 0) {
+      size_t i = 0;
+      size_t min_size = std::min(dst_size, src_size);
+      for (; i < min_size; ++i) {
+        if (dst_hashes[i] != src_hashes[i]) break;
+      }
+      //impossible to match any block_hashes within current_root
+      if (i == 0) return;
+      bool c_root_splited = false;
+      if (i < dst_size) {
+        auto new_lm = lt_pool.alloc();
+        if (new_lm == nullptr) return;
+        new_lm->state = NODE_STATE_NORMAL;
+        new_lm->lease_time = current_root->get_lease_meta()->lease_time;
+        auto new_root = current_root->split(i);
+        new_root->set_lease_meta(new_lm);
+        current_root = new_root;
+        assert(current_root != nullptr);
+        c_root_splited = true;
+      }
+      if (i < src_size) {
+        matched_root_child = root_child->split(i);
+        // no need to set lease meta for matched_root_child, since we will delete it later
+        if (c_root_splited) {// set the matched part of root_child to current_root's children
+          current_root->set_child(root_child->get_head_hash(), root_child);
+          if (matched_root_child != nullptr &&
+              matched_root_child != root_child) {
+            delete matched_root_child;
+          }
+          return;
+        }
+      } else if (i == src_hashes.size()) {// matched all block_hashes within root_child
+        matched_root_child = root_child;
+      }
+  }
+
+  // 2) Merge children: for each child of root_child, keep current_root child if head collision; otherwise attach
+  root_child->for_each_child([&](HashType head, CRadixNode* src_child){
+    if (current_root->lookup_child(head)) {
+      // Child exists in destination, recursively merge into it and discard src_child structure
+      CRadixNode* dst_child = current_root->get_child(head);
+      attach_and_merge_root_child(temp_tree, src_child, dst_child, lt_pool);
+    } else {
+      // No collision; attach src_child under current_root
+      current_root->set_child(head, src_child);
+      src_child->set_parent(current_root);
+    }
+  });
+
+  // matched_root_child node data has been merged or its children re-attached; clear its
+  delete matched_root_child;
+}
+
+} // namespace flexkv
+
+

--- a/csrc/distributed_radix_tree.h
+++ b/csrc/distributed_radix_tree.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <atomic>
+#include <torch/extension.h>
+#include <pthread.h>
+
+#include "radix_tree.h"
+#include "block_meta.h"
+#include "lock_free_q.h"
+#include "lease_meta_mempool.h"
+
+namespace flexkv {
+
+CRadixNode* dfs_build_subtree_from_meta(const BlockMeta* current_meta,
+                                CRadixTreeIndex* index,
+                                CRadixNode* parent_node,
+                                const std::unordered_map<int64_t, std::vector<BlockMeta*>>& parent_to_children,
+                                std::unordered_set<int64_t>& processed_hashes,
+                                LeaseMetaMemPool& lt_pool,
+                                bool is_ready);
+
+void attach_and_merge_root_child(CRadixTreeIndex* temp_tree, CRadixNode* root_child,
+   CRadixNode* current_root, LeaseMetaMemPool& lt_pool);
+
+class RedisMetaChannel; // forward declaration
+
+class RefRadixTree : public CRadixTreeIndex {
+public:
+  RefRadixTree(int tokens_per_block, int max_num_blocks = 1000000);
+  ~RefRadixTree();
+  // Decrement reference count; when it reaches zero, delete this instance
+  void dec_ref_cnt();
+  void inc_ref_cnt();
+  // Wrappers mirroring CRadixTreeIndex APIs
+  void lock(CRadixNode *node) override;
+  void unlock(CRadixNode *node) override;
+  bool is_empty() override;
+  void set_ready(CRadixNode *node, bool ready = true, int ready_length = -1) override;
+  std::shared_ptr<CMatchResult> match_prefix(torch::Tensor &block_hashes,
+    int num_blocks, bool update_cache_info = true) override;
+private:
+
+  // Override base methods with custom behavior
+  CRadixNode *insert(torch::Tensor &physical_block_ids,
+    torch::Tensor &block_hashes, int num_blocks, int num_insert_blocks,
+    bool ready = true, CRadixNode *node = nullptr, int num_matched_blocks = -1,
+    int last_node_matched_length = -1) override;
+
+  int evict(torch::Tensor &evicted_blocks, int num_evicted) override;
+  std::atomic<uint32_t> ref_cnt;
+
+};
+
+struct RefCntGuard {
+  RefRadixTree *owner;
+  explicit RefCntGuard(RefRadixTree *o) : owner(o) {
+    owner->inc_ref_cnt();
+  }
+  RefCntGuard(const RefCntGuard&) = delete;
+  RefCntGuard& operator=(const RefCntGuard&) = delete;
+  ~RefCntGuard() {
+    if (owner) owner->dec_ref_cnt();
+  }
+};
+
+class DistributedRadixTree {
+private:
+  RedisMetaChannel *channel;
+  uint32_t node_id;
+  int tokens_per_block;
+  int max_num_blocks;
+  LeaseMetaMemPool lt_pool;
+  // refresh worker tunables
+  size_t refresh_batch_size_ = 128;
+  uint32_t rebuild_interval_ms_ = 1000;
+  uint32_t idle_sleep_ms_ = 10;
+  uint32_t renew_threshold_ms_ = 5000; // 5 seconds before expiry to renew lease
+  LockFreeQueue<CRadixNode*> renew_lease_queue;
+  bool refresh_started = false;
+  volatile bool refresh_should_stop = false;
+  pthread_t refresh_tid{};
+  std::atomic<RefRadixTree *> c_index;
+  std::atomic<RefRadixTree *> old_index;
+  void refresh_worker();
+  static void* refresh_worker_trampoline(void* arg);
+  void refresh_nodes_lease_from_redis(const std::vector<CRadixNode*> &batch);
+
+public:
+  DistributedRadixTree(int tokens_per_block, int max_num_blocks,
+                  uint32_t node_id,
+                  size_t lt_pool_initial_capacity = 0,
+                  size_t refresh_batch_size = 128,
+                  uint32_t rebuild_interval_ms = 1000,
+                  uint32_t idle_sleep_ms = 10);
+  ~DistributedRadixTree();
+
+  void set_meta_channel(RedisMetaChannel *ch) { channel = ch; }
+  void set_node_id(uint32_t nid) { node_id = nid; }
+
+  void start(RedisMetaChannel *channel);
+  void stop();
+  RefRadixTree* remote_tree_refresh();
+  std::shared_ptr<CMatchResult> match_prefix(torch::Tensor &block_hashes,
+    int num_blocks, bool update_cache_info = true);
+  // Convenience wrappers delegating to current reference index
+  void lock(CRadixNode *node);
+  void unlock(CRadixNode *node);
+  bool is_empty();
+  void set_ready(CRadixNode *node, bool ready = true, int ready_length = -1);
+};
+
+} // namespace flexkv
+
+

--- a/csrc/lease_meta_mempool.cpp
+++ b/csrc/lease_meta_mempool.cpp
@@ -1,0 +1,115 @@
+#include "lease_meta_mempool.h"
+
+#include <algorithm>
+#include <cassert>
+
+namespace flexkv {
+
+LeaseMetaMemPool::LeaseMetaMemPool(size_t initial_capacity)
+  : growth_block_size(std::max<size_t>(initial_capacity, 64)), total_capacity(0), free_count(0) {
+  if (initial_capacity > 0) {
+    allocate_block(initial_capacity);
+  }
+}
+
+LeaseMetaMemPool::~LeaseMetaMemPool() {
+  // Reclaim allocated raw buffer. Requires quiescence (no concurrent access).
+  if (allocated_block.raw) {
+    ::operator delete[](allocated_block.raw);
+    allocated_block = {nullptr, 0};
+  }
+}
+
+void LeaseMetaMemPool::allocate_block(size_t count) {
+  assert(count > 0);
+  // layout: [pool_ptr(LeaseMetaMemPool*)][LeaseMeta x count]
+  const size_t header_size = sizeof(LeaseMetaMemPool*);
+  const size_t stride = header_size + sizeof(LeaseMeta);
+  const size_t bytes = stride * count;
+  char* raw = reinterpret_cast<char*>(::operator new[](bytes));
+  // Construct per-object header and object, and seed free queue
+  {
+    std::lock_guard<std::mutex> lk(allocated_mu);
+    for (size_t i = 0; i < count; ++i) {
+      char* slot = raw + i * stride;
+      *reinterpret_cast<LeaseMetaMemPool**>(slot) = this;
+      LeaseMeta* obj = reinterpret_cast<LeaseMeta*>(slot + header_size);
+      new (obj) LeaseMeta();
+      free_queue.push_back(obj);
+    }
+  }
+  // record the single allocated block for reclamation
+  allocated_block = {raw, bytes};
+  total_capacity.fetch_add(count, std::memory_order_relaxed);
+  free_count.fetch_add(count, std::memory_order_relaxed);
+}
+
+void LeaseMetaMemPool::grow_if_needed() {
+  // No-op here; growth is triggered on-demand in alloc() when pop fails.
+}
+
+LeaseMeta *LeaseMetaMemPool::alloc() {
+  LeaseMeta* ptr = nullptr;
+  {
+    std::unique_lock<std::mutex> lk(allocated_mu);
+    if (free_queue.empty()) {
+      lk.unlock();
+      allocate_block(growth_block_size);
+      if (growth_block_size < (1ULL << 20)) {
+        growth_block_size = growth_block_size * 2;
+      }
+      lk.lock();
+    }
+    if (!free_queue.empty()) {
+      ptr = free_queue.back();
+      free_queue.pop_back();
+      allocated_set.insert(ptr);
+    }
+  }
+  // Reset to defaults
+  ptr->state = NODE_STATE_NORMAL;
+  ptr->lease_time = 0;
+  free_count.fetch_sub(1, std::memory_order_relaxed);
+  return ptr;
+}
+
+void LeaseMetaMemPool::free(LeaseMeta *ptr) {
+  if (ptr == nullptr) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lk(allocated_mu);
+    auto it = allocated_set.find(ptr);
+    if (it == allocated_set.end()) {
+      // not allocated from this pool or double free, ignore safely
+      return;
+    }
+    allocated_set.erase(it);
+    // Reset for reuse then push back to free queue under the same lock
+    ptr->state = NODE_STATE_EVICTED;
+    ptr->lease_time = 0;
+    free_queue.push_back(ptr);
+  }
+  free_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+void LeaseMetaMemPool::release(LeaseMeta *ptr) {
+  if (ptr == nullptr) return;
+  // Retrieve the owning pool pointer from header before the object
+  char* p = reinterpret_cast<char*>(ptr);
+  const size_t header_size = sizeof(LeaseMetaMemPool*);
+  LeaseMetaMemPool* pool = *reinterpret_cast<LeaseMetaMemPool**>(p - header_size);
+  pool->free(ptr);
+}
+
+size_t LeaseMetaMemPool::capacity() const {
+  return total_capacity.load(std::memory_order_relaxed);
+}
+
+size_t LeaseMetaMemPool::free_size() const {
+  return free_count.load(std::memory_order_relaxed);
+}
+
+} // namespace flexkv
+
+

--- a/csrc/lease_meta_mempool.h
+++ b/csrc/lease_meta_mempool.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <atomic>
+#include <set>
+#include <mutex>
+#include <vector>
+
+#include <deque>
+
+namespace flexkv {
+enum NodeState {
+  NODE_STATE_NORMAL,
+  NODE_STATE_ABOUT_TO_EVICT,
+  NODE_STATE_EVICTED,
+};
+
+struct LeaseMeta {
+  volatile NodeState state;
+  volatile uint32_t lease_time;
+  LeaseMeta() : state(NODE_STATE_NORMAL), lease_time(0) {
+  }
+};
+// A lock-free memory pool for LeaseMeta objects.
+class LeaseMetaMemPool {
+private:
+  struct BlockInfo {
+    void* raw;
+    size_t bytes;
+  };
+
+  // Single allocated block info
+  BlockInfo allocated_block{nullptr, 0};
+  // Free pool of individual LeaseMeta pointers.
+  std::deque<LeaseMeta*> free_queue;
+  // Block growth size when pool needs to expand.
+  size_t growth_block_size;
+  // Stats
+  std::atomic<size_t> total_capacity;
+  std::atomic<size_t> free_count;
+
+  // Track currently allocated (checked-out) LeaseMeta pointers
+  std::set<LeaseMeta*> allocated_set;
+  std::mutex allocated_mu;
+
+  void allocate_block(size_t count);
+  void grow_if_needed();
+
+public:
+  explicit LeaseMetaMemPool(size_t initial_capacity = 0);
+  ~LeaseMetaMemPool();
+
+  // Allocates one LeaseMeta from the pool. Grows on demand.
+  LeaseMeta *alloc();
+
+  // Returns a LeaseMeta to the pool. The object is reset for reuse.
+  void free(LeaseMeta *ptr);
+
+  // Static helper to release a LeaseMeta* without holding a pool reference.
+  // The pool pointer is stored in-band immediately before each LeaseMeta object.
+  static void release(LeaseMeta *ptr);
+
+  // Iterate over currently allocated items and invoke callback for each.
+  // The iteration is done on a snapshot to avoid holding the mutex while executing user code.
+  template<typename Fn>
+  void for_each_allocated_item(Fn&& fn) {
+    std::vector<LeaseMeta*> snapshot;
+    {
+      std::lock_guard<std::mutex> lk(allocated_mu);
+      snapshot.assign(allocated_set.begin(), allocated_set.end());
+    }
+    for (LeaseMeta* ptr : snapshot) {
+      fn(ptr);
+    }
+  }
+
+  // traversal removed (single block)
+
+  // Observability helpers.
+  size_t capacity() const;    // total LeaseMeta ever allocated by the pool
+  size_t free_size() const;   // currently available LeaseMeta count
+};
+
+} // namespace flexkv
+
+

--- a/csrc/local_radix_tree.cpp
+++ b/csrc/local_radix_tree.cpp
@@ -1,0 +1,413 @@
+#include "local_radix_tree.h"
+#include "redis_meta_channel.h"
+
+#include <algorithm>
+#include <pthread.h>
+#include <unistd.h>
+#include <queue>
+#include <sys/time.h>
+
+namespace flexkv {
+
+static inline int64_t get_prev_hash(const std::deque<int64_t> &hashes, size_t idx) {
+  if (idx == 0) return 0;
+  return hashes[idx - 1];
+}
+
+static inline uint64_t get_now_ms() {
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+  return (uint64_t)now.tv_sec * 1000 + (uint64_t)(now.tv_usec / 1000);
+}
+
+LocalRadixTree::LocalRadixTree(int tokens_per_block, int max_num_blocks, uint32_t ttl_ms, uint32_t renew_ms, uint32_t batch_sz, uint32_t idle_sleep_ms, size_t lt_pool_initial_capacity)
+  : CRadixTreeIndex(tokens_per_block, max_num_blocks), channel(nullptr), node_id(0), lease_ttl_ms(ttl_ms), refresh_batch_size(batch_sz), lease_pool(lt_pool_initial_capacity) {
+  this->idle_sleep_ms = idle_sleep_ms;
+  if (renew_ms == 0) {
+    renew_lease_ms = (uint32_t)(ttl_ms * 2 / 10);
+    if (renew_lease_ms == 0) {
+      renew_lease_ms = 10;
+    }
+  } else {
+    renew_lease_ms = renew_ms;
+  }
+}
+
+CRadixNode *LocalRadixTree::insert(torch::Tensor &physical_block_ids,
+  torch::Tensor &block_hashes, int num_blocks, int num_insert_blocks,
+  bool ready, CRadixNode *last_node, int num_matched_blocks, int last_node_matched_length) {
+  // Mirror CRadixTreeIndex::insert but attach LeaseMeta for every newly created node
+  if (num_insert_blocks == -1) {
+    num_insert_blocks = num_blocks;
+  }
+  assert(num_insert_blocks >= 0);
+  assert(num_insert_blocks <= num_blocks);
+  assert(physical_block_ids.ndim() == 1);
+
+  if (last_node == nullptr) {
+    auto match_result = match_prefix(block_hashes, num_blocks, true);
+    num_matched_blocks = match_result->num_matched_blocks;
+    last_node_matched_length = match_result->last_node_matched_length;
+    last_node = match_result->last_node;
+  }
+
+  assert(last_node != nullptr);
+  assert(last_node_matched_length != 0 || is_root(last_node));
+  assert(physical_block_ids.size() == num_insert_blocks - num_matched_blocks);
+
+  if (num_matched_blocks >= num_insert_blocks) {
+    return nullptr;
+  }
+
+  // Handle split if the last node only partially matched
+  if (last_node_matched_length < last_node->size()) {
+    CRadixNode *new_parent = last_node->split(last_node_matched_length);
+    assert(new_parent != nullptr);
+    LeaseMeta *newlm = lease_pool.alloc();
+    assert(newlm != nullptr);
+    LeaseMeta *org_lm = last_node->get_lease_meta();
+    assert(org_lm != nullptr);
+    newlm->state = org_lm->state;
+    newlm->lease_time = org_lm->lease_time;
+    new_parent->set_lease_meta(newlm);
+    last_node = new_parent;
+  }
+
+  if (last_node->is_leaf()) {
+    remove_leaf(last_node);
+  }
+
+  // Create the new leaf node and attach LeaseMeta immediately
+  CRadixNode *new_node = new CRadixNode(this, ready, 0);
+
+  auto &new_block_hashes = new_node->get_block_hashes();
+  auto &new_physical_blocks = new_node->get_physical_blocks();
+  auto block_hashes_ptr = block_hashes.data_ptr<int64_t>();
+  auto physical_block_ids_ptr = physical_block_ids.data_ptr<int64_t>();
+  for (auto i = 0; i + num_matched_blocks < num_insert_blocks; i++) {
+    new_block_hashes.insert(new_block_hashes.end(), block_hashes_ptr[i + num_matched_blocks]);
+    new_physical_blocks.insert(new_physical_blocks.end(), physical_block_ids_ptr[i]);
+  }
+  LeaseMeta *newlm = lease_pool.alloc();
+  assert(newlm != nullptr);
+  new_node->set_lease_meta(newlm);
+  newlm->state = NODE_STATE_NORMAL;
+  newlm->lease_time = get_now_ms() + lease_ttl_ms;
+
+  new_node->set_parent(last_node);
+  last_node->set_child(new_node->get_head_hash(), new_node);
+
+  add_node(new_node);
+  add_leaf(new_node);
+  return new_node;
+}
+
+void LocalRadixTree::set_meta_channel(RedisMetaChannel *ch) {
+  channel = ch;
+  if (channel) {
+    node_id = channel->get_node_id();
+  }
+}
+
+size_t LocalRadixTree::local_block_report(size_t max_batch) {
+  if (channel == nullptr || max_batch == 0) return 0;
+  size_t processed = 0;
+  NewBlockMeta* node_ptr = nullptr;
+  // 1) publish new block metas
+  while (processed < max_batch && new_block_queue.pop(node_ptr)) {
+    publish_node_blocks(node_ptr);
+    delete node_ptr; // release the temporary copied node
+    processed++;
+  }
+
+  // 2) update state to ABOUT_TO_EVICT for queued hashes
+  // Consume at most (max_batch - processed) items from about_to_evict_blocks_queue
+  size_t budget = (max_batch > processed) ? (max_batch - processed) : 0;
+  std::deque<int64_t>* about_q_ptr = nullptr;
+  while (budget > 0 && about_to_evict_blocks_queue.pop(about_q_ptr)) {
+    if (about_q_ptr) {
+      channel->update_block_state_batch(node_id, about_q_ptr, NODE_STATE_ABOUT_TO_EVICT);
+    }
+    delete about_q_ptr;
+    about_q_ptr = nullptr;
+    processed++;
+    budget--;
+  }
+
+  // 3) delete evicted blocks
+  budget = (max_batch > processed) ? (max_batch - processed) : 0;
+  std::deque<int64_t>* evicted_q_ptr = nullptr;
+  while (budget > 0 && evicted_blocks_queue.pop(evicted_q_ptr)) {
+    if (evicted_q_ptr) {
+      channel->delete_blockmeta_batch(node_id, evicted_q_ptr);
+    }
+    delete evicted_q_ptr;
+    evicted_q_ptr = nullptr;
+    processed++;
+    budget--;
+  }
+
+  return processed;
+}
+
+void LocalRadixTree::insert_and_publish(const CRadixNode *node) {
+  if (node == nullptr) return;
+  // Create a detached copy of the node sufficient for publishing
+  CRadixNode *src = const_cast<CRadixNode *>(node);
+  // alloc a new node metadata
+  NewBlockMeta *cp = new NewBlockMeta();
+  cp->parent_hash = src->get_parent()->get_head_hash();
+  // Copy block hashes and physical blocks
+  auto &dst_hashes = cp->block_hashes;
+  auto &dst_phys = cp->physical_blocks;
+  auto &src_hashes = src->get_block_hashes();
+  auto &src_phys = src->get_physical_blocks();
+  auto *src_lm = src->get_lease_meta();
+  if (src_lm != nullptr) {
+    cp->lease_meta.state = src_lm->state;
+    cp->lease_meta.lease_time = src_lm->lease_time;
+  }
+  dst_hashes.insert(dst_hashes.end(), src_hashes.begin(), src_hashes.end());
+  dst_phys.insert(dst_phys.end(), src_phys.begin(), src_phys.end());
+  // Lease meta is optional for publishing; keep nullptr so publisher treats as defaults
+  new_block_queue.push(cp);
+}
+
+void* LocalRadixTree::refresh_worker_trampoline(void* arg) {
+  auto* self = reinterpret_cast<LocalRadixTree*>(arg);
+  self->refresh_worker();
+  return nullptr;
+}
+
+void LocalRadixTree::refresh_worker() {
+  // Simple loop: try to renew in small batches; sleep briefly when idle
+  const size_t batch = refresh_batch_size;
+  struct timeval tv0; gettimeofday(&tv0, nullptr);
+  uint64_t now_ms0 = (uint64_t)tv0.tv_sec * 1000 + (uint64_t)(tv0.tv_usec / 1000);
+  uint64_t next_renew_ms = now_ms0 + renew_lease_ms;
+  while (!refresh_should_stop) {
+    size_t n = local_block_report(batch);
+    struct timeval tv; gettimeofday(&tv, nullptr);
+    uint64_t now_ms = (uint64_t)tv.tv_sec * 1000 + (uint64_t)(tv.tv_usec / 1000);
+    if (now_ms >= next_renew_ms) {
+      renew_relese_time();
+      next_renew_ms = now_ms + renew_lease_ms;
+    }
+    if (n == 0) {
+      usleep(1000 * idle_sleep_ms);
+    }
+  }
+}
+
+void LocalRadixTree::start(RedisMetaChannel *ch) {
+  if (refresh_started) return;
+  // Initialize channel and node_id from ch
+  set_meta_channel(ch);
+  if (channel == nullptr) return;
+  refresh_should_stop = false;
+  refresh_started = true;
+  pthread_create(&refresh_tid, nullptr, &LocalRadixTree::refresh_worker_trampoline, this);
+}
+void LocalRadixTree::renew_relese_time() {
+  // compute new lease expiry (ms)
+  struct timeval tv; gettimeofday(&tv, nullptr);
+  uint32_t now_ms = (uint32_t)(tv.tv_sec * 1000 + tv.tv_usec / 1000);
+  uint32_t new_lt = now_ms + lease_ttl_ms;
+  // update in-memory metas 
+  lease_pool.for_each_allocated_item([&](LeaseMeta* m){
+    if (m != nullptr && m->state == NODE_STATE_NORMAL) {
+      m->lease_time = new_lt;
+    }
+  });
+  // batch update redis for this node
+  if (channel) {
+    channel->renew_node_leases(node_id, new_lt);
+  }
+}
+
+void LocalRadixTree::stop() {
+  if (!refresh_started) return;
+  refresh_should_stop = true;
+  pthread_join(refresh_tid, nullptr);
+  refresh_started = false;
+}
+
+void LocalRadixTree::publish_node_blocks(NewBlockMeta *node) {
+  if (channel == nullptr || node == nullptr) return;
+  auto &hashes = node->block_hashes;
+  auto &phys = node->physical_blocks;
+  auto *lease = &node->lease_meta;
+  size_t n = std::min(hashes.size(), phys.size());
+  if (n == 0) return;
+  std::vector<BlockMeta> metas;
+  metas.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    BlockMeta meta;
+    if (i == 0) {
+      meta.ph = node->parent_hash;
+    } else {
+      meta.ph = get_prev_hash(hashes, i);
+    }
+    meta.pb = phys[i];
+    meta.nid = node_id;
+    meta.hash = hashes[i];
+    meta.lt = lease ? lease->lease_time : 0;
+    meta.state = lease ? lease->state : NODE_STATE_NORMAL;
+    metas.push_back(meta);
+  }
+  channel->publish(metas);
+}
+
+int LocalRadixTree::evict(torch::Tensor &evicted_blocks, int num_evicted) {
+  int64_t *evicted_blocks_ptr = evicted_blocks.data_ptr<int64_t>();
+  int has_evicted = 0;
+  std::priority_queue<CRadixNode*, std::vector<CRadixNode*>, CRadixNode::Compare> expired_q;
+  std::priority_queue<CRadixNode*, std::vector<CRadixNode*>, CRadixNode::Compare> fresh_q;
+  std::deque<int64_t> *evicted_q = new std::deque<int64_t>();
+  std::deque<int64_t> *about_to_evict_q = nullptr;
+
+  // now in ms
+  struct timeval now_tv; gettimeofday(&now_tv, nullptr);
+  uint64_t now_ms = (uint64_t)now_tv.tv_sec * 1000 + (uint64_t)(now_tv.tv_usec / 1000);
+
+  // Partition leaf candidates by lease expiry
+  for (auto it = leaf_list.begin(); it != leaf_list.end(); ++it) {
+    CRadixNode *node = *it;
+    if (!node->evictable()) continue;
+    LeaseMeta *lm = node->get_lease_meta();
+    bool expired = (lm == nullptr) || ((uint64_t)lm->lease_time <= now_ms);
+    if (expired) expired_q.push(node); else fresh_q.push(node);
+  }
+
+  auto push_parent_if_candidate = [&](CRadixNode *parent){
+    if (parent->is_leaf() && !is_root(parent)) {
+      add_leaf(parent);
+    }
+    if (parent->evictable()) {
+      LeaseMeta *plm = parent->get_lease_meta();
+      bool pexpired = (plm == nullptr) || ((uint64_t)plm->lease_time <= now_ms);
+      if (pexpired) expired_q.push(parent); else fresh_q.push(parent);
+    }
+  };
+
+  auto evict_node = [&](CRadixNode *node, int need) -> int {
+    int done = 0;
+    if (node->size() > need) {
+      auto hashs = node->get_block_hashes();
+      auto remaining = node->size() - need;
+      evicted_q->insert(evicted_q->end(), hashs.begin() + remaining, hashs.end());
+      auto blocks = node->shrink(need);
+      for (auto it = blocks->begin(); it != blocks->end(); ++it) {
+        evicted_blocks_ptr[has_evicted + done] = *it;
+        done++;
+      }
+      delete blocks;
+    } else {
+      auto parent = node->get_parent();
+      auto &blocks = node->get_physical_blocks();
+      auto hashs = node->get_block_hashes();
+      evicted_q->insert(evicted_q->end(), hashs.begin(), hashs.end());
+      assert(parent != nullptr);
+      parent->remove_child(node->get_head_hash());
+      for (auto it = blocks.begin(); it != blocks.end(); ++it) {
+        if (done >= need) break;
+        evicted_blocks_ptr[has_evicted + done] = *it;
+        done++;
+      }
+      push_parent_if_candidate(parent);
+      node->clear_parent();
+      remove_leaf(node);
+      remove_node(node);
+    }
+    return done;
+  };
+
+  // Evict expired first
+  while (has_evicted < num_evicted && !expired_q.empty()) {
+    CRadixNode *node = expired_q.top(); expired_q.pop();
+    has_evicted += evict_node(node, num_evicted - has_evicted);
+  }
+
+  // If still not enough, mark fresh leaves as ABOUT_TO_EVICT without removing now
+  if (has_evicted < num_evicted) {
+    int remaining = num_evicted - has_evicted;
+    while (remaining > 0 && !fresh_q.empty()) {
+      if (about_to_evict_q == nullptr) {
+        about_to_evict_q = new std::deque<int64_t>();
+      }
+      CRadixNode *node = fresh_q.top(); fresh_q.pop();
+      int node_sz = node->size();
+      if (node_sz <= 0) continue;
+      if (remaining < node_sz) {
+        // Need to mark only a subset of this node. Split to isolate 'remaining' blocks.
+        // Ensure split preconditions: 0 < remaining < node_sz and node has a parent (not root)
+        if (remaining > 0) {
+          CRadixNode *subset = node->split(remaining);
+          // Attach LeaseMeta if missing and mark ABOUT_TO_EVICT
+          LeaseMeta *newlm = lease_pool.alloc();
+          assert(newlm != nullptr);
+          // get current lease meta
+          LeaseMeta *slm = node->get_lease_meta();
+          assert(slm != nullptr);
+          // set new lease meta
+          subset->set_lease_meta(newlm);
+          newlm->state = slm->state;
+          newlm->lease_time = slm->lease_time;
+          if (slm->state == NODE_STATE_NORMAL) {
+            slm->state = NODE_STATE_ABOUT_TO_EVICT;
+            auto hashs = subset->get_block_hashes();
+            about_to_evict_q->insert(about_to_evict_q->end(), hashs.begin(), hashs.end());
+          }
+          remaining -= subset->size(); // should equal 'remaining'
+        }
+      } else {
+        // Mark whole node
+        LeaseMeta *lm = node->get_lease_meta();
+        assert(lm != nullptr);
+        if (lm->state == NODE_STATE_NORMAL) {
+          lm->state = NODE_STATE_ABOUT_TO_EVICT;
+          auto hashs = node->get_block_hashes();
+          about_to_evict_q->insert(about_to_evict_q->end(), hashs.begin(), hashs.end());
+        }
+        remaining -= node_sz;
+      }
+    }
+  }
+  if (evicted_q->size() > 0) {
+    evicted_blocks_queue.push(evicted_q);
+  }
+  if (about_to_evict_q && about_to_evict_q->size() > 0) {
+    about_to_evict_blocks_queue.push(about_to_evict_q);
+  }
+  return has_evicted;
+}
+
+// Delegate wrappers to base CRadixTreeIndex
+std::shared_ptr<CMatchResult> LocalRadixTree::match_prefix(torch::Tensor &block_hashes,
+  int num_blocks, bool update_cache_info) {
+  return CRadixTreeIndex::match_prefix(block_hashes, num_blocks, update_cache_info);
+}
+
+int LocalRadixTree::total_unready_blocks() { return CRadixTreeIndex::total_unready_blocks(); }
+int LocalRadixTree::total_ready_blocks() { return CRadixTreeIndex::total_ready_blocks(); }
+int LocalRadixTree::total_cached_blocks() { return CRadixTreeIndex::total_cached_blocks(); }
+int LocalRadixTree::total_node_num() { return CRadixTreeIndex::total_node_num(); }
+void LocalRadixTree::reset() { CRadixTreeIndex::reset(); }
+bool LocalRadixTree::is_root(CRadixNode *node) { return CRadixTreeIndex::is_root(node); }
+void LocalRadixTree::remove_node(CRadixNode *node) { CRadixTreeIndex::remove_node(node); }
+void LocalRadixTree::remove_leaf(CRadixNode *node) { CRadixTreeIndex::remove_leaf(node); }
+void LocalRadixTree::add_node(CRadixNode *node) { CRadixTreeIndex::add_node(node); }
+void LocalRadixTree::add_leaf(CRadixNode *node) { CRadixTreeIndex::add_leaf(node); }
+void LocalRadixTree::lock(CRadixNode *node) { CRadixTreeIndex::lock(node); }
+void LocalRadixTree::unlock(CRadixNode *node) { CRadixTreeIndex::unlock(node); }
+bool LocalRadixTree::is_empty() { return CRadixTreeIndex::is_empty(); }
+void LocalRadixTree::inc_node_count() { CRadixTreeIndex::inc_node_count(); }
+void LocalRadixTree::dec_node_count() { CRadixTreeIndex::dec_node_count(); }
+void LocalRadixTree::set_ready(CRadixNode *node, bool ready, int ready_length) {
+  CRadixTreeIndex::set_ready(node, ready, ready_length);
+}
+
+} // namespace flexkv
+
+
+

--- a/csrc/local_radix_tree.h
+++ b/csrc/local_radix_tree.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <torch/extension.h>
+#include <pthread.h>
+
+#include "radix_tree.h"
+#include "block_meta.h"
+#include "lock_free_q.h"
+#include "lease_meta_mempool.h"
+
+namespace flexkv {
+
+class RedisMetaChannel; // forward declaration
+
+struct NewBlockMeta {
+  int64_t parent_hash;
+  struct LeaseMeta lease_meta;
+  std::deque<int64_t> block_hashes;
+  std::deque<int64_t> physical_blocks;
+};
+
+class LocalRadixTree : public CRadixTreeIndex {
+private:
+  RedisMetaChannel *channel;
+  uint32_t node_id;
+  uint32_t lease_ttl_ms;
+  uint32_t renew_lease_ms;
+  uint32_t refresh_batch_size;
+  uint32_t idle_sleep_ms = 10;
+  // Queue created by default to buffer newly produced nodes for publishing
+  LockFreeQueue<NewBlockMeta*> new_block_queue;
+  // Queues to record eviction decisions
+  LockFreeQueue<std::deque<int64_t>*> evicted_blocks_queue;
+  LockFreeQueue<std::deque<int64_t>*> about_to_evict_blocks_queue;
+  // Background refresh worker
+  bool refresh_started = false;
+  volatile bool refresh_should_stop = false;
+  pthread_t refresh_tid{};
+  // Lease meta memory pool for nodes created by this LocalRadixTree
+  LeaseMetaMemPool lease_pool;
+  void refresh_worker();
+  static void* refresh_worker_trampoline(void* arg);
+
+  void publish_node_blocks(CRadixNode *node);
+  // Pop at most max_batch nodes from new_block_queue and publish their BlockMeta to Redis.
+  // Returns number of nodes published.
+  size_t local_block_report(size_t max_batch = 1024);
+  // Renew in-memory LeaseMeta times and refresh Redis lt for this node
+  void renew_relese_time();
+public:
+  LocalRadixTree(int tokens_per_block,
+                 int max_num_blocks = 1000000,
+                 uint32_t lease_ttl_ms = 100000,
+                 uint32_t renew_lease_ms = 0,
+                 uint32_t refresh_batch_size = 256,
+                 uint32_t idle_sleep_ms = 10,
+                 size_t lt_pool_initial_capacity = 0);
+
+  void set_meta_channel(RedisMetaChannel *ch);
+
+  // Enqueue a copy of the given node to be published later by local_block_renew.
+  void insert_and_publish(const CRadixNode *node);
+
+  // Start background thread; initialize channel and node_id from ch first
+  void start(RedisMetaChannel *ch);
+  // Stop background thread gracefully
+  void stop();
+
+  // Override insert to attach a LeaseMeta from the pool to new nodes
+  CRadixNode *insert(torch::Tensor &physical_block_ids,
+    torch::Tensor &block_hashes, int num_blocks, int num_insert_blocks,
+    bool ready = true, CRadixNode *node = nullptr, int num_matched_blocks = -1,
+    int last_node_matched_length = -1) override;
+
+  // Override evict: prefer evicting expired leases; otherwise mark as ABOUT_TO_EVICT
+  int evict(torch::Tensor &evicted_blocks, int num_evicted) override;
+
+  // Wrappers that mirror CRadixTreeIndex APIs
+  std::shared_ptr<CMatchResult> match_prefix(torch::Tensor &block_hashes,
+    int num_blocks, bool update_cache_info = true) override;
+  int total_unready_blocks();
+  int total_ready_blocks();
+  int total_cached_blocks();
+  int total_node_num();
+  void reset();
+  bool is_root(CRadixNode *node);
+  void remove_node(CRadixNode *node);
+  void remove_leaf(CRadixNode *node);
+  void add_node(CRadixNode *node);
+  void add_leaf(CRadixNode *node);
+  void lock(CRadixNode *node);
+  void unlock(CRadixNode *node);
+  bool is_empty();
+  void inc_node_count();
+  void dec_node_count();
+  void set_ready(CRadixNode *node, bool ready = true, int ready_length = -1);
+};
+
+} // namespace flexkv
+
+
+

--- a/csrc/lock_free_q.h
+++ b/csrc/lock_free_q.h
@@ -1,0 +1,102 @@
+#ifndef LOCK_FREE_Q_H
+#define LOCK_FREE_Q_H
+
+#include <atomic>
+#include <memory>
+#include <functional>
+
+namespace flexkv {
+    // Thread-safe and lock-free queue for worker threads
+template<typename T>
+class LockFreeQueue {
+private:
+    struct Node {
+        T data;
+        std::atomic<Node*> next;
+        Node(const T& item) : data(item), next(nullptr) {}
+    };
+    
+    std::atomic<Node*> head;
+    std::atomic<Node*> tail;
+    
+public:
+    LockFreeQueue() {
+        Node* dummy = new Node(T{});
+        head.store(dummy);
+        tail.store(dummy);
+    }
+    
+    ~LockFreeQueue() {
+        Node* current = head.load();
+        while (current) {
+            Node* next = current->next.load();
+            delete current;
+            current = next;
+        }
+    }
+    
+    void push(const T& item) {
+        Node* new_node = new Node(item);
+        Node* old_tail = tail.load();
+        
+        while (true) {
+            Node* next = old_tail->next.load();
+            if (old_tail == tail.load()) {
+                if (next == nullptr) {
+                    if (old_tail->next.compare_exchange_weak(next, new_node)) {
+                        tail.compare_exchange_strong(old_tail, new_node);
+                        return;
+                    }
+                } else {
+                    tail.compare_exchange_strong(old_tail, next);
+                }
+            }
+        }
+    }
+    
+    bool pop(T& item) {
+        Node* old_head = head.load();
+        Node* old_tail = tail.load();
+        
+        while (true) {
+            Node* next = old_head->next.load();
+            if (old_head == head.load()) {
+                if (old_head == old_tail) {
+                    if (next == nullptr) {
+                        return false;
+                    }
+                    tail.compare_exchange_strong(old_tail, next);
+                } else {
+                    if (next == nullptr) {
+                        return false;
+                    }
+                    item = next->data;
+                    if (head.compare_exchange_weak(old_head, next)) {
+                        delete old_head;
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Traverse the queue and invoke callback for each node's data in FIFO order.
+    // IMPORTANT: This is only safe when no concurrent pops are deleting nodes
+    // (e.g., in a quiescent state or when external synchronization prevents node reclamation).
+    template<typename Fn>
+    void Traverse(Fn&& fn) const {
+        Node* cur = head.load(std::memory_order_acquire);
+        if (cur == nullptr) {
+            return;
+        }
+        Node* node = cur->next.load(std::memory_order_acquire); // skip dummy
+        while (node != nullptr) {
+            fn(node->data);
+            node = node->next.load(std::memory_order_acquire);
+        }
+    }
+};
+
+} // namespace flexkv
+
+#endif // LOCK_FREE_Q_H

--- a/csrc/pcfs/pcfs.h
+++ b/csrc/pcfs/pcfs.h
@@ -77,6 +77,23 @@ void transfer_kv_blocks_cfs_mmap_multi_thread(
     int round_robin, int64_t num_remote_blocks_per_file, bool use_mmap = false,
     int num_threads_per_file = 8, bool is_mla = false);
 
+// New function for shared PCFS read operations
+void shared_transfer_kv_blocks_remote_read(
+  const std::vector<std::uint64_t> &file_nodeids,
+  const std::vector<std::vector<int64_t>> &cfs_blocks_partition,
+  const std::vector<std::vector<int64_t>> &cpu_blocks_partition,
+  const torch::Tensor &cpu_layer_id_list,
+  int64_t cpu_tensor_ptr,
+  int64_t cpu_layer_stride_in_bytes,
+  int64_t cpu_kv_stride_in_bytes,
+  int64_t cfs_layer_stride_in_bytes,
+  int64_t cfs_block_stride_in_bytes,
+  int64_t cfs_kv_stride_in_bytes,
+  int64_t block_size_in_bytes,
+  int64_t total_layers,
+  bool is_mla = false,
+  int num_threads_per_file = 8);
+
 } // namespace flexkv
 #endif
 

--- a/csrc/redis_meta_channel.cpp
+++ b/csrc/redis_meta_channel.cpp
@@ -1,0 +1,464 @@
+#include "redis_meta_channel.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include <sstream>
+#include <mutex>
+#include <iomanip>
+
+namespace flexkv {
+
+static std::string resp_bulk(const std::string &s) {
+  std::ostringstream oss;
+  oss << "$" << s.size() << "\r\n" << s << "\r\n";
+  return oss.str();
+}
+
+static std::string resp_array(const std::vector<std::string> &argv) {
+  std::ostringstream oss;
+  oss << "*" << argv.size() << "\r\n";
+  for (auto &a : argv) {
+    oss << resp_bulk(a);
+  }
+  return oss.str();
+}
+
+RedisTCPClient::RedisTCPClient() : sockfd(-1), port(0), timeout_ms(3000) {}
+
+RedisTCPClient::~RedisTCPClient() { close(); }
+
+bool RedisTCPClient::connect(const std::string &h, int p, int t_ms) {
+  host = h; port = p; timeout_ms = t_ms;
+  sockfd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (sockfd < 0) return false;
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  if (::inet_pton(AF_INET, host.c_str(), &addr.sin_addr) <= 0) return false;
+  if (::connect(sockfd, (sockaddr*)&addr, sizeof(addr)) < 0) return false;
+  return true;
+}
+
+void RedisTCPClient::close() {
+  if (sockfd >= 0) {
+    ::shutdown(sockfd, SHUT_RDWR);
+    ::close(sockfd);
+  }
+  sockfd = -1;
+}
+
+bool RedisTCPClient::send_all(const std::string &buf) {
+  size_t sent = 0;
+  while (sent < buf.size()) {
+    ssize_t n = ::send(sockfd, buf.data() + sent, buf.size() - sent, 0);
+    if (n <= 0) return false;
+    sent += (size_t)n;
+  }
+  return true;
+}
+
+bool RedisTCPClient::recv_line(std::string &line) {
+  line.clear();
+  char c;
+  while (true) {
+    ssize_t n = ::recv(sockfd, &c, 1, 0);
+    if (n <= 0) return false;
+    if (c == '\r') {
+      char lf;
+      if (::recv(sockfd, &lf, 1, 0) <= 0) return false;
+      if (lf != '\n') return false;
+      break;
+    }
+    line.push_back(c);
+  }
+  return true;
+}
+
+bool RedisTCPClient::recv_nbytes(size_t n, std::string &out) {
+  out.resize(n);
+  size_t got = 0;
+  while (got < n) {
+    ssize_t r = ::recv(sockfd, &out[got], n - got, 0);
+    if (r <= 0) return false;
+    got += (size_t)r;
+  }
+  // consume CRLF
+  char crlf[2];
+  if (::recv(sockfd, crlf, 2, 0) != 2) return false;
+  return true;
+}
+
+bool RedisTCPClient::command(const std::vector<std::string> &argv, std::vector<std::string> &out) {
+  out.clear();
+  std::string req = resp_array(argv);
+  if (!send_all(req)) return false;
+  std::string line;
+  if (!recv_line(line)) return false;
+  if (line.empty()) return false;
+  if (line[0] == '+') { // simple string
+    out.push_back(line.substr(1));
+    return true;
+  } else if (line[0] == ':') { // integer
+    out.push_back(line.substr(1));
+    return true;
+  } else if (line[0] == '$') { // bulk string
+    int len = std::stoi(line.substr(1));
+    if (len < 0) return true; // nil
+    std::string bulk;
+    if (!recv_nbytes((size_t)len, bulk)) return false;
+    out.push_back(bulk);
+    return true;
+  } else if (line[0] == '*') { // array
+    int cnt = std::stoi(line.substr(1));
+    for (int i = 0; i < cnt; ++i) {
+      if (!recv_line(line)) return false;
+      if (line.empty() || line[0] != '$') return false;
+      int len = std::stoi(line.substr(1));
+      if (len < 0) { out.emplace_back(); continue; }
+      std::string bulk;
+      if (!recv_nbytes((size_t)len, bulk)) return false;
+      out.push_back(bulk);
+    }
+    return true;
+  }
+  return false;
+}
+
+bool RedisTCPClient::pipeline(const std::vector<std::vector<std::string>> &batch,
+                              std::vector<std::vector<std::string>> &replies) {
+  replies.clear();
+  if (batch.empty()) return true;
+  // Build one big request
+  std::ostringstream req;
+  for (const auto &argv : batch) req << resp_array(argv);
+  std::string payload = req.str();
+  if (!send_all(payload)) return false;
+
+  // Receive replies sequentially
+  replies.reserve(batch.size());
+  for (size_t i = 0; i < batch.size(); ++i) {
+    std::vector<std::string> one;
+    // Parse a single reply using same logic as command()
+    std::string line;
+    if (!recv_line(line)) return false;
+    if (line.empty()) return false;
+    if (line[0] == '+') {
+      one.push_back(line.substr(1));
+    } else if (line[0] == ':') {
+      one.push_back(line.substr(1));
+    } else if (line[0] == '$') {
+      int len = std::stoi(line.substr(1));
+      if (len >= 0) {
+        std::string bulk;
+        if (!recv_nbytes((size_t)len, bulk)) return false;
+        one.push_back(bulk);
+      } else {
+        one.emplace_back();
+      }
+    } else if (line[0] == '*') {
+      int cnt = std::stoi(line.substr(1));
+      for (int j = 0; j < cnt; ++j) {
+        if (!recv_line(line)) return false;
+        if (line.empty() || line[0] != '$') return false;
+        int len = std::stoi(line.substr(1));
+        if (len < 0) { one.emplace_back(); continue; }
+        std::string bulk;
+        if (!recv_nbytes((size_t)len, bulk)) return false;
+        one.push_back(bulk);
+      }
+    } else {
+      return false;
+    }
+    replies.push_back(std::move(one));
+  }
+  return true;
+}
+bool RedisMetaChannel::hmget_two_fields_for_keys(const std::vector<std::string> &keys,
+                                                 const std::string &field1,
+                                                 const std::string &field2,
+                                                 std::vector<std::pair<std::string, std::string>> &out) {
+  out.clear();
+  if (keys.empty()) return true;
+  std::vector<std::vector<std::string>> batch;
+  batch.reserve(keys.size());
+  for (const auto &k : keys) batch.push_back({"HMGET", k, field1, field2});
+  std::vector<std::vector<std::string>> replies;
+  if (!client.pipeline(batch, replies)) return false;
+  out.reserve(replies.size());
+  for (const auto &r : replies) {
+    if (r.size() >= 2) out.emplace_back(r[0], r[1]);
+    else if (r.size() == 1) out.emplace_back(r[0], std::string());
+    else out.emplace_back(std::string(), std::string());
+  }
+  return out.size() == keys.size();
+}
+
+static std::string to_hex_u64(uint64_t value) {
+  std::ostringstream oss;
+  oss << std::hex << std::nouppercase << value;
+  return oss.str();
+}
+
+RedisMetaChannel::RedisMetaChannel(const std::string &h, int p, uint32_t node_id,
+                                   const std::string &lip,
+                                   const std::string &bk)
+  : host(h), port(p), node_id(node_id), blocks_key(bk), local_ip(lip) {
+}
+
+bool RedisMetaChannel::connect() {
+  return client.connect(host, port, 3000);
+}
+std::string RedisMetaChannel::make_block_key(uint32_t node_id, uint64_t hash) const {
+  std::ostringstream oss;
+  oss << blocks_key << ":block:" << node_id << ":" << std::hex << std::nouppercase << hash;
+  return oss.str();
+}
+
+
+// register_node removed; node id is now set via constructor
+
+std::string RedisMetaChannel::to_string(const BlockMeta &m) {
+  // ph|pb|nid|hash|lt|state
+  std::ostringstream oss;
+  oss << m.ph << '|' << m.pb << '|' << m.nid << '|' << m.hash << '|' << m.lt << '|' << (int)m.state;
+  return oss.str();
+}
+
+bool RedisMetaChannel::from_string(const std::string &s, BlockMeta &m) {
+  std::istringstream iss(s);
+  std::string tok;
+  if (!std::getline(iss, tok, '|')) return false; m.ph = std::stoll(tok);
+  if (!std::getline(iss, tok, '|')) return false; m.pb = std::stoll(tok);
+  if (!std::getline(iss, tok, '|')) return false; m.nid = (uint32_t)std::stoul(tok);
+  if (!std::getline(iss, tok, '|')) return false; m.hash = std::stoll(tok);
+  if (!std::getline(iss, tok, '|')) return false; m.lt = (uint32_t)std::stoul(tok);
+  if (!std::getline(iss, tok, '|')) return false; m.state = (NodeState)std::stoi(tok);
+  return true;
+}
+
+void RedisMetaChannel::publish(const BlockMeta &meta) {
+  std::vector<std::string> resp;
+  // Key format: <blocks_key>:block:<nid>:<hash_hex>
+  std::string key = make_block_key(meta.nid, (uint64_t)meta.hash);
+  client.command({
+      "HSET", key,
+      "ph", std::to_string(meta.ph),
+      "pb", std::to_string(meta.pb),
+      "nid", std::to_string(meta.nid),
+      "hash", std::to_string(meta.hash),
+      "lt", std::to_string(meta.lt),
+      "state", std::to_string((int)meta.state)
+  }, resp);
+}
+
+void RedisMetaChannel::publish(const std::vector<BlockMeta> &metas, size_t batch_size) {
+  if (metas.empty()) return;
+  if (batch_size == 0) batch_size = 100;
+
+  size_t total = metas.size();
+  size_t idx = 0;
+  std::vector<std::vector<std::string>> batch;
+  batch.reserve(batch_size);
+  while (idx < total) {
+    batch.clear();
+    size_t end = std::min(idx + batch_size, total);
+    for (size_t i = idx; i < end; ++i) {
+      const BlockMeta &m = metas[i];
+      std::string key = make_block_key(m.nid, (uint64_t)m.hash);
+      batch.push_back({
+        "HSET", key,
+        "ph", std::to_string(m.ph),
+        "pb", std::to_string(m.pb),
+        "nid", std::to_string(m.nid),
+        "hash", std::to_string(m.hash),
+        "lt", std::to_string(m.lt),
+        "state", std::to_string((int)m.state)
+      });
+    }
+    std::vector<std::vector<std::string>> replies;
+    client.pipeline(batch, replies);
+    idx = end;
+  }
+}
+
+size_t RedisMetaChannel::load(std::vector<BlockMeta> &out, size_t max_items) {
+  out.clear();
+  if (max_items == 0) return 0;
+
+  // Fetch keys: KEYS <blocks_key>:block:*
+  std::vector<std::string> keys;
+  if (!client.command({"KEYS", blocks_key + ":block:*"}, keys)) return 0;
+  if (keys.empty()) return 0;
+
+  size_t total = std::min(keys.size(), max_items);
+  out.reserve(total);
+
+  const size_t batch_size = 100;
+  size_t idx = 0;
+  while (idx < total) {
+    size_t end = std::min(idx + batch_size, total);
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      batch.push_back({"HMGET", keys[i], "ph", "pb", "nid", "hash", "lt", "state"});
+    }
+    std::vector<std::vector<std::string>> replies;
+    if (!client.pipeline(batch, replies)) break;
+    for (const auto &fields : replies) {
+      if (fields.size() != 6) continue;
+      BlockMeta m{};
+      if (!fields[0].empty()) m.ph = std::stoll(fields[0]); else m.ph = 0;
+      if (!fields[1].empty()) m.pb = std::stoll(fields[1]); else m.pb = 0;
+      if (!fields[2].empty()) m.nid = (uint32_t)std::stoul(fields[2]); else m.nid = 0;
+      if (!fields[3].empty()) m.hash = std::stoll(fields[3]); else m.hash = 0;
+      if (!fields[4].empty()) m.lt = (uint32_t)std::stoul(fields[4]); else m.lt = 0;
+      if (!fields[5].empty()) m.state = (NodeState)std::stoi(fields[5]); else m.state = (NodeState)0;
+      out.push_back(m);
+    }
+    idx = end;
+  }
+  return out.size();
+}
+
+uint32_t RedisMetaChannel::get_node_id() const {
+  return node_id;
+}
+
+void RedisMetaChannel::renew_node_leases(uint32_t node_id, uint32_t new_lt, size_t batch_size) {
+  // Discover keys for this node and update lt via pipeline
+  std::vector<std::string> keys;
+  if (!list_block_keys(node_id, keys)) return;
+  if (keys.empty()) return;
+  if (batch_size == 0) batch_size = 200;
+  size_t idx = 0, total = keys.size();
+  while (idx < total) {
+    size_t end = std::min(idx + batch_size, total);
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      batch.push_back({"HSET", keys[i], "lt", std::to_string(new_lt)});
+    }
+    std::vector<std::vector<std::string>> replies;
+    client.pipeline(batch, replies);
+    idx = end;
+  }
+}
+
+bool RedisMetaChannel::list_keys(const std::string &pattern, std::vector<std::string> &keys) {
+  keys.clear();
+  return client.command({"KEYS", pattern}, keys);
+}
+
+bool RedisMetaChannel::list_node_keys(std::vector<std::string> &keys) {
+  keys.clear();
+  return client.command({"KEYS", "node:*"}, keys);
+}
+
+bool RedisMetaChannel::list_block_keys(uint32_t node_id, std::vector<std::string> &keys) {
+  keys.clear();
+  std::string pattern = blocks_key + ":block:" + std::to_string(node_id) + ":*";
+  return client.command({"KEYS", pattern}, keys);
+}
+
+bool RedisMetaChannel::hmget_field_for_keys(const std::vector<std::string> &keys,
+                                            const std::string &field,
+                                            std::vector<std::string> &values) {
+  values.clear();
+  if (keys.empty()) return true;
+  std::vector<std::vector<std::string>> batch;
+  batch.reserve(keys.size());
+  for (const auto &k : keys) batch.push_back({"HMGET", k, field});
+  std::vector<std::vector<std::string>> replies;
+  if (!client.pipeline(batch, replies)) return false;
+  values.reserve(replies.size());
+  for (const auto &r : replies) {
+    if (!r.empty()) values.push_back(r[0]); else values.emplace_back();
+  }
+  return values.size() == keys.size();
+}
+
+size_t RedisMetaChannel::load_metas_by_keys(const std::vector<std::string> &keys,
+                                            std::vector<BlockMeta> &out) {
+  out.clear();
+  if (keys.empty()) return 0;
+  const size_t batch_size = 100;
+  size_t idx = 0, total = keys.size();
+  while (idx < total) {
+    size_t end = std::min(idx + batch_size, total);
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      batch.push_back({"HMGET", keys[i], "ph", "pb", "nid", "hash", "lt", "state"});
+    }
+    std::vector<std::vector<std::string>> replies;
+    if (!client.pipeline(batch, replies)) break;
+    for (const auto &fields : replies) {
+      if (fields.size() != 6) continue;
+      BlockMeta m{};
+      if (!fields[0].empty()) m.ph = std::stoll(fields[0]); else m.ph = 0;
+      if (!fields[1].empty()) m.pb = std::stoll(fields[1]); else m.pb = 0;
+      if (!fields[2].empty()) m.nid = (uint32_t)std::stoul(fields[2]); else m.nid = 0;
+      if (!fields[3].empty()) m.hash = std::stoll(fields[3]); else m.hash = 0;
+      if (!fields[4].empty()) m.lt = (uint32_t)std::stoul(fields[4]); else m.lt = 0;
+      if (!fields[5].empty()) m.state = (NodeState)std::stoi(fields[5]); else m.state = (NodeState)0;
+      out.push_back(m);
+    }
+    idx = end;
+  }
+  return out.size();
+}
+
+static std::string key_for_block(RedisMetaChannel* ch, uint32_t node_id, int64_t hash) {
+  return ch->make_block_key(node_id, (uint64_t)hash);
+}
+
+void RedisMetaChannel::update_block_state_batch(uint32_t node_id,
+                                                std::deque<int64_t> *hashes,
+                                                NodeState state,
+                                                size_t batch_size) {
+  if (hashes == nullptr || hashes->empty()) return;
+  if (batch_size == 0) batch_size = 200;
+  size_t idx = 0, total = hashes->size();
+  while (idx < total) {
+    size_t end = std::min(idx + batch_size, total);
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      std::string key = key_for_block(this, node_id, (*hashes)[i]);
+      batch.push_back({"HSET", key, "state", std::to_string((int)state)});
+    }
+    std::vector<std::vector<std::string>> replies;
+    client.pipeline(batch, replies);
+    idx = end;
+  }
+}
+
+void RedisMetaChannel::delete_blockmeta_batch(uint32_t node_id,
+                                              std::deque<int64_t> *hashes,
+                                              size_t batch_size) {
+  if (hashes == nullptr || hashes->empty()) return;
+  if (batch_size == 0) batch_size = 200;
+  size_t idx = 0, total = hashes->size();
+  while (idx < total) {
+    size_t end = std::min(idx + batch_size, total);
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      std::string key = key_for_block(this, node_id, (*hashes)[i]);
+      batch.push_back({"DEL", key});
+    }
+    std::vector<std::vector<std::string>> replies;
+    client.pipeline(batch, replies);
+    idx = end;
+  }
+}
+
+} // namespace flexkv
+
+

--- a/csrc/redis_meta_channel.h
+++ b/csrc/redis_meta_channel.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <sstream>
+#include <iomanip>
+#include <deque>
+
+#include "block_meta.h"
+
+namespace flexkv {
+
+// Minimal RESP/Redis TCP client (single-threaded, blocking) for a few commands we need.
+class RedisTCPClient {
+private:
+  int sockfd;
+  std::string host;
+  int port;
+  int timeout_ms;
+
+  bool send_all(const std::string &buf);
+  bool recv_line(std::string &line);
+  bool recv_nbytes(size_t n, std::string &out);
+
+public:
+  RedisTCPClient();
+  ~RedisTCPClient();
+
+  bool connect(const std::string &host, int port, int timeout_ms = 3000);
+  void close();
+
+  // Sends a RESP array command and parses a single reply into raw components.
+  // For arrays: returns vector of bulk strings; for integers: one element with decimal string; for simple strings: as one element.
+  bool command(const std::vector<std::string> &argv, std::vector<std::string> &out);
+
+  // Sends multiple RESP array commands in a single pipeline and collects replies in order.
+  // replies[i] corresponds to batch[i]. Returns false if send/receive fails at any point.
+  bool pipeline(const std::vector<std::vector<std::string>> &batch,
+                std::vector<std::vector<std::string>> &replies);
+};
+
+
+
+class RedisMetaChannel {
+private:
+  RedisTCPClient client;
+  std::string host;
+  int port;
+  uint32_t node_id;
+  std::string blocks_key;        // legacy, unused for list storage
+  std::string local_ip;
+
+public:
+  RedisMetaChannel(const std::string &host, int port, uint32_t node_id,
+                   const std::string &local_ip,
+                   const std::string &blocks_key = "blocks");
+
+  bool connect();
+  // Build Redis block key: <blocks_key>:block:<node_id>:<hash_hex>
+  std::string make_block_key(uint32_t node_id, uint64_t hash) const;
+  void publish(const BlockMeta &meta);
+  void publish(const std::vector<BlockMeta> &metas, size_t batch_size = 100);
+  size_t load(std::vector<BlockMeta> &out, size_t max_items);
+
+  // Batch update lt for all block metas belonging to node_id
+  void renew_node_leases(uint32_t node_id, uint32_t new_lt, size_t batch_size = 200);
+
+  // Returns the global node id assigned to this process, or UINT32_MAX if uninitialized.
+  uint32_t get_node_id() const;
+  const std::string &get_local_ip() const { return local_ip; }
+
+  // Batch update state for given hashes belonging to node_id
+  void update_block_state_batch(uint32_t node_id,
+                                std::deque<int64_t> *hashes,
+                                NodeState state,
+                                size_t batch_size = 200);
+
+  // Batch delete metas for given hashes belonging to node_id
+  void delete_blockmeta_batch(uint32_t node_id,
+                              std::deque<int64_t> *hashes,
+                              size_t batch_size = 200);
+
+  // Generic helpers for metadata queries
+  bool list_keys(const std::string &pattern, std::vector<std::string> &keys);
+
+  // List node keys: KEYS node:*
+  bool list_node_keys(std::vector<std::string> &keys);
+  // List block keys for a specific node: KEYS <blocks_key>:block:<node_id>:*
+  bool list_block_keys(uint32_t node_id, std::vector<std::string> &keys);
+
+  // Pipeline HMGET for a single field over many keys. values.size()==keys.size() on success
+  bool hmget_field_for_keys(const std::vector<std::string> &keys,
+                            const std::string &field,
+                            std::vector<std::string> &values);
+
+  // Pipeline HMGET for two fields over many keys. out[i] = {field1, field2} for keys[i]
+  bool hmget_two_fields_for_keys(const std::vector<std::string> &keys,
+                                 const std::string &field1,
+                                 const std::string &field2,
+                                 std::vector<std::pair<std::string, std::string>> &out);
+
+  // Load BlockMeta for provided keys via HMGET ph pb nid hash lt state
+  size_t load_metas_by_keys(const std::vector<std::string> &keys,
+                            std::vector<BlockMeta> &out);
+};
+
+} // namespace flexkv
+
+

--- a/flexkv/cache/__init__.py
+++ b/flexkv/cache/__init__.py
@@ -1,0 +1,11 @@
+from .redis_meta import RedisMetaChannel, BlockMeta
+from .radix_remote import DistributedRadixTree, LocalRadixTree
+
+__all__ = [
+    "RedisMetaChannel",
+    "BlockMeta",
+    "DistributedRadixTree",
+    "LocalRadixTree",
+]
+
+

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -24,6 +24,8 @@ import numpy as np
 import nvtx
 import torch
 from flexkv.c_ext import CRadixNode, CRadixTreeIndex, CMatchResult
+from flexkv.cache.pcfs_cache_engine import PCFSCacheEngine
+from flexkv.cache.redis_meta import RedisMeta
 
 from flexkv.cache.mempool import Mempool
 from flexkv.cache.radixtree import RadixTreeIndex, RadixNode, MatchResult
@@ -35,17 +37,7 @@ from flexkv.common.transfer import (
     DeviceType, TransferOpGraph, TransferOp, TransferType
 )
 from flexkv.common.debug import flexkv_logger
-@dataclass
-class MatchResultAccel:
-    num_ready_matched_blocks: int = 0
-    num_matched_blocks: int = 0
-    last_ready_node: Optional['CRadixNode'] = None
-    last_node: Optional['CRadixNode'] = None
-    last_node_matched_length: int = 0
-    physical_blocks: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
-
-    def __post_init__(self) -> None:
-        assert self.physical_blocks.ndim == 1
+from flexkv.common.type import MatchResultAccel
 
 class CacheEngineAccel:
     def __init__(self,
@@ -79,10 +71,19 @@ class CacheEngineAccel:
         sequence_meta.gen_hashes()
         match_result = self.index.match_prefix(torch.from_numpy(sequence_meta.block_hashes).to(torch.int64),
                                               sequence_meta.num_blocks, True)
+        # physical blocks
+        phys = torch.tensor(match_result.physical_blocks, dtype=torch.int64).numpy()
+        # optional block_node_ids
+        try:
+            bnis = getattr(match_result, "block_node_ids")
+            bnids_np = torch.tensor(bnis, dtype=torch.uint32).numpy() if bnis is not None else None
+        except Exception:
+            bnids_np = None
         return MatchResultAccel(match_result.num_ready_matched_blocks, match_result.num_matched_blocks,
                             match_result.last_ready_node, match_result.last_node,
                             match_result.last_node_matched_length,
-                            torch.tensor(match_result.physical_blocks, dtype=torch.int64).numpy())
+                            phys,
+                            bnids_np)
 
     def insert(self,
                sequence_meta: SequenceMeta,
@@ -224,8 +225,23 @@ class GlobalCacheEngine:
         self.cpu_cache_engine = None
         self.ssd_cache_engine = None
         self.remote_cache_engine = None
-
+        if cache_config.enable_kv_sharing:
+            self.redis_meta = RedisMeta(
+                cache_config.redis_host,
+                cache_config.redis_port,
+                cache_config.redis_password,
+                cache_config.local_ip,
+            )
+            self.redis_meta.init_meta()
+            self.node_id = self.redis_meta.get_node_id()
+            self.enable_kv_sharing = True
+        else:
+            self.enable_kv_sharing = False
         self.cache_engines = {}
+        if cache_config.index_accel:
+            self.index_accel = True
+        else:
+            self.index_accel = False
 
         if cache_config.enable_cpu:
             if cache_config.index_accel:
@@ -252,7 +268,10 @@ class GlobalCacheEngine:
                                                 cache_config.evict_ratio)
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
         if cache_config.enable_remote:
-            if cache_config.index_accel:
+            if cache_config.enable_kv_sharing:
+                # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine)
+                self.remote_cache_engine = PCFSCacheEngine.from_cache_config(cache_config, self.node_id, meta=self.redis_meta)
+            elif cache_config.index_accel:
                 self.remote_cache_engine = CacheEngineAccel(DeviceType.REMOTE,
                                                    cache_config.num_remote_blocks,
                                                    cache_config.tokens_per_block,
@@ -377,16 +396,20 @@ class GlobalCacheEngine:
         assert self.cache_config.enable_cpu and self.cache_config.enable_remote
         assert self.cpu_cache_engine is not None
         assert self.remote_cache_engine is not None
-
-        cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all(sequence_meta)
-
+        if self.index_accel:
+            cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all_accel(sequence_meta)
+        else:
+            cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all(sequence_meta)
         cpu_matched_blocks = cpu_matched_result.physical_blocks[
             :cpu_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
         ssd_matched_blocks = ssd_matched_result.physical_blocks[
             :ssd_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
         remote_matched_blocks = remote_matched_result.physical_blocks[
             :remote_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
-
+        shared_pcfs_read = self.cache_config.enable_kv_sharing and self.index_accel
+        remote_file_nodeids = None
+        if shared_pcfs_read:
+            remote_file_nodeids = remote_matched_result.block_node_ids
         fragment123_num_blocks = max(len(cpu_matched_blocks), len(ssd_matched_blocks), len(remote_matched_blocks))
         #early return if no blocks to transfer
         if fragment123_num_blocks == 0:
@@ -406,7 +429,9 @@ class GlobalCacheEngine:
         fragment123_cpu_blocks = cpu_matched_blocks
         fragment2_ssd_blocks = ssd_matched_blocks[-fragment2_num_blocks:]
         fragment3_remote_blocks = remote_matched_blocks[-fragment3_num_blocks:]
-
+        fragment3_remote_file_nodeids = None
+        if shared_pcfs_read:
+            fragment3_remote_file_nodeids = remote_file_nodeids[-fragment3_num_blocks:]
         cpu_node_to_unlock = cpu_matched_result.last_ready_node
         ssd_node_to_unlock = ssd_matched_result.last_ready_node
         remote_node_to_unlock = remote_matched_result.last_ready_node
@@ -456,7 +481,8 @@ class GlobalCacheEngine:
                 src_block_ids = fragment3_remote_blocks,
                 dst_block_ids = fragment123_cpu_blocks[-fragment3_num_blocks:],
                 layer_id = 0,
-                layer_granularity = layer_num
+                layer_granularity = layer_num,
+                src_block_node_ids = fragment3_remote_file_nodeids
             )
             transfer_graph.add_transfer_op(op_remote2h)
 
@@ -732,7 +758,7 @@ class GlobalCacheEngine:
         assert self.remote_cache_engine is not None
 
         if self.cache_config.index_accel:
-            cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all_accel(sequence_meta)
+            cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all_accel(sequence_meta, False)
         else:
             cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all(sequence_meta)
         cpu_matched_blocks = cpu_matched_result.physical_blocks[
@@ -1016,7 +1042,8 @@ class GlobalCacheEngine:
     
     @nvtx.annotate("Match All Prefix accel", color="yellow")
     def match_all_accel(self,
-                        sequence_meta: SequenceMeta) -> Tuple[MatchResultAccel, MatchResultAccel, MatchResultAccel]:
+                        sequence_meta: SequenceMeta,
+                        is_get: bool = True) -> Tuple[MatchResultAccel, MatchResultAccel, MatchResultAccel]:
         cpu_matched_result = MatchResultAccel()
         ssd_matched_result = MatchResultAccel()
         remote_matched_result = MatchResultAccel()
@@ -1026,7 +1053,13 @@ class GlobalCacheEngine:
         if self.ssd_cache_engine:
             ssd_matched_result = self.ssd_cache_engine.match(sequence_meta)
         if self.remote_cache_engine:
-            remote_matched_result = self.remote_cache_engine.match(sequence_meta)
+            if self.enable_kv_sharing:
+                if is_get:
+                    remote_matched_result = self.remote_cache_engine.match_all(sequence_meta)
+                else:
+                    remote_matched_result = self.remote_cache_engine.match_local(sequence_meta)
+            else:
+                remote_matched_result = self.remote_cache_engine.match(sequence_meta)
 
         return cpu_matched_result, ssd_matched_result, remote_matched_result
     

--- a/flexkv/cache/pcfs_cache_engine.py
+++ b/flexkv/cache/pcfs_cache_engine.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple, TYPE_CHECKING, List, Dict
+
+import numpy as np
+import torch
+
+from flexkv.c_ext import CRadixNode
+from flexkv import c_ext
+from flexkv.cache.mempool import Mempool
+from flexkv.cache.radix_remote import LocalRadixTree, DistributedRadixTree
+from flexkv.cache.redis_meta import RedisMetaChannel as _PyRedisMetaChannel
+from flexkv.cache.redis_meta import RedisMeta
+from flexkv.common.block import SequenceMeta
+from flexkv.common.exceptions import InvalidConfigError, NotEnoughSpaceError
+if TYPE_CHECKING:
+    from flexkv.common.config import CacheConfig
+from flexkv.common.transfer import DeviceType
+from flexkv.common.type import MatchResultAccel
+
+
+class PCFSCacheEngine:
+    def __init__(self,
+                 num_total_blocks: int,
+                 tokens_per_block: int,
+                 evict_ratio: float,
+                 *,
+                 # Optional runtime wiring for remote/local trees
+                 local_max_num_blocks: Optional[int] = None,
+                 local_lease_ttl_ms: int = 100000,
+                 local_renew_lease_ms: int = 0,
+                 local_refresh_batch_size: int = 256,
+                 local_idle_sleep_ms: int = 10,
+                 local_lt_pool_initial_capacity: int = 0,
+                 remote_max_num_blocks: Optional[int] = None,
+                 remote_node_id: int = 0,
+                 remote_lt_pool_initial_capacity: int = 0,
+                 remote_refresh_batch_size: int = 128,
+                 remote_rebuild_interval_ms: int = 1000,
+                 remote_idle_sleep_ms: int = 10,
+                 meta: Optional[RedisMeta] = None) -> None:
+        if num_total_blocks <= 0:
+            raise InvalidConfigError(f"Invalid num_total_blocks: {num_total_blocks}")
+        if tokens_per_block <= 0 or (tokens_per_block & (tokens_per_block - 1)) != 0:
+            raise InvalidConfigError(
+                f"Invalid tokens_per_block: {tokens_per_block}, tokens_per_block must be a power of 2"
+            )
+
+        # PCFS cache engine is always REMOTE device type
+        self.device_type = DeviceType.REMOTE
+        self._meta: Optional[RedisMeta] = meta
+        # Mapping: node_id -> list of PCFS file_nodeids
+        self.nid_to_file_nodeids: Dict[int, List[int]] = {}
+        # Partition parameter used for mapping block_id to file index
+        self.round_robin: int = 1
+
+        # Local index (authoritative for mutations)
+        self.local_index = LocalRadixTree(
+            tokens_per_block=tokens_per_block,
+            max_num_blocks=int(local_max_num_blocks or num_total_blocks),
+            lease_ttl_ms=int(local_lease_ttl_ms),
+            renew_lease_ms=int(local_renew_lease_ms),
+            refresh_batch_size=int(local_refresh_batch_size),
+            idle_sleep_ms=int(local_idle_sleep_ms),
+            lt_pool_initial_capacity=int(local_lt_pool_initial_capacity),
+        )
+
+
+        # Remote reference index (read-only, built from Redis)
+        self.remote_index = DistributedRadixTree(
+            tokens_per_block=tokens_per_block,
+            max_num_blocks=int(remote_max_num_blocks or num_total_blocks),
+            node_id=int(remote_node_id),
+            lt_pool_initial_capacity=int(remote_lt_pool_initial_capacity),
+            refresh_batch_size=int(remote_refresh_batch_size),
+            rebuild_interval_ms=int(remote_rebuild_interval_ms),
+            idle_sleep_ms=int(remote_idle_sleep_ms),
+        )
+        # defer channel start to start(meta)
+
+        # Local memory pool for physical blocks on this device
+        self.mempool = Mempool(num_total_blocks=num_total_blocks)
+
+        self.tokens_per_block = tokens_per_block
+        self.num_total_blocks = num_total_blocks
+        self.evict_ratio = evict_ratio
+
+    def start(self) -> None:
+        if self._meta is None:
+            raise InvalidConfigError("RedisMeta is not provided; ensure from_cache_config stores it or pass it to start().")
+        self.remote_ch = self._meta.get_redis_meta_channel("RPCFSB")
+        self.local_ch = self._meta.get_redis_meta_channel("PCFSB")
+                # Load and store mapping of node_id -> file_nodeids from Redis
+        try:
+            self.nid_to_file_nodeids = self._meta.load_pcfs_file_nodeids()
+        except Exception:
+            raise InvalidConfigError("Failed to load PCFS file nodeids from Redis")
+        self.local_index.start(self.local_ch)
+        self.remote_index.start(self.remote_ch)
+
+    def stop(self) -> None:
+        self.local_index.stop()
+        self.remote_index.stop()
+
+    def reset(self) -> None:
+        self.local_index.reset()
+        self.mempool.reset()
+
+    def match_all(self, sequence_meta: SequenceMeta) -> MatchResultAccel:
+        sequence_meta.gen_hashes()
+        block_hashes_t = torch.from_numpy(sequence_meta.block_hashes).to(torch.int64)
+        num_blocks = sequence_meta.num_blocks
+
+        # Query both local and remote
+        mr_local = self.local_index.match_prefix(block_hashes_t, int(num_blocks), True)
+        mr_remote = self.remote_index.match_prefix(block_hashes_t, int(num_blocks), True)
+
+        # Choose the one with the larger matched length; tie-break on ready length
+        local_key = (int(mr_local.num_matched_blocks), int(mr_local.num_ready_matched_blocks))
+        remote_key = (int(mr_remote.num_matched_blocks), int(mr_remote.num_ready_matched_blocks))
+        chosen = mr_local if local_key >= remote_key else mr_remote
+
+        # physical blocks
+        phys_np = torch.tensor(chosen.physical_blocks, dtype=torch.int64).numpy()
+        #block_node_ids = torch.tensor(chosen.block_node_ids, dtype=torch.uint32).numpy() if chosen.block_node_ids is not None else None
+        # optional block_node_ids
+        bnids_np = None
+        if chosen is mr_remote:
+            block_node_ids = torch.tensor(chosen.block_node_ids, dtype=torch.uint32).numpy() if chosen.block_node_ids is not None else None
+            if block_node_ids is None:
+                raise Exception("Failed to get block_node_ids")
+            bnids_np = self.nodeids_to_file_nodeids(block_node_ids, phys_np)
+            if bnids_np is None:
+                raise Exception("Failed to get file_nodeids")
+            bnids_len = bnids_np.shape[0]
+            if bnids_len != phys_np.shape[0]:
+                raise Exception("bnids_len != phys_np.shape[0]")
+        return MatchResultAccel(
+            num_ready_matched_blocks=int(chosen.num_ready_matched_blocks),
+            num_matched_blocks=int(chosen.num_matched_blocks),
+            last_ready_node=chosen.last_ready_node,
+            last_node=chosen.last_node,
+            last_node_matched_length=int(chosen.last_node_matched_length),
+            physical_blocks=phys_np,
+            block_node_ids=bnids_np,
+        )
+
+    def nodeids_to_file_nodeids(self,
+                                 block_node_ids: np.ndarray,
+                                 physical_blocks: np.ndarray) -> Optional[np.ndarray]:
+        """Convert per-block node ids to per-block PCFS file_nodeids.
+
+        For each i:
+          nid = block_node_ids[i]
+          file_nodeids_list = self.nid_to_file_nodeids[nid]
+          remote_file_num = len(file_nodeids_list)
+          block_id = physical_blocks[i]
+          f_idx = (block_id // self.round_robin) % remote_file_num
+          out[i] = file_nodeids_list[f_idx]
+        """
+        try:
+            bnids_np = np.asarray(block_node_ids, dtype=np.uint32)
+            phys_np = np.asarray(physical_blocks, dtype=np.int64)
+        except Exception:
+            return None
+        if bnids_np.shape[0] != phys_np.shape[0]:
+            raise Exception("block_node_ids and physical_blocks must have the same length")
+        out = np.full(phys_np.shape, fill_value=-1, dtype=np.int64)
+        rr = max(1, int(self.round_robin))
+        for i in range(bnids_np.shape[0]):
+            nid = int(bnids_np[i])
+            file_list = self.nid_to_file_nodeids.get(nid)
+            if not file_list:
+                break
+            remote_file_num = len(file_list)
+            if remote_file_num <= 0:
+                break
+            block_id = int(phys_np[i])
+            f_idx = (block_id // rr) % remote_file_num
+            out[i] = int(file_list[f_idx])
+        return out
+
+    def match_local(self, sequence_meta: SequenceMeta) -> MatchResultAccel:
+        sequence_meta.gen_hashes()
+        block_hashes_t = torch.from_numpy(sequence_meta.block_hashes).to(torch.int64)
+        num_blocks = sequence_meta.num_blocks
+
+        mr_local = self.local_index.match_prefix(block_hashes_t, int(num_blocks), True)
+
+        phys_np = torch.tensor(mr_local.physical_blocks, dtype=torch.int64).numpy()
+
+        return MatchResultAccel(
+            num_ready_matched_blocks=int(mr_local.num_ready_matched_blocks),
+            num_matched_blocks=int(mr_local.num_matched_blocks),
+            last_ready_node=mr_local.last_ready_node,
+            last_node=mr_local.last_node,
+            last_node_matched_length=int(mr_local.last_node_matched_length),
+            physical_blocks=phys_np,
+            block_node_ids=None,
+        )
+
+    def insert(self,
+               sequence_meta: SequenceMeta,
+               physical_block_ids: torch.Tensor,
+               num_insert_blocks: int = -1,
+               is_ready: bool = True,
+               match_result: Optional[MatchResultAccel] = None) -> Optional[CRadixNode]:
+        sequence_meta.gen_hashes()
+        phys_t = torch.from_numpy(physical_block_ids).to(torch.int64) if isinstance(physical_block_ids, np.ndarray) else physical_block_ids.to(torch.int64)
+        hashes_t = torch.from_numpy(sequence_meta.block_hashes).to(torch.int64)
+        if match_result is None:
+            return self.local_index.insert(
+                phys_t, hashes_t, int(sequence_meta.num_blocks), int(num_insert_blocks), bool(is_ready)
+            )
+        else:
+            return self.local_index.insert(
+                phys_t, hashes_t, int(sequence_meta.num_blocks), int(num_insert_blocks), bool(is_ready),
+                match_result.last_node, int(match_result.num_matched_blocks), int(match_result.last_node_matched_length)
+            )
+
+    def lock_node(self, node: CRadixNode) -> None:
+        if node is None:
+            return
+        try:
+            is_remote_node = bool(node.has_block_node_ids())
+        except Exception:
+            is_remote_node = False
+        if is_remote_node:
+            self.remote_index.lock(node)
+        else:
+            self.local_index.lock(node)
+
+    def cleanup(self, node: CRadixNode, cleanup_length: int) -> None:
+        if node is None:
+            return
+        try:
+            is_remote_node = bool(node.has_block_node_ids())
+        except Exception:
+            is_remote_node = False
+        if is_remote_node:
+            self.remote_index.unlock(node)
+            self.remote_index.set_ready(node, True, int(cleanup_length))
+        else:
+            self.local_index.unlock(node)
+            self.local_index.set_ready(node, True, int(cleanup_length))
+
+    def take(self,
+             num_required_blocks: int,
+             protected_node: Optional[CRadixNode] = None,
+             strict: bool = True) -> torch.Tensor:
+        if num_required_blocks > self.mempool.num_free_blocks:
+            if protected_node is not None:
+                self.local_index.lock(protected_node)
+            evict_block_num = max(
+                num_required_blocks - self.mempool.num_free_blocks,
+                int(self.mempool.num_total_blocks * self.evict_ratio),
+            )
+            target_blocks = torch.zeros(evict_block_num, dtype=torch.int64)
+            num_evicted = self.local_index.evict(target_blocks, evict_block_num)
+            if num_evicted != evict_block_num:
+                target_blocks.resize_(num_evicted)
+            self.mempool.recycle_blocks(target_blocks.numpy())
+            if protected_node is not None:
+                self.local_index.unlock(protected_node)
+        if strict and num_required_blocks > self.mempool.num_free_blocks:
+            raise NotEnoughSpaceError(
+                "Not enough free blocks to take, ", required=num_required_blocks, available=self.mempool.num_free_blocks
+            )
+        num_allocated_blocks = min(num_required_blocks, self.mempool.num_free_blocks)
+        return self.mempool.allocate_blocks(num_allocated_blocks)
+
+    def recycle(self, physical_blocks: np.ndarray) -> None:
+        self.mempool.recycle_blocks(physical_blocks)
+
+
+    @classmethod
+    def from_cache_config(cls, cache_config: "CacheConfig", node_id: int, meta: Optional[RedisMeta] = None) -> "PCFSCacheEngine":
+        """Create a PCFSCacheEngine from CacheConfig.
+
+        This replaces RemotePCFSCacheEngine. It wires both local and remote
+        radix trees using parameters from CacheConfig and the provided node_id.
+        """
+        num_blocks = int(cache_config.num_remote_blocks or 0)
+
+        # 1) Generate unique remote_file_prefix using uuid and build remote_cache_path
+        if cache_config.remote_file_prefix is None:
+            raise InvalidConfigError("remote_file_prefix must be provided in CacheConfig when enable_remote is True")
+        if cache_config.remote_file_num is None or cache_config.remote_file_num <= 0:
+            raise InvalidConfigError("remote_file_num must be a positive integer in CacheConfig when enable_remote is True")
+
+        # Prefer uuid from RedisMeta to ensure cluster-wide uniqueness, fallback to Python uuid if meta is None
+        try:
+            unique_suffix = meta.get_uuid() if meta is not None else __import__("uuid").uuid4().hex
+        except Exception:
+            unique_suffix = __import__("uuid").uuid4().hex
+
+        new_prefix = f"{cache_config.remote_file_prefix}_{unique_suffix}"
+        cache_config.remote_file_prefix = new_prefix
+        cache_config.remote_cache_path = [
+            f"{cache_config.remote_file_prefix}_{i}" for i in range(cache_config.remote_file_num)
+        ]
+
+        # 2) Create PCFS instance and lookup/create files to collect nodeids
+        remote_cfg = cache_config.remote_config_custom or {}
+        pcfs_fsid = remote_cfg.get("pcfs_fsid")
+        pcfs_port = remote_cfg.get("pcfs_port")
+        pcfs_ip = remote_cfg.get("pcfs_ip")
+        pcfs_parent_nodeid = remote_cfg.get("pcfs_parent_nodeid")
+        if None in (pcfs_fsid, pcfs_port, pcfs_ip, pcfs_parent_nodeid):
+            raise InvalidConfigError("Some required PCFS config fields are missing: pcfs_fsid, pcfs_port, pcfs_ip, pcfs_parent_nodeid")
+
+        pcfs = c_ext.Pcfs(pcfs_fsid, pcfs_port, pcfs_ip, False, pcfs_parent_nodeid)
+        if not pcfs.init():
+            raise InvalidConfigError(f"PCFS init failed: fsid={pcfs_fsid}, ip={pcfs_ip}")
+
+        node_ids: List[int] = []
+        # Derive file size if available; otherwise, use 0 when not provided (only lookup or create placeholder)
+        # Prefer explicit file_size mode
+        file_size = 0
+        if getattr(cache_config, "remote_cache_size_mode", "file_size") == "file_size":
+            file_size = int(cache_config.remote_file_size or 0)
+
+        for remote_path in cache_config.remote_cache_path:
+            nodeid = pcfs.lookup_or_create_file(remote_path, file_size, True)
+            if nodeid == 0:
+                raise InvalidConfigError(f"lookup or create file failed for file: {remote_path}")
+            node_ids.append(int(nodeid))
+
+        # 3) Register nodeids into Redis for discovery
+        if meta is not None:
+            meta.add_node_ids(node_ids)
+
+        # Set global pcfs instance for subsequent C++ remote transfers
+        try:
+            c_ext.set_pcfs_instance(pcfs)
+        except Exception:
+            pass
+
+        return cls(
+            num_total_blocks=num_blocks,
+            tokens_per_block=int(cache_config.tokens_per_block),
+            evict_ratio=float(cache_config.evict_ratio),
+            local_max_num_blocks=num_blocks,
+            local_lease_ttl_ms=int(getattr(cache_config, "lease_ttl_ms", 100000)),
+            local_renew_lease_ms=int(getattr(cache_config, "renew_lease_ms", 0)),
+            local_refresh_batch_size=int(getattr(cache_config, "refresh_batch_size", 256)),
+            local_idle_sleep_ms=int(getattr(cache_config, "idle_sleep_ms", 10)),
+            local_lt_pool_initial_capacity=int(getattr(cache_config, "lt_pool_initial_capacity", 0)),
+            remote_max_num_blocks=num_blocks,
+            remote_node_id=int(node_id),
+            remote_lt_pool_initial_capacity=int(getattr(cache_config, "lt_pool_initial_capacity", 0)),
+            remote_refresh_batch_size=int(getattr(cache_config, "refresh_batch_size", 128)),
+            remote_rebuild_interval_ms=int(getattr(cache_config, "rebuild_interval_ms", 1000)),
+            remote_idle_sleep_ms=int(getattr(cache_config, "idle_sleep_ms", 10)),
+            meta=meta,
+        )
+

--- a/flexkv/cache/radix_remote.py
+++ b/flexkv/cache/radix_remote.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Optional, Any
+from flexkv.cache.redis_meta import RedisMetaChannel as _PyRedisMetaChannel
+import torch
+
+from c_ext import DistributedRadixTree as _CDistributedRadixTree
+from c_ext import LocalRadixTree as _CLocalRadixTree
+from c_ext import RedisMetaChannel as _CRedisMetaChannel
+from c_ext import CMatchResult
+from c_ext import CRadixNode
+
+
+class DistributedRadixTree:
+    def __init__(self,
+                 tokens_per_block: int,
+                 max_num_blocks: int,
+                 node_id: int,
+                 lt_pool_initial_capacity: int = 0,
+                 refresh_batch_size: int = 128,
+                 rebuild_interval_ms: int = 1000,
+                 idle_sleep_ms: int = 10) -> None:
+        if _CDistributedRadixTree is None:
+            raise ImportError("c_ext.DistributedRadixTree is not available")
+        self._c = _CDistributedRadixTree(int(tokens_per_block), int(max_num_blocks), int(node_id),
+                                         int(lt_pool_initial_capacity), int(refresh_batch_size), int(rebuild_interval_ms), int(idle_sleep_ms))
+
+    def start(self, channel: _PyRedisMetaChannel) -> None:
+        ch = getattr(channel, "_c", channel)
+        self._c.start(ch)
+
+    def stop(self) -> None:
+        self._c.stop()
+
+    def remote_tree_refresh(self):
+        return self._c.remote_tree_refresh()
+
+    def match_prefix(self, block_hashes: torch.Tensor, num_blocks: int, update_cache_info: bool = True):
+        return self._c.match_prefix(block_hashes, int(num_blocks), bool(update_cache_info))
+
+    def lock(self, node: "CRadixNode") -> None:
+        self._c.lock(node)
+
+    def unlock(self, node: "CRadixNode") -> None:
+        self._c.unlock(node)
+
+    def is_empty(self) -> bool:
+        return bool(self._c.is_empty())
+
+    def set_ready(self, node: "CRadixNode", ready: bool = True, ready_length: int = -1) -> None:
+        self._c.set_ready(node, bool(ready), int(ready_length))
+
+
+class LocalRadixTree:
+    def __init__(self,
+                 tokens_per_block: int,
+                 max_num_blocks: int = 1000000,
+                 lease_ttl_ms: int = 100000,
+                 renew_lease_ms: int = 0,
+                 refresh_batch_size: int = 256,
+                 idle_sleep_ms: int = 10,
+                 lt_pool_initial_capacity: int = 0) -> None:
+        if _CLocalRadixTree is None:
+            raise ImportError("c_ext.LocalRadixTree is not available")
+        self._c = _CLocalRadixTree(int(tokens_per_block), int(max_num_blocks), int(lease_ttl_ms), int(renew_lease_ms), int(refresh_batch_size), int(idle_sleep_ms), int(lt_pool_initial_capacity))
+
+    def set_meta_channel(self, channel: _PyRedisMetaChannel) -> None:
+        ch = getattr(channel, "_c", channel)
+        self._c.set_meta_channel(ch)
+
+    def start(self, channel: _PyRedisMetaChannel) -> None:
+        ch = getattr(channel, "_c", channel)
+        self._c.start(ch)
+
+    def stop(self) -> None:
+        self._c.stop()
+
+    # Mirror base class methods on LocalRadixTree
+    def match_prefix(self, block_hashes: torch.Tensor, num_blocks: int, update_cache_info: bool = True):
+        return self._c.match_prefix(block_hashes, int(num_blocks), bool(update_cache_info))
+
+    def total_unready_blocks(self) -> int:
+        return int(self._c.total_unready_blocks())
+
+    def total_ready_blocks(self) -> int:
+        return int(self._c.total_ready_blocks())
+
+    def total_cached_blocks(self) -> int:
+        return int(self._c.total_cached_blocks())
+
+    def total_node_num(self) -> int:
+        return int(self._c.total_node_num())
+
+    def reset(self) -> None:
+        self._c.reset()
+
+    def is_root(self, node: "CRadixNode") -> bool:
+        # Note: CRadixNode pointer type is opaque in Python; in practice this is used internally
+        return bool(self._c.is_root(node))
+
+    def remove_node(self, node: "CRadixNode") -> None:
+        self._c.remove_node(node)
+
+    def remove_leaf(self, node: "CRadixNode") -> None:
+        self._c.remove_leaf(node)
+
+    def add_node(self, node: "CRadixNode") -> None:
+        self._c.add_node(node)
+
+    def add_leaf(self, node: "CRadixNode") -> None:
+        self._c.add_leaf(node)
+
+    def lock(self, node: "CRadixNode") -> None:
+        self._c.lock(node)
+
+    def unlock(self, node: "CRadixNode") -> None:
+        self._c.unlock(node)
+
+    def is_empty(self) -> bool:
+        return bool(self._c.is_empty())
+
+    def inc_node_count(self) -> None:
+        self._c.inc_node_count()
+
+    def dec_node_count(self) -> None:
+        self._c.dec_node_count()
+
+    def set_ready(self, node: "CRadixNode", ready: bool = True, ready_length: int = -1) -> None:
+        self._c.set_ready(node, bool(ready), int(ready_length))
+
+    def insert_and_publish(self, node: "CRadixNode") -> None:
+        self._c.insert_and_publish(node)
+
+

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+from dataclasses import dataclass
+from enum import IntEnum
+from uuid import uuid1
+try:  # redis-py
+    import redis as _redis
+except Exception:  # pragma: no cover
+    _redis = None  # type: ignore
+
+try:
+    from c_ext import RedisMetaChannel as _CRedisMetaChannel, BlockMeta as _CBlockMeta
+except Exception as e:  # pragma: no cover
+    _CRedisMetaChannel = None  # type: ignore
+    _CBlockMeta = None  # type: ignore
+
+
+class NodeState(IntEnum):
+    NODE_STATE_NORMAL = 0
+    NODE_STATE_ABOUT_TO_EVICT = 1
+    NODE_STATE_EVICTED = 2
+
+
+@dataclass
+class BlockMeta:
+    ph: int = 0
+    pb: int = 0
+    nid: int = 0
+    hash: int = 0
+    lt: int = 0
+    state: NodeState = NodeState.NODE_STATE_NORMAL
+
+    def to_c(self) -> "_CBlockMeta":
+        cm = _CBlockMeta()
+        cm.ph = int(self.ph)
+        cm.pb = int(self.pb)
+        cm.nid = int(self.nid)
+        cm.hash = int(self.hash)
+        cm.lt = int(self.lt)
+        cm.state = int(self.state)
+        return cm
+
+    @staticmethod
+    def from_c(cm: "_CBlockMeta") -> "BlockMeta":
+        return BlockMeta(
+            ph=int(cm.ph),
+            pb=int(cm.pb),
+            nid=int(cm.nid),
+            hash=int(cm.hash),
+            lt=int(cm.lt),
+            state=NodeState(int(cm.state))
+        )
+
+
+class RedisMetaChannel:
+    def __init__(self, host: str, port: int, node_id: int, local_ip: str, blocks_key: str = "blocks") -> None:
+        if _CRedisMetaChannel is None:
+            raise ImportError("c_ext.RedisMetaChannel is not available")
+        self._c = _CRedisMetaChannel(host, int(port), int(node_id), str(local_ip), str(blocks_key))
+
+    def connect(self) -> bool:
+        return bool(self._c.connect())
+
+    @property
+    def node_id(self) -> int:
+        return int(self._c.get_node_id())
+
+    @property
+    def local_ip(self) -> str:
+        return str(self._c.get_local_ip())
+
+    def make_block_key(self, node_id: int, hash_value: int) -> str:
+        return str(self._c.make_block_key(int(node_id), int(hash_value)))
+
+    def publish_one(self, meta: BlockMeta) -> None:
+        self._c.publish_one(meta.to_c())
+
+    def publish_batch(self, metas: Iterable[BlockMeta], batch_size: int = 100) -> None:
+        cms = [m.to_c() for m in metas]
+        self._c.publish_batch(cms, int(batch_size))
+
+    def load(self, max_items: int) -> List[BlockMeta]:
+        cms = self._c.load(int(max_items))
+        return [BlockMeta.from_c(cm) for cm in cms]
+
+    def list_keys(self, pattern: str) -> List[str]:
+        return list(self._c.list_keys(pattern))
+
+    def list_node_keys(self) -> List[str]:
+        return list(self._c.list_node_keys())
+
+    def list_block_keys(self, node_id: int) -> List[str]:
+        return list(self._c.list_block_keys(int(node_id)))
+
+    def hmget_field_for_keys(self, keys: Iterable[str], field: str) -> List[str]:
+        return list(self._c.hmget_field_for_keys(list(keys), field))
+
+    def hmget_two_fields_for_keys(self, keys: Iterable[str], f1: str, f2: str) -> List[Tuple[str, str]]:
+        return [(a, b) for a, b in self._c.hmget_two_fields_for_keys(list(keys), f1, f2)]
+
+    def update_block_state_batch(self, node_id: int, hashes: Iterable[int], state: int, batch_size: int = 200) -> None:
+        self._c.update_block_state_batch(int(node_id), list(int(h) for h in hashes), int(state), int(batch_size))
+
+    def delete_blockmeta_batch(self, node_id: int, hashes: Iterable[int], batch_size: int = 200) -> None:
+        self._c.delete_blockmeta_batch(int(node_id), list(int(h) for h in hashes), int(batch_size))
+
+
+class RedisMeta:
+    def __init__(self, host: str, port: int, password: str | None = None, local_ip: str = "127.0.0.1", decode_responses: bool = True) -> None:
+        if _redis is None:  # pragma: no cover
+            raise ImportError("redis-py is required: pip install redis")
+        self.host = host
+        self.port = int(port)
+        self.local_ip = str(local_ip)
+        self._uuid = str(uuid1())
+        self.db = 0
+        self.password = password
+        self.decode_responses = bool(decode_responses)
+        self._node_id: int | None = None
+
+    def _client(self):
+        return _redis.Redis(host=self.host, port=self.port, db=self.db, password=self.password, decode_responses=self.decode_responses)
+
+    def init_meta(self) -> int:
+        r = self._client()
+        node_id = int(r.incr("global:node_id"))
+        r.hset(f"node:{node_id}", mapping={"ip": self.local_ip, "uuid": self._uuid})
+        self._node_id = node_id
+        return node_id
+
+    def get_node_id(self) -> int:
+        if self._node_id is None:
+            raise RuntimeError("node_id is not registered yet. Call init_meta() first.")
+        return int(self._node_id)
+
+    def get_redis_meta_channel(self, blocks_key: str = "blocks") -> "RedisMetaChannel":
+        nid = self.get_node_id()
+        return RedisMetaChannel(self.host, int(self.port), int(nid), self.local_ip, str(blocks_key))
+
+    def unregister_node(self, node_id: int | None = None) -> None:
+        r = self._client()
+        nid = int(node_id) if node_id is not None else (self._node_id if self._node_id is not None else -1)
+        if nid >= 0:
+            r.delete(f"node:{nid}")
+        self._node_id = None
+
+    def get_uuid(self) -> str:
+        return self._uuid
+
+    def add_node_ids(self, node_ids: Iterable[int | str]) -> int:
+        # Append a list of pcfs file node ids to Redis list key pcfs:<node_id>
+        nid = self.get_node_id()
+        values = [str(v) for v in node_ids]
+        if not values:
+            return 0
+        r = self._client()
+        # rpush returns the new length of the list
+        return int(r.rpush(f"pcfs:{nid}", *values))
+
+    def regist_buffer(self, mrs: Iterable[object]) -> int:
+        """Register RDMA memory regions in Redis.
+
+        Each element in mrs can be one of:
+          - dict with keys {"buffer_ptr": ..., "buffer_size": ...}
+          - tuple/list (buffer_ptr, buffer_size)
+        Stored as hash: key = buffer:<node_id>:<buffer_ptr>, field "buffer_size" = <buffer_size>.
+        Returns the number of regions processed.
+        """
+        nid = self.get_node_id()
+        r = self._client()
+        pipe = r.pipeline()
+        processed = 0
+        for mr in mrs:
+            if isinstance(mr, dict):
+                ptr = mr.get("buffer_ptr")
+                size = mr.get("buffer_size")
+            elif isinstance(mr, (tuple, list)) and len(mr) >= 2:
+                ptr, size = mr[0], mr[1]
+            else:
+                continue
+            if ptr is None or size is None:
+                continue
+            key = f"buffer:{nid}:{int(ptr)}"
+            pipe.hset(key, mapping={"buffer_size": int(size)})
+            processed += 1
+        if processed:
+            pipe.execute()
+        return processed
+
+    def unregist_buffer(self, buffer_ptr: int | str) -> bool:
+        """Unregister a previously registered RDMA memory region by buffer_ptr.
+
+        Looks up key buffer:<node_id>:<buffer_ptr> and deletes it if present.
+        Returns True if the key existed and was deleted, otherwise False.
+        """
+        nid = self.get_node_id()
+        key = f"buffer:{nid}:{int(buffer_ptr)}"
+        r = self._client()
+        exists = bool(r.exists(key))
+        if exists:
+            r.delete(key)
+            return True
+        return False
+
+    def regist_node_meta(self, node_id: int, addr: str, cpu_buffer_ptr: int, ssd_buffer_ptr: int) -> None:
+        """Register node meta information as a Redis hash.
+
+        Key: meta:<node_id>
+        Fields: node_id (int), addr (str), cpu_buffer_ptr (int), ssd_buffer_ptr (int)
+        """
+        r = self._client()
+        key = f"meta:{int(node_id)}"
+        r.hset(key, mapping={
+            "node_id": int(node_id),
+            "addr": str(addr),
+            "cpu_buffer_ptr": int(cpu_buffer_ptr),
+            "ssd_buffer_ptr": int(ssd_buffer_ptr),
+        })
+
+    def get_node_meta(self, node_id: int) -> dict:
+        """Get node meta information from Redis.
+
+        Reads key meta:<node_id> and returns a dict with fields:
+        node_id (int), addr (str), cpu_buffer_ptr (int), ssd_buffer_ptr (int).
+        Returns empty dict if the key does not exist.
+        """
+        r = self._client()
+        key = f"meta:{int(node_id)}"
+        data = r.hgetall(key)
+        if not data:
+            return {}
+        out: dict[str, int | str] = {}
+        nid = data.get("node_id")
+        out["node_id"] = int(nid) if nid is not None and nid != "" else int(node_id)
+        out["addr"] = data.get("addr", "")
+        cb = data.get("cpu_buffer_ptr")
+        sb = data.get("ssd_buffer_ptr")
+        out["cpu_buffer_ptr"] = int(cb) if cb is not None and cb != "" else 0
+        out["ssd_buffer_ptr"] = int(sb) if sb is not None and sb != "" else 0
+        return out
+
+    def unregist_node_meta(self, node_id: int) -> bool:
+        """Unregister node meta by node_id. Returns True if deleted."""
+        r = self._client()
+        key = f"meta:{int(node_id)}"
+        return bool(r.delete(key))
+
+
+    def load_pcfs_file_nodeids(self) -> dict[int, list[int]]:
+        """Load all PCFS file node IDs grouped by node id from Redis.
+
+        - Scans keys matching pattern "pcfs:*" (each is a list for a node's file node IDs)
+        - For each key, fetches the list via LRANGE and converts elements to ints
+        - Returns dict: { node_id: [file_nodeid, ...], ... }
+        """
+        r = self._client()
+        result: dict[int, list[int]] = {}
+        try:
+            keys = r.keys("pcfs:*")
+        except Exception:
+            return result
+        for key in keys:
+            try:
+                if not isinstance(key, str):
+                    key = str(key)
+                if not key.startswith("pcfs:"):
+                    continue
+                nid_part = key.split(":", 1)[1]
+                node_id = int(nid_part)
+            except Exception:
+                continue
+            try:
+                values = r.lrange(key, 0, -1)
+                file_nodeids = [int(v) for v in values]
+            except Exception:
+                file_nodeids = []
+            result[node_id] = file_nodeids
+        return result
+

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -31,6 +31,7 @@ class CacheConfig:
     enable_cpu: bool = True
     enable_ssd: bool = False
     enable_remote: bool = False
+    enable_kv_sharing: bool = False
     use_gds: bool = False
     use_pinned_memory: bool = False
     index_accel: bool = False
@@ -65,6 +66,20 @@ class CacheConfig:
     remote_file_prefix: Optional[str] = None
     remote_cache_path: Optional[Union[str, List[str]]] = None
     remote_config_custom: Optional[Dict[str, Any]] = None
+
+    # KV sharing / distributed radix tree tunables
+    lt_pool_initial_capacity: int = 10000000
+    refresh_batch_size: int = 128
+    rebuild_interval_ms: int = 1000
+    idle_sleep_ms: int = 10
+    lease_ttl_ms: int = 100000
+    renew_lease_ms: int = 0
+
+    # Redis configs (for KV sharing / metadata)
+    redis_host: str = "127.0.0.1"
+    redis_port: int = 6379
+    local_ip: str = "127.0.0.1"
+    redis_password: Optional[str] = None
 
     # Trace configs
     enable_trace: bool = True

--- a/flexkv/common/type.py
+++ b/flexkv/common/type.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+import numpy as np
+
+
+@dataclass
+class MatchResultAccel:
+    num_ready_matched_blocks: int = 0
+    num_matched_blocks: int = 0
+    last_ready_node: Optional['CRadixNode'] = None
+    last_node: Optional['CRadixNode'] = None
+    last_node_matched_length: int = 0
+    physical_blocks: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
+    block_node_ids: Optional[np.ndarray] = None
+
+    def __post_init__(self) -> None:
+        assert self.physical_blocks.ndim == 1
+
+

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -81,6 +81,7 @@ class TransferEngine:
         self._ssd_handle = ssd_handle
         self._remote_handle = remote_handle
         self._cache_config = cache_config
+        self._enable_pcfs_sharing = cache_config.index_accel and cache_config.enable_kv_sharing
 
         self.pin_buffer = SharedOpPool(2048, self.model_config.max_req_tokens // self.cache_config.tokens_per_block)
 
@@ -174,6 +175,7 @@ class TransferEngine:
                 remote_kv_layout=self._remote_handle.kv_layout,
                 dtype=self._cpu_handle.dtype,
                 remote_config_custom=self._remote_handle.remote_config_custom,
+                enable_pcfs_sharing=self._enable_pcfs_sharing,
             )
             self.remotecpu_write_worker: WorkerHandle = CPURemoteTransferWorker.create_worker(
                 finished_ops_queue=self.finished_ops_queue,


### PR DESCRIPTION
To implement distributed sharing of the KV Cache, it is necessary to first share the block meta information of the KV Cache. This commit implements the classes DistributedRadixTree and LocalRadixTree, which can be used to realize shared KV Cache between CPU and SSD, as well as distributed sharing of PCFS KV block meta information. Based on DistributedRadixTree and LocalRadixTree, this commit also implements a Python wrapper, PCFSCacheEngine, for distributed sharing in PCFS. The CacheEngine implementations for CPU and SSD can also refer to PCFSCacheEngine.