### PR TITLE
feat(vllm): add multi-version compatibility for vllm_v1_adapter.py (v0.10.0 ~ v0.16.0+)

### DIFF
--- a/examples/vllm_adaption/vllm_0_16_0-flexkv-connector.patch
+++ b/examples/vllm_adaption/vllm_0_16_0-flexkv-connector.patch
@@ -1,0 +1,495 @@
+From 0dfe92afb702ca066d4b280f74b89539ca8650cd Mon Sep 17 00:00:00 2001
+From: phaedonsun <phaedonsun@tencent.com>
+Date: Wed, 11 Feb 2026 15:35:54 +0800
+Subject: [PATCH] [KV Connector] Add FlexKV connector support
+
+This commit introduces the FlexKV connector, enabling integration with FlexKV, a distributed KV Store and multi-level cache management system for ultra-large-scale LLM inference.
+
+Signed-off-by: phaedonsun <phaedonsun@tencent.com>
+---
+ docs/features/disagg_prefill.md               |   6 +
+ .../prefix_caching_flexkv.py                  | 194 ++++++++++++++
+ .../kv_transfer/kv_connector/factory.py       |   6 +
+ .../kv_connector/v1/flexkv_connector.py       | 241 ++++++++++++++++++
+ 4 files changed, 447 insertions(+)
+ create mode 100644 examples/offline_inference/prefix_caching_flexkv.py
+ create mode 100644 vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py
+
+diff --git a/docs/features/disagg_prefill.md b/docs/features/disagg_prefill.md
+index af5f77747fac..f7d3f9a70f7e 100644
+--- a/docs/features/disagg_prefill.md
++++ b/docs/features/disagg_prefill.md
+@@ -44,6 +44,12 @@ For NixlConnector, you may also specify one or multiple NIXL_Backend. Such as:
+   --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"block_size": 64, "cpu_bytes_to_use": 1000000000}}'
+   ```
+ 
++- **FlexKVConnectorV1**: refer to [examples/offline_inference/prefix_caching_flexkv.py](../../examples/offline_inference/prefix_caching_flexkv.py) for the example usage of FlexKVConnectorV1. FlexKV is a distributed KV Store and multi-level cache management system for ultra-large-scale LLM inference.
++
++  ```bash
++  --kv-transfer-config '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
++  ```
++
+ ## Benchmarks
+ 
+ Please refer to [benchmarks/disagg_benchmarks](../../benchmarks/disagg_benchmarks) for disaggregated prefilling benchmarks.
+diff --git a/examples/offline_inference/prefix_caching_flexkv.py b/examples/offline_inference/prefix_caching_flexkv.py
+new file mode 100644
+index 000000000000..503907b19d99
+--- /dev/null
++++ b/examples/offline_inference/prefix_caching_flexkv.py
+@@ -0,0 +1,194 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++This example shows how to use FlexKV with vLLM for prefix caching.
++
++FlexKV is a distributed KV Store and multi-level cache management system for
++ultra-large-scale LLM inference.
++
++Requirements:
++    - Install FlexKV:
++        1. git clone git@github.com:taco-project/FlexKV.git
++        2. cd FlexKV && bash build.sh
++    - Ensure FlexKV is compatible with your vLLM version.
++
++Usage:
++    1. Run this script:
++       python examples/offline_inference/prefix_caching_flexkv.py
++
++    2. The script will:
++       - Create a FlexKV configuration file.
++       - Set the FLEXKV_CONFIG_PATH environment variable.
++       - Run vLLM with FlexKVConnectorV1 enabled.
++       - Compare results between regular execution, vLLM's default prefix caching, and FlexKV.
++"""
++
++import json
++import os
++import time
++
++from vllm import LLM, SamplingParams
++from vllm.distributed import cleanup_dist_env_and_memory
++
++# NOTE: This is just a running example. For benchmarking purpose,
++# please see benchmarks/benchmark_prefix_caching.py
++
++
++flexkv_config = {
++    "server_recv_port": f"ipc:///tmp/flexkv_test_{os.getpid()}",
++    "cache_config": {
++        "enable_cpu": True,
++        "num_cpu_blocks": 10240,
++    },
++    "num_log_interval_requests": 200,
++}
++flexkv_config_path = f"./flexkv_config_{os.getpid()}.json"
++with open(flexkv_config_path, "w") as f:
++    json.dump(flexkv_config, f)
++os.environ["FLEXKV_CONFIG_PATH"] = flexkv_config_path
++
++
++# Common prefix.
++prefix = (
++    "You are an expert school principal, skilled in effectively managing "
++    "faculty and staff. Draft 10-15 questions for a potential first grade "
++    "Head Teacher for my K-12, all-girls', independent school that emphasizes "
++    "community, joyful discovery, and life-long learning. The candidate is "
++    "coming in for a first-round panel interview for a 8th grade Math "
++    "teaching role. They have 5 years of previous teaching experience "
++    "as an assistant teacher at a co-ed, public school with experience "
++    "in middle school math teaching. Based on these information, fulfill "
++    "the following paragraph: "
++)
++
++# Sample prompts.
++prompts = [
++    "Hello, my name is",
++    "The president of the United States is",
++    "The capital of France is",
++    "The future of AI is",
++]
++
++generating_prompts = [prefix + prompt for prompt in prompts]
++
++# Create a sampling params object.
++sampling_params = SamplingParams(temperature=0.0)
++
++kv_transfer_config = {
++    "kv_connector": "FlexKVConnectorV1",
++    "kv_role": "kv_both",
++}
++
++model_path = os.environ.get("MODEL_PATH")
++if model_path is None:
++    raise ValueError("Please set the MODEL_PATH environment variable.")
++tp_size = 8
++gpu_memory_utilization = 0.4
++
++
++def main():
++    # Create an LLM without prefix caching as a baseline.
++    regular_llm = LLM(
++        model=model_path,
++        enable_prefix_caching=False,
++        gpu_memory_utilization=gpu_memory_utilization,
++        tensor_parallel_size=tp_size,
++    )
++
++    print("Results without `enable_prefix_caching`")
++
++    # ruff: noqa: E501
++    # Generate texts from the prompts. The output is a list of RequestOutput objects
++    # that contain the prompt, generated text, and other information.
++    outputs = regular_llm.generate(generating_prompts, sampling_params)
++
++    regular_generated_texts = []
++    # Print the outputs.
++    print("-" * 50)
++    for output in outputs:
++        prompt = output.prompt
++        generated_text = output.outputs[0].text
++        regular_generated_texts.append(generated_text)
++        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
++        print("-" * 50)
++
++    # Destroy the LLM object and free up the GPU memory.
++    del regular_llm
++    cleanup_dist_env_and_memory()
++
++    # Create an LLM with prefix caching enabled.
++    prefix_cached_llm = LLM(
++        model=model_path,
++        enable_prefix_caching=True,
++        gpu_memory_utilization=gpu_memory_utilization,
++        tensor_parallel_size=tp_size,
++        kv_transfer_config=kv_transfer_config,
++    )
++
++    # Warmup so that the shared prompt's KV cache is computed.
++    prefix_cached_llm.generate(generating_prompts[0], sampling_params)
++
++    # wait for offload kv task finished.
++    time.sleep(2)
++
++    # Generate with prefix caching.
++    outputs = prefix_cached_llm.generate(generating_prompts, sampling_params)
++
++    print("Results with `enable_prefix_caching`")
++
++    cached_generated_texts = []
++    # Print the outputs. You should see the same outputs as before.
++    print("-" * 50)
++    for output in outputs:
++        prompt = output.prompt
++        generated_text = output.outputs[0].text
++        cached_generated_texts.append(generated_text)
++        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
++        print("-" * 50)
++
++    # Compare the results and display the speedup
++    generated_same = all(
++        [
++            regular_generated_texts[i] == cached_generated_texts[i]
++            for i in range(len(prompts))
++        ]
++    )
++    print(f"Generated answers are the same: {generated_same}")
++
++    # wait for offload kv task finished.
++    time.sleep(2)
++
++    # reset prefix cache to use flexkv
++    prefix_cached_llm.reset_prefix_cache()
++
++    # Generate with prefix caching.
++    outputs = prefix_cached_llm.generate(generating_prompts, sampling_params)
++
++    print("Results with `flexkv`")
++
++    flexkv_generated_texts = []
++    # Print the outputs. You should see the same outputs as before.
++    print("-" * 50)
++    for output in outputs:
++        prompt = output.prompt
++        generated_text = output.outputs[0].text
++        flexkv_generated_texts.append(generated_text)
++        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
++        print("-" * 50)
++
++    # Compare the results and display the speedup
++    generated_same = all(
++        [
++            regular_generated_texts[i] == flexkv_generated_texts[i]
++            for i in range(len(prompts))
++        ]
++    )
++    print(f"Generated answers are the same: {generated_same}")
++
++
++if __name__ == "__main__":
++    try:
++        main()
++    finally:
++        if os.path.exists(flexkv_config_path):
++            os.remove(flexkv_config_path)
+diff --git a/vllm/distributed/kv_transfer/kv_connector/factory.py b/vllm/distributed/kv_transfer/kv_connector/factory.py
+index 1ceac39711b2..92d03e7e9810 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
++++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
+@@ -201,3 +201,9 @@ def get_connector_class(
+     "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector",
+     "MooncakeConnector",
+ )
++
++KVConnectorFactory.register_connector(
++    "FlexKVConnectorV1",
++    "vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector",
++    "FlexKVConnectorV1",
++)
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py b/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py
+new file mode 100644
+index 000000000000..07d1b50d892a
+--- /dev/null
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py
+@@ -0,0 +1,241 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from collections.abc import Iterable
++from typing import TYPE_CHECKING, Any
++
++import torch
++
++from vllm.config import VllmConfig
++from vllm.distributed.kv_transfer.kv_connector.v1.base import (
++    KVConnectorBase_V1,
++    KVConnectorMetadata,
++    KVConnectorRole,
++)
++from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
++from vllm.logger import init_logger
++from vllm.v1.core.sched.output import SchedulerOutput
++from vllm.v1.outputs import KVConnectorOutput
++
++if TYPE_CHECKING:
++    from vllm.distributed.kv_events import KVCacheEvent
++    from vllm.forward_context import ForwardContext
++    from vllm.v1.attention.backend import AttentionMetadata
++    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
++    from vllm.v1.kv_cache_interface import KVCacheConfig
++    from vllm.v1.request import Request
++
++logger = init_logger(__name__)
++
++
++# FlexKV is a distributed KV Store and multi-level cache management system for
++# ultra-large-scale LLM inference.
++# GitHub: https://github.com/taco-project/FlexKV
++class FlexKVConnectorV1(KVConnectorBase_V1):
++    def __init__(
++        self,
++        vllm_config: "VllmConfig",
++        role: KVConnectorRole,
++        kv_cache_config: "KVCacheConfig",
++    ):
++        super().__init__(
++            vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
++        )
++        try:
++            from flexkv.integration.vllm.vllm_v1_adapter import FlexKVConnectorV1Impl
++        except ImportError as e:
++            raise ImportError(
++                "FlexKV is not installed. Please install it to use FlexKVConnectorV1. "
++            ) from e
++        self._flexkv_connector = FlexKVConnectorV1Impl(vllm_config, role)
++
++    def shutdown(self):
++        self._flexkv_connector.shutdown()
++
++    # ==============================
++    # Worker-side methods
++    # ==============================
++    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
++        """
++        Start loading the KV cache from the connector to vLLM's paged
++        KV buffer. This is called from the forward context before the
++        forward pass to enable async loading during model execution.
++
++        Args:
++            forward_context (ForwardContext): the forward context.
++            **kwargs (Any): additional arguments for the load operation
++
++        Note:
++            The number of elements in kv_caches and layer_names should be
++            the same.
++
++        """
++        self._flexkv_connector.start_load_kv(forward_context, **kwargs)
++
++    def wait_for_layer_load(self, layer_name: str) -> None:
++        """
++        Block until the KV for a specific layer is loaded into vLLM's
++        paged buffer. This is called from within attention layer to ensure
++        async copying from start_load_kv is complete.
++
++        This interface will be useful for layer-by-layer pipelining.
++
++        Args:
++            layer_name: the name of that layer
++        """
++        self._flexkv_connector.wait_for_layer_load(layer_name)
++
++    def save_kv_layer(
++        self,
++        layer_name: str,
++        kv_layer: torch.Tensor,
++        attn_metadata: "AttentionMetadata",
++        **kwargs,
++    ) -> None:
++        """
++        Start saving the a layer of KV cache from vLLM's paged buffer
++        to the connector. This is called from within attention layer to
++        enable async copying during execution.
++
++        Args:
++            layer_name (str): the name of the layer.
++            kv_layer (torch.Tensor): the paged KV buffer of the current
++                layer in vLLM.
++            attn_metadata (AttentionMetadata): the attention metadata.
++            **kwargs (Any): additional arguments for the save operation.
++        """
++        self._flexkv_connector.save_kv_layer(
++            layer_name, kv_layer, attn_metadata, **kwargs
++        )
++
++    def wait_for_save(self):
++        """
++        Block until all the save operations is done. This is called
++        as the forward context exits to ensure that the async saving
++        from save_kv_layer is complete before finishing the forward.
++
++        This prevents overwrites of paged KV buffer before saving done.
++        """
++        self._flexkv_connector.wait_for_save()
++
++    def get_finished(
++        self, finished_req_ids: set[str]
++    ) -> tuple[set[str] | None, set[str] | None]:
++        """
++        Notifies worker-side connector ids of requests that have
++        finished generating tokens.
++
++        Returns:
++            ids of requests that have finished asynchronous transfer
++            (requests that previously returned True from request_finished()),
++            tuple of (sending/saving ids, recving/loading ids).
++            The finished saves/sends req ids must belong to a set provided in a
++            call to this method (this call or a prior one).
++        """
++        return self._flexkv_connector.get_finished(finished_req_ids)
++
++    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
++        """
++        Initialize with the KV caches. Useful for pre-registering the
++        KV Caches in the KVConnector (e.g. for NIXL).
++
++        Args:
++            kv_caches: dictionary of layer names, kv cache
++        """
++        self._flexkv_connector.register_kv_caches(kv_caches)
++
++    # ==============================
++    # Scheduler-side methods
++    # ==============================
++    def get_num_new_matched_tokens(
++        self,
++        request: "Request",
++        num_computed_tokens: int,
++    ) -> tuple[int, bool]:
++        """
++        Get number of new tokens that can be loaded from the
++        external KV cache beyond the num_computed_tokens.
++
++        Args:
++            request (Request): the request object.
++            num_computed_tokens (int): the number of locally
++                computed tokens for this request
++
++        Returns:
++            the number of tokens that can be loaded from the
++            external KV cache beyond what is already computed.
++        """
++        return self._flexkv_connector.get_num_new_matched_tokens(
++            request, num_computed_tokens
++        )
++
++    def update_state_after_alloc(
++        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
++    ):
++        """
++        Update KVConnector state after block allocation.
++        """
++        self._flexkv_connector.update_state_after_alloc(
++            request, blocks, num_external_tokens
++        )
++
++    def build_connector_meta(
++        self, scheduler_output: SchedulerOutput
++    ) -> KVConnectorMetadata:
++        """
++        Build the connector metadata for this step.
++
++        This function should NOT modify fields in the scheduler_output.
++        Also, calling this function will reset the state of the connector.
++
++        Args:
++            scheduler_output (SchedulerOutput): the scheduler output object.
++        """
++        return self._flexkv_connector.build_connector_meta(scheduler_output)
++
++    def update_connector_output(self, connector_output: KVConnectorOutput):
++        """
++        Update KVConnector state from worker-side connectors output.
++
++        Args:
++            connector_output (KVConnectorOutput): the worker-side
++                connectors output.
++        """
++        self._flexkv_connector.update_connector_output(connector_output)
++
++    def request_finished(
++        self,
++        request: "Request",
++        block_ids: list[int],
++    ) -> tuple[bool, dict[str, Any] | None]:
++        """
++        Called when a request has finished, before its blocks are freed.
++
++        Returns:
++            True if the request is being saved/sent asynchronously and blocks
++            should not be freed until the request_id is returned from
++            get_finished().
++            Optional KVTransferParams to be included in the request outputs
++            returned by the engine.
++        """
++        return self._flexkv_connector.request_finished(request, block_ids)
++
++    def take_events(self) -> Iterable["KVCacheEvent"]:
++        """
++        Collect buffered KV cache events.
++
++        Returns:
++            New KV cache events since the last call.
++        """
++        return self._flexkv_connector.take_events()
++
++    def get_kv_connector_stats(self) -> KVConnectorStats | None:
++        """
++        Get the KV connector stats collected during the last interval.
++        """
++        return self._flexkv_connector.get_kv_connector_stats()
++
++    def get_block_ids_with_load_errors(self) -> set[int]:
++        """
++        Get the block ids that have failed to load.
++        """
++        return self._flexkv_connector.get_block_ids_with_load_errors()

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -21,8 +21,20 @@ from flexkv.transfer_manager import TransferManagerOnRemote
 # vllm
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata, KVConnectorRole)
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.parallel_state import get_tp_group
+
+# KVConnectorStats: available since v0.11.0
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+except ImportError:
+    KVConnectorStats = None  # type: ignore[misc,assignment]
+
+# KVConnectorOutput: available since v0.10.1
+try:
+    from vllm.v1.outputs import KVConnectorOutput as _KVConnectorOutput
+    _HAS_KV_CONNECTOR_OUTPUT = True
+except ImportError:
+    _HAS_KV_CONNECTOR_OUTPUT = False
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -30,13 +42,14 @@ if TYPE_CHECKING:
     try:
         from vllm.v1.attention.backend import AttentionMetadata
     except ImportError:
-        # vllm <= 0.8.x used the old path
+        # vllm <= 0.13.x used the old path
         from vllm.attention.backends.abstract import AttentionMetadata  # type: ignore[no-redef]
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.request import Request
-    from vllm.v1.outputs import KVConnectorOutput
+    if _HAS_KV_CONNECTOR_OUTPUT:
+        from vllm.v1.outputs import KVConnectorOutput
 
 
 logger = flexkv_logger
@@ -882,11 +895,14 @@ class FlexKVConnectorV1Impl:
     def update_connector_output(self, connector_output: "KVConnectorOutput"):
         """
         Update KVConnector state from worker-side connectors output.
+        Available since vLLM v0.10.1.
 
         Args:
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
+        if not _HAS_KV_CONNECTOR_OUTPUT:
+            return
 
         finished_sending, finished_recving = self.connector.query_finished_task()
         connector_output.finished_sending = finished_sending
@@ -919,10 +935,14 @@ class FlexKVConnectorV1Impl:
             return []
         return collector.take_events()
 
-    def get_kv_connector_stats(self) -> Optional[KVConnectorStats]:
+    def get_kv_connector_stats(self) -> Optional["KVConnectorStats"]:
         """
         Get the KV connector stats collected during the last interval.
+        Available since vLLM v0.11.0.
         """
+        if KVConnectorStats is None:
+            return None
+
         if self.role != KVConnectorRole.SCHEDULER:
             return None
 


### PR DESCRIPTION
修改vllm_v1_adapter.py，兼容vllm的不同release版本。

- Guard KVConnectorStats import with try/except for v0.10.0/v0.10.1
- Guard KVConnectorOutput import with try/except for v0.10.0
- Add runtime checks in update_connector_output() and get_kv_connector_stats()
- Fix AttentionMetadata fallback comment (v0.13.x, not v0.8.x)