### PR TITLE
Fix: Multiple Security & Reliability Issues 

### DIFF
--- a/csrc/dist/lease_meta_mempool.h
+++ b/csrc/dist/lease_meta_mempool.h
@@ -30,8 +30,8 @@ private:
     size_t bytes;
   };
 
-  // Single allocated block info
-  BlockInfo allocated_block{nullptr, 0};
+  // All allocated blocks for reclamation
+  std::vector<BlockInfo> allocated_blocks;
   // Free pool of individual LeaseMeta pointers.
   std::deque<LeaseMeta*> free_queue;
   // Block growth size when pool needs to expand.

--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -131,10 +131,6 @@ CRadixNode *LocalRadixTree::insert(torch::Tensor &physical_block_ids,
     LeaseMeta *org_lm = last_node->get_lease_meta();
     if (is_root(last_node)) {
       // root node's lease meta is nullptr
-      LeaseMeta *newlm = lease_pool.alloc();
-      assert(newlm != nullptr);
-      newlm->state = NODE_STATE_NORMAL;
-      newlm->lease_time = get_now_ms() + lease_ttl_ms + safety_ttl_ms;
       new_parent->set_lease_meta(nullptr);
     } else if (org_lm != nullptr) {
       // copy the lease meta to the new parent node
@@ -740,6 +736,3 @@ size_t LocalRadixTree::drain_pending_queues() {
 }
 
 } // namespace flexkv
-
-
-

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -51,8 +51,11 @@ TPTransferThreadGroup::TPTransferThreadGroup(
   mtxs_ = std::vector<std::mutex>(num_gpus_);
   cvs_ = std::vector<std::condition_variable>(num_gpus_);
 
-  cudaMallocHost((void **)&gpu_blocks_,
+  cudaError_t malloc_err = cudaMallocHost((void **)&gpu_blocks_,
                  num_gpus_ * num_tensors_per_gpu_ * sizeof(void *));
+  if (malloc_err != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaMallocHost failed: ") + cudaGetErrorString(malloc_err));
+  }
   for (size_t i = 0; i < gpu_block_ptrs_flat.size(); ++i) {
     gpu_blocks_[i] = reinterpret_cast<void *>(gpu_block_ptrs_flat[i]);
   }
@@ -88,8 +91,12 @@ TPTransferThreadGroup::TPTransferThreadGroup(
 
   streams_.resize(num_gpus_);
   for (int i = 0; i < num_gpus_; i += 1) {
-    cudaSetDevice(gpu_device_ids_[i]);
-    cudaStreamCreate(&streams_[i]);
+    cudaError_t err = cudaSetDevice(gpu_device_ids_[i]);
+    if (err != cudaSuccess)
+      throw std::runtime_error(std::string("cudaSetDevice failed: ") + cudaGetErrorString(err));
+    err = cudaStreamCreate(&streams_[i]);
+    if (err != cudaSuccess)
+      throw std::runtime_error(std::string("cudaStreamCreate failed: ") + cudaGetErrorString(err));
   }
   // create the thread pool
   stop_pool_=false;

--- a/flexkv/common/block.py
+++ b/flexkv/common/block.py
@@ -12,7 +12,9 @@ def _get_namespace_hash_key(namespace: Optional[List[str]]) -> Optional[np.ndarr
     if not namespace or len(namespace) == 0:
         return None
     
-    namespace_key = ":".join(namespace)
+    # Use null character as delimiter to prevent ambiguity
+    # e.g. ["a:b", "c"] → "a:b\x00c" != ["a", "b:c"] → "a\x00b:c"
+    namespace_key = "\x00".join(namespace)
     namespace_bytes = namespace_key.encode('utf-8')
     namespace_array = np.frombuffer(namespace_bytes, dtype=np.uint8).astype(np.int64)
     return namespace_array

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -73,7 +73,7 @@ class ClientManager:
         if client_id is None:
             if len(self.free_client_ids) == 0:
                 flexkv_logger.error("Client full. DP client registration failed.")
-                raise
+                raise RuntimeError("Client full. DP client registration failed.")
             client_id = self.free_client_ids.popleft()
         send_to_client = get_zmq_socket(
             context, zmq.SocketType.PUSH, client_recv_port, False
@@ -90,7 +90,7 @@ class ClientManager:
     def delete_dp_client(self, client_id: int) -> None:
         if client_id not in self.client_dict:
             flexkv_logger.error(f"DP client: {client_id} dosen't exist. Delete failed.")
-            raise
+            raise KeyError(f"DP client: {client_id} doesn't exist. Delete failed.")
         self.client_dict.pop(client_id)
         self.free_client_ids.appendleft(client_id)
         flexkv_logger.info(f"Delete DP client: {client_id} succeeded.")

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -247,6 +247,7 @@ class TransferWorkerBase(ABC):
                             break
                         batch_ops.append(op)
                     for op in batch_ops:
+                        transfer_status = False
                         try:
                             nvtx.push_range(f"launch {op.transfer_type.name} op_id: {op.transfer_op_id}, "
                                                 f"graph_id: {op.transfer_graph_id}, "


### PR DESCRIPTION
## Summary

Fix several reliability and correctness issues found during code review, spanning C++ CUDA 
layer, memory management, Python server error handling, namespace key generation, and 
transfer worker state tracking.

## Changes

### 1. CUDA Device ID Miscalculation in Destructor
- **File**: `csrc/gds/tp_gds_transfer_thread_group.cpp`
- Destructor used hardcoded formula `dp_group_id_ * num_gpus_ + i` to compute device ID, 
  which could target the wrong GPU. Changed to `gpu_device_ids_[i]` to match constructor logic.

### 2. CUDA API Error Checking
- **Files**: `csrc/gds/tp_gds_transfer_thread_group.cpp`, `csrc/tp_transfer_thread_group.cpp`
- Added error checking for `cudaMallocHost`, `cudaSetDevice`, and `cudaStreamCreate` calls. 
  Previously these could silently fail; now they throw `std::runtime_error` with descriptive 
  messages.

### 3. Memory Pool Leak on Expansion
- **Files**: `csrc/dist/lease_meta_mempool.cpp`, `csrc/dist/lease_meta_mempool.h`
- `LeaseMetaMemPool` stored only a single `BlockInfo`, so each pool expansion overwrote the 
  previous pointer, leaking all prior allocations. Changed to `std::vector<BlockInfo>` to 
  track all allocated blocks and release them all in the destructor.

### 4. Remove Dead Code in Radix Tree Insert
- **File**: `csrc/dist/local_radix_tree.cpp`
- Removed unreachable lease meta allocation for the root node (root node's lease meta is 
  always nullptr), and cleaned up trailing blank lines.

### 5. Namespace Delimiter Collision
- **File**: `flexkv/common/block.py`
- Replaced `:` delimiter with `\x00` (null character) for joining namespace components, 
  preventing `["a:b", "c"]` and `["a", "b:c"]` from producing identical keys.

### 6. Bare `raise` Without Active Exception
- **File**: `flexkv/server/server.py`
- `ClientManager.delete_dp_client` and registration code used bare `raise` outside of an 
  except block, which would cause `RuntimeError: No active exception to re-raise`. Changed 
  to raise explicit `RuntimeError` / `KeyError` with descriptive messages.

### 7. Transfer Worker Status Initialization
- **File**: `flexkv/transfer/worker.py`
- `transfer_status` was not initialized before the try block in the batch operation loop. 
  If an exception occurred, the variable could reference a stale value from a previous 
  iteration. Added `transfer_status = False` initialization before each operation.