### PR TITLE
[bugfix] fix match local bug

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -99,11 +99,16 @@ class CacheEngineAccel:
                 bnids_np = None
         except Exception:
             bnids_np = None
-        return MatchResultAccel(match_result.num_ready_matched_blocks, match_result.num_matched_blocks,
-                            match_result.last_ready_node, match_result.last_node,
-                            match_result.last_node_matched_length,
-                            phys,
-                            bnids_np)
+        return MatchResultAccel(
+            num_ready_matched_blocks=match_result.num_ready_matched_blocks,
+            num_matched_blocks=match_result.num_matched_blocks,
+            last_ready_node=match_result.last_ready_node,
+            last_node=match_result.last_node,
+            last_node_matched_length=match_result.last_node_matched_length,
+            physical_blocks=phys,
+            block_node_ids=bnids_np,
+            matched_pos="remote" if self.device_type == DeviceType.REMOTE else "local",
+        )
 
     def insert(self,
                sequence_meta: SequenceMeta,


### PR DESCRIPTION
When `index_accel=True (default)`,` CacheEngineAccel.match()` returns `MatchResultAccel `without setting` matched_pos`, leaving it as None. In` _get_impl_local()`, the CPU cache insert condition checks `matched_pos == "local"`, which is always False when matched_pos is None. As a result, data loaded from SSD into CPU staging buffers is always freed **instead of being inserted into the CPU cache.**