### PR TITLE
[misc] better cpu block layout for tp > 1 (considering layerfirst and blockfirst type)

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -405,7 +405,7 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("cpu_kv_stride_in_bytes"),
            py::arg("cpu_layer_stride_in_bytes"),
            py::arg("cpu_block_stride_in_bytes"),
-           py::arg("cpu_chunk_size_in_bytes"), py::arg("transfer_sms"),
+           py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_sms"),
            py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
            py::arg("layer_id"), py::arg("layer_granularity"),
            py::arg("is_mla"));

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -147,7 +147,7 @@ void TPTransferThreadGroup::tp_group_transfer(
     const int64_t cpu_kv_stride_in_bytes,
     const int64_t cpu_layer_stride_in_bytes,
     const int64_t cpu_block_stride_in_bytes,
-    const int64_t cpu_chunk_size_in_bytes, const int transfer_sms,
+    const int64_t cpu_tp_stride_in_bytes, const int transfer_sms,
     const bool is_host_to_device, const bool use_ce_transfer,
     const int layer_id, const int layer_granularity, const bool is_mla) {
 
@@ -171,7 +171,7 @@ void TPTransferThreadGroup::tp_group_transfer(
         int64_t *cpu_block_ids =
             static_cast<int64_t *>(cpu_block_id_tensor.data_ptr());
         void *cpu_ptr = cpu_blocks_;
-        int64_t cpu_startoff_inside_chunks = i * gpu_chunk_sizes_in_bytes_[i];
+        int64_t cpu_startoff_inside_chunks = i * cpu_tp_stride_in_bytes;
         if (is_mla && !is_host_to_device) {
           cpu_startoff_inside_chunks = i * gpu_chunk_sizes_in_bytes_[i] / num_gpus_;
         } else if (is_mla && is_host_to_device) {

--- a/csrc/tp_transfer_thread_group.h
+++ b/csrc/tp_transfer_thread_group.h
@@ -51,7 +51,7 @@ public:
                          const int64_t cpu_kv_stride_in_bytes,
                          const int64_t cpu_layer_stride_in_bytes,
                          const int64_t cpu_block_stride_in_bytes,
-                         const int64_t cpu_chunk_size_in_bytes,
+                         const int64_t cpu_tp_stride_in_bytes,
                          const int transfer_sms, const bool is_host_to_device,
                          const bool use_ce_transfer, const int layer_id,
                          const int layer_granularity, const bool is_mla);

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -94,6 +94,7 @@ def shutdown_tp_client(tp_client_processes):
     {'dtype': torch.float32},
     {'use_mla': True},
     {'tp_size': 4, 'dp_size': 1, 'use_mla': True},
+    {'tp_size': 4, 'dp_size': 1},
 ], indirect=True)
 @pytest.mark.parametrize("cache_config", [
     {'enable_cpu': True, 'enable_ssd': False, 'num_cpu_blocks': 1024},


### PR DESCRIPTION
In tp scenario, we want the "tp dim" always after the "block dim" in cpu layout. i.e., for layerfirst cpu blocks, the layout is treated as `[layer, kv_dim, block_num, **tp**, tokens_per_block, head_num, head_size]`, and for blockfirst cpu blocks, the layout is treated as `[block_num, **tp**, layer, kv_dim, tokens_per_block, head_num, head_size]`. This is for larger data copy granuality.