### PR TITLE
[feature] bind multiple get requests into one batch

### DIFF
--- a/flexkv/common/request.py
+++ b/flexkv/common/request.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, List, Optional
+from typing import Union, List, Optional
 
 import torch
 import numpy as np
@@ -34,7 +34,9 @@ class KVResponseStatus(Enum):
 class KVResponse:
     status: KVResponseStatus
     task_id: int
-    return_mask: Optional[np.ndarray]
+    return_mask: Optional[Union[np.ndarray, List[np.ndarray]]]
 
-    def get_mask(self) -> torch.Tensor:
-        return torch.from_numpy(self.return_mask) if self.return_mask is not None else None
+    def get_mask(self, idx: int) -> torch.Tensor:
+        assert self.return_mask is not None and isinstance(self.return_mask, list), "return_mask must be a list of np.ndarray"
+        assert idx < len(self.return_mask), "idx out of range"
+        return torch.from_numpy(self.return_mask[idx])

--- a/flexkv/common/tracer.py
+++ b/flexkv/common/tracer.py
@@ -278,7 +278,9 @@ class FlexKVTracer:
 
     def trace_launch_tasks(self,
                           task_ids: List[int],
-                          slot_mappings: List[Union[torch.Tensor, np.ndarray]]):
+                          slot_mappings: List[Union[torch.Tensor, np.ndarray]],
+                          as_batch: bool = False,
+                          batch_id: int = -1):
         """Record a launch_tasks operation"""
         if not self.enabled:
             return
@@ -296,6 +298,8 @@ class FlexKVTracer:
             "task_ids": task_ids,
             "slot_mappings": slot_mappings_list,
             "slot_mappings_shapes": slot_mappings_shapes,
+            "as_batch": as_batch,
+            "batch_id": batch_id,
         }
         
         record = {

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -174,7 +174,8 @@ class KVManager:
 
     def launch(self,
                task_ids: Union[int, List[int]],
-               slot_mappings: Union[np.ndarray, List[np.ndarray], torch.Tensor, List[torch.Tensor]]) -> None:
+               slot_mappings: Union[np.ndarray, List[np.ndarray], torch.Tensor, List[torch.Tensor]],
+               as_batch: bool = False) -> List[int]:
         if isinstance(task_ids, int):
             task_ids = [task_ids]
         if not isinstance(slot_mappings, List):
@@ -182,10 +183,10 @@ class KVManager:
         if isinstance(slot_mappings[0], torch.Tensor):
             slot_mappings = [slot_mapping.numpy() for slot_mapping in slot_mappings]
         if self.server_client_mode:
-            self.dp_client.launch_tasks(task_ids, slot_mappings)
+            return self.dp_client.launch_tasks(task_ids, slot_mappings, as_batch)
         else:
-            self.kv_task_engine.launch_tasks(task_ids, slot_mappings)
-
+            return self.kv_task_engine.launch_tasks(task_ids, slot_mappings, as_batch)
+            
     def cancel(self, task_ids: Union[int, List[int]]) -> None:
         if isinstance(task_ids, int):
             task_ids = [task_ids]

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -158,9 +158,14 @@ class KVDPClient:
         self,
         task_ids: List[int],
         slot_mappings: List[np.ndarray],
-    ) -> None:
-        req = LaunchTaskRequest(self.dp_client_id, task_ids, slot_mappings)
+        as_batch: bool = False,
+    ) -> List[int]:
+        batch_id = -1
+        if as_batch:
+            batch_id = self._get_task_id()
+        req = LaunchTaskRequest(self.dp_client_id, task_ids, slot_mappings, as_batch, batch_id)
         self.send_to_server.send_pyobj(req)
