### PR TITLE
docs: add Updates section and announce official vLLM & Dynamo mainline merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ FlexKV is released under the **Apache-2.0 License**. See the [LICENSE](LICENSE) 
 
 - **Mar 17, 2026**: 🎉 FlexKV has been officially merged into [vLLM](https://github.com/vllm-project/vllm) mainline ([PR #34328](https://github.com/vllm-project/vllm/pull/34328))! Starting from **vLLM v0.17.2**, `FlexKVConnectorV1` is built in — no patch required. See [docs/vllm_adapter/README_en.md](docs/vllm_adapter/README_en.md) for updated usage.
 
+- **Mar 3, 2026**: 🎉 FlexKV has been officially merged into [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) ([PR #5858](https://github.com/ai-dynamo/dynamo/pull/5858))! FlexKV is now a native KV Cache Offloading option in Dynamo, enabling KV-aware routing + multi-level cache offloading in a unified pipeline. See [docs/dynamo_integration/README_en.md](docs/dynamo_integration/README_en.md).
+
 - **Jan 28, 2026**: [Mooncake Transfer Engine](https://github.com/kvcache-ai/Mooncake) integration is now available — FlexKV supports [distributed KVCache reuse](docs/dist_reuse/README_en.md) with high-performance RDMA-based cross-node transfer.
 
 - **Jan 2026**: TensorRT-LLM support added ([#48](https://github.com/taco-project/FlexKV/pull/48)), enabling FlexKV multi-level caching in TRT-LLM inference pipelines. TP16 support for both vLLM and TRT-LLM ([#53](https://github.com/taco-project/FlexKV/pull/53), [#59](https://github.com/taco-project/FlexKV/pull/59)).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ FlexKV is a distributed KV store and multi-level cache management system develop
 
 FlexKV is released under the **Apache-2.0 License**. See the [LICENSE](LICENSE) file for details.
 
+## Updates
+
+- **Mar 17, 2026**: 🎉 FlexKV has been officially merged into [vLLM](https://github.com/vllm-project/vllm) mainline ([PR #34328](https://github.com/vllm-project/vllm/pull/34328))! Starting from **vLLM v0.17.2**, `FlexKVConnectorV1` is built in — no patch required. See [docs/vllm_adapter/README_en.md](docs/vllm_adapter/README_en.md) for updated usage.
+
+- **Jan 28, 2026**: [Mooncake Transfer Engine](https://github.com/kvcache-ai/Mooncake) integration is now available — FlexKV supports [distributed KVCache reuse](docs/dist_reuse/README_en.md) with high-performance RDMA-based cross-node transfer.
+
+- **Jan 2026**: TensorRT-LLM support added ([#48](https://github.com/taco-project/FlexKV/pull/48)), enabling FlexKV multi-level caching in TRT-LLM inference pipelines. TP16 support for both vLLM and TRT-LLM ([#53](https://github.com/taco-project/FlexKV/pull/53), [#59](https://github.com/taco-project/FlexKV/pull/59)).
+
+- **Dec 2025**: GPU Direct Storage (GDS) support added ([#25](https://github.com/taco-project/FlexKV/pull/25)), enabling direct SSD-to-GPU transfers without CPU involvement.
+
+- **Nov 2025**: FlexKV transitioned from client-server mode to a **directly-callable library** (commit [0290841](https://github.com/taco-project/FlexKV/commit/0290841dce65ae9b036a23d733cf94e47e814934)), eliminating inter-process communication overhead. This is the v1.0.0 API.
 
 ## Main Change for latest version
 ### Feature

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,6 +6,18 @@ FlexKV是腾讯云TACO团队和社区合作开发推出的面向超大规模 LLM
 
 FlexKV 采用 **Apache-2.0 开源协议**，详细信息请参见 [LICENSE](LICENSE) 文件。
 
+## Updates
+
+- **2026 年 3 月 17 日**：🎉 FlexKV 正式合并进入 [vLLM](https://github.com/vllm-project/vllm) 官方主干（[PR #34328](https://github.com/vllm-project/vllm/pull/34328)）！从 **vLLM v0.17.2** 起，`FlexKVConnectorV1` 已内置，**无需再手动打 patch**。详见 [docs/vllm_adapter/README_zh.md](docs/vllm_adapter/README_zh.md)。
+
+- **2026 年 1 月 28 日**：集成 [Mooncake Transfer Engine](https://github.com/kvcache-ai/Mooncake)，FlexKV 支持基于 RDMA 的高性能跨节点 [分布式 KVCache 复用](docs/dist_reuse/README_zh.md)。
+
+- **2026 年 1 月**：新增 TensorRT-LLM 支持（[#48](https://github.com/taco-project/FlexKV/pull/48)），vLLM 和 TRT-LLM 均支持 TP16（[#53](https://github.com/taco-project/FlexKV/pull/53)、[#59](https://github.com/taco-project/FlexKV/pull/59)）。
+
+- **2025 年 12 月**：新增 GPU Direct Storage（GDS）支持（[#25](https://github.com/taco-project/FlexKV/pull/25)），实现 SSD 到 GPU 的直接传输，绕过 CPU。
+
+- **2025 年 11 月**：FlexKV 从 client-server 模式升级为**可直接调用的库函数**（commit [0290841](https://github.com/taco-project/FlexKV/commit/0290841dce65ae9b036a23d733cf94e47e814934)），消除进程间通信开销，即 v1.0.0 API。
+
 ## 最新版本主要变更
 ### 功能
 通用功能:

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,6 +10,8 @@ FlexKV 采用 **Apache-2.0 开源协议**，详细信息请参见 [LICENSE](LICE
 
 - **2026 年 3 月 17 日**：🎉 FlexKV 正式合并进入 [vLLM](https://github.com/vllm-project/vllm) 官方主干（[PR #34328](https://github.com/vllm-project/vllm/pull/34328)）！从 **vLLM v0.17.2** 起，`FlexKVConnectorV1` 已内置，**无需再手动打 patch**。详见 [docs/vllm_adapter/README_zh.md](docs/vllm_adapter/README_zh.md)。
 
+- **2026 年 3 月 3 日**：🎉 FlexKV 正式合并进入 [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo)（[PR #5858](https://github.com/ai-dynamo/dynamo/pull/5858)）！FlexKV 成为 Dynamo 原生支持的 KV Cache Offloading 方案，实现 KV 感知路由与多级缓存卸载联合部署。详见 [docs/dynamo_integration/README_zh.md](docs/dynamo_integration/README_zh.md)。
+
 - **2026 年 1 月 28 日**：集成 [Mooncake Transfer Engine](https://github.com/kvcache-ai/Mooncake)，FlexKV 支持基于 RDMA 的高性能跨节点 [分布式 KVCache 复用](docs/dist_reuse/README_zh.md)。
 
 - **2026 年 1 月**：新增 TensorRT-LLM 支持（[#48](https://github.com/taco-project/FlexKV/pull/48)），vLLM 和 TRT-LLM 均支持 TP16（[#53](https://github.com/taco-project/FlexKV/pull/53)、[#59](https://github.com/taco-project/FlexKV/pull/59)）。

--- a/docs/vllm_adapter/README_en.md
+++ b/docs/vllm_adapter/README_en.md
@@ -1,13 +1,23 @@
 # Using FlexKV in vLLM
 
+## 🎉 Important Update (March 17, 2026)
+
+**FlexKV has been officially merged into the vLLM mainline on March 17, 2026 (PR [#34328](https://github.com/vllm-project/vllm/pull/34328)).**
+
+Starting from **vLLM v0.17.2rc0** (commit [`8cb24d3`](https://github.com/vllm-project/vllm/commit/8cb24d3aedb9f431fb15a636a3e11a00262f5991)), `FlexKVConnectorV1` is built into vLLM — **no patch is needed anymore**.
+
+> **Recommended**: Install vLLM >= v0.17.2 (stable release) or build from the latest `main` branch directly. The patch files under `examples/vllm_adaption/` are retained for users who need to use vLLM < 0.17.2.
+
+---
+
 ## Current Version vs. Legacy Version
 In commit [`0290841dce65ae9b036a23d733cf94e47e814934`](https://github.com/taco-project/FlexKV/commit/0290841dce65ae9b036a23d733cf94e47e814934), we introduced a major update:  
 **FlexKV has transitioned from a client-server architecture to a library function that inference acceleration engines (such as vLLM) can directly invoke**, reducing inter-process communication overhead.
 
 This change involves significant API adjustments. Therefore, please note:
 
-- **Version >= `1.0.0`**: Use the **current version API**; the vLLM patch is located in `examples/vllm_adaption/`.
-- **Version == `0.1.0`**: Supports the **legacy version API**; the vLLM patch is located in `examples/vllm_adaption_legacy/`.
+- **Version >= `1.0.0`**: Use the **current version API**.
+- **Version == `0.1.0`**: Supports the **legacy version API** only; the vLLM patch is located in `examples/vllm_adaption_legacy/`.
 
 ---
 
@@ -15,7 +25,8 @@ This change involves significant API adjustments. Therefore, please note:
 
 ### Supported Versions
 - FlexKV >= `1.0.0`
-- vLLM versions >= `0.8.5` can generally follow the example code for adaptation
+- **vLLM >= `0.17.2` (recommended)**: FlexKVConnectorV1 is built in — no patch required
+- vLLM `0.10.1` ~ `0.17.1`: Manual patch required, see [Using Older vLLM (Patch Required)](#using-older-vllm-patch-required)
 
 ### Configuration
 
@@ -40,23 +51,27 @@ export FLEXKV_CONFIG_PATH="./flexkv_config.yml"
 
 > Note: The `flexkv_config.yml` configuration is provided as a simple example only. For full parameter options, please refer to [`docs/flexkv_config_reference/README_en.md`](../../docs/flexkv_config_reference/README_en.md)
 
-### Running
-We provide an adaptation example based on **vLLM 0.10.1.1**:
+### Running (Recommended: vLLM >= 0.17.2, No Patch Needed)
 
-1. apply patch && installation
+1. Install vLLM (>= 0.17.2 stable, or build from official `main` branch)
 ```bash
-cd vllm
-git apply FLEXKV_DIR/examples/vllm_adaption/vllm_0_10_1_1-flexkv-connector.patch
-pip install -e . # build and install vllm from source
+pip install vllm>=0.17.2
+# Or install from source (latest main):
+# git clone https://github.com/vllm-project/vllm.git && cd vllm && pip install -e .
 ```
 
-2. offline test
+2. Install FlexKV
+```bash
+pip install flexkv  # or build from source: ./build.sh
+```
+
+3. offline test
 ```bash
 # VLLM_DIR/examples/offline_inference/prefix_caching_flexkv.py
 python examples/offline_inference/prefix_caching_flexkv.py
 ```
 
-3. online serving
+4. online serving
 ```bash
 VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
      --tensor-parallel-size 8 \
@@ -71,8 +86,25 @@ VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
      --enable-prefix-caching \
      --kv-transfer-config \
         '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
-
 ```
+
+### Using Older vLLM (Patch Required)
+
+If you need to use FlexKV with vLLM < 0.17.2, apply the corresponding patch manually:
+
+| vLLM Version | Patch File |
+|---|---|
+| 0.10.1.1 | `examples/vllm_adaption/vllm_0_10_1_1-flexkv-connector.patch` |
+| 0.14.1+ | `examples/vllm_adaption/vllm_up_0_14_1-flexkv-connector.patch` |
+| 0.16.0 | `examples/vllm_adaption/vllm_0_16_0-flexkv-connector.patch` |
+
+```bash
+cd vllm
+git apply FLEXKV_DIR/examples/vllm_adaption/<patch-file>
+pip install -e .
+```
+
+---
 
 ## Legacy Version (<= 0.1.0) – Not Recommended for Current Use
 

--- a/docs/vllm_adapter/README_zh.md
+++ b/docs/vllm_adapter/README_zh.md
@@ -1,11 +1,22 @@
 # 在 vLLM 中使用 FlexKV
 
+## 🎉 重要更新（2026年3月17日）
+
+**FlexKV 已于 2026 年 3 月 17 日正式合并进入 vLLM 官方主干（PR [#34328](https://github.com/vllm-project/vllm/pull/34328)）。**
+
+从 **vLLM v0.17.2rc0**（commit [`8cb24d3`](https://github.com/vllm-project/vllm/commit/8cb24d3aedb9f431fb15a636a3e11a00262f5991)）起，`FlexKVConnectorV1` 已内置于 vLLM，**无需再手动打 patch**。
+
+> **推荐做法**：直接安装 vLLM >= v0.17.2 正式版（或当前 main 分支），不再需要使用 `examples/vllm_adaption/` 下的 patch 文件。  
+> 旧版 patch 仍保留于 `examples/vllm_adaption/` 目录，供需要使用 vLLM < 0.17.2 的用户参考。
+
+---
+
 ## 当前版本与 Legacy 版本说明
 在 commit [`0290841dce65ae9b036a23d733cf94e47e814934`](https://github.com/taco-project/FlexKV/commit/0290841dce65ae9b036a23d733cf94e47e814934)，我们更新了一个重要功能：
  **FlexKV 从 client-server 模式，变为推理加速引擎（如 vLLM）可直接调用的库函数**，以减少进程间消息传递的开销。
 这一变更引发了较大的 API 调整。因此，请注意：
 
-- **版本 >= `1.0.0`**：应使用 **当前版本 API**，vLLM patch位于 `examples/vllm_adaption/`。
+- **版本 >= `1.0.0`**：应使用 **当前版本 API**。
 - **版本 == `0.1.0`**：仅支持 **Legacy 版本 API**, vLLM patch位于`examples/vllm_adaption_legacy/`。
 
 ---
@@ -14,7 +25,8 @@
 
 ### 适用版本
 - FlexKV >= `1.0.0`
-- vLLM 原则上>= `0.8.5`版本均可参考示例代码进行修改
+- **vLLM >= `0.17.2`（推荐）**：内置 FlexKVConnectorV1，无需打 patch，直接使用
+- vLLM `0.10.1` ~ `0.17.1`：需手动 apply patch，参见[使用旧版 vLLM（需 patch）](#使用旧版-vllm需-patch)
 
 ### 配置
 
@@ -39,23 +51,27 @@ export FLEXKV_CONFIG_PATH="./flexkv_config.yml"
 
 > 注：`flexkv_config.yml`配置仅为简单示例，选项请参考[`docs/flexkv_config_reference/README_zh.md`](../../docs/flexkv_config_reference/README_zh.md)
 
-### 运行
-我们提供了基于 **vLLM 0.10.1.1** 的适配示例：
+### 运行（推荐：vLLM >= 0.17.2，无需 patch）
 
-1. apply patch && installation
+1. 安装 vLLM（>= 0.17.2 正式版，或从官方 main 分支源码安装）
 ```bash
-cd vllm
-git apply FLEXKV_DIR/examples/vllm_adaption/vllm_0_10_1_1-flexkv-connector.patch
-pip install -e . # build and install vllm from source
+pip install vllm>=0.17.2
+# 或从源码安装最新 main 分支：
+# git clone https://github.com/vllm-project/vllm.git && cd vllm && pip install -e .
 ```
 
-2. offline test
+2. 安装 FlexKV
 ```bash
-# VLLM_DIR/examples/offline_inference/prefix_caching_flexkv.py
+pip install flexkv  # 或从源码编译：./build.sh
+```
+
+3. offline test
+```bash
+# 参考 VLLM_DIR/examples/offline_inference/prefix_caching_flexkv.py
 python examples/offline_inference/prefix_caching_flexkv.py
 ```
 
-3. online serving
+4. online serving
 ```bash
 VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
      --tensor-parallel-size 8 \
@@ -70,10 +86,27 @@ VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
      --enable-prefix-caching \
      --kv-transfer-config \
         '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
-
 ```
 
-## Legacy版本（<= 0.1.0）,目前的版本尽量不要使用
+### 使用旧版 vLLM（需 patch）
+
+如需在 vLLM < 0.17.2 上使用 FlexKV，请手动 apply 对应版本的 patch：
+
+| vLLM 版本 | patch 文件 |
+|---|---|
+| 0.10.1.1 | `examples/vllm_adaption/vllm_0_10_1_1-flexkv-connector.patch` |
+| 0.14.1+ | `examples/vllm_adaption/vllm_up_0_14_1-flexkv-connector.patch` |
+| 0.16.0 | `examples/vllm_adaption/vllm_0_16_0-flexkv-connector.patch` |
+
+```bash
+cd vllm
+git apply FLEXKV_DIR/examples/vllm_adaption/<对应patch文件>
+pip install -e .
+```
+
+---
+
+## Legacy版本（<= 0.1.0），目前的版本尽量不要使用
 
 ### 适用版本
 - FlexKV <= `0.1.0`


### PR DESCRIPTION
## Summary

Add `Updates` section to README (Mooncake-style milestone log) and update vLLM adapter docs.

## Changes

### README.md / README_zh.md
- Add `Updates` section:
  - 🎉 Mar 17, 2026: FlexKV → vLLM mainline (PR #34328), no patch from v0.17.2
  - 🎉 Mar 3, 2026: FlexKV → NVIDIA Dynamo mainline (PR #5858)
  - Jan 28, 2026: Mooncake Transfer Engine integration
  - Earlier: TRT-LLM, GDS, v1.0.0 API

### docs/vllm_adapter/README_en.md / README_zh.md
- Add announcement banner for vLLM mainline merge
- Recommend vLLM >= 0.17.2 (no patch) as primary path
- Demote patch-based install to secondary section with version table