### PR TITLE
[feature] Mla d2h transfer optimization

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -45,7 +45,7 @@ void transfer_kv_blocks_binding(
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   flexkv::transfer_kv_blocks(
       num_blocks, start_layer_id, num_layers, gpu_block_ids, gpu_layer_ptrs,
-      gpu_kv_stride_in_bytes, gpu_block_stride_in_bytes, cpu_block_ids, cpu_ptr,
+      gpu_kv_stride_in_bytes, gpu_block_stride_in_bytes, 0, cpu_block_ids, cpu_ptr,
       cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
       cpu_block_stride_in_bytes, 0, chunk_size_in_bytes, stream, transfer_sms,
       is_host_to_device, use_ce_transfer, is_mla);

--- a/csrc/transfer.cu
+++ b/csrc/transfer.cu
@@ -26,6 +26,7 @@ namespace flexkv {
 __global__ void transfer_kv_blocks_kernel(
     int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
     int64_t **gpu_layer_ptrs, int64_t gpu_kv_stride, int64_t gpu_block_stride,
+    int64_t gpu_startoff_inside_chunks,
     int64_t *cpu_block_ids, int64_t *cpu_ptr, int64_t cpu_kv_stride,
     int64_t cpu_layer_stride, int64_t cpu_block_stride,
     int64_t cpu_startoff_inside_chunks, int64_t copy_size, bool is_mla,
@@ -47,7 +48,8 @@ __global__ void transfer_kv_blocks_kernel(
         cpu_startoff_inside_chunks;
     int64_t *gpu_chunk_ptr = gpu_layer_ptrs[layer_idx] +
                              kv_idx * gpu_kv_stride +
-                             gpu_block_idx * gpu_block_stride;
+                             gpu_block_idx * gpu_block_stride +
+                             gpu_startoff_inside_chunks;
 
     int64_t *src_chunk_ptr = is_host_to_device ? cpu_chunk_ptr : gpu_chunk_ptr;
     int64_t *dst_chunk_ptr = is_host_to_device ? gpu_chunk_ptr : cpu_chunk_ptr;
@@ -63,7 +65,8 @@ __global__ void transfer_kv_blocks_kernel(
 void transfer_kv_blocks(
     int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
     void **gpu_layer_ptrs, int64_t gpu_kv_stride_in_bytes,
-    int64_t gpu_block_stride_in_bytes, int64_t *cpu_block_ids, void *cpu_ptr,
+    int64_t gpu_block_stride_in_bytes, int64_t gpu_startoff_inside_chunks,
+    int64_t *cpu_block_ids, void *cpu_ptr,
     int64_t cpu_kv_stride_in_bytes, int64_t cpu_layer_stride_in_bytes,
     int64_t cpu_block_stride_in_bytes, int64_t cpu_startoff_inside_chunks,
     int64_t chunk_size_in_bytes, cudaStream_t stream, int transfer_sms,
@@ -90,6 +93,8 @@ void transfer_kv_blocks(
   int64_t cpu_layer_stride_int64 = cpu_layer_stride_in_bytes / sizeof(int64_t);
   int64_t cpu_startoff_inside_chunks_int64 =
       cpu_startoff_inside_chunks / sizeof(int64_t);
+  int64_t gpu_startoff_inside_chunks_int64 =
+      gpu_startoff_inside_chunks / sizeof(int64_t);
   int64_t chunk_size_in_int64 = chunk_size_in_bytes / sizeof(int64_t);
 
   dim3 blockDim(block_size);
@@ -107,7 +112,8 @@ void transfer_kv_blocks(
               cpu_startoff_inside_chunks_int64;
           int64_t *gpu_chunk_ptr = gpu_layer_ptrs_int64[i] +
                                    j * gpu_kv_stride_int64 +
-                                   gpu_block_idx * gpu_block_stride_int64;
+                                   gpu_block_idx * gpu_block_stride_int64 +
+                                   gpu_startoff_inside_chunks_int64;
 
           if (is_host_to_device) {
             cudaMemcpyAsync(gpu_chunk_ptr, cpu_chunk_ptr, chunk_size_in_bytes,
@@ -123,6 +129,7 @@ void transfer_kv_blocks(
     transfer_kv_blocks_kernel<<<gridDim, blockDim, 0, stream>>>(
         num_blocks, start_layer_id, num_layers, gpu_block_ids,
         gpu_layer_ptrs_int64, gpu_kv_stride_int64, gpu_block_stride_int64,
+        gpu_startoff_inside_chunks_int64,
         cpu_block_ids, cpu_ptr_int64, cpu_kv_stride_int64,
         cpu_layer_stride_int64, cpu_block_stride_int64,
         cpu_startoff_inside_chunks_int64, chunk_size_in_int64, is_mla,

--- a/csrc/transfer.cuh
+++ b/csrc/transfer.cuh
@@ -23,7 +23,8 @@ namespace flexkv {
 void transfer_kv_blocks(
     int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
     void **gpu_layer_ptrs, int64_t gpu_kv_stride_in_bytes,
-    int64_t gpu_block_stride_in_bytes, int64_t *cpu_block_ids, void *cpu_ptr,
+    int64_t gpu_block_stride_in_bytes, int64_t gpu_startoff_inside_chunks,
+    int64_t *cpu_block_ids, void *cpu_ptr,
     int64_t cpu_kv_stride_in_bytes, int64_t cpu_layer_stride_in_bytes,
     int64_t cpu_block_stride_in_bytes, int64_t cpu_startoff_inside_chunks,
     int64_t chunk_size_in_bytes, cudaStream_t stream, int transfer_sms,


### PR DESCRIPTION
When we use tp, d2h transfer has multiple redundant data transfer for mla. This is fixed in this pr. No extra data transfer.