### PR TITLE
[misc] Replace std::map with std::unordered_map in RadixTree

### DIFF
--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <torch/extension.h>
 #include <vector>
+#include <unordered_map>
 #include <iostream>
 #include <execinfo.h>
 
@@ -20,7 +21,7 @@ private:
 
   std::deque<int64_t> block_hashes;
   std::deque<int64_t> physical_blocks;
-  std::map<HashType, CRadixNode *> children;
+  std::unordered_map<HashType, CRadixNode *> children;
 
   CRadixTreeIndex *index;
   CRadixNode *parent;


### PR DESCRIPTION
# [misc] Replace std::map with std::unordered_map in RadixTree

## I. Problem Description

The current C++ implementation of `CRadixNode` uses `std::map<HashType, CRadixNode *>` to store child node mappings. In KVCache scenarios, RadixTree's prefix matching operations require frequent child node lookups, and the O(log n) lookup complexity of `std::map` impacts overall performance, especially in scenarios with large numbers of tokens (e.g., 100k+ tokens).

**Current Implementation**:
```cpp
std::map<HashType, CRadixNode *> children;
```

**Limitations**:
- Child node lookup has O(log n) time complexity, requiring tree traversal
- In deep prefix matching paths, the cumulative lookup overhead is significant
- Inconsistent with Python implementation (Python version uses hash table)

## II. Time Complexity Comparison

### Before (std::map - Red-Black Tree Implementation)

| Operation | Time Complexity | Description |
|-----------|----------------|------------|
| Lookup (`find`) | O(log n) | Requires tree traversal, log₂(n) comparisons |
| Insert (`insert`) | O(log n) | Requires maintaining red-black tree balance |
| Delete (`erase`) | O(log n) | Requires maintaining red-black tree balance |

**Real-World Scenario Analysis**:
- Assuming each node has an average of 10 child nodes (n = 10)
- One child node lookup requires: log₂(10) ≈ 3.3 comparisons
- For a prefix matching path with depth 10, total lookups: 10 × 3.3 ≈ **33 comparisons**

### After (std::unordered_map - Hash Table Implementation)

| Operation | Average Time Complexity | Worst Case | Description |
|-----------|-------------------------|------------|-------------|
| Lookup (`find`) | **O(1)** | O(n) | Hash table lookup, average 1 hash computation + 1 bucket access |
| Insert (`insert`) | **O(1)** | O(n) | Hash table insert, average 1 operation |
| Delete (`erase`) | **O(1)** | O(n) | Hash table delete, average 1 operation |

**Real-World Scenario Analysis**:
- Assuming each node has an average of 10 child nodes (n = 10)
- One child node lookup requires: 1 hash computation + 1 bucket access (average case)
- For a prefix matching path with depth 10, total lookups: 10 × 1 = **10 operations**

**Performance Improvement**:
- Lookup operations: reduced from **33 comparisons** to **10 operations** (approximately **3.3x improvement**)
- In scenarios with large numbers of tokens (e.g., 100k+ tokens), the performance improvement is more significant

## III. Worst-Case Probability Analysis

The worst case for `std::unordered_map` occurs when all keys' hash values map to the same bucket, causing lookup to degenerate to O(n).

**Probability Analysis**:
- **HashType**: `uint64_t` (64-bit), generated by XXHash algorithm with uniform distribution
- **Collision Probability**: Assuming k child nodes and m buckets, the probability of all keys colliding is `1/m^(k-1)`
- **Example Calculation**: Assuming 10 child nodes and 17 buckets, the probability of all keys colliding is approximately `1/17^9 ≈ 8.5×10^-12`

**Conclusion**: The probability of worst-case scenarios is **below 10^-12 magnitude** (decreases exponentially as the number of child nodes increases), making it **virtually impossible** in real-world KVCache scenarios.

## IV. Standard Implementation References

**Python Implementation**: FlexKV's Python version `RadixNode` uses `Dict[HashType, RadixNode]` (hash table implementation) with O(1) average lookup time.

**SGLang HiCache Implementation**: SGLang's HiCache project (high-performance KV Cache implementation) also uses `std::unordered_map` to implement RadixTree child node mappings.

**Conclusion**: Using `std::unordered_map` is an industry-standard practice, consistent with the Python implementation, and validates the effectiveness of hash tables in KVCache scenarios.

## V. Code Compatibility Verification

- All operations on `children` (`find`, `insert`, `erase`, `begin`, etc.) are compatible with `std::unordered_map`
- Verified that no code depends on element ordering (`std::unordered_map` does not guarantee order)

## VI. Risk Assessment

**Risk Level**: Very Low

1. **Extremely low hash collision probability**: As analyzed above, the probability of all keys colliding is below 10^-12 magnitude
2. **Standard implementation**: Both Python version and SGLang HiCache use hash tables, validating feasibility
3. **Standard library support**: `std::unordered_map` is a C++11 standard library, stable and reliable
4. **API compatibility**: `std::unordered_map` and `std::map` have essentially the same interface
5. **Rollback plan**: If issues arise, can easily revert to `std::map`