+        return [batch_id] if as_batch else task_ids
 
     def cancel_task(
         self,

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -65,6 +65,8 @@ class LaunchTaskRequest:
     dp_client_id: int
     task_ids: List[int]
     slot_mappings: List[np.ndarray]
+    as_batch: bool = False
+    batch_id: int = -1
 
 @dataclass
 class CancelTaskRequest:

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -344,7 +344,7 @@ class KVServer:
 
     def _handle_launch_task_request(self, req: LaunchTaskRequest) -> None:
         """Handle LaunchTask request"""
-        self.kv_task_engine.launch_tasks(req.task_ids, req.slot_mappings)
+        self.kv_task_engine.launch_tasks(req.task_ids, req.slot_mappings, req.as_batch, req.batch_id)
 
     def _handle_cancel_task_request(self, req: CancelTaskRequest) -> None:
         """Handle CancelTask request"""

--- a/tests/replay_from_tracer.py
+++ b/tests/replay_from_tracer.py
@@ -358,7 +358,8 @@ class FlexKVReplayEngine:
         data = event['data']
         task_ids = data['task_ids']
         slot_mappings_list = data['slot_mappings']
-        
+        as_batch = data.get('as_batch', False)
+        batch_id = data.get('batch_id', -1)
         self.log(f"🚀🚀🚀Replaying launch_tasks for task_ids: {task_ids}")
         
         try:
@@ -369,7 +370,7 @@ class FlexKVReplayEngine:
             print(f"Launching {len(task_ids)} tasks with slot_mappings")
             
             # Call launch_tasks
-            self.kvmanager.launch_tasks(task_ids, slot_mappings)
+            self.kvmanager.launch_tasks(task_ids, slot_mappings, as_batch, batch_id)
             
             self.log(f"launch_tasks completed successfully for {len(task_ids)} tasks")
             

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -1,6 +1,7 @@
 import time
 import os
 import shutil
+import random
 
 import pytest
 import torch
@@ -96,7 +97,7 @@ def shutdown_tp_client(tp_client_processes):
 ], indirect=True)
 @pytest.mark.parametrize("cache_config", [
     {'enable_cpu': True, 'enable_ssd': False, 'num_cpu_blocks': 1024},
-    {'enable_cpu': True, 'enable_ssd': True, 'num_cpu_blocks': 1024, 'num_ssd_blocks': 2048},
+    {'enable_cpu': True, 'enable_ssd': True, 'num_cpu_blocks': 256, 'num_ssd_blocks': 2048},
     # GDS test configs
     {'enable_cpu': True, 'enable_gds': True, 'enable_ssd': True, \
         'enable_remote': False, 'num_ssd_blocks': 512},
@@ -327,6 +328,83 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     total_time = end_time - start_time
     print(f"Total time: {total_time} s")
     print(f"Total cache hit rate: {total_cache_hit / (total_cache_hit + total_cache_miss)}")
+
+    # =============== Test batched launched get ===============
+    print("\n========== Testing batched launched get ==========")
+    
+    # Use the first few request_pairs that were written in initial phase
+    batch_size = 6
+    
+    batched_get_task_ids = []
+    batched_slot_mappings = []
+    batched_req_info = []  # Store (token_ids, block_ids) for verification
+    
+    # Create multiple get_match requests
+    for i in range(batch_size):
+        token_ids, block_ids, dp_id = request_pairs[random.randint(0, num_requests - 1)]
+        slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
+        
+        request_id, return_mask = kvmanager.get_match(
+            token_ids=token_ids,
+            layer_granularity=-1,
+            token_mask=None,
+            dp_id=dp_id,
+        )
+        batched_get_task_ids.append(request_id)
+        batched_slot_mappings.append(slot_mapping)
+        batched_req_info.append((token_ids, block_ids, request_id))
+        print(f"Created get_match request {request_id} for request_pair[{i}]")
+    
+    # Launch all get requests as a batch
+    print(f"Launching {len(batched_get_task_ids)} get requests as batch...")
+    batch_id = kvmanager.launch(
+        task_ids=batched_get_task_ids,
+        slot_mappings=batched_slot_mappings,
+        as_batch=True
+    )[0]
+    print(f"Returned task_ids after batch launch: {batch_id}")
+    
+    # Wait for the batched get to complete
+    # When as_batch=True, launch returns [batch_id], we need to wait on batch_id
+    batch_results = kvmanager.wait(batch_id, completely=True)
+    print(f"Batch wait returned {len(batch_results)} results")
+    
+    # Verify results
+    batched_cache_hit = 0
+    batched_cache_miss = 0
+    kvresponse = batch_results[batch_id]
+    assert kvresponse.status == KVResponseStatus.SUCCESS, \
+        f"Batched get task {batch_id} failed with status {kvresponse.status}"
+    for mask in kvresponse.return_mask:
+        batched_cache_hit += return_mask.sum().item()
+        batched_cache_miss += len(return_mask) - return_mask.sum().item()
+        print(f"Task {batch_id}: cache_hit={batched_cache_hit}, cache_miss={batched_cache_miss}")
+    
+    # GPU KV cache verification for batched get
+    if gpu_kv_verifier is not None:
+        for idx, (token_ids, block_ids, req_id) in enumerate(batched_req_info):
+            # Find the corresponding response
+            # Note: when batched, the returned task_id might be the batch_id
+            # We need to verify based on the actual data
+            valid_fetched_tokens = kvresponse.return_mask[idx].sum().item() // tokens_per_block * tokens_per_block
+            if valid_fetched_tokens > 0:
+                # Verify that GPU blocks contain correct data
+                verify_result = gpu_kv_verifier.verify_kv_blocks(
+                    token_ids[:valid_fetched_tokens],
+                    block_ids[:valid_fetched_tokens // tokens_per_block]
+                )
+    
+    print(f"Batched get test completed: hit={batched_cache_hit}, miss={batched_cache_miss}")
+    
+    # Since we read data that was written before, cache hit should be high
+    if enable_cpu and num_cpu_blocks >= num_gpu_blocks:
+        assert batched_cache_miss == 0, \
+            f"Expected 0 cache miss for batched get, but got {batched_cache_miss}"
+        print("  ✓ Batched launched get verification PASSED (100% cache hit)")
+    else:
+        print(f"  Batched launched get completed (cache hit rate: "
+                f"{batched_cache_hit / (batched_cache_hit + batched_cache_miss):.2%})")
+
     if enable_cpu and num_cpu_blocks >= num_gpu_blocks or \
         enable_ssd and num_ssd_blocks >= num_gpu_blocks or \
         enable_remote and num_remote_blocks >= num_gpu_blocks or \


### PR DESCRIPTION
Now we can bind multiple get requests into one batch, through `kvmanager.launch(..., as_batch=True)` to sync/wait and execute more efficiently. Also get prepared for layerwise transfer.