### PR TITLE
feat: add MUSA support for FlexKV

### DIFF
--- a/csrc/musa/bindings_musa.cpp
+++ b/csrc/musa/bindings_musa.cpp
@@ -1,0 +1,494 @@
+/*
+ * MUSA bindings for FlexKV — mirrors csrc/bindings.cpp for CUDA.
+ *
+ * When built with MUSA SDK (FLEXKV_HAS_MUSA_SDK defined), calls the real
+ * MUSA transfer kernel via transfer_musa.muh and exposes TPTransferThreadGroupMusa.
+ * Without the SDK, provides a C++-only stub so the extension can still be
+ * imported for testing the dispatch/build path.
+ *
+ * SSD transfer (io_uring/pread/pwrite) and CFS remote transfer are pure CPU
+ * operations shared with the CUDA extension — they are included here so that
+ * a MUSA-only build can work end-to-end.
+ *
+ * GDS uses GDSManagerMusa (muFile) when FLEXKV_ENABLE_GDS and MUSA SDK are
+ * both available.
+ */
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <map>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+#include "../transfer_ssd.h"
+#include "../cache_utils.h"
+#include "../radix_tree.h"
+
+#ifdef FLEXKV_ENABLE_CFS
+#include "../pcfs/pcfs.h"
+#endif
+
+#ifdef FLEXKV_HAS_MUSA_SDK
+#include <musa_runtime.h>
+#include "transfer_musa.muh"
+#include "tp_transfer_thread_group_musa.h"
+
+#ifdef FLEXKV_ENABLE_GDS
+#include "gds/gds_manager_musa.h"
+#include "gds/tp_gds_transfer_thread_group_musa.h"
+#endif
+
+#if __has_include(<torch_musa/csrc/core/MUSAStream.h>)
+#include <torch_musa/csrc/core/MUSAStream.h>
+static musaStream_t get_current_musa_stream() {
+    return c10::musa::getCurrentMUSAStream(-1).stream();
+}
+#else
+static musaStream_t get_current_musa_stream() {
+    return (musaStream_t)0;  /* default stream when torch_musa headers not available */
+}
+#endif
+#else
+#include "gtensor_handler_musa.h"
+#endif
+
+namespace py = pybind11;
+
+// ---------------------------------------------------------------------------
+// GPU-CPU transfer (MUSA kernel or stub)
+// ---------------------------------------------------------------------------
+
+void transfer_kv_blocks_binding_musa(
+    torch::Tensor& gpu_block_id_tensor,
+    torch::Tensor& gpu_tensor_ptrs_tensor,
+    int64_t gpu_kv_stride_in_bytes,
+    int64_t gpu_block_stride_in_bytes,
+    int64_t gpu_layer_stride_in_bytes,
+    torch::Tensor& cpu_block_id_tensor,
+    torch::Tensor& cpu_tensor,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int start_layer_id,
+    int num_layers,
+    int transfer_sms,
+    bool is_host_to_device,
+    bool use_ce_transfer,
+    bool is_mla,
+    int gpu_block_type) {
+
+#ifdef FLEXKV_HAS_MUSA_SDK
+    int num_blocks = gpu_block_id_tensor.numel();
+    int64_t* gpu_block_ids = static_cast<int64_t*>(gpu_block_id_tensor.data_ptr());
+    void** gpu_tensor_ptrs = static_cast<void**>(gpu_tensor_ptrs_tensor.data_ptr());
+    int64_t* cpu_block_ids = static_cast<int64_t*>(cpu_block_id_tensor.data_ptr());
+    void* cpu_ptr = static_cast<void*>(cpu_tensor.data_ptr());
+
+    musaStream_t stream = get_current_musa_stream();
+
+    flexkv::BackendType backend_type;
+    if (gpu_block_type == 0)
+        backend_type = flexkv::BackendType::VLLM;
+    else if (gpu_block_type == 1)
+        backend_type = flexkv::BackendType::TRTLLM;
+    else if (gpu_block_type == 2)
+        backend_type = flexkv::BackendType::SGLANG;
+    else
+        throw std::runtime_error("Unsupported gpu_block_type: " + std::to_string(gpu_block_type));
+
+    flexkv::GTensorHandler handler(
+        backend_type,
+        reinterpret_cast<int64_t**>(gpu_tensor_ptrs),
+        num_layers,
+        gpu_kv_stride_in_bytes,
+        gpu_block_stride_in_bytes,
+        gpu_layer_stride_in_bytes);
+
+    switch (backend_type) {
+        case flexkv::BackendType::VLLM:
+            flexkv::transfer_kv_blocks<flexkv::BackendType::VLLM>(
+                num_blocks, start_layer_id, num_layers, gpu_block_ids, handler, 0,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                cpu_block_stride_in_bytes, 0, chunk_size_in_bytes, stream, transfer_sms,
+                is_host_to_device, use_ce_transfer, is_mla);
+            break;
+        case flexkv::BackendType::TRTLLM:
+            flexkv::transfer_kv_blocks<flexkv::BackendType::TRTLLM>(
+                num_blocks, start_layer_id, num_layers, gpu_block_ids, handler, 0,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                cpu_block_stride_in_bytes, 0, chunk_size_in_bytes, stream, transfer_sms,
+                is_host_to_device, use_ce_transfer, is_mla);
+            break;
+        case flexkv::BackendType::SGLANG:
+            flexkv::transfer_kv_blocks<flexkv::BackendType::SGLANG>(
+                num_blocks, start_layer_id, num_layers, gpu_block_ids, handler, 0,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                cpu_block_stride_in_bytes, 0, chunk_size_in_bytes, stream, transfer_sms,
+                is_host_to_device, use_ce_transfer, is_mla);
+            break;
+    }
+
+    musaError_t err = musaGetLastError();
+    if (err != musaSuccess)
+        throw std::runtime_error(std::string("MUSA transfer error: ") + musaGetErrorString(err));
+#else
+    (void)gpu_block_id_tensor; (void)gpu_tensor_ptrs_tensor;
+    (void)gpu_kv_stride_in_bytes; (void)gpu_block_stride_in_bytes;
+    (void)gpu_layer_stride_in_bytes; (void)cpu_block_id_tensor;
+    (void)cpu_tensor; (void)cpu_kv_stride_in_bytes;
+    (void)cpu_layer_stride_in_bytes; (void)cpu_block_stride_in_bytes;
+    (void)chunk_size_in_bytes; (void)start_layer_id;
+    (void)num_layers; (void)transfer_sms;
+    (void)is_host_to_device; (void)use_ce_transfer;
+    (void)is_mla; (void)gpu_block_type;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// SSD transfer binding (io_uring / pread-pwrite — pure CPU, shared with CUDA)
+// ---------------------------------------------------------------------------
+
+void transfer_kv_blocks_ssd_binding_musa(
+    flexkv::SSDIOCTX& ioctx,
+    const torch::Tensor& cpu_layer_id_list, int64_t cpu_tensor_ptr,
+    const torch::Tensor& ssd_block_ids, const torch::Tensor& cpu_block_ids,
+    int64_t cpu_layer_stride_in_bytes, int64_t cpu_kv_stride_in_bytes,
+    int64_t ssd_layer_stride_in_bytes, int64_t ssd_kv_stride_in_bytes,
+    int64_t chunk_size_in_bytes, int64_t block_stride_in_bytes,
+    bool is_read, int num_blocks_per_file, int round_robin = 1,
+    int num_threads_per_device = 16, bool is_mla = false) {
+
+    TORCH_CHECK(ssd_block_ids.dtype() == torch::kInt64, "ssd_block_ids must be int64");
+    TORCH_CHECK(cpu_block_ids.dtype() == torch::kInt64, "cpu_block_ids must be int64");
+
+    flexkv::transfer_kv_blocks_ssd(
+        ioctx, cpu_layer_id_list, cpu_tensor_ptr, ssd_block_ids,
+        cpu_block_ids, cpu_layer_stride_in_bytes, cpu_kv_stride_in_bytes,
+        ssd_layer_stride_in_bytes, ssd_kv_stride_in_bytes, chunk_size_in_bytes,
+        block_stride_in_bytes, is_read, num_blocks_per_file, round_robin,
+        num_threads_per_device, is_mla);
+}
+
+// ---------------------------------------------------------------------------
+// CFS remote transfer binding (pure CPU, shared with CUDA)
+// ---------------------------------------------------------------------------
+
+#ifdef FLEXKV_ENABLE_CFS
+void transfer_kv_blocks_remote_musa(
+    const py::list& file_nodeid_list, const torch::Tensor& cpu_layer_id_list,
+    int64_t cpu_tensor_ptr, const torch::Tensor& remote_block_ids,
+    const torch::Tensor& cpu_block_ids, int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes, int64_t remote_layer_stride_in_bytes,
+    int64_t remote_block_stride_in_bytes, int64_t remote_kv_stride_in_bytes,
+    int64_t block_size_in_bytes, int64_t total_layers, bool is_read,
+    int partition_block_type, int round_robin,
+    int64_t num_remote_blocks_per_file, bool use_mmap = false,
+    int num_threads_per_file = 8, bool is_mla = false) {
+
+    TORCH_CHECK(remote_block_ids.dtype() == torch::kInt64, "remote_block_ids must be int64");
+    TORCH_CHECK(cpu_block_ids.dtype() == torch::kInt64, "cpu_block_ids must be int64");
+
+    std::vector<std::uint64_t> file_nodeids;
+    for (const auto& file_nodeid : file_nodeid_list) {
+        file_nodeids.push_back(file_nodeid.cast<std::uint64_t>());
+    }
+
+    flexkv::transfer_kv_blocks_cfs_mmap_multi_thread(
+        file_nodeids, cpu_layer_id_list, cpu_tensor_ptr, remote_block_ids,
+        cpu_block_ids, cpu_layer_stride_in_bytes, cpu_kv_stride_in_bytes,
+        remote_layer_stride_in_bytes, remote_block_stride_in_bytes,
+        remote_kv_stride_in_bytes, block_size_in_bytes, total_layers, is_read,
+        partition_block_type, round_robin, num_remote_blocks_per_file, use_mmap,
+        num_threads_per_file, is_mla);
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// GDS MUSA transfer binding (muFile — requires MUSA SDK)
+// ---------------------------------------------------------------------------
+
+#if defined(FLEXKV_HAS_MUSA_SDK) && defined(FLEXKV_ENABLE_GDS)
+void transfer_kv_blocks_gds_binding_musa(
+    GDSManagerMusa& gds_manager,
+    const torch::Tensor& gpu_layer_id_list,
+    const torch::Tensor& gpu_layer_ptrs_tensor,
+    const torch::Tensor& ssd_block_ids,
+    const torch::Tensor& gpu_block_ids,
+    int64_t gpu_kv_stride_in_bytes,
+    int64_t gpu_block_stride_in_bytes,
+    int64_t gpu_layer_stride_in_bytes,
+    int64_t ssd_layer_stride_in_bytes,
+    int64_t ssd_block_stride_in_bytes,
+    int64_t ssd_kv_stride_in_bytes,
+    int64_t block_size_in_bytes,
+    int64_t ssd_copy_off_inside_chunks,
+    int num_blocks_per_file,
+    int64_t total_layers,
+    bool is_read,
+    bool verbose = false,
+    bool is_mla = false,
+    int gpu_block_type = 0,
+    int gpu_device_id = 0) {
+
+    TORCH_CHECK(gpu_layer_ptrs_tensor.dtype() == torch::kInt64, "gpu_layer_ptrs must be int64");
+    TORCH_CHECK(ssd_block_ids.dtype() == torch::kInt64, "ssd_block_ids must be int64");
+    TORCH_CHECK(gpu_block_ids.dtype() == torch::kInt64, "gpu_block_ids must be int64");
+    TORCH_CHECK(gpu_layer_id_list.dtype() == torch::kInt32, "gpu_layer_id_list must be int32");
+
+    flexkv::BackendType backend_type;
+    if (gpu_block_type == 0) backend_type = flexkv::BackendType::VLLM;
+    else if (gpu_block_type == 1) backend_type = flexkv::BackendType::TRTLLM;
+    else if (gpu_block_type == 2) backend_type = flexkv::BackendType::SGLANG;
+    else throw std::runtime_error("Unsupported gpu_block_type: " + std::to_string(gpu_block_type));
+
+    void** gpu_tensor_ptrs = static_cast<void**>(gpu_layer_ptrs_tensor.data_ptr());
+    flexkv::GTensorHandler handler(
+        backend_type,
+        reinterpret_cast<int64_t**>(gpu_tensor_ptrs),
+        total_layers,
+        gpu_kv_stride_in_bytes,
+        gpu_block_stride_in_bytes,
+        gpu_layer_stride_in_bytes);
+
+    switch (backend_type) {
+        case flexkv::BackendType::VLLM:
+            flexkv::transfer_kv_blocks_gds_musa<flexkv::BackendType::VLLM>(
+                gds_manager, gpu_layer_id_list, handler, ssd_block_ids, gpu_block_ids,
+                ssd_layer_stride_in_bytes, ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes,
+                block_size_in_bytes, ssd_copy_off_inside_chunks, ssd_block_stride_in_bytes,
+                gpu_device_id, num_blocks_per_file, total_layers, is_read, verbose, is_mla);
+            break;
+        case flexkv::BackendType::TRTLLM:
+            flexkv::transfer_kv_blocks_gds_musa<flexkv::BackendType::TRTLLM>(
+                gds_manager, gpu_layer_id_list, handler, ssd_block_ids, gpu_block_ids,
+                ssd_layer_stride_in_bytes, ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes,
+                block_size_in_bytes, ssd_copy_off_inside_chunks, ssd_block_stride_in_bytes,
+                gpu_device_id, num_blocks_per_file, total_layers, is_read, verbose, is_mla);
+            break;
+        case flexkv::BackendType::SGLANG:
+            flexkv::transfer_kv_blocks_gds_musa<flexkv::BackendType::SGLANG>(
+                gds_manager, gpu_layer_id_list, handler, ssd_block_ids, gpu_block_ids,
+                ssd_layer_stride_in_bytes, ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes,
+                block_size_in_bytes, ssd_copy_off_inside_chunks, ssd_block_stride_in_bytes,
+                gpu_device_id, num_blocks_per_file, total_layers, is_read, verbose, is_mla);
+            break;
+    }
+}
+#endif
+
+// ===========================================================================
+// Module definition
+// ===========================================================================
+
+PYBIND11_MODULE(c_ext_musa, m) {
+    // --- GPU-CPU transfer ---
+    m.def("transfer_kv_blocks", &transfer_kv_blocks_binding_musa,
+          "Transfer multi-layer KV-cache between CPU and GPU (MUSA)",
+          py::arg("gpu_block_id_tensor"), py::arg("gpu_tensor_ptrs_tensor"),
+          py::arg("gpu_kv_stride_in_bytes"), py::arg("gpu_block_stride_in_bytes"),
+          py::arg("gpu_layer_stride_in_bytes"), py::arg("cpu_block_id_tensor"),
+          py::arg("cpu_tensor"), py::arg("cpu_kv_stride_in_bytes"),
+          py::arg("cpu_layer_stride_in_bytes"), py::arg("cpu_block_stride_in_bytes"),
+          py::arg("chunk_size_in_bytes"), py::arg("start_layer_id"),
+          py::arg("num_layers"), py::arg("transfer_sms") = -1,
+          py::arg("is_host_to_device") = true, py::arg("use_ce_transfer") = false,
+          py::arg("is_mla") = false, py::arg("gpu_block_type") = 0);
+
+    // --- SSD transfer (io_uring / pread-pwrite) ---
+    m.def("transfer_kv_blocks_ssd", &transfer_kv_blocks_ssd_binding_musa,
+          "Transfer KV blocks between SSD and CPU memory (shared with CUDA)",
+          py::arg("ioctx"), py::arg("cpu_layer_id_list"),
+          py::arg("cpu_tensor_ptr"), py::arg("ssd_block_ids"),
+          py::arg("cpu_block_ids"), py::arg("cpu_layer_stride_in_bytes"),
+          py::arg("cpu_kv_stride_in_bytes"), py::arg("ssd_layer_stride_in_bytes"),
+          py::arg("ssd_kv_stride_in_bytes"), py::arg("chunk_size_in_bytes"),
+          py::arg("block_stride_in_bytes"), py::arg("is_read"),
+          py::arg("num_blocks_per_file"), py::arg("round_robin") = 1,
+          py::arg("num_threads_per_device") = 16, py::arg("is_mla") = false);
+
+    // --- SSD I/O context ---
+    py::class_<flexkv::SSDIOCTX>(m, "SSDIOCTX")
+        .def(py::init<std::map<int, std::vector<std::string>>&, int, int, int>());
+
+    // --- Hash utilities ---
+    m.def("get_hash_size", &flexkv::get_hash_size, "Get the size of the hash result");
+    m.def("gen_hashes", &flexkv::gen_hashes, "Generate hashes for a tensor",
+          py::arg("hasher"), py::arg("token_ids"), py::arg("tokens_per_block"),
+          py::arg("block_hashes"));
+
+    py::class_<flexkv::Hasher>(m, "Hasher")
+        .def(py::init<>())
+        .def("reset", &flexkv::Hasher::reset)
+        .def("update",
+             py::overload_cast<const torch::Tensor&>(&flexkv::Hasher::update),
+             "Update the hasher with a tensor", py::arg("input"))
+        .def("update",
+             py::overload_cast<const void*, size_t>(&flexkv::Hasher::update),
+             "Update the hasher with pointer and size", py::arg("input"),
+             py::arg("size"))
+        .def("digest", &flexkv::Hasher::digest, "Return the hash value");
+
+    // --- Radix tree index (mirrors CUDA bindings) ---
+    py::class_<flexkv::CRadixTreeIndex>(m, "CRadixTreeIndex")
+        .def(py::init([](int tokens_per_block, unsigned int max_num_blocks, int hit_reward_seconds, std::string eviction_policy) {
+             auto policy = flexkv::parse_eviction_policy(eviction_policy);
+             return new flexkv::CRadixTreeIndex(tokens_per_block, max_num_blocks, hit_reward_seconds, policy);
+        }),
+             py::arg("tokens_per_block"),
+             py::arg("max_num_blocks") = 1000000,
+             py::arg("hit_reward_seconds") = 0,
+             py::arg("eviction_policy") = "lru")
+        .def("is_empty", &flexkv::CRadixTreeIndex::is_empty)
+        .def("reset", &flexkv::CRadixTreeIndex::reset)
+        .def("lock", &flexkv::CRadixTreeIndex::lock, py::arg("node"))
+        .def("unlock", &flexkv::CRadixTreeIndex::unlock, py::arg("node"))
+        .def("set_ready", &flexkv::CRadixTreeIndex::set_ready,
+             py::arg("node"), py::arg("ready"), py::arg("ready_length"))
+        .def("insert", &flexkv::CRadixTreeIndex::insert, py::return_value_policy::reference,
+             py::arg("physical_block_ids"), py::arg("block_hashes"), py::arg("num_blocks"),
+             py::arg("num_insert_blocks"), py::arg("ready") = true, py::arg("node") = nullptr,
+             py::arg("num_matched_blocks") = -1, py::arg("last_node_matched_length") = -1,
+             py::call_guard<py::gil_scoped_release>())
+        .def("evict",
+             py::overload_cast<torch::Tensor &, int>(&flexkv::CRadixTreeIndex::evict),
+             py::arg("evicted_blocks"), py::arg("num_evicted"),
+             py::call_guard<py::gil_scoped_release>())
+        .def("evict",
+             py::overload_cast<torch::Tensor &, torch::Tensor &, int>(&flexkv::CRadixTreeIndex::evict),
+             py::arg("evicted_blocks"), py::arg("evicted_block_hashes"), py::arg("num_evicted"),
+             py::call_guard<py::gil_scoped_release>())
+        .def("total_cached_blocks", &flexkv::CRadixTreeIndex::total_cached_blocks)
+        .def("total_unready_blocks", &flexkv::CRadixTreeIndex::total_unready_blocks)
+        .def("total_ready_blocks", &flexkv::CRadixTreeIndex::total_ready_blocks)
+        .def("match_prefix", &flexkv::CRadixTreeIndex::match_prefix,
+             py::arg("block_hashes"), py::arg("num_blocks"), py::arg("update_cache_info"),
+             py::call_guard<py::gil_scoped_release>());
+
+    py::class_<flexkv::CRadixNode>(m, "CRadixNode")
+        .def(py::init<flexkv::CRadixTreeIndex *, bool, int>())
+        .def(py::init<flexkv::CRadixTreeIndex *, bool, int, bool>())
+        .def("size", &flexkv::CRadixNode::size)
+        .def("has_block_node_ids", &flexkv::CRadixNode::has_block_node_ids)
+        .def_property_readonly("parent", &flexkv::CRadixNode::get_parent, py::return_value_policy::reference);
+
+    py::class_<flexkv::CMatchResult, std::shared_ptr<flexkv::CMatchResult>>(m, "CMatchResult")
+        .def(py::init<int, int, int, flexkv::CRadixNode *, flexkv::CRadixNode *, torch::Tensor, torch::Tensor>())
+        .def_readonly("last_ready_node", &flexkv::CMatchResult::last_ready_node)
+        .def_readonly("last_node", &flexkv::CMatchResult::last_node)
+        .def_readonly("physical_blocks", &flexkv::CMatchResult::physical_blocks)
+        .def_readonly("block_node_ids", &flexkv::CMatchResult::block_node_ids)
+        .def_readonly("num_ready_matched_blocks", &flexkv::CMatchResult::num_ready_matched_blocks)
+        .def_readonly("num_matched_blocks", &flexkv::CMatchResult::num_matched_blocks)
+        .def_readonly("last_node_matched_length", &flexkv::CMatchResult::last_node_matched_length);
+
+    // --- CFS remote transfer ---
+#ifdef FLEXKV_ENABLE_CFS
+    m.def("transfer_kv_blocks_remote", &transfer_kv_blocks_remote_musa,
+          "Transfer KV blocks between remote and CPU memory",
+          py::arg("file_nodeid_list"), py::arg("cpu_layer_id_list"),
+          py::arg("cpu_tensor_ptr"), py::arg("remote_block_ids"),
+          py::arg("cpu_block_ids"), py::arg("cpu_layer_stride_in_bytes"),
+          py::arg("cpu_kv_stride_in_bytes"),
+          py::arg("remote_layer_stride_in_bytes"),
+          py::arg("remote_block_stride_in_bytes"),
+          py::arg("remote_kv_stride_in_bytes"), py::arg("block_size_in_bytes"),
+          py::arg("total_layers"), py::arg("is_read"),
+          py::arg("partition_block_type"), py::arg("round_robin"),
+          py::arg("num_remote_blocks_per_file"), py::arg("use_mmap") = false,
+          py::arg("num_threads_per_file") = 16, py::arg("is_mla") = false);
+
+    py::class_<flexkv::Pcfs>(m, "Pcfs")
+        .def(py::init<const std::string&, uint32_t, const std::string&, bool,
+                      const uint64_t>())
+        .def("init", &flexkv::Pcfs::init)
+        .def("destroy", &flexkv::Pcfs::destroy)
+        .def("lookup_or_create_file", &flexkv::Pcfs::lookup_or_create_file,
+             py::arg("filename"), py::arg("file_size"), py::arg("need_create"),
+             py::call_guard<py::gil_scoped_release>())
+        .def("open", &flexkv::Pcfs::open)
+        .def("close", &flexkv::Pcfs::close)
+        .def("write", &flexkv::Pcfs::write)
+        .def("read", &flexkv::Pcfs::read);
+
+    m.def("set_pcfs_instance", &flexkv::set_pcfs_instance,
+          "Set the global Pcfs instance from a pointer", py::arg("pcfs"));
+    m.def("call_pcfs_read", &flexkv::call_pcfs_read, "Call Pcfs::read from C++",
+          py::arg("file_nodeid"), py::arg("offset"), py::arg("buffer"),
+          py::arg("size"), py::arg("thread_id"));
+    m.def("call_pcfs_write", &flexkv::call_pcfs_write, "Call Pcfs::write from C++",
+          py::arg("file_nodeid"), py::arg("offset"), py::arg("buffer"),
+          py::arg("size"), py::arg("thread_id"));
+#endif
+
+    // --- GPU-CPU TP transfer ---
+#ifdef FLEXKV_HAS_MUSA_SDK
+    m.attr("HAS_MUSA_SDK") = true;
+
+    py::class_<flexkv::TPTransferThreadGroupMusa>(m, "TPTransferThreadGroupMusa")
+        .def(py::init<int, const std::vector<std::vector<torch::Tensor>>&,
+                      torch::Tensor&, int, int,
+                      torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&>(),
+             py::arg("num_gpus"), py::arg("gpu_blocks"), py::arg("cpu_blocks"),
+             py::arg("dp_group_id"), py::arg("num_layers"),
+             py::arg("gpu_kv_strides_tensor"), py::arg("gpu_block_strides_tensor"),
+             py::arg("gpu_layer_strides_tensor"), py::arg("gpu_chunk_sizes_tensor"))
+        .def("tp_group_transfer",
+             &flexkv::TPTransferThreadGroupMusa::tp_group_transfer,
+             py::arg("gpu_block_id_tensor"), py::arg("cpu_block_id_tensor"),
+             py::arg("cpu_kv_stride_in_bytes"),
+             py::arg("cpu_layer_stride_in_bytes"),
+             py::arg("cpu_block_stride_in_bytes"),
+             py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_sms"),
+             py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
+             py::arg("layer_id"), py::arg("layer_granularity"),
+             py::arg("is_mla"));
+
+    // --- GDS (muFile) ---
+#ifdef FLEXKV_ENABLE_GDS
+    m.def("transfer_kv_blocks_gds", &transfer_kv_blocks_gds_binding_musa,
+          "Transfer KV blocks between GPU and GDS storage (MUSA/muFile)",
+          py::arg("gds_manager"), py::arg("gpu_layer_id_list"),
+          py::arg("gpu_layer_ptrs_tensor"), py::arg("ssd_block_ids"),
+          py::arg("gpu_block_ids"), py::arg("gpu_kv_stride_in_bytes"),
+          py::arg("gpu_block_stride_in_bytes"), py::arg("gpu_layer_stride_in_bytes"),
+          py::arg("ssd_layer_stride_in_bytes"), py::arg("ssd_block_stride_in_bytes"),
+          py::arg("ssd_kv_stride_in_bytes"), py::arg("block_size_in_bytes"),
+          py::arg("ssd_copy_off_inside_chunks"), py::arg("num_blocks_per_file"),
+          py::arg("total_layers"), py::arg("is_read"),
+          py::arg("verbose") = false, py::arg("is_mla") = false,
+          py::arg("gpu_block_type") = 0, py::arg("gpu_device_id") = 0);
+
+    py::class_<GDSManagerMusa>(m, "GDSManagerMusa")
+        .def(py::init<std::map<int, std::vector<std::string>>&, int, int>(),
+             py::arg("ssd_files"), py::arg("num_devices"), py::arg("round_robin") = 1)
+        .def("is_ready", &GDSManagerMusa::is_ready)
+        .def("synchronize", &GDSManagerMusa::synchronize)
+        .def("get_last_error", &GDSManagerMusa::get_last_error);
+
+    py::class_<flexkv::TPGDSTransferThreadGroupMusa>(m, "TPGDSTransferThreadGroupMusa")
+        .def(py::init<int, const std::vector<std::vector<torch::Tensor>>&,
+                      std::map<int, std::vector<std::string>>&, int, int,
+                      torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&>(),
+             py::arg("num_gpus"), py::arg("gpu_blocks"), py::arg("ssd_files"),
+             py::arg("dp_group_id"), py::arg("num_layers"),
+             py::arg("gpu_kv_strides_tensor"), py::arg("gpu_block_strides_tensor"),
+             py::arg("gpu_layer_strides_tensor"), py::arg("gpu_chunk_sizes_tensor"))
+        .def("tp_group_transfer",
+             &flexkv::TPGDSTransferThreadGroupMusa::tp_group_transfer,
+             py::arg("gpu_block_id_tensor"), py::arg("ssd_block_id_tensor"),
+             py::arg("ssd_layer_stride_in_bytes"),
+             py::arg("ssd_kv_stride_in_bytes"), py::arg("ssd_block_stride_in_bytes"),
+             py::arg("ssd_tp_stride_in_bytes"), py::arg("num_blocks_per_file"),
+             py::arg("is_read"), py::arg("layer_id"), py::arg("layer_granularity"),
+             py::arg("is_mla"));
+#endif  // FLEXKV_ENABLE_GDS
+
+#else
+    m.attr("HAS_MUSA_SDK") = false;
+#endif  // FLEXKV_HAS_MUSA_SDK
+}
+

--- a/csrc/musa/gds/gds_manager_musa.cpp
+++ b/csrc/musa/gds/gds_manager_musa.cpp
@@ -1,0 +1,602 @@
+/*
+ * GDS Manager for MUSA — mirrors csrc/gds/gds_manager.cpp.
+ * Uses muFile APIs (muFileDriverOpen, muFileRead, muFileWrite, etc.)
+ * and musa* runtime APIs (musaStream_t, musaMalloc, musaSetDevice, etc.).
+ * Compile/link when MUSA SDK and muFile are available.
+ */
+#include "gds_manager_musa.h"
+#include "layout_transform_musa.muh"
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <cerrno>
+#include <mufile.h>
+#include <vector>
+#include <map>
+#include <sys/stat.h>
+
+GDSManagerMusa::GDSManagerMusa(std::map<int, std::vector<std::string>>& ssd_files,
+                               int num_devices,
+                               int round_robin)
+    : is_ready_(false), num_devices_(num_devices),
+      round_robin_(round_robin),
+      driver_initialized_(false), next_batch_id_(1), stop_workers_(false), num_worker_threads_(0)
+{
+    if (!initialize_driver()) {
+        return;
+    }
+
+    musaError_t musa_status = musaStreamCreate(&shared_stream_);
+    if (musa_status != musaSuccess) {
+        set_error("Failed to create shared MUSA stream");
+        return;
+    }
+
+    initialize_worker_threads();
+
+    this->num_files_per_device_ = ssd_files[0].size();
+
+    file_paths_.resize(num_devices);
+    for (const auto& kv : ssd_files) {
+        int device_id = kv.first;
+        file_paths_[device_id] = kv.second;
+
+        for (const auto& filename : kv.second) {
+            add_file(filename.c_str());
+        }
+    }
+
+    is_ready_ = true;
+    set_error("GDS Manager (MUSA) initialized successfully");
+}
+
+GDSManagerMusa::~GDSManagerMusa() {
+    shutdown_worker_threads();
+    cleanup();
+}
+
+bool GDSManagerMusa::is_ready() const { return is_ready_; }
+const std::string& GDSManagerMusa::get_last_error() const { return last_error_; }
+int GDSManagerMusa::get_num_devices() const { return num_devices_; }
+int GDSManagerMusa::get_num_files_per_device() const { return num_files_per_device_; }
+int GDSManagerMusa::get_round_robin() const { return round_robin_; }
+int GDSManagerMusa::get_num_worker_threads() const { return num_worker_threads_; }
+void GDSManagerMusa::set_error(const std::string& error) { last_error_ = error; }
+
+bool GDSManagerMusa::initialize_driver() {
+    if (driver_initialized_) {
+        return true;
+    }
+
+    MUfileError_t status = muFileDriverOpen();
+    if (status.err == 0) {
+        driver_initialized_ = true;
+        return true;
+    } else {
+        set_error("Failed to initialize muFile driver");
+        return false;
+    }
+}
+
+bool GDSManagerMusa::add_file(const char* filename) {
+    if (!filename) {
+        set_error("Invalid filename");
+        return false;
+    }
+    return open_file_internal(filename);
+}
+
+bool GDSManagerMusa::remove_file(const char* filename) {
+    if (!filename) {
+        set_error("Invalid filename");
+        return false;
+    }
+    close_file_internal(filename);
+    return true;
+}
+
+bool GDSManagerMusa::open_file_internal(const char* filename) {
+    std::string file_key(filename);
+
+    if (file_resources_.find(file_key) != file_resources_.end()) {
+        return true;
+    }
+
+    FileResource resource;
+    resource.filepath = filename;
+
+    resource.fd = open(filename, O_CREAT | O_RDWR | O_DIRECT, 0644);
+    if (resource.fd < 0) {
+        set_error("Failed to open file: " + file_key);
+        return false;
+    }
+
+    MUfileDescr_t mf_descr;
+    memset(&mf_descr, 0, sizeof(mf_descr));
+    mf_descr.handle.fd = resource.fd;
+    mf_descr.type = MU_FILE_HANDLE_TYPE_OPAQUE_FD;
+
+    MUfileError_t status = muFileHandleRegister(&resource.mf_handle, &mf_descr);
+    if (status.err != 0) {
+        close(resource.fd);
+        set_error("Failed to register file with muFile: " + file_key);
+        return false;
+    }
+
+    file_resources_[file_key] = resource;
+    return true;
+}
+
+void GDSManagerMusa::close_file_internal(const char* filename) {
+    std::string file_key(filename);
+    auto it = file_resources_.find(file_key);
+    if (it != file_resources_.end()) {
+        FileResource& resource = it->second;
+        muFileHandleDeregister(resource.mf_handle);
+        if (resource.fd >= 0) {
+            close(resource.fd);
+        }
+        file_resources_.erase(it);
+    }
+}
+
+GDSManagerMusa::FileResource* GDSManagerMusa::get_or_create_file_resource(const char* filename) {
+    std::string file_key(filename);
+    auto it = file_resources_.find(file_key);
+
+    if (it != file_resources_.end()) {
+        return &(it->second);
+    }
+
+    if (open_file_internal(filename)) {
+        it = file_resources_.find(file_key);
+        if (it != file_resources_.end()) {
+            return &(it->second);
+        }
+    }
+
+    return nullptr;
+}
+
+void GDSManagerMusa::cleanup() {
+    if (is_ready_) {
+        musaStreamSynchronize(shared_stream_);
+    }
+
+    for (auto& pair : batch_info_) {
+        muFileBatchIODestroy(static_cast<MUfileBatchHandle_t>(pair.second.batch_handle));
+    }
+    batch_info_.clear();
+
+    for (auto& pair : file_resources_) {
+        FileResource& resource = pair.second;
+        muFileHandleDeregister(resource.mf_handle);
+        if (resource.fd >= 0) {
+            close(resource.fd);
+        }
+    }
+    file_resources_.clear();
+
+    if (is_ready_) {
+        musaStreamDestroy(shared_stream_);
+    }
+    is_ready_ = false;
+}
+
+size_t GDSManagerMusa::get_file_count() const {
+    return file_resources_.size();
+}
+
+const std::vector<std::string>& GDSManagerMusa::get_file_paths(int device_id) const {
+    return file_paths_[device_id];
+}
+
+void GDSManagerMusa::synchronize() {
+    if (is_ready_) {
+        musaStreamSynchronize(shared_stream_);
+    }
+}
+
+musaStream_t GDSManagerMusa::get_stream() const {
+    return is_ready_ ? shared_stream_ : nullptr;
+}
+
+void GDSManagerMusa::initialize_worker_threads() {
+    unsigned int hw_threads = std::thread::hardware_concurrency();
+    num_worker_threads_ = std::min(hw_threads > 0 ? hw_threads : 8, 16u);
+
+    stop_workers_ = false;
+    worker_threads_.reserve(num_worker_threads_);
+
+    for (int i = 0; i < num_worker_threads_; ++i) {
+        worker_threads_.emplace_back([this]() {
+            while (true) {
+                Task task;
+                {
+                    std::unique_lock<std::mutex> lock(queue_mutex_);
+                    queue_cv_.wait(lock, [this]{
+                        return stop_workers_ || !task_queue_.empty();
+                    });
+                    if (stop_workers_ && task_queue_.empty()) {
+                        return;
+                    }
+                    task = std::move(task_queue_.front());
+                    task_queue_.pop();
+                }
+                task();
+            }
+        });
+    }
+}
+
+void GDSManagerMusa::shutdown_worker_threads() {
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        stop_workers_ = true;
+    }
+    queue_cv_.notify_all();
+    for (auto& thread : worker_threads_) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+    worker_threads_.clear();
+}
+
+std::future<void> GDSManagerMusa::enqueue_task(std::function<void()> task) {
+    auto pkg = std::make_shared<std::packaged_task<void()>>(std::move(task));
+    std::future<void> fut = pkg->get_future();
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        task_queue_.emplace([pkg]() { (*pkg)(); });
+    }
+    queue_cv_.notify_one();
+    return fut;
+}
+
+ssize_t GDSManagerMusa::write(const char* filename, const void* gpu_data, size_t size, size_t file_offset) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    FileResource* resource = get_or_create_file_resource(filename);
+    if (!resource) { set_error("Failed to get or create resource for file: " + std::string(filename)); return -1; }
+    ssize_t bytes_written = muFileWrite(resource->mf_handle, gpu_data, size, file_offset, 0);
+    if (bytes_written < 0) { set_error("muFileWrite failed for file: " + std::string(filename)); return -1; }
+    return bytes_written;
+}
+
+ssize_t GDSManagerMusa::read(const char* filename, void* gpu_buffer, size_t size, size_t file_offset) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    FileResource* resource = get_or_create_file_resource(filename);
+    if (!resource) { set_error("Failed to get or create resource for file: " + std::string(filename)); return -1; }
+    ssize_t bytes_read = muFileRead(resource->mf_handle, gpu_buffer, size, file_offset, 0);
+    if (bytes_read < 0) { set_error("muFileRead failed for file: " + std::string(filename)); return -1; }
+    return bytes_read;
+}
+
+ssize_t GDSManagerMusa::write_async(const char* filename, void* gpu_data, size_t size, size_t file_offset) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    FileResource* resource = get_or_create_file_resource(filename);
+    if (!resource) { set_error("Failed to get or create resource for file: " + std::string(filename)); return -1; }
+
+    size_t write_size = size;
+    off_t write_offset = file_offset;
+    off_t buffer_offset = 0;
+    ssize_t bytes_written = 0;
+
+    MUfileError_t status = muFileWriteAsync(resource->mf_handle, gpu_data,
+                                            &write_size, &write_offset, &buffer_offset,
+                                            &bytes_written, shared_stream_);
+    if (status.err != 0) { set_error("muFileWriteAsync failed for file: " + std::string(filename)); return -1; }
+    return bytes_written;
+}
+
+ssize_t GDSManagerMusa::read_async(const char* filename, void* gpu_buffer, size_t size, size_t file_offset) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    FileResource* resource = get_or_create_file_resource(filename);
+    if (!resource) { set_error("Failed to get or create resource for file: " + std::string(filename)); return -1; }
+
+    size_t read_size = size;
+    off_t read_offset = file_offset;
+    off_t buffer_offset = 0;
+    ssize_t bytes_read = 0;
+
+    MUfileError_t status = muFileReadAsync(resource->mf_handle, gpu_buffer,
+                                           &read_size, &read_offset, &buffer_offset,
+                                           &bytes_read, shared_stream_);
+    if (status.err != 0) { set_error("muFileReadAsync failed for file: " + std::string(filename)); return -1; }
+    return bytes_read;
+}
+
+int GDSManagerMusa::batch_write(const struct BatchWriteOpMusa* operations, int batch_size) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    if (!operations || batch_size <= 0) { set_error("Invalid batch write parameters"); return -1; }
+
+    std::vector<MUfileIOParams_t> io_params(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+        const BatchWriteOpMusa& op = operations[i];
+        if (!op.filename) { if (op.result) *op.result = -1; continue; }
+        FileResource* resource = get_or_create_file_resource(op.filename);
+        if (!resource) { if (op.result) *op.result = -1; continue; }
+
+        io_params[i].mode = MUFILE_BATCH;
+        io_params[i].fh = resource->mf_handle;
+        io_params[i].u.batch.devPtr_base = const_cast<void*>(op.gpu_data);
+        io_params[i].u.batch.devPtr_offset = 0;
+        io_params[i].u.batch.file_offset = op.file_offset;
+        io_params[i].u.batch.size = op.size;
+        io_params[i].opcode = MUFILE_WRITE;
+    }
+
+    MUfileBatchHandle_t batch_handle;
+    MUfileError_t error = muFileBatchIOSetUp(&batch_handle, batch_size);
+    if (error.err != 0) { set_error("muFileBatchIOSetUp failed for batch write"); return -1; }
+
+    unsigned int flags = 0;
+    MUfileError_t status = muFileBatchIOSubmit(batch_handle, batch_size, io_params.data(), flags);
+    if (status.err != 0) { set_error("muFileBatchIOSubmit failed for batch write"); return -1; }
+
+    int batch_id = next_batch_id_++;
+    BatchInfo batch_info;
+    batch_info.batch_handle = static_cast<void*>(batch_handle);
+    batch_info.batch_size = batch_size;
+    batch_info_[batch_id] = batch_info;
+    return batch_id;
+}
+
+int GDSManagerMusa::batch_synchronize(int batch_id) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    auto it = batch_info_.find(batch_id);
+    if (it == batch_info_.end()) { set_error("Invalid batch ID"); return -1; }
+
+    BatchInfo& batch_info = it->second;
+    MUfileBatchHandle_t batch_handle = static_cast<MUfileBatchHandle_t>(batch_info.batch_handle);
+
+    unsigned int num_completed = 0;
+    unsigned int nr = 0;
+    std::vector<MUfileIOEvents_t> io_events(batch_info.batch_size);
+
+    while (num_completed != static_cast<unsigned int>(batch_info.batch_size)) {
+        memset(io_events.data(), 0, io_events.size() * sizeof(MUfileIOEvents_t));
+        nr = static_cast<unsigned int>(batch_info.batch_size);
+        MUfileError_t status = muFileBatchIOGetStatus(batch_handle, batch_info.batch_size, &nr, io_events.data(), NULL);
+        if (status.err != 0) {
+            set_error("muFileBatchIOGetStatus failed");
+            muFileBatchIODestroy(batch_handle);
+            batch_info_.erase(it);
+            return -1;
+        }
+        num_completed += nr;
+    }
+    muFileBatchIODestroy(batch_handle);
+    batch_info_.erase(it);
+    return 0;
+}
+
+int GDSManagerMusa::batch_read(const struct BatchReadOpMusa* operations, int batch_size) {
+    if (!is_ready_) { set_error("GDS Manager (MUSA) not ready"); return -1; }
+    if (!operations || batch_size <= 0) { set_error("Invalid batch read parameters"); return -1; }
+
+    std::vector<MUfileIOParams_t> io_params(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+        const BatchReadOpMusa& op = operations[i];
+        if (!op.filename) { if (op.result) *op.result = -1; continue; }
+        FileResource* resource = get_or_create_file_resource(op.filename);
+        if (!resource) { if (op.result) *op.result = -1; continue; }
+
+        io_params[i].mode = MUFILE_BATCH;
+        io_params[i].fh = resource->mf_handle;
+        io_params[i].u.batch.devPtr_base = op.gpu_buffer;
+        io_params[i].u.batch.devPtr_offset = 0;
+        io_params[i].u.batch.file_offset = op.file_offset;
+        io_params[i].u.batch.size = op.size;
+        io_params[i].opcode = MUFILE_READ;
+    }
+
+    MUfileBatchHandle_t batch_handle;
+    MUfileError_t error = muFileBatchIOSetUp(&batch_handle, batch_size);
+    if (error.err != 0) { set_error("muFileBatchIOSetUp failed for batch read"); return -1; }
+    unsigned int flags = 0;
+    MUfileError_t status = muFileBatchIOSubmit(batch_handle, batch_size, io_params.data(), flags);
+    if (status.err != 0) { set_error("muFileBatchIOSubmit failed for batch read"); return -1; }
+
+    int batch_id = next_batch_id_.fetch_add(1);
+    BatchInfo batch_info;
+    batch_info.batch_handle = static_cast<void*>(batch_handle);
+    batch_info.batch_size = batch_size;
+    batch_info_[batch_id] = batch_info;
+    return batch_id;
+}
+
+namespace flexkv {
+
+static void partition_and_remap_blocks_by_device_gds_musa(
+    const int64_t* ssd_block_ids, const int64_t* gpu_block_ids, int num_blocks,
+    int num_devices, int round_robin,
+    std::vector<std::vector<int>>& gpu_blocks_partition,
+    std::vector<std::vector<int>>& ssd_blocks_partition) {
+    for (int i = 0; i < num_blocks; i++) {
+        int64_t ssd_block_id = ssd_block_ids[i];
+        int64_t gpu_block_id = gpu_block_ids[i];
+        int device_id = (ssd_block_id / round_robin) % num_devices;
+        int block_id_in_device =
+            ((ssd_block_id / round_robin) / num_devices) * round_robin +
+            (ssd_block_id % round_robin);
+        ssd_blocks_partition[device_id].push_back(block_id_in_device);
+        gpu_blocks_partition[device_id].push_back(gpu_block_id);
+    }
+}
+
+template<BackendType Type>
+void transfer_kv_blocks_gds_musa(
+    GDSManagerMusa& gds_manager,
+    const torch::Tensor& gpu_layer_id_list,
+    GTensorHandler gpu_tensor_handler,
+    const torch::Tensor& ssd_block_ids,
+    const torch::Tensor& gpu_block_ids,
+    int64_t ssd_layer_stride_in_bytes,
+    int64_t ssd_block_stride_in_bytes,
+    int64_t ssd_kv_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int64_t ssd_copy_off_inside_chunks,
+    int64_t gpu_buffer_size_in_bytes,
+    int gpu_id,
+    int num_blocks_per_file,
+    int64_t total_layers,
+    bool is_read,
+    bool verbose,
+    bool is_mla
+) {
+    if (!gds_manager.is_ready()) {
+        throw std::runtime_error("GDS Manager (MUSA) not ready: " + gds_manager.get_last_error());
+    }
+
+    int num_devices = gds_manager.get_num_devices();
+    int num_files_per_device = gds_manager.get_num_files_per_device();
+    int round_robin = gds_manager.get_round_robin();
+    int num_worker_threads = gds_manager.get_num_worker_threads();
+
+    const int64_t* ssd_block_id_ptr = ssd_block_ids.data_ptr<int64_t>();
+    const int64_t* gpu_block_id_ptr = gpu_block_ids.data_ptr<int64_t>();
+    const int num_layers = gpu_layer_id_list.size(0);
+    const int32_t* gpu_layer_id_list_ptr = gpu_layer_id_list.data_ptr<int32_t>();
+    const int num_transfers = ssd_block_ids.size(0);
+
+    if (num_transfers == 0) return;
+
+    std::vector<std::vector<int>> gpu_blocks_partition(num_devices);
+    std::vector<std::vector<int>> ssd_blocks_partition(num_devices);
+    partition_and_remap_blocks_by_device_gds_musa(
+        ssd_block_id_ptr, gpu_block_id_ptr, num_transfers, num_devices, round_robin,
+        gpu_blocks_partition, ssd_blocks_partition);
+
+    musaSetDevice(gpu_id);
+
+    const int num_slots = std::max(num_worker_threads, 1);
+    void* buffer_ptr = nullptr;
+    const int64_t total_buffer_size = gpu_buffer_size_in_bytes * num_slots;
+
+    musaError_t musa_status = musaMalloc(&buffer_ptr, total_buffer_size);
+    if (musa_status != musaSuccess) {
+        throw std::runtime_error("Failed to allocate GPU buffer: " +
+                                std::string(musaGetErrorString(musa_status)));
+    }
+
+    std::vector<musaStream_t> slot_streams(num_slots);
+    auto slot_mutexes = std::make_unique<std::mutex[]>(num_slots);
+    for (int i = 0; i < num_slots; i++) {
+        musaStreamCreate(&slot_streams[i]);
+    }
+
+    int64_t* d_gpu_block_ids = nullptr;
+    musaError_t malloc_status = musaMalloc(&d_gpu_block_ids, num_slots * sizeof(int64_t));
+    if (malloc_status != musaSuccess) {
+        for (auto& stream : slot_streams) musaStreamDestroy(stream);
+        musaFree(buffer_ptr);
+        throw std::runtime_error("Failed to allocate d_gpu_block_ids");
+    }
+
+    const int64_t buffer_layer_stride = ssd_layer_stride_in_bytes / sizeof(int64_t);
+    const int64_t buffer_kv_stride = ssd_kv_stride_in_bytes / sizeof(int64_t);
+    const int64_t buffer_block_stride = gpu_buffer_size_in_bytes / sizeof(int64_t);
+    const int64_t buffer_chunk_offset = ssd_copy_off_inside_chunks / sizeof(int64_t);
+    const int64_t chunk_size = chunk_size_in_bytes / sizeof(int64_t);
+    const int32_t start_layer = gpu_layer_id_list_ptr[0];
+
+    std::vector<std::future<void>> futures;
+    futures.reserve(num_transfers);
+
+    for (int device_id = 0; device_id < num_devices; device_id++) {
+        const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
+        const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
+        const std::vector<std::string>& file_list = gds_manager.get_file_paths(device_id);
+
+        for (size_t j = 0; j < gpu_blocks.size(); j++) {
+            const int gpu_block_id = gpu_blocks[j];
+            const int ssd_block_id = ssd_blocks[j];
+            const int slot_id = (device_id * gpu_blocks.size() + j) % num_slots;
+
+            futures.push_back(gds_manager.enqueue_task([&, device_id, gpu_block_id, ssd_block_id, slot_id, gpu_id]() {
+                musaSetDevice(gpu_id);
+
+                std::lock_guard<std::mutex> slot_lock(slot_mutexes[slot_id]);
+                musaStream_t slot_stream = slot_streams[slot_id];
+                musaStreamSynchronize(slot_stream);
+
+                const int file_id_in_device = ssd_block_id % num_files_per_device;
+                const int64_t block_id_in_file = ssd_block_id / num_files_per_device;
+                const std::string& filename = file_list[file_id_in_device];
+
+                char* buffer_slot_ptr = reinterpret_cast<char*>(buffer_ptr) +
+                                       slot_id * gpu_buffer_size_in_bytes;
+
+                const int64_t ssd_block_offset =
+                    ssd_block_stride_in_bytes * block_id_in_file + ssd_copy_off_inside_chunks +
+                    start_layer * ssd_layer_stride_in_bytes;
+
+                int64_t* d_my_block_id = d_gpu_block_ids + slot_id;
+                const int64_t gpu_block_id_64 = gpu_block_id;
+                musaMemcpyAsync(d_my_block_id, &gpu_block_id_64, sizeof(int64_t),
+                               musaMemcpyHostToDevice, slot_stream);
+                musaStreamSynchronize(slot_stream);
+
+                if (is_read) {
+                    gds_manager.read(filename.c_str(), buffer_slot_ptr, gpu_buffer_size_in_bytes, ssd_block_offset);
+
+                    launch_layout_transform_kernel_musa<Type>(
+                        reinterpret_cast<int64_t*>(buffer_slot_ptr),
+                        buffer_layer_stride, buffer_kv_stride, buffer_block_stride,
+                        chunk_size, gpu_tensor_handler, d_my_block_id,
+                        1, num_layers, is_mla, true, slot_stream);
+                } else {
+                    launch_layout_transform_kernel_musa<Type>(
+                        reinterpret_cast<int64_t*>(buffer_slot_ptr),
+                        buffer_layer_stride, buffer_kv_stride, buffer_block_stride,
+                        chunk_size, gpu_tensor_handler, d_my_block_id,
+                        1, num_layers, is_mla, false, slot_stream);
+                    musaStreamSynchronize(slot_stream);
+
+                    gds_manager.write(filename.c_str(), buffer_slot_ptr, gpu_buffer_size_in_bytes, ssd_block_offset);
+                }
+
+                if (verbose) {
+                    std::cerr << "GDS-MUSA: " << (is_read ? "Read" : "Write")
+                              << " SSD: " << ssd_block_id << " GPU: " << gpu_block_id
+                              << " Slot: " << slot_id << " Device: " << device_id
+                              << std::endl;
+                }
+            }));
+        }
+    }
+
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    for (int i = 0; i < num_slots; i++) {
+        musaStreamSynchronize(slot_streams[i]);
+    }
+
+    for (auto& stream : slot_streams) {
+        musaStreamDestroy(stream);
+    }
+    musaFree(d_gpu_block_ids);
+    musaFree(buffer_ptr);
+
+    gds_manager.synchronize();
+}
+
+template void transfer_kv_blocks_gds_musa<BackendType::VLLM>(
+    GDSManagerMusa&, const torch::Tensor&, GTensorHandler, const torch::Tensor&,
+    const torch::Tensor&, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+    int, int, int64_t, bool, bool, bool);
+
+template void transfer_kv_blocks_gds_musa<BackendType::TRTLLM>(
+    GDSManagerMusa&, const torch::Tensor&, GTensorHandler, const torch::Tensor&,
+    const torch::Tensor&, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+    int, int, int64_t, bool, bool, bool);
+
+template void transfer_kv_blocks_gds_musa<BackendType::SGLANG>(
+    GDSManagerMusa&, const torch::Tensor&, GTensorHandler, const torch::Tensor&,
+    const torch::Tensor&, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+    int, int, int64_t, bool, bool, bool);
+
+}  // namespace flexkv

--- a/csrc/musa/gds/gds_manager_musa.h
+++ b/csrc/musa/gds/gds_manager_musa.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <cstddef>
+#include <sys/types.h>
+#include <string>
+#include <unordered_map>
+#include <map>
+#include <vector>
+#include <initializer_list>
+#include <atomic>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <functional>
+#include <future>
+#include <torch/extension.h>
+#include "../gtensor_handler_musa.h"
+#include <musa_runtime.h>
+#include <mufile.h>
+
+/*
+ * GPU Direct Storage Manager for MUSA — mirrors csrc/gds/gds_manager.h.
+ * Uses muFile APIs instead of cuFile, musaStream_t instead of cudaStream_t.
+ */
+class GDSManagerMusa {
+public:
+    GDSManagerMusa(std::map<int, std::vector<std::string>>& ssd_files,
+                   int num_devices,
+                   int round_robin = 1);
+    ~GDSManagerMusa();
+
+    bool is_ready() const;
+    bool add_file(const char* filename);
+    bool remove_file(const char* filename);
+
+    ssize_t write(const char* filename, const void* gpu_data, size_t size, size_t file_offset = 0);
+    ssize_t read(const char* filename, void* gpu_buffer, size_t size, size_t file_offset = 0);
+    ssize_t write_async(const char* filename, void* gpu_data, size_t size, size_t file_offset = 0);
+    ssize_t read_async(const char* filename, void* gpu_buffer, size_t size, size_t file_offset = 0);
+
+    void synchronize();
+    musaStream_t get_stream() const;
+
+    size_t get_file_count() const;
+    const std::vector<std::string>& get_file_paths(int device_id) const;
+    const std::string& get_last_error() const;
+    int get_num_devices() const;
+    int get_num_files_per_device() const;
+    int get_round_robin() const;
+    int get_num_worker_threads() const;
+
+    int batch_write(const struct BatchWriteOpMusa* operations, int count);
+    int batch_read(const struct BatchReadOpMusa* operations, int count);
+    int batch_synchronize(int batch_id);
+
+    std::future<void> enqueue_task(std::function<void()> task);
+
+private:
+    GDSManagerMusa(const GDSManagerMusa&) = delete;
+    GDSManagerMusa& operator=(const GDSManagerMusa&) = delete;
+    GDSManagerMusa(GDSManagerMusa&&) = delete;
+    GDSManagerMusa& operator=(GDSManagerMusa&&) = delete;
+
+    struct FileResource {
+        int fd;
+        MUfileHandle_t mf_handle;
+        std::string filepath;
+
+        FileResource() : fd(-1) {}
+    };
+
+    bool is_ready_;
+    std::string last_error_;
+
+    int num_devices_;
+    int num_files_per_device_;
+    int round_robin_;
+    std::vector<std::vector<std::string>> file_paths_;
+
+    std::unordered_map<std::string, FileResource> file_resources_;
+    bool driver_initialized_;
+    musaStream_t shared_stream_;
+    std::atomic<int> next_batch_id_;
+
+    struct BatchInfo {
+        void* batch_handle;     // MUfileBatchHandle_t
+        int batch_size;
+    };
+    std::unordered_map<int, BatchInfo> batch_info_;
+
+    using Task = std::function<void()>;
+    std::vector<std::thread> worker_threads_;
+    std::queue<Task> task_queue_;
+    std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::atomic<bool> stop_workers_;
+    int num_worker_threads_;
+
+    void set_error(const std::string& error);
+    bool initialize_driver();
+    bool open_file_internal(const char* filename);
+    void close_file_internal(const char* filename);
+    FileResource* get_or_create_file_resource(const char* filename);
+    void cleanup();
+    void initialize_worker_threads();
+    void shutdown_worker_threads();
+};
+
+struct BatchWriteOpMusa {
+    const char* filename;
+    void* gpu_data;
+    size_t size;
+    size_t file_offset;
+    ssize_t* result;
+};
+
+struct BatchReadOpMusa {
+    const char* filename;
+    void* gpu_buffer;
+    size_t size;
+    size_t file_offset;
+    ssize_t* result;
+};
+
+namespace flexkv {
+
+template<BackendType Type>
+void transfer_kv_blocks_gds_musa(
+    GDSManagerMusa& gds_manager,
+    const torch::Tensor& gpu_layer_id_list,
+    GTensorHandler gpu_tensor_handler,
+    const torch::Tensor& ssd_block_ids,
+    const torch::Tensor& gpu_block_ids,
+    int64_t ssd_layer_stride_in_bytes,
+    int64_t ssd_block_stride_in_bytes,
+    int64_t ssd_kv_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int64_t ssd_copy_off_inside_chunks,
+    int64_t gpu_buffer_size_in_bytes,
+    int gpu_id,
+    int num_blocks_per_file,
+    int64_t total_layers,
+    bool is_read,
+    bool verbose = false,
+    bool is_mla = false
+);
+
+} // namespace flexkv

--- a/csrc/musa/gds/layout_transform_musa.mu
+++ b/csrc/musa/gds/layout_transform_musa.mu
@@ -1,0 +1,114 @@
+/*
+ * MUSA layout transform kernel — mirrors csrc/gds/layout_transform.cu.
+ * Uses musa* APIs. Compile with mcc when MUSA SDK is available.
+ */
+#include <musa_runtime.h>
+#include <cstdio>
+#include "layout_transform_musa.muh"
+
+namespace flexkv {
+
+#define FLOAT4_PTR(ptr) reinterpret_cast<float4*>(ptr)
+
+template<BackendType Type>
+__global__ void layout_transform_kernel_musa(
+    int64_t* buffer_base,
+    int64_t buffer_layer_stride,
+    int64_t buffer_kv_stride,
+    int64_t buffer_block_stride,
+    int64_t chunk_size,
+    GTensorHandler gpu_handler,
+    int64_t* gpu_block_ids,
+    int num_blocks,
+    int num_layers,
+    bool is_mla,
+    bool buffer_to_target
+) {
+    int kv_dim = is_mla ? 1 : 2;
+    int num_chunks = num_layers * kv_dim * num_blocks;
+    int64_t chunk_size_in_float4 = chunk_size * sizeof(int64_t) / sizeof(float4);
+
+    for (int chunk_idx = blockIdx.x; chunk_idx < num_chunks; chunk_idx += gridDim.x) {
+        int block_local_idx = chunk_idx % num_blocks;
+        int layer_idx = chunk_idx / (num_blocks * kv_dim);
+        int kv_idx = (chunk_idx % (num_blocks * kv_dim)) / num_blocks;
+
+        int64_t gpu_block_idx = gpu_block_ids[block_local_idx];
+
+        int64_t* buffer_ptr = buffer_base +
+                               block_local_idx * buffer_block_stride +
+                               layer_idx * buffer_layer_stride +
+                               kv_idx * buffer_kv_stride;
+
+        int64_t* gpu_ptr = ptr_at<Type>(gpu_handler, layer_idx, kv_idx, gpu_block_idx);
+
+        int64_t* src_ptr = buffer_to_target ? buffer_ptr : gpu_ptr;
+        int64_t* dst_ptr = buffer_to_target ? gpu_ptr : buffer_ptr;
+
+        for (int64_t idx = threadIdx.x; idx < chunk_size_in_float4; idx += blockDim.x) {
+            float4 element = FLOAT4_PTR(src_ptr)[idx];
+            FLOAT4_PTR(dst_ptr)[idx] = element;
+        }
+    }
+}
+
+template<BackendType Type>
+void launch_layout_transform_kernel_musa(
+    int64_t* buffer_base,
+    int64_t buffer_layer_stride,
+    int64_t buffer_kv_stride,
+    int64_t buffer_block_stride,
+    int64_t chunk_size,
+    GTensorHandler gpu_handler,
+    int64_t* gpu_block_ids,
+    int num_blocks,
+    int num_layers,
+    bool is_mla,
+    bool buffer_to_target,
+    musaStream_t stream
+) {
+    if (num_blocks == 0 || num_layers == 0) return;
+
+    int block_size = 128;
+    int kv_dim = is_mla ? 1 : 2;
+    int num_chunks = num_layers * kv_dim * num_blocks;
+
+    int device_id;
+    musaGetDevice(&device_id);
+
+    int max_blocks_per_sm = 1;
+    musaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_blocks_per_sm, layout_transform_kernel_musa<Type>, block_size, 0);
+
+    int available_blocks_per_sm = 4;
+
+    int grid_size = std::min(num_chunks, available_blocks_per_sm * max_blocks_per_sm);
+
+    layout_transform_kernel_musa<Type><<<grid_size, block_size, 0, stream>>>(
+        buffer_base,
+        buffer_layer_stride,
+        buffer_kv_stride,
+        buffer_block_stride,
+        chunk_size,
+        gpu_handler,
+        gpu_block_ids,
+        num_blocks,
+        num_layers,
+        is_mla,
+        buffer_to_target
+    );
+}
+
+template void launch_layout_transform_kernel_musa<BackendType::VLLM>(
+    int64_t*, int64_t, int64_t, int64_t, int64_t, GTensorHandler, int64_t*,
+    int, int, bool, bool, musaStream_t);
+
+template void launch_layout_transform_kernel_musa<BackendType::TRTLLM>(
+    int64_t*, int64_t, int64_t, int64_t, int64_t, GTensorHandler, int64_t*,
+    int, int, bool, bool, musaStream_t);
+
+template void launch_layout_transform_kernel_musa<BackendType::SGLANG>(
+    int64_t*, int64_t, int64_t, int64_t, int64_t, GTensorHandler, int64_t*,
+    int, int, bool, bool, musaStream_t);
+
+} // namespace flexkv

--- a/csrc/musa/gds/layout_transform_musa.muh
+++ b/csrc/musa/gds/layout_transform_musa.muh
@@ -1,0 +1,27 @@
+/*
+ * MUSA layout transform kernel — mirrors csrc/gds/layout_transform.cuh.
+ * Uses musa_runtime.h and musaStream_t.
+ */
+#pragma once
+
+#include <musa_runtime.h>
+#include "../gtensor_handler_musa.h"
+
+namespace flexkv {
+
+template<BackendType Type>
+void launch_layout_transform_kernel_musa(
+    int64_t* buffer_base,
+    int64_t buffer_layer_stride,
+    int64_t buffer_kv_stride,
+    int64_t buffer_block_stride,
+    int64_t chunk_size,
+    GTensorHandler gpu_handler,
+    int64_t* gpu_block_ids,
+    int num_blocks,
+    int num_layers,
+    bool is_mla,
+    bool buffer_to_target,
+    musaStream_t stream);
+
+} // namespace flexkv

--- a/csrc/musa/gds/tp_gds_transfer_thread_group_musa.cpp
+++ b/csrc/musa/gds/tp_gds_transfer_thread_group_musa.cpp
@@ -1,0 +1,226 @@
+/*
+ * MUSA TP GDS Transfer Thread Group — mirrors csrc/gds/tp_gds_transfer_thread_group.cpp.
+ * Uses musa* APIs and GDSManagerMusa. Compile/link with MUSA SDK and muFile.
+ */
+#include "tp_gds_transfer_thread_group_musa.h"
+#include "gds_manager_musa.h"
+#include <stdexcept>
+
+namespace flexkv {
+
+TPGDSTransferThreadGroupMusa::TPGDSTransferThreadGroupMusa(
+    int num_gpus,
+    const std::vector<std::vector<torch::Tensor>>& gpu_blocks,
+    std::map<int, std::vector<std::string>>& ssd_files,
+    int dp_group_id,
+    int num_layers,
+    torch::Tensor& gpu_kv_strides_tensor,
+    torch::Tensor& gpu_block_strides_tensor,
+    torch::Tensor& gpu_layer_strides_tensor,
+    torch::Tensor& gpu_chunk_sizes_tensor) {
+
+  num_gpus_ = num_gpus;
+  dp_group_id_ = dp_group_id;
+
+  gpu_kv_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_block_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_layer_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_chunk_sizes_in_bytes_ = new int64_t[num_gpus];
+
+  int64_t* kv_strides_ptr = gpu_kv_strides_tensor.data_ptr<int64_t>();
+  int64_t* block_strides_ptr = gpu_block_strides_tensor.data_ptr<int64_t>();
+  int64_t* layer_strides_ptr = gpu_layer_strides_tensor.data_ptr<int64_t>();
+  int64_t* chunk_sizes_ptr = gpu_chunk_sizes_tensor.data_ptr<int64_t>();
+
+  for (int i = 0; i < num_gpus; i++) {
+    gpu_kv_strides_in_bytes_[i] = kv_strides_ptr[i];
+    gpu_block_strides_in_bytes_[i] = block_strides_ptr[i];
+    gpu_layer_strides_in_bytes_[i] = layer_strides_ptr[i];
+    gpu_chunk_sizes_in_bytes_[i] = chunk_sizes_ptr[i];
+  }
+
+  num_tensors_per_gpu_ = gpu_blocks[0].size();
+  musaMallocHost((void**)&gpu_blocks_, num_gpus_ * num_tensors_per_gpu_ * sizeof(void*));
+
+  for (int i = 0; i < num_gpus_; ++i) {
+    for (int j = 0; j < num_tensors_per_gpu_; ++j) {
+      gpu_blocks_[i * num_tensors_per_gpu_ + j] = gpu_blocks[i][j].data_ptr();
+    }
+  }
+
+  if (num_tensors_per_gpu_ == 1) {
+    backend_type_ = BackendType::TRTLLM;
+  } else if (num_tensors_per_gpu_ == num_layers) {
+    backend_type_ = BackendType::VLLM;
+  } else if (num_tensors_per_gpu_ == num_layers * 2) {
+    backend_type_ = BackendType::SGLANG;
+  } else {
+    throw std::runtime_error("Unsupported GPU block type: " + std::to_string(num_tensors_per_gpu_));
+  }
+
+  gpu_tensor_handlers_.reserve(num_gpus_);
+  for (int i = 0; i < num_gpus_; i++) {
+    int64_t** gpu_blocks_ptr = reinterpret_cast<int64_t**>(gpu_blocks_ + i * num_tensors_per_gpu_);
+    gpu_tensor_handlers_.emplace_back(
+        backend_type_, gpu_blocks_ptr, num_layers,
+        gpu_kv_strides_in_bytes_[i], gpu_block_strides_in_bytes_[i],
+        gpu_layer_strides_in_bytes_[i]);
+  }
+
+  gds_managers_.resize(num_gpus_);
+  for (int i = 0; i < num_gpus_; ++i) {
+    gds_managers_[i] = new GDSManagerMusa(ssd_files, ssd_files.size(), 1);
+    if (!gds_managers_[i]->is_ready()) {
+      throw std::runtime_error("Failed to initialize GDS Manager (MUSA) for GPU " + std::to_string(i) +
+                              ": " + gds_managers_[i]->get_last_error());
+    }
+  }
+
+  queues_.resize(num_gpus_);
+  mtxs_ = std::vector<std::mutex>(num_gpus_);
+  cvs_ = std::vector<std::condition_variable>(num_gpus_);
+
+  streams_.resize(num_gpus_);
+  for (int i = 0; i < num_gpus_; ++i) {
+    musaSetDevice(dp_group_id_ * num_gpus_ + i);
+    musaStreamCreate(&streams_[i]);
+  }
+
+  stop_pool_ = false;
+  for (int i = 0; i < num_gpus_; ++i) {
+    threads_.emplace_back([this, i]() {
+      int device_id = dp_group_id_ * num_gpus_ + i;
+      musaSetDevice(device_id);
+
+      while (true) {
+        Task task;
+        {
+          std::unique_lock<std::mutex> lk(mtxs_[i]);
+          cvs_[i].wait(lk, [&] { return stop_pool_ || !queues_[i].empty(); });
+          if (stop_pool_ && queues_[i].empty()) return;
+          task = std::move(queues_[i].front());
+          queues_[i].pop();
+        }
+        task();
+      }
+    });
+  }
+}
+
+TPGDSTransferThreadGroupMusa::~TPGDSTransferThreadGroupMusa() {
+  stop_pool_ = true;
+  for (auto& cv : cvs_) cv.notify_all();
+  for (auto& t : threads_) if (t.joinable()) t.join();
+
+  for (auto* manager : gds_managers_) {
+    delete manager;
+  }
+
+  for (size_t i = 0; i < streams_.size(); ++i) {
+    musaSetDevice(dp_group_id_ * num_gpus_ + static_cast<int>(i));
+    musaStreamDestroy(streams_[i]);
+  }
+
+  if (gpu_blocks_) {
+    musaFreeHost(gpu_blocks_);
+  }
+
+  gpu_tensor_handlers_.clear();
+  delete[] gpu_kv_strides_in_bytes_;
+  delete[] gpu_block_strides_in_bytes_;
+  delete[] gpu_layer_strides_in_bytes_;
+  delete[] gpu_chunk_sizes_in_bytes_;
+}
+
+std::future<void> TPGDSTransferThreadGroupMusa::enqueue_for_gpu(int gpu_idx, Task task) {
+  auto pkg = std::make_shared<std::packaged_task<void()>>(std::move(task));
+  auto fut = pkg->get_future();
+  {
+    std::lock_guard<std::mutex> lk(mtxs_[gpu_idx]);
+    queues_[gpu_idx].emplace([pkg] { (*pkg)(); });
+  }
+  cvs_[gpu_idx].notify_one();
+  return fut;
+}
+
+void TPGDSTransferThreadGroupMusa::tp_group_transfer(
+    const torch::Tensor& gpu_block_id_tensor,
+    const torch::Tensor& ssd_block_id_tensor,
+    const int64_t ssd_layer_stride_in_bytes,
+    const int64_t ssd_kv_stride_in_bytes,
+    const int64_t ssd_block_stride_in_bytes,
+    const int64_t ssd_tp_stride_in_bytes,
+    const int64_t num_blocks_per_file,
+    const bool is_read,
+    const int layer_id,
+    const int layer_granularity,
+    const bool is_mla) {
+
+  std::atomic<bool> failed{false};
+  std::string error_msg;
+  std::vector<std::future<void>> futures;
+  futures.reserve(num_gpus_);
+
+  for (int i = 0; i < num_gpus_; ++i) {
+    futures.emplace_back(enqueue_for_gpu(i, [&, i]() {
+      try {
+        torch::Tensor layer_id_list = torch::arange(layer_id, layer_id + layer_granularity,
+                                                    torch::TensorOptions().dtype(torch::kInt32));
+        int64_t ssd_copy_off_inside_chunks;
+        int64_t gpu_chunk_size_in_bytes = gpu_chunk_sizes_in_bytes_[i];
+        if (is_mla) {
+            ssd_copy_off_inside_chunks = 0;
+        } else {
+          ssd_copy_off_inside_chunks = i * ssd_tp_stride_in_bytes;
+        }
+
+        int64_t chunk_size = gpu_chunk_size_in_bytes;
+        switch (backend_type_) {
+          case BackendType::VLLM:
+            flexkv::transfer_kv_blocks_gds_musa<BackendType::VLLM>(
+                *gds_managers_[i], layer_id_list, gpu_tensor_handlers_[i],
+                ssd_block_id_tensor, gpu_block_id_tensor, ssd_layer_stride_in_bytes,
+                ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes, chunk_size,
+                ssd_copy_off_inside_chunks, ssd_tp_stride_in_bytes, i, num_blocks_per_file, layer_granularity,
+                is_read, false, is_mla);
+            break;
+          case BackendType::TRTLLM:
+            flexkv::transfer_kv_blocks_gds_musa<BackendType::TRTLLM>(
+                *gds_managers_[i], layer_id_list, gpu_tensor_handlers_[i],
+                ssd_block_id_tensor, gpu_block_id_tensor, ssd_layer_stride_in_bytes,
+                ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes, chunk_size,
+                ssd_copy_off_inside_chunks, ssd_tp_stride_in_bytes, i, num_blocks_per_file, layer_granularity,
+                is_read, false, is_mla);
+            break;
+          case BackendType::SGLANG:
+            flexkv::transfer_kv_blocks_gds_musa<BackendType::SGLANG>(
+                *gds_managers_[i], layer_id_list, gpu_tensor_handlers_[i],
+                ssd_block_id_tensor, gpu_block_id_tensor, ssd_layer_stride_in_bytes,
+                ssd_block_stride_in_bytes, ssd_kv_stride_in_bytes, chunk_size,
+                ssd_copy_off_inside_chunks, ssd_tp_stride_in_bytes, i, num_blocks_per_file, layer_granularity,
+                is_read, false, is_mla);
+            break;
+        }
+
+        musaError_t err = musaGetLastError();
+        if (err != musaSuccess) {
+          failed = true;
+          error_msg = musaGetErrorString(err);
+        }
+      } catch (const std::exception& e) {
+        failed = true;
+        error_msg = e.what();
+      }
+    }));
+  }
+
+  for (auto& f : futures) {
+    f.get();
+  }
+
+  if (failed) {
+    throw std::runtime_error("tp_gds_group_transfer (MUSA) failed: " + error_msg);
+  }
+}
+
+} // namespace flexkv

--- a/csrc/musa/gds/tp_gds_transfer_thread_group_musa.h
+++ b/csrc/musa/gds/tp_gds_transfer_thread_group_musa.h
@@ -1,0 +1,80 @@
+/*
+ * MUSA TP GDS Transfer Thread Group — mirrors csrc/gds/tp_gds_transfer_thread_group.h.
+ * Uses musaStream_t and musa* APIs. Build when MUSA SDK and muFile are available.
+ */
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <musa_runtime.h>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <torch/extension.h>
+#include <vector>
+#include <string>
+#include <map>
+#include <queue>
+#include <functional>
+#include <future>
+#include "../gtensor_handler_musa.h"
+
+class GDSManagerMusa;
+
+namespace flexkv {
+
+class TPGDSTransferThreadGroupMusa {
+public:
+  TPGDSTransferThreadGroupMusa(
+      int num_gpus,
+      const std::vector<std::vector<torch::Tensor>>& gpu_blocks,
+      std::map<int, std::vector<std::string>>& ssd_files,
+      int dp_group_id,
+      int num_layers,
+      torch::Tensor& gpu_kv_strides_tensor,
+      torch::Tensor& gpu_block_strides_tensor,
+      torch::Tensor& gpu_layer_strides_tensor,
+      torch::Tensor& gpu_chunk_sizes_tensor);
+  ~TPGDSTransferThreadGroupMusa();
+
+  void tp_group_transfer(
+      const torch::Tensor& gpu_block_id_tensor,
+      const torch::Tensor& ssd_block_id_tensor,
+      const int64_t ssd_layer_stride_in_bytes,
+      const int64_t ssd_kv_stride_in_bytes,
+      const int64_t ssd_block_stride_in_bytes,
+      const int64_t ssd_tp_stride_in_bytes,
+      const int64_t num_blocks_per_file,
+      const bool is_read,
+      const int layer_id,
+      const int layer_granularity,
+      const bool is_mla);
+
+private:
+  using Task = std::function<void()>;
+  std::future<void> enqueue_for_gpu(int gpu_idx, Task task);
+
+  int num_gpus_;
+  int dp_group_id_;
+  void** gpu_blocks_;
+  int num_tensors_per_gpu_;
+
+  int64_t* gpu_kv_strides_in_bytes_;
+  int64_t* gpu_block_strides_in_bytes_;
+  int64_t* gpu_layer_strides_in_bytes_;
+  int64_t* gpu_chunk_sizes_in_bytes_;
+
+  BackendType backend_type_;
+  std::vector<GTensorHandler> gpu_tensor_handlers_;
+
+  std::vector<GDSManagerMusa*> gds_managers_;
+  std::vector<std::thread> threads_;
+  std::vector<musaStream_t> streams_;
+
+  std::vector<std::queue<Task>> queues_;
+  std::vector<std::mutex> mtxs_;
+  std::vector<std::condition_variable> cvs_;
+  std::atomic<bool> stop_pool_;
+};
+
+} // namespace flexkv

--- a/csrc/musa/gtensor_handler_musa.h
+++ b/csrc/musa/gtensor_handler_musa.h
@@ -1,0 +1,82 @@
+/*
+ * GTensorHandler for MUSA - backend-agnostic GPU tensor descriptor.
+ * Mirrors csrc/gtensor_handler.cuh with musa_runtime.h (no CUDA dependency).
+ */
+#pragma once
+
+#include <musa_runtime.h>
+#include <cstdint>
+
+namespace flexkv {
+
+enum class BackendType {
+    VLLM,
+    TRTLLM,
+    SGLANG
+};
+
+struct GTensorHandler {
+    BackendType type;
+    int64_t **gpu_tensor_ptrs;
+    int64_t num_layers;
+    int64_t gpu_kv_stride;
+    int64_t gpu_block_stride;
+    int64_t gpu_layer_stride;
+
+    __host__ __device__
+    GTensorHandler()
+        : type(BackendType::VLLM),
+          gpu_tensor_ptrs(nullptr),
+          num_layers(0),
+          gpu_kv_stride(0),
+          gpu_block_stride(0),
+          gpu_layer_stride(0) {}
+
+    __host__ __device__
+    GTensorHandler(BackendType type,
+                   int64_t **gpu_tensor_ptrs,
+                   int64_t num_layers,
+                   int64_t gpu_kv_stride_in_bytes,
+                   int64_t gpu_block_stride_in_bytes,
+                   int64_t gpu_layer_stride_in_bytes)
+        : type(type),
+          gpu_tensor_ptrs(gpu_tensor_ptrs),
+          num_layers(num_layers),
+          gpu_kv_stride(gpu_kv_stride_in_bytes / sizeof(int64_t)),
+          gpu_block_stride(gpu_block_stride_in_bytes / sizeof(int64_t)),
+          gpu_layer_stride(gpu_layer_stride_in_bytes / sizeof(int64_t)) {}
+};
+
+template<BackendType Type>
+__device__ __host__ inline
+int64_t* ptr_at(const GTensorHandler& handler,
+                int64_t layer_idx, int64_t kv_idx, int64_t block_idx);
+
+template<>
+__device__ __host__ inline
+int64_t* ptr_at<BackendType::VLLM>(const GTensorHandler& handler,
+                                   int64_t layer_idx, int64_t kv_idx, int64_t block_idx) {
+    return handler.gpu_tensor_ptrs[layer_idx] +
+           kv_idx * handler.gpu_kv_stride +
+           block_idx * handler.gpu_block_stride;
+}
+
+template<>
+__device__ __host__ inline
+int64_t* ptr_at<BackendType::TRTLLM>(const GTensorHandler& handler,
+                                     int64_t layer_idx, int64_t kv_idx, int64_t block_idx) {
+    return handler.gpu_tensor_ptrs[0] +
+           block_idx * handler.gpu_block_stride +
+           layer_idx * handler.gpu_layer_stride +
+           kv_idx * handler.gpu_kv_stride;
+}
+
+template<>
+__device__ __host__ inline
+int64_t* ptr_at<BackendType::SGLANG>(const GTensorHandler& handler,
+                                     int64_t layer_idx, int64_t kv_idx, int64_t block_idx) {
+    return handler.gpu_tensor_ptrs[kv_idx * handler.num_layers + layer_idx] +
+           block_idx * handler.gpu_block_stride;
+}
+
+}  // namespace flexkv

--- a/csrc/musa/tp_transfer_thread_group_musa.cpp
+++ b/csrc/musa/tp_transfer_thread_group_musa.cpp
@@ -1,0 +1,217 @@
+/*
+ * MUSA TPTransferThreadGroup - mirrors csrc/tp_transfer_thread_group.cpp
+ * Uses musa* APIs. Compile and link with transfer_musa.mu when MUSA SDK is available.
+ */
+#include "tp_transfer_thread_group_musa.h"
+#include "transfer_musa.muh"
+#include <stdexcept>
+
+namespace flexkv {
+
+TPTransferThreadGroupMusa::TPTransferThreadGroupMusa(
+    int num_gpus, const std::vector<std::vector<torch::Tensor>>& gpu_blocks,
+    torch::Tensor& cpu_blocks, int dp_group_id,
+    int num_layers,
+    torch::Tensor& gpu_kv_strides_tensor,
+    torch::Tensor& gpu_block_strides_tensor,
+    torch::Tensor& gpu_layer_strides_tensor,
+    torch::Tensor& gpu_chunk_sizes_tensor) {
+
+  num_gpus_ = num_gpus;
+
+  gpu_kv_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_block_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_layer_strides_in_bytes_ = new int64_t[num_gpus];
+  gpu_chunk_sizes_in_bytes_ = new int64_t[num_gpus];
+
+  int64_t* kv_strides_ptr = gpu_kv_strides_tensor.data_ptr<int64_t>();
+  int64_t* block_strides_ptr = gpu_block_strides_tensor.data_ptr<int64_t>();
+  int64_t* layer_strides_ptr = gpu_layer_strides_tensor.data_ptr<int64_t>();
+  int64_t* chunk_sizes_ptr = gpu_chunk_sizes_tensor.data_ptr<int64_t>();
+
+  for (int i = 0; i < num_gpus; i++) {
+    gpu_kv_strides_in_bytes_[i] = kv_strides_ptr[i];
+    gpu_block_strides_in_bytes_[i] = block_strides_ptr[i];
+    gpu_chunk_sizes_in_bytes_[i] = chunk_sizes_ptr[i];
+    gpu_layer_strides_in_bytes_[i] = layer_strides_ptr[i];
+  }
+
+  queues_.resize(num_gpus_);
+  mtxs_ = std::vector<std::mutex>(num_gpus_);
+  cvs_ = std::vector<std::condition_variable>(num_gpus_);
+
+  num_tensors_per_gpu_ = gpu_blocks[0].size();
+  musaMallocHost((void**)&gpu_blocks_,
+                 num_gpus_ * num_tensors_per_gpu_ * sizeof(void*));
+  for (int i = 0; i < num_gpus_; ++i) {
+    for (int j = 0; j < num_tensors_per_gpu_; ++j) {
+      gpu_blocks_[i * num_tensors_per_gpu_ + j] = gpu_blocks[i][j].data_ptr();
+    }
+  }
+
+  if (num_tensors_per_gpu_ == 1) {
+    backend_type_ = BackendType::TRTLLM;
+  } else if (num_tensors_per_gpu_ == num_layers) {
+    backend_type_ = BackendType::VLLM;
+  } else if (num_tensors_per_gpu_ == num_layers * 2) {
+    backend_type_ = BackendType::SGLANG;
+  } else {
+    throw std::runtime_error("Unsupported GPU block type: " + std::to_string(num_tensors_per_gpu_));
+  }
+
+  gpu_tensor_handlers_.reserve(num_gpus_);
+  for (int i = 0; i < num_gpus_; i++) {
+    int64_t** gpu_blocks_ptr = reinterpret_cast<int64_t**>(gpu_blocks_ + i * num_tensors_per_gpu_);
+    gpu_tensor_handlers_.emplace_back(
+        backend_type_,
+        gpu_blocks_ptr,
+        num_layers,
+        gpu_kv_strides_in_bytes_[i],
+        gpu_block_strides_in_bytes_[i],
+        gpu_layer_strides_in_bytes_[i]);
+  }
+
+  cpu_blocks_ = cpu_blocks.data_ptr();
+
+  dp_group_id_ = dp_group_id;
+  streams_.resize(num_gpus_);
+  for (int i = 0; i < num_gpus_; i += 1) {
+    musaSetDevice(dp_group_id * num_gpus_ + i);
+    musaStreamCreate(&streams_[i]);
+  }
+  stop_pool_ = false;
+  for (int i = 0; i < num_gpus_; ++i) {
+    threads_.emplace_back([this, i]() {
+      int device_id = dp_group_id_ * num_gpus_ + i;
+      musaSetDevice(device_id);
+
+      while (true) {
+        Task task;
+        {
+          std::unique_lock<std::mutex> lk(mtxs_[i]);
+          cvs_[i].wait(lk, [&] { return stop_pool_ || !queues_[i].empty(); });
+          if (stop_pool_ && queues_[i].empty()) return;
+
+          task = std::move(queues_[i].front());
+          queues_[i].pop();
+        }
+        task();
+      }
+    });
+  }
+}
+
+TPTransferThreadGroupMusa::~TPTransferThreadGroupMusa() {
+  stop_pool_ = true;
+  for (auto& cv : cvs_) cv.notify_all();
+  for (auto& t : threads_)
+    if (t.joinable()) t.join();
+
+  musaFreeHost(gpu_blocks_);
+
+  gpu_tensor_handlers_.clear();
+  delete[] gpu_kv_strides_in_bytes_;
+  delete[] gpu_block_strides_in_bytes_;
+  delete[] gpu_layer_strides_in_bytes_;
+  delete[] gpu_chunk_sizes_in_bytes_;
+}
+
+std::future<void> TPTransferThreadGroupMusa::enqueue_for_gpu(int gpu_idx, Task task) {
+  auto pkg = std::make_shared<std::packaged_task<void()>>(std::move(task));
+  auto fut = pkg->get_future();
+  {
+    std::lock_guard<std::mutex> lk(mtxs_[gpu_idx]);
+    queues_[gpu_idx].emplace([pkg] { (*pkg)(); });
+  }
+  cvs_[gpu_idx].notify_one();
+  return fut;
+}
+
+void TPTransferThreadGroupMusa::tp_group_transfer(
+    const torch::Tensor& gpu_block_id_tensor,
+    const torch::Tensor& cpu_block_id_tensor,
+    const int64_t cpu_kv_stride_in_bytes,
+    const int64_t cpu_layer_stride_in_bytes,
+    const int64_t cpu_block_stride_in_bytes,
+    const int64_t cpu_tp_stride_in_bytes, const int transfer_sms,
+    const bool is_host_to_device, const bool use_ce_transfer,
+    const int layer_id, const int layer_granularity, const bool is_mla) {
+
+  std::atomic<bool> failed{false};
+  std::string error_msg;
+  std::vector<std::future<void>> futures;
+  futures.reserve(num_gpus_);
+
+  for (int i = 0; i < num_gpus_; ++i) {
+    futures.emplace_back(enqueue_for_gpu(i, [&, i]() {
+      try {
+        int num_blocks = gpu_block_id_tensor.numel();
+        int num_layers = layer_granularity;
+
+        int64_t* gpu_block_ids = static_cast<int64_t*>(gpu_block_id_tensor.data_ptr());
+        int64_t* cpu_block_ids = static_cast<int64_t*>(cpu_block_id_tensor.data_ptr());
+        void* cpu_ptr = cpu_blocks_;
+        int64_t cpu_startoff_inside_chunks = i * cpu_tp_stride_in_bytes;
+        if (is_mla && !is_host_to_device) {
+          cpu_startoff_inside_chunks = i * gpu_chunk_sizes_in_bytes_[i] / num_gpus_;
+        } else if (is_mla && is_host_to_device) {
+          cpu_startoff_inside_chunks = 0;
+        }
+        int64_t gpu_startoff_inside_chunks =
+            is_mla && !is_host_to_device ? i * gpu_chunk_sizes_in_bytes_[i] / num_gpus_ : 0;
+        int64_t chunk_size = is_mla && !is_host_to_device
+                                 ? gpu_chunk_sizes_in_bytes_[i] / num_gpus_
+                                 : gpu_chunk_sizes_in_bytes_[i];
+
+        switch (backend_type_) {
+          case BackendType::VLLM:
+            flexkv::transfer_kv_blocks<BackendType::VLLM>(
+                num_blocks, layer_id, layer_granularity, gpu_block_ids,
+                gpu_tensor_handlers_[i], gpu_startoff_inside_chunks,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes,
+                cpu_layer_stride_in_bytes, cpu_block_stride_in_bytes,
+                cpu_startoff_inside_chunks, chunk_size, streams_[i],
+                transfer_sms, is_host_to_device, use_ce_transfer, is_mla);
+            break;
+          case BackendType::TRTLLM:
+            flexkv::transfer_kv_blocks<BackendType::TRTLLM>(
+                num_blocks, layer_id, layer_granularity, gpu_block_ids,
+                gpu_tensor_handlers_[i], gpu_startoff_inside_chunks,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes,
+                cpu_layer_stride_in_bytes, cpu_block_stride_in_bytes,
+                cpu_startoff_inside_chunks, chunk_size, streams_[i],
+                transfer_sms, is_host_to_device, use_ce_transfer, is_mla);
+            break;
+          case BackendType::SGLANG:
+            flexkv::transfer_kv_blocks<BackendType::SGLANG>(
+                num_blocks, layer_id, layer_granularity, gpu_block_ids,
+                gpu_tensor_handlers_[i], gpu_startoff_inside_chunks,
+                cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes,
+                cpu_layer_stride_in_bytes, cpu_block_stride_in_bytes,
+                cpu_startoff_inside_chunks, chunk_size, streams_[i],
+                transfer_sms, is_host_to_device, use_ce_transfer, is_mla);
+            break;
+        }
+
+        musaError_t err = musaGetLastError();
+        if (err != musaSuccess) {
+          failed = true;
+          error_msg = musaGetErrorString(err);
+        }
+      } catch (const std::exception& e) {
+        failed = true;
+        error_msg = e.what();
+      }
+    }));
+  }
+
+  for (auto& f : futures) {
+    f.get();
+  }
+
+  if (failed) {
+    throw std::runtime_error("tp_group_transfer (MUSA) failed: " + error_msg);
+  }
+}
+
+}  // namespace flexkv

--- a/csrc/musa/tp_transfer_thread_group_musa.h
+++ b/csrc/musa/tp_transfer_thread_group_musa.h
@@ -1,0 +1,72 @@
+/*
+ * MUSA TPTransferThreadGroup - mirrors csrc/tp_transfer_thread_group.h
+ * Uses musaStream_t and musa* APIs. Build when MUSA SDK and transfer_musa are available.
+ */
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <musa_runtime.h>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <torch/extension.h>
+#include <vector>
+#include <queue>
+#include <functional>
+#include <future>
+#include <string>
+#include "transfer_musa.muh"
+#include "gtensor_handler_musa.h"
+
+namespace flexkv {
+
+class TPTransferThreadGroupMusa {
+ public:
+  TPTransferThreadGroupMusa(
+      int num_gpus, const std::vector<std::vector<torch::Tensor>>& gpu_blocks,
+      torch::Tensor& cpu_blocks, int dp_group_id,
+      int num_layers,
+      torch::Tensor& gpu_kv_strides_tensor,
+      torch::Tensor& gpu_block_strides_tensor,
+      torch::Tensor& gpu_layer_strides_tensor,
+      torch::Tensor& gpu_chunk_sizes_tensor);
+  ~TPTransferThreadGroupMusa();
+
+  void tp_group_transfer(const torch::Tensor& gpu_block_id_tensor,
+                         const torch::Tensor& cpu_block_id_tensor,
+                         const int64_t cpu_kv_stride_in_bytes,
+                         const int64_t cpu_layer_stride_in_bytes,
+                         const int64_t cpu_block_stride_in_bytes,
+                         const int64_t cpu_tp_stride_in_bytes,
+                         const int transfer_sms, const bool is_host_to_device,
+                         const bool use_ce_transfer, const int layer_id,
+                         const int layer_granularity, const bool is_mla);
+
+ private:
+  using Task = std::function<void()>;
+  std::future<void> enqueue_for_gpu(int gpu_idx, Task task);
+
+  int num_gpus_;
+  int dp_group_id_;
+  void** gpu_blocks_;
+  void* cpu_blocks_;
+  int num_tensors_per_gpu_;
+  int64_t* gpu_kv_strides_in_bytes_;
+  int64_t* gpu_block_strides_in_bytes_;
+  int64_t* gpu_layer_strides_in_bytes_;
+  int64_t* gpu_chunk_sizes_in_bytes_;
+
+  BackendType backend_type_;
+  std::vector<GTensorHandler> gpu_tensor_handlers_;
+
+  std::vector<std::thread> threads_;
+  std::vector<musaStream_t> streams_;
+
+  std::vector<std::queue<Task>> queues_;
+  std::vector<std::mutex> mtxs_;
+  std::vector<std::condition_variable> cvs_;
+  std::atomic<bool> stop_pool_;
+};
+
+}  // namespace flexkv

--- a/csrc/musa/transfer_musa.mu
+++ b/csrc/musa/transfer_musa.mu
@@ -1,0 +1,137 @@
+/*
+ * MUSA implementation of KV block transfer.
+ * Mirrors csrc/transfer.cu with musa* APIs (musaStream_t, musaMemcpyAsync, etc.).
+ * Compile with mcc when MUSA SDK is available; link with bindings_musa.cpp.
+ * Integrates with torch_musa (PyTorch for MUSA) for stream/device when available.
+ */
+#include <musa_runtime.h>
+#include "transfer_musa.muh"
+
+namespace flexkv {
+
+#define FLOAT4_PTR(ptr) reinterpret_cast<float4 *>(ptr)
+
+template<BackendType Type>
+__global__ void transfer_kv_blocks_kernel(
+    int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
+    GTensorHandler gpu_handler,
+    int64_t gpu_startoff_inside_chunks,
+    int64_t *cpu_block_ids, int64_t *cpu_ptr, int64_t cpu_kv_stride,
+    int64_t cpu_layer_stride, int64_t cpu_block_stride,
+    int64_t cpu_startoff_inside_chunks, int64_t copy_size, bool is_mla,
+    bool is_host_to_device) {
+  int kv_dim = is_mla ? 1 : 2;
+  int num_chunks = num_layers * kv_dim * num_blocks;
+  int64_t copy_size_in_float4 = copy_size * sizeof(int64_t) / sizeof(float4);
+
+  for (int chunk_idx = blockIdx.x; chunk_idx < num_chunks; chunk_idx += gridDim.x) {
+    int layer_idx = chunk_idx / (num_blocks * kv_dim);
+    int kv_idx = (chunk_idx % (num_blocks * kv_dim)) / num_blocks;
+    int gpu_block_idx = gpu_block_ids[chunk_idx % num_blocks];
+    int cpu_block_idx = cpu_block_ids[chunk_idx % num_blocks];
+
+    int64_t *cpu_chunk_ptr =
+        cpu_ptr + (layer_idx + start_layer_id) * cpu_layer_stride +
+        kv_idx * cpu_kv_stride + cpu_block_idx * cpu_block_stride +
+        cpu_startoff_inside_chunks;
+
+    int64_t *gpu_ptr = ptr_at<Type>(gpu_handler, layer_idx, kv_idx, gpu_block_idx);
+    int64_t *gpu_chunk_ptr = reinterpret_cast<int64_t*>(gpu_ptr) + gpu_startoff_inside_chunks;
+
+    int64_t *src_chunk_ptr = is_host_to_device ? cpu_chunk_ptr : gpu_chunk_ptr;
+    int64_t *dst_chunk_ptr = is_host_to_device ? gpu_chunk_ptr : cpu_chunk_ptr;
+
+    for (int64_t idx = threadIdx.x; idx < copy_size_in_float4; idx += blockDim.x) {
+      float4 element = __ldg(&FLOAT4_PTR(src_chunk_ptr)[idx]);
+      FLOAT4_PTR(dst_chunk_ptr)[idx] = element;
+    }
+  }
+}
+
+template<BackendType Type>
+void transfer_kv_blocks(
+    int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
+    GTensorHandler gpu_tensor_handler,
+    int64_t gpu_startoff_inside_chunks,
+    int64_t *cpu_block_ids, void *cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes, int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes, int64_t cpu_startoff_inside_chunks,
+    int64_t chunk_size_in_bytes, musaStream_t stream, int transfer_sms,
+    bool is_host_to_device, bool use_ce_transfer, bool is_mla) {
+
+  int block_size = 128;
+  static int max_blocks_per_sm = -1;
+  if (max_blocks_per_sm == -1) {
+    musaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_blocks_per_sm, transfer_kv_blocks_kernel<Type>, block_size, 0);
+  }
+
+  if (transfer_sms == -1) {
+    transfer_sms = 4;
+  }
+
+  int block_count = transfer_sms * max_blocks_per_sm;
+
+  int64_t *cpu_ptr_int64 = reinterpret_cast<int64_t *>(cpu_ptr);
+  int64_t cpu_kv_stride_int64 = cpu_kv_stride_in_bytes / sizeof(int64_t);
+  int64_t cpu_block_stride_int64 = cpu_block_stride_in_bytes / sizeof(int64_t);
+  int64_t cpu_layer_stride_int64 = cpu_layer_stride_in_bytes / sizeof(int64_t);
+  int64_t cpu_startoff_inside_chunks_int64 =
+      cpu_startoff_inside_chunks / sizeof(int64_t);
+  int64_t gpu_startoff_inside_chunks_int64 =
+      gpu_startoff_inside_chunks / sizeof(int64_t);
+  int64_t chunk_size_in_int64 = chunk_size_in_bytes / sizeof(int64_t);
+
+  dim3 blockDim(block_size);
+  dim3 gridDim(block_count);
+
+  if (use_ce_transfer) {
+    int kv_dim = is_mla ? 1 : 2;
+    for (int i = 0; i < num_layers; i++) {
+      for (int j = 0; j < kv_dim; j++) {
+        for (int k = 0; k < num_blocks; k++) {
+          int64_t gpu_block_idx = gpu_block_ids[k];
+          int64_t cpu_block_idx = cpu_block_ids[k];
+
+          int64_t *cpu_chunk_ptr =
+              cpu_ptr_int64 + (i + start_layer_id) * cpu_layer_stride_int64 +
+              j * cpu_kv_stride_int64 + cpu_block_idx * cpu_block_stride_int64 +
+              cpu_startoff_inside_chunks_int64;
+
+          int64_t *gpu_ptr = ptr_at<Type>(gpu_tensor_handler, i, j, gpu_block_idx);
+          int64_t *gpu_chunk_ptr = reinterpret_cast<int64_t*>(gpu_ptr) +
+                                   gpu_startoff_inside_chunks_int64;
+
+          if (is_host_to_device) {
+            musaMemcpyAsync(gpu_chunk_ptr, cpu_chunk_ptr, chunk_size_in_bytes,
+                            musaMemcpyHostToDevice, stream);
+          } else {
+            musaMemcpyAsync(cpu_chunk_ptr, gpu_chunk_ptr, chunk_size_in_bytes,
+                            musaMemcpyDeviceToHost, stream);
+          }
+        }
+      }
+    }
+  } else {
+    transfer_kv_blocks_kernel<Type><<<gridDim, blockDim, 0, stream>>>(
+        num_blocks, start_layer_id, num_layers, gpu_block_ids,
+        gpu_tensor_handler, gpu_startoff_inside_chunks_int64,
+        cpu_block_ids, cpu_ptr_int64, cpu_kv_stride_int64,
+        cpu_layer_stride_int64, cpu_block_stride_int64,
+        cpu_startoff_inside_chunks_int64, chunk_size_in_int64, is_mla,
+        is_host_to_device);
+  }
+  musaStreamSynchronize(stream);
+}
+
+template void transfer_kv_blocks<BackendType::VLLM>(
+    int, int, int, int64_t*, GTensorHandler, int64_t, int64_t*, void*,
+    int64_t, int64_t, int64_t, int64_t, int64_t, musaStream_t, int, bool, bool, bool);
+template void transfer_kv_blocks<BackendType::TRTLLM>(
+    int, int, int, int64_t*, GTensorHandler, int64_t, int64_t*, void*,
+    int64_t, int64_t, int64_t, int64_t, int64_t, musaStream_t, int, bool, bool, bool);
+template void transfer_kv_blocks<BackendType::SGLANG>(
+    int, int, int, int64_t*, GTensorHandler, int64_t, int64_t*, void*,
+    int64_t, int64_t, int64_t, int64_t, int64_t, musaStream_t, int, bool, bool, bool);
+
+}  // namespace flexkv

--- a/csrc/musa/transfer_musa.muh
+++ b/csrc/musa/transfer_musa.muh
@@ -1,0 +1,23 @@
+/*
+ * MUSA transfer API - mirrors csrc/transfer.cuh with musaStream_t.
+ * Header for MUSA kernel/host code (.mu); used with torch_musa when available.
+ */
+#pragma once
+
+#include <musa_runtime.h>
+#include "gtensor_handler_musa.h"
+
+namespace flexkv {
+
+template<BackendType Type>
+void transfer_kv_blocks(
+    int num_blocks, int start_layer_id, int num_layers, int64_t *gpu_block_ids,
+    GTensorHandler gpu_tensor_handler,
+    int64_t gpu_startoff_inside_chunks,
+    int64_t *cpu_block_ids, void *cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes, int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes, int64_t cpu_startoff_inside_chunks,
+    int64_t chunk_size_in_bytes, musaStream_t stream, int transfer_sms,
+    bool is_host_to_device, bool use_ce_transfer, bool is_mla);
+
+}  // namespace flexkv

--- a/csrc/transfer_ssd.h
+++ b/csrc/transfer_ssd.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <errno.h>
 #include <liburing.h>
+#include <fcntl.h>
 #include <linux/ioprio.h>
 #include <sys/syscall.h>
 #include <torch/extension.h>

--- a/docs/musa/musa_support_system_design.md
+++ b/docs/musa/musa_support_system_design.md
@@ -1,0 +1,276 @@
+# MUSA Support System Design Document
+
+This document describes the system design for adding Moore Threads MUSA GPU support to FlexKV, with a parallel API (nvcc→mcc, cuda*→musa*), leaving the existing CUDA implementation unchanged.
+
+---
+
+## 1. Understanding of Current CUDA Implementation
+
+### 1.1 Architecture
+
+```mermaid
+flowchart LR
+  subgraph python [Python]
+    worker[worker.py]
+    bindings[flexkv.c_ext]
+  end
+  subgraph cpp [C++ / CUDA]
+    bindings_cpp[bindings.cpp]
+    transfer_cu[transfer.cu]
+    layout_cu[layout_transform.cu]
+    tp_tg[tp_transfer_thread_group]
+    gds[gds_manager]
+  end
+  worker -->|transfer_kv_blocks| bindings
+  bindings --> bindings_cpp
+  bindings_cpp -->|at::cuda::getCurrentCUDAStream| transfer_cu
+  transfer_cu --> layout_cu
+  tp_tg --> transfer_cu
+  gds --> layout_cu
+```
+
+
+
+### 1.2 CUDA-Related Surface
+
+
+| Layer        | Files                                                                                                                             | CUDA usage                                                                                                                                                                      |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Kernels**  | `csrc/transfer.cu`, `csrc/gds/layout_transform.cu`                                                                                | `__global__` kernels, `cudaStream_t`, `cudaMemcpyAsync`, `cudaStreamSynchronize`, `cudaOccupancyMaxActiveBlocksPerMultiprocessor`                                               |
+| **Headers**  | `csrc/transfer.cuh`, `csrc/gtensor_handler.cuh`, `csrc/gds/layout_transform.cuh`                                                  | `#include <cuda_runtime.h>`, `__host__ __device__` in gtensor_handler                                                                                                           |
+| **C++ host** | `csrc/bindings.cpp`, `csrc/tp_transfer_thread_group.cpp`, `csrc/gds/gds_manager.cpp`, `csrc/gds/tp_gds_transfer_thread_group.cpp` | `cudaStream_t`, `cudaMalloc`/`cudaFree`, `cudaMallocHost`/`cudaFreeHost`, `cudaSetDevice`, `cudaStreamCreate`/`Destroy`, `cudaGetLastError`, `at::cuda::getCurrentCUDAStream()` |
+| **Build**    | `setup.py`                                                                                                                        | `cpp_extension.CUDAExtension`, nvcc for `.cu`, `-lcuda`; with GDS: `-lcufile`                                                                                                   |
+| **Python**   | `flexkv/transfer/worker.py`, `flexkv/common/memory_handle.py`                                                                     | `torch.cuda.Stream`, `cudart.cudaHostRegister`/`cudaHostUnregister`, `cudart.cudaIpcGetMemHandle`/`cudaIpcOpenMemHandle`                                                        |
+
+
+**API mapping (C++/CUDA → MUSA):**
+
+- **Compiler:** `nvcc` → `mcc` (MUSA compiler).
+- **Runtime types:** `cudaStream_t` → `musaStream_t`, `cudaError_t` → `musaError_t`.
+- **Runtime APIs:** `cudaMalloc` → `musaMalloc`, `cudaFree` → `musaFree`, `cudaMallocHost` → `musaMallocHost`, `cudaFreeHost` → `musaFreeHost`, `cudaMemcpyAsync` → `musaMemcpyAsync`, `cudaStreamCreate`/`Destroy`/`Synchronize` → `musaStreamCreate`/`Destroy`/`Synchronize`, `cudaSetDevice`/`cudaGetDevice` → `musaSetDevice`/`musaGetDevice`, `cudaGetLastError`/`cudaSuccess`/`cudaGetErrorString` → `musaGetLastError`/`musaSuccess`/`musaGetErrorString`, `cudaOccupancyMaxActiveBlocksPerMultiprocessor` → MUSA occupancy API.
+- **Kernel qualifiers:** `__global__`/`__device__`/`__host__` kept or mapped per MUSA SDK.
+- **PyTorch / torch_musa:** MUSA has the **torch_musa** project (PyTorch for Moore Threads MUSA GPUs). The MUSA path uses `torch.musa` for current stream and device when available. See: [MooreThreads/torch_musa](https://github.com/MooreThreads/torch_musa).
+
+### 1.3 Build and Entry Points
+
+- **Build:** Single extension `flexkv.c_ext` in `setup.py` via `CUDAExtension`; sources include `transfer.cu` and, when `FLEXKV_ENABLE_GDS=1`, `gds/layout_transform.cu`. No CMake for CUDA.
+- **Entry:** Python calls `flexkv.c_ext.transfer_kv_blocks` (and GDS/TP variants); bindings use `at::cuda::getCurrentCUDAStream()` and dispatch to `flexkv::transfer_kv_blocks<BackendType>`.
+
+---
+
+## 2. Design Principles
+
+- **Same API shape:** MUSA mirrors CUDA (musa* types and functions; mcc for device code).
+- **Zero impact on CUDA:** Existing CUDA sources and the current CUDA build path remain unchanged; no `#ifdef` inside current `.cu`/`.cpp` for MUSA.
+- **TDD:** Tests added or specified first; implementation satisfies them (build, dispatch, and, where possible, correctness).
+- **Backend abstraction first:** A unified `gpu_runtime` module is introduced *before* wiring any MUSA transfer path, ensuring every Python-level `torch.cuda.`* call goes through a single dispatch layer. This is the foundational design decision that makes the rest of the feature possible without scattering `if musa:` checks throughout the codebase.
+
+---
+
+## 3. Backend Abstraction Layer (`gpu_runtime`)
+
+This is the **key design** of the MUSA feature. Rather than adding MUSA conditionals to every file that calls `torch.cuda`, we introduce a centralized backend abstraction module `flexkv/common/gpu_runtime.py` that all Python modules go through.
+
+### 3.1 Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     Python Modules                       │
+│  worker.py  memory_handle.py  allocator.py  kvtask.py   │
+│  transfer_engine.py  client.py  vllm_adapter  trtllm_*  │
+└──────────────────────┬───────────────────────────────────┘
+                       │ calls gpu_runtime.*
+                       ▼
+┌──────────────────────────────────────────────────────────┐
+│           flexkv/common/gpu_runtime.py                   │
+│                                                          │
+│  get_gpu_backend() ──► "cuda" | "musa"                   │
+│                                                          │
+│  Device:    set_device, current_device, device_count     │
+│  Stream:    create_stream, stream_context                │
+│  Sync:      synchronize, empty_cache                     │
+│  Host mem:  host_register, host_unregister               │
+│  IPC:       ipc_get_mem_handle, ipc_open_mem_handle      │
+│  Utility:   get_device_string, get_device, is_gpu_tensor │
+│             is_initialized, init_runtime                 │
+└─────────────┬──────────────────────┬─────────────────────┘
+              │                      │
+    ┌─────────▼──────────┐  ┌───────▼──────────────┐
+    │   torch.cuda.*     │  │   torch.musa.*        │
+    │   libcudart.so     │  │   libmusart.so        │
+    └────────────────────┘  └───────────────────────┘
+```
+
+### 3.2 Detection and Dispatch
+
+`get_gpu_backend()` checks (in order):
+
+1. `os.environ["FLEXKV_GPU_BACKEND"]` — explicit override (for testing).
+2. `torch.musa.is_available()` — MUSA hardware present.
+3. `torch.cuda.is_available()` — fallback to CUDA.
+
+When MUSA is selected but `torch.musa` is unavailable, all device/stream/sync functions raise `RuntimeError` rather than silently falling back to CUDA.
+
+### 3.3 Call-Site Migration
+
+All Python modules that previously called `torch.cuda.*` directly now go through `gpu_runtime`:
+
+
+| Call site                            | Before                                                | After                                                          |
+| ------------------------------------ | ----------------------------------------------------- | -------------------------------------------------------------- |
+| `memory_handle.py` IPC export/import | `cudart.cudaIpcGetMemHandle` / `cudaIpcOpenMemHandle` | `gpu_runtime.ipc_get_mem_handle()` / `ipc_open_mem_handle()`   |
+| `memory_handle.py` device strings    | `f"cuda:{device_id}"`                                 | `gpu_runtime.get_device_string(device_id)`                     |
+| `allocator.py` device selection      | `torch.cuda.current_device()`                         | `gpu_runtime.current_device()`                                 |
+| `transfer_engine.py` shutdown        | `torch.cuda.empty_cache(); synchronize()`             | `gpu_runtime.empty_cache(); synchronize()`                     |
+| `worker.py` stream creation          | `torch.cuda.Stream()`, `torch.cuda.stream(s)`         | `gpu_runtime.create_stream()`, `gpu_runtime.stream_context(s)` |
+| `kvtask.py` multi-node TP check      | `torch.cuda.device_count()`                           | `gpu_runtime.device_count()`                                   |
+| Integration adapters                 | `torch.cuda.current_device()`, `device_count()`       | `gpu_runtime.current_device()`, `device_count()`               |
+| `server/client.py` tensor check      | `tensor.is_cuda`                                      | `gpu_runtime.is_gpu_tensor(tensor)`                            |
+
+
+### 3.4 Extension Module Dispatch
+
+`flexkv/common/gpu_backend.py` provides:
+
+- `get_gpu_backend() → str` — returns `"cuda"` or `"musa"`.
+- `get_transfer_kv_blocks_module()` — returns `flexkv.c_ext_musa` (if MUSA and built) or `flexkv.c_ext`.
+
+`flexkv/transfer/worker.py` uses this at import time:
+
+```python
+_transfer_module = get_transfer_kv_blocks_module()
+transfer_kv_blocks     = _transfer_module.transfer_kv_blocks
+transfer_kv_blocks_ssd = _transfer_module.transfer_kv_blocks_ssd
+```
+
+TP and GDS classes follow the same MUSA-first, CUDA-fallback pattern.
+
+---
+
+## 4. Proposed Architecture for MUSA
+
+### 4.1 Strategy: Parallel MUSA Tree and Optional Extension
+
+- **New code only under a dedicated subtree** (`csrc/musa/`):
+  - MUSA-only sources that mirror the CUDA kernel + host logic using `musa_runtime.h` and `musa`* APIs.
+  - Shared logic that does not touch CUDA (e.g. `GTensorHandler`, `BackendType`, `ptr_at`) can be reused via a header-only copy or shared include.
+- **Build:**
+  - **Default (CUDA):** Unchanged. `setup.py` keeps building `flexkv.c_ext` with nvcc and CUDA sources only.
+  - **MUSA:** Gated by `FLEXKV_USE_MUSA=1`. Build a **second** extension `flexkv.c_ext_musa`. Compiles only MUSA sources with `mcc`, links `-lmusa`, and does **not** compile any of the current CUDA `.cu`/`.cpp`.
+
+### 4.2 Component Mapping
+
+
+| Component                | CUDA (current)                         | MUSA (new)                                         |
+| ------------------------ | -------------------------------------- | -------------------------------------------------- |
+| Transfer kernel + host   | `csrc/transfer.cu` / `transfer.cuh`    | `csrc/musa/transfer_musa.mu` + `transfer_musa.muh` |
+| Layout transform (GDS)   | `csrc/gds/layout_transform.cu`         | `csrc/musa/gds/layout_transform_musa.mu`           |
+| GTensorHandler           | `csrc/gtensor_handler.cuh`             | `csrc/musa/gtensor_handler_musa.h`                 |
+| Bindings                 | `bindings.cpp`                         | `csrc/musa/bindings_musa.cpp`                      |
+| TP transfer thread group | `tp_transfer_thread_group.cpp`         | `csrc/musa/tp_transfer_thread_group_musa.cpp`      |
+| GDS manager              | `gds/gds_manager.cpp`                  | `csrc/musa/gds/gds_manager_musa.cpp`               |
+| SSD transfer             | `csrc/transfer_ssd.cpp`                | Shared (pure CPU I/O, no GPU code)                 |
+| Hash / Radix tree        | `csrc/hash.cpp`, `csrc/radix_tree.cpp` | Shared (pure CPU)                                  |
+| CFS remote               | `csrc/pcfs/pcfs.cpp`                   | Shared (pure CPU I/O)                              |
+| Python                   | `from flexkv.c_ext import ...`         | `from flexkv.c_ext_musa import ...`                |
+
+
+### 4.3 Stream and Device Handling
+
+- **CUDA:** `bindings.cpp` uses `at::cuda::getCurrentCUDAStream()`. No change.
+- **MUSA:** `bindings_musa.cpp` uses `at::musa::getCurrentMUSAStream()` when MUSA SDK is available. Python backend abstraction handles stream creation via `gpu_runtime.create_stream()`.
+
+---
+
+## 5. TDD Strategy
+
+### 5.1 Test-First Approach
+
+1. **Build tests (no hardware)**
+  When `FLEXKV_USE_MUSA=1` and MUSA SDK is present, run build and assert the MUSA extension builds. When MUSA is not requested, only `flexkv.c_ext` is in the extension list.
+2. **Runtime dispatch tests**
+  When MUSA is available and selected, the worker imports `c_ext_musa` and can call `transfer_kv_blocks` without crashing. When only CUDA is available, the existing `c_ext` path is used (no regression).
+3. **Backend abstraction tests**
+  `gpu_runtime` functions dispatch correctly; when MUSA is selected but `torch.musa` is unavailable, functions raise `RuntimeError` instead of silently using CUDA.
+4. **Correctness / parity tests (MUSA hardware)**
+  Reuse or mirror existing transfer tests to run the same transfer with CUDA and, on a MUSA machine, with MUSA; compare outputs. Use pytest markers for CUDA-only and MUSA-only tests.
+
+### 5.2 Test Layout
+
+
+| File                                 | Scope                                                       | Marker              |
+| ------------------------------------ | ----------------------------------------------------------- | ------------------- |
+| `tests/test_musa_build.py`           | Build config: extension list with/without `FLEXKV_USE_MUSA` | —                   |
+| `tests/test_gpu_backend_dispatch.py` | Backend selection (CUDA vs MUSA), correct module resolution | —                   |
+| `tests/test_gpu_runtime.py`          | `gpu_runtime` wrappers: device, stream, IPC, error handling | —                   |
+| `tests/test_transfer_musa.py`        | MUSA transfer (stub or real) via `c_ext_musa`               | `@pytest.mark.musa` |
+
+
+No new tests alter existing CUDA-only tests.
+
+---
+
+## 6. Implementation Phases
+
+### Phase 1 — Build and Stub
+
+- Add `flexkv/build_config.py`, `flexkv/common/gpu_backend.py`.
+- Add `csrc/musa/bindings_musa.cpp` (stub `transfer_kv_blocks`), `csrc/musa/gtensor_handler_musa.h`.
+- Extend `setup.py`: detect `FLEXKV_USE_MUSA`, `MUSA_HOME`, `mcc`; build `flexkv.c_ext_musa`.
+- Add tests: `test_musa_build.py`, `test_gpu_backend_dispatch.py`, `test_transfer_musa.py`.
+- Add all documentation under `docs/musa/`.
+
+### Phase 2 — Transfer, Backend Abstraction, and GDS
+
+- Implement `gpu_runtime.py` with full backend abstraction (device, stream, IPC, host mem, sync).
+- Add `tests/test_gpu_runtime.py`.
+- Implement MUSA transfer kernel: `transfer_musa.mu`, `transfer_musa.muh`.
+- Implement MUSA TP transfer: `tp_transfer_thread_group_musa.cpp/.h`.
+- Implement MUSA GDS: `csrc/musa/gds/` (gds_manager_musa, layout_transform_musa, tp_gds_transfer_thread_group_musa) with muFile APIs.
+- Migrate all Python modules from `torch.cuda.`* to `gpu_runtime.*`.
+
+### Phase 3 — SSD / CFS / Remote Transfer in c_ext_musa
+
+- Expose SSD, hash, radix tree, CFS, and GDS bindings in `bindings_musa.cpp`.
+- Reuse backend-agnostic C++ sources (`transfer_ssd.cpp`, `hash.cpp`, `radix_tree.cpp`).
+- Update `setup.py` for shared sources and conditional CFS/GDS linking.
+- Update `worker.py` import dispatch for full API surface.
+
+---
+
+## 7. Build with MUSA SDK
+
+When `FLEXKV_USE_MUSA=1`, the default build produces a **C++-only** `flexkv.c_ext_musa` extension (stub `transfer_kv_blocks` and no TP). When the MUSA SDK and `mcc` are available:
+
+- **Kernel/host:** `csrc/musa/transfer_musa.mu`, `csrc/musa/transfer_musa.muh`, `csrc/musa/gtensor_handler_musa.h` — compile with `mcc`; link with `-lmusa`. Integrates with **torch_musa** for stream/device.
+- **TP transfer:** `csrc/musa/tp_transfer_thread_group_musa.cpp/.h` — uses `musa`* APIs.
+- **SSD/Hash/Radix (always):** `csrc/transfer_ssd.cpp`, `csrc/hash.cpp`, `csrc/radix_tree.cpp` — pure CPU, shared with CUDA extension; link `-luring`, `-lxxhash`.
+- **CFS (`FLEXKV_ENABLE_CFS=1`):** `csrc/pcfs/pcfs.cpp` + `-lhifs_client_sdk`.
+- **GDS (`FLEXKV_ENABLE_GDS=1` + MUSA SDK):** `csrc/musa/gds/*.cpp` and `*.mu` + `-lmufile`.
+
+---
+
+## 8. GDS for MUSA (muFile)
+
+cuFile APIs map 1:1 to muFile APIs:
+
+
+| cuFile (CUDA)                                                 | muFile (MUSA)                                                 |
+| ------------------------------------------------------------- | ------------------------------------------------------------- |
+| `cuFileDriverOpen`                                            | `muFileDriverOpen`                                            |
+| `cuFileHandleRegister` / `Deregister`                         | `muFileHandleRegister` / `Deregister`                         |
+| `cuFileRead` / `cuFileWrite`                                  | `muFileRead` / `muFileWrite`                                  |
+| `cuFileReadAsync` / `cuFileWriteAsync`                        | `muFileReadAsync` / `muFileWriteAsync`                        |
+| `cuFileBatchIOSetUp` / `Submit` / `GetStatus` / `Destroy`     | `muFileBatchIOSetUp` / `Submit` / `GetStatus` / `Destroy`     |
+| `CUfileHandle_t`, `CUfileDescr_t`, `CUfileError_t`            | `MUfileHandle_t`, `MUfileDescr_t`, `MUfileError_t`            |
+| `CUfileBatchHandle_t`, `CUfileIOParams_t`, `CUfileIOEvents_t` | `MUfileBatchHandle_t`, `MUfileIOParams_t`, `MUfileIOEvents_t` |
+| `CU_FILE_HANDLE_TYPE_OPAQUE_FD`                               | `MU_FILE_HANDLE_TYPE_OPAQUE_FD`                               |
+| `CUFILE_BATCH` / `CUFILE_READ` / `CUFILE_WRITE`               | `MUFILE_BATCH` / `MUFILE_READ` / `MUFILE_WRITE`               |
+
+
+MUSA GDS files live under `csrc/musa/gds/`:
+
+- `gds_manager_musa.h` / `.cpp` — GDSManagerMusa class with muFile + musa* APIs.
+- `layout_transform_musa.muh` / `.mu` — Layout transform kernel compiled with mcc.
+- `tp_gds_transfer_thread_group_musa.h` / `.cpp` — TP GDS group using musa* streams and GDSManagerMusa.
+

--- a/docs/musa/musa_test_plan.md
+++ b/docs/musa/musa_test_plan.md
@@ -1,0 +1,294 @@
+# MUSA Support Feature — Test Plan
+
+Test strategy, cases, and execution for the MUSA support feature.
+
+---
+
+## 1. Test Strategy
+
+- **No impact on CUDA:** All existing CUDA tests and flows must behave as before when MUSA is not used.
+- **TDD:** Build and backend-dispatch tests define expected behavior; MUSA transfer test validates stub (and future real impl) under `@pytest.mark.musa`.
+- **Backend abstraction coverage:** `gpu_runtime` functions are tested for correct dispatch, error handling (MUSA selected but unavailable), and device/stream/IPC operations.
+- **Environments:** Default CI may have no MUSA SDK or hardware; MUSA-specific tests are skippable or run only when MUSA is available.
+
+---
+
+## 2. Prerequisites & Environment Setup
+
+### 2.1 MUSA Test Machine Setup
+
+```bash
+# 1. Verify MUSA driver and device
+mthreads-gmi                        # Should list MUSA GPU(s)
+
+# 2. Verify MUSA SDK
+echo $MUSA_HOME                      # e.g. /usr/local/musa
+ls $MUSA_HOME/bin/mcc                # MUSA compiler must exist
+
+# 3. Verify torch_musa
+python3 -c "import torch_musa; import torch; print(torch.musa.is_available())"
+# Expected: True
+
+# 4. Clone repo and apply patch
+git clone <repo-url> FlexKV && cd FlexKV
+git apply musa_flexkv_all.patch
+
+# 5. Install dependencies (MUSA-specific)
+pip install -r requirements-musa.txt
+
+# 6. Build with MUSA enabled (debug mode skips Cython for faster iteration)
+FLEXKV_USE_MUSA=1 FLEXKV_DEBUG=1 pip install -e .
+```
+
+### 2.2 Verify Build Output
+
+```bash
+# Check the MUSA extension was built
+python3 -c "import flexkv.c_ext_musa; print('c_ext_musa imported OK')"
+
+# Check HAS_MUSA_SDK attribute (True if mcc was found during build)
+python3 -c "import flexkv.c_ext_musa as m; print('HAS_MUSA_SDK:', m.HAS_MUSA_SDK)"
+
+# On a MUSA-only machine (no nvcc), verify c_ext was skipped
+python3 -c "
+try:
+    import flexkv.c_ext
+    print('c_ext imported (CUDA available)')
+except ImportError:
+    print('c_ext NOT built (expected on MUSA-only machine)')
+"
+```
+
+---
+
+## 3. Test Cases & Execution
+
+### 3.1 Build Configuration Tests
+
+**File:** `tests/test_musa_build.py`
+
+| # | Test | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | `test_default_build_includes_only_c_ext` | Without `FLEXKV_USE_MUSA`, `get_cpp_extension_names()` returns only `["flexkv.c_ext"]`. | Always run; temporarily clears `FLEXKV_USE_MUSA` if set. |
+| 2 | `test_musa_build_includes_c_ext_musa` | With `FLEXKV_USE_MUSA=1`, extension list includes both `flexkv.c_ext` and `flexkv.c_ext_musa`. | Always run; sets env in test. |
+| 3 | `test_musa_disabled_omits_c_ext_musa` | With `FLEXKV_USE_MUSA=0` or unset, `flexkv.c_ext_musa` is not in the list. | Always run. |
+
+**Execute:**
+
+```bash
+# Run on any machine (no GPU required)
+pytest tests/test_musa_build.py -v
+
+# Expected output:
+# test_default_build_includes_only_c_ext PASSED
+# test_musa_build_includes_c_ext_musa PASSED
+# test_musa_disabled_omits_c_ext_musa PASSED
+```
+
+---
+
+### 3.2 Backend Dispatch Tests
+
+**File:** `tests/test_gpu_backend_dispatch.py`
+
+| # | Test | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | `test_get_gpu_backend_returns_cuda_or_musa` | `get_gpu_backend()` returns `"cuda"` or `"musa"`. | Always run. |
+| 2 | `test_cuda_available_uses_c_ext_by_default` | When CUDA is available and no override, `get_transfer_kv_blocks_module()` returns `flexkv.c_ext`. | Requires `torch.cuda.is_available()`. |
+| 3 | `test_musa_override_selects_c_ext_musa_when_built` | With `FLEXKV_GPU_BACKEND=musa`, backend is `"musa"` and module has `transfer_kv_blocks`. | Always run. |
+| 4 | `test_c_ext_musa_importable_when_built` | If `flexkv.c_ext_musa` is built, it can be imported and has `transfer_kv_blocks`. | Skip if `c_ext_musa` not built. |
+
+**Execute:**
+
+```bash
+# On MUSA machine (with c_ext_musa built)
+pytest tests/test_gpu_backend_dispatch.py -v
+
+# On CUDA machine (to verify no regression)
+pytest tests/test_gpu_backend_dispatch.py -v
+
+# Expected: all applicable tests PASSED, others SKIPPED
+```
+
+---
+
+### 3.3 GPU Runtime Abstraction Tests
+
+**File:** `tests/test_gpu_runtime.py`
+
+| # | Test | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | `test_current_device_returns_int` | `gpu_runtime.current_device()` returns a non-negative int. | Requires GPU. |
+| 2 | `test_device_count_positive` | `gpu_runtime.device_count()` returns a positive int. | Requires GPU. |
+| 3 | `test_empty_cache_no_error` | `gpu_runtime.empty_cache()` runs without error. | Requires GPU. |
+| 4 | `test_create_stream_returns_stream` | `gpu_runtime.create_stream()` returns a stream object. | Requires GPU. |
+| 5 | `test_get_device_string_format` | `gpu_runtime.get_device_string(0)` returns `"cuda:0"` or `"musa:0"`. | Always run. |
+| 6 | `test_musa_unavailable_raises_*` | When MUSA selected but `torch.musa` unavailable, all runtime functions raise `RuntimeError`. | Always run (mocks backend). |
+
+**Execute:**
+
+```bash
+# On MUSA machine — validates real torch.musa dispatch
+pytest tests/test_gpu_runtime.py -v
+
+# Verify device string is "musa:0"
+python3 -c "
+from flexkv.common import gpu_runtime
+print('Backend:', gpu_runtime.get_gpu_backend())
+print('Device string:', gpu_runtime.get_device_string(0))
+print('Device count:', gpu_runtime.device_count())
+print('Current device:', gpu_runtime.current_device())
+"
+# Expected on MUSA: Backend: musa, Device string: musa:0
+```
+
+---
+
+### 3.4 MUSA Transfer Tests
+
+**File:** `tests/test_transfer_musa.py`
+
+| # | Test | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | `test_transfer_kv_blocks_musa_no_crash` | Calls `c_ext_musa.transfer_kv_blocks` with minimal tensors; no exception. | `@pytest.mark.musa`; skip if `c_ext_musa` not built. |
+
+**Execute:**
+
+```bash
+# On MUSA machine with MUSA SDK build
+pytest tests/test_transfer_musa.py -v -m musa
+
+# Stub-only build (no MUSA SDK) — still should pass (no-op stub)
+FLEXKV_USE_MUSA=1 pytest tests/test_transfer_musa.py -v -m musa
+
+# Quick manual smoke test of the transfer binding
+python3 -c "
+import torch
+import flexkv.c_ext_musa as m
+print('transfer_kv_blocks available:', hasattr(m, 'transfer_kv_blocks'))
+print('HAS_MUSA_SDK:', m.HAS_MUSA_SDK)
+print('SSD transfer available:', hasattr(m, 'transfer_kv_blocks_ssd'))
+print('Hasher available:', hasattr(m, 'Hasher'))
+print('CRadixTreeIndex available:', hasattr(m, 'CRadixTreeIndex'))
+"
+```
+
+---
+
+### 3.5 Regression: Existing CUDA Behavior
+
+Ensure existing tests pass with the new backend dispatch and no MUSA override.
+
+**Execute:**
+
+```bash
+# Run on a CUDA machine to ensure no regression
+pytest tests/test_kvmanager.py -v
+pytest tests/test_memory_handle.py -v
+pytest tests/test_cache_engine.py -v
+
+# Full suite excluding MUSA-specific tests
+pytest tests/ -v -m "not musa"
+```
+
+| Area | Command | Expected |
+|------|---------|----------|
+| Transfer / KV manager | `pytest tests/test_kvmanager.py -v` | Worker uses `c_ext`; same behavior as before. |
+| Memory handle | `pytest tests/test_memory_handle.py -v` | IPC now via `gpu_runtime` but behavior identical on CUDA. |
+| Cache engine | `pytest tests/test_cache_engine.py -v` | No change in behavior. |
+
+---
+
+## 4. End-to-End Validation on MUSA Machine
+
+### 4.1 Build & Install
+
+```bash
+cd FlexKV
+git checkout main
+git apply musa_flexkv_all.patch
+
+# MUSA-only build (no CUDA)
+FLEXKV_USE_MUSA=1 FLEXKV_DEBUG=1 pip install -e .
+```
+
+### 4.2 Run All MUSA Tests
+
+```bash
+# Step 1: Build config tests (no GPU needed)
+pytest tests/test_musa_build.py -v
+# Expected: 3/3 PASSED
+
+# Step 2: GPU runtime tests
+pytest tests/test_gpu_runtime.py -v
+# Expected: all PASSED (real MUSA dispatch)
+
+# Step 3: Transfer stub/real tests
+pytest tests/test_transfer_musa.py -v -m musa
+# Expected: PASSED (stub or real kernel depending on build)
+
+# Step 4: Full MUSA test suite in one command (use this on MUSA-only machines)
+pytest tests/test_musa_build.py tests/test_gpu_runtime.py tests/test_transfer_musa.py -v
+```
+
+### 4.3 Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `ModuleNotFoundError: flexkv.c_ext_musa` | Extension not built | Verify `FLEXKV_USE_MUSA=1` was set during `pip install` |
+| `ImportError: libmusa.so` | MUSA runtime not in LD path | `export LD_LIBRARY_PATH=$MUSA_HOME/lib:$LD_LIBRARY_PATH` |
+| `HAS_MUSA_SDK = False` | `mcc` not found during build | Verify `$MUSA_HOME/bin/mcc` exists and `MUSA_HOME` is set |
+| `RuntimeError: MUSA backend ... torch.musa unavailable` | `torch_musa` not installed | `pip install torch_musa` or use `requirements-musa.txt` |
+| `pip install` pulls `nvtx` or CUDA packages | Wrong requirements file | Use `pip install -r requirements-musa.txt` on MUSA machines |
+| `error: flexkv.c_ext build failed` on MUSA-only machine | CUDA ext attempted without nvcc | Verify `FLEXKV_USE_MUSA=1` is set — this skips CUDA ext |
+| `pytest tests/ -v -m musa` fails with `ModuleNotFoundError: flexkv.c_ext` or `nvtx` | Collection imports non-MUSA tests that need CUDA | Use explicit file list: `pytest tests/test_musa_build.py tests/test_gpu_runtime.py tests/test_transfer_musa.py -v -m musa` |
+
+---
+
+## 5. Environment Matrix
+
+| Environment | FLEXKV_USE_MUSA | MUSA SDK / mcc | Expected |
+|-------------|-----------------|----------------|----------|
+| CI (CUDA only) | 0 or unset | No | Only `flexkv.c_ext` built; non-musa tests pass; musa tests skipped. |
+| CI (MUSA stub) | 1 | No | `flexkv.c_ext_musa` built (C++ stub); build + dispatch tests pass. |
+| MUSA dev (SDK) | 1 | Yes | Full MUSA build with `transfer_musa.mu`, TP; all MUSA tests pass. |
+| MUSA dev (SDK + GDS) | 1 | Yes + muFile | Full build including GDS/muFile; GDS transfer tests can run. |
+| MUSA-only (no CUDA) | 1 | Yes | `flexkv.c_ext` skipped; only `c_ext_musa` built; all MUSA tests pass. |
+
+---
+
+## 6. Running the Full Test Suite
+
+```bash
+# All tests (musa tests skip if c_ext_musa not built / no MUSA)
+pytest tests/ -v
+
+# Exclude MUSA-only tests (e.g. CI without MUSA)
+pytest tests/ -v -m "not musa"
+
+# Only MUSA-related tests (use this on MUSA-only machines)
+pytest tests/test_musa_build.py tests/test_gpu_runtime.py tests/test_transfer_musa.py -v
+
+# Only MUSA hardware tests — use explicit file list on MUSA-only machines
+# (pytest tests/ -v -m musa fails there because collection imports test_cache_engine,
+# test_kvmanager, test_namespace_isolation which require flexkv.c_ext or nvtx)
+pytest tests/test_musa_build.py tests/test_gpu_runtime.py tests/test_transfer_musa.py -v -m musa
+```
+
+---
+
+## 7. Pytest Marker
+
+- **`musa`:** Marks tests that require or specifically target the MUSA backend (e.g. `c_ext_musa` or MUSA device).
+- Defined in `pyproject.toml` under `[tool.pytest.ini_options]` → `markers`.
+- Use `-m musa` to run only MUSA tests, `-m "not musa"` to exclude them.
+
+---
+
+## 8. Test-to-Phase Mapping
+
+| Phase | Test Files | What is validated |
+|-------|-----------|-------------------|
+| Phase 1 | `test_musa_build.py`, `test_transfer_musa.py` | Build config, stub import |
+| Phase 2 | `test_gpu_runtime.py` + all Phase 1 tests | Backend abstraction (device, stream, IPC, error handling), Python migration correctness |
+| Phase 3 | All Phase 1+2 tests + regression suite | SSD/CFS/GDS bindings via `c_ext_musa`, full API parity |

--- a/flexkv/build_config.py
+++ b/flexkv/build_config.py
@@ -1,0 +1,31 @@
+"""
+Build configuration helpers for FlexKV.
+Used by setup.py and tests to get the list of C++ extensions to build.
+"""
+import os
+import shutil
+
+
+def _has_cuda_toolkit():
+    """Return True if a CUDA toolkit (nvcc) is available on this system."""
+    return (
+        bool(os.environ.get("CUDA_HOME"))
+        or bool(os.environ.get("CUDA_PATH"))
+        or shutil.which("nvcc") is not None
+    )
+
+
+def get_cpp_extension_names():
+    """
+    Return list of C++ extension module names that would be built
+    under the current environment (FLEXKV_USE_MUSA, etc.).
+    """
+    enable_musa = os.environ.get("FLEXKV_USE_MUSA", "0").strip() == "1"
+    has_cuda = _has_cuda_toolkit()
+
+    names = []
+    if has_cuda or not enable_musa:
+        names.append("flexkv.c_ext")
+    if enable_musa:
+        names.append("flexkv.c_ext_musa")
+    return names

--- a/flexkv/common/gpu_backend.py
+++ b/flexkv/common/gpu_backend.py
@@ -1,0 +1,69 @@
+"""
+GPU backend detection and dispatch for FlexKV.
+Selects CUDA (flexkv.c_ext) or MUSA (flexkv.c_ext_musa) based on availability.
+
+MUSA uses the torch_musa project (PyTorch for Moore Threads MUSA GPUs).
+When torch.musa is available, backend is 'musa' and transfer uses c_ext_musa.
+See: https://github.com/MooreThreads/torch_musa
+"""
+from typing import Optional, Any
+
+
+def get_gpu_backend() -> str:
+    """
+    Return the active GPU backend: 'cuda' or 'musa'.
+    Prefers CUDA if both are available unless explicitly overridden.
+    """
+    import torch
+    # Allow override for testing or explicit MUSA selection
+    import os
+    if os.environ.get("FLEXKV_GPU_BACKEND", "").lower() == "musa":
+        return "musa"
+    if torch.cuda.is_available():
+        return "cuda"
+    if _musa_available():
+        return "musa"
+    return "cuda"  # default name for extension; may not be available
+
+
+def _musa_available() -> bool:
+    """Return True if torch.musa (torch_musa project) is available and has devices."""
+    try:
+        import torch
+        musa = getattr(torch, "musa", None)
+        if musa is None:
+            return False
+        return getattr(musa, "is_available", lambda: False)()
+    except Exception:
+        return False
+
+
+def get_transfer_kv_blocks_module() -> Any:
+    """
+    Return the module that provides transfer_kv_blocks for the active backend.
+    Either flexkv.c_ext (CUDA) or flexkv.c_ext_musa (MUSA).
+    """
+    backend = get_gpu_backend()
+    if backend == "musa":
+        try:
+            return __import__("flexkv.c_ext_musa", fromlist=["transfer_kv_blocks"])
+        except ImportError:
+            # MUSA extension not built; fall back to c_ext (will fail if no CUDA)
+            try:
+                return __import__("flexkv.c_ext", fromlist=["transfer_kv_blocks"])
+            except ImportError:
+                raise ImportError(
+                    "Neither flexkv.c_ext_musa nor flexkv.c_ext is available. "
+                    "Please build FlexKV with CUDA support or MUSA support."
+                )
+    try:
+        return __import__("flexkv.c_ext", fromlist=["transfer_kv_blocks"])
+    except ImportError:
+        # Try MUSA as fallback
+        try:
+            return __import__("flexkv.c_ext_musa", fromlist=["transfer_kv_blocks"])
+        except ImportError:
+            raise ImportError(
+                "Neither flexkv.c_ext nor flexkv.c_ext_musa is available. "
+                "Please build FlexKV with CUDA support or MUSA support."
+            )

--- a/flexkv/common/gpu_runtime.py
+++ b/flexkv/common/gpu_runtime.py
@@ -1,0 +1,253 @@
+"""
+GPU runtime abstraction for FlexKV — CUDA and MUSA.
+
+Provides backend-agnostic wrappers for host memory registration, stream
+acquisition, device management, IPC handles, and cache control so callers
+do not need to know which GPU backend is active.
+
+MUSA support uses the torch_musa project:
+  https://github.com/MooreThreads/torch_musa
+"""
+import contextlib
+import ctypes
+from typing import Any, Generator, Optional, Tuple
+
+import torch
+
+from flexkv.common.gpu_backend import get_gpu_backend
+
+_runtime_lib = None
+_backend: str = ""
+
+
+def _load_runtime():
+    global _runtime_lib, _backend
+    if _runtime_lib is not None:
+        return
+    _backend = get_gpu_backend()
+    if _backend == "musa":
+        _runtime_lib = ctypes.CDLL("libmusart.so")
+    else:
+        _runtime_lib = ctypes.CDLL("libcudart.so")
+
+
+def _require_musa_module():
+    """Return ``torch.musa`` or raise if the MUSA backend was selected but is unavailable."""
+    musa_mod = getattr(torch, "musa", None)
+    if musa_mod is None:
+        raise RuntimeError(
+            "GPU backend is 'musa' but torch.musa is not available. "
+            "Install torch_musa (https://github.com/MooreThreads/torch_musa) "
+            "or set FLEXKV_GPU_BACKEND to 'cuda'."
+        )
+    return musa_mod
+
+
+# ---------------------------------------------------------------------------
+# Host memory registration
+# ---------------------------------------------------------------------------
+
+def host_register(tensor: torch.Tensor) -> None:
+    """Register a CPU tensor for pinned-memory access on the active backend."""
+    _load_runtime()
+    ptr = tensor.data_ptr()
+    size = tensor.numel() * tensor.element_size()
+    if _backend == "musa":
+        ret = _runtime_lib.musaHostRegister(
+            ctypes.c_void_p(ptr), ctypes.c_size_t(size), 1
+        )
+        if ret != 0:
+            raise RuntimeError(f"musaHostRegister failed with error code {ret}")
+    else:
+        ret = _runtime_lib.cudaHostRegister(
+            ctypes.c_void_p(ptr), ctypes.c_size_t(size), 1
+        )
+        if ret != 0:
+            raise RuntimeError(f"cudaHostRegister failed with error code {ret}")
+
+
+def host_unregister(tensor: torch.Tensor) -> None:
+    """Unregister a previously registered CPU tensor."""
+    _load_runtime()
+    ptr = tensor.data_ptr()
+    if _backend == "musa":
+        _runtime_lib.musaHostUnregister(ctypes.c_void_p(ptr))
+    else:
+        _runtime_lib.cudaHostUnregister(ctypes.c_void_p(ptr))
+
+
+# ---------------------------------------------------------------------------
+# Device management
+# ---------------------------------------------------------------------------
+
+def set_device(device_id: int) -> None:
+    """Set the active GPU device."""
+    if get_gpu_backend() == "musa":
+        _require_musa_module().set_device(device_id)
+    else:
+        torch.cuda.set_device(device_id)
+
+
+def current_device() -> int:
+    """Return the index of the currently selected GPU device."""
+    if get_gpu_backend() == "musa":
+        return _require_musa_module().current_device()
+    return torch.cuda.current_device()
+
+
+def device_count() -> int:
+    """Return the number of available GPU devices."""
+    if get_gpu_backend() == "musa":
+        return _require_musa_module().device_count()
+    return torch.cuda.device_count()
+
+
+def get_device_string(device_id: int) -> str:
+    """Return the device string for the given device id, e.g. ``'cuda:0'`` or ``'musa:0'``."""
+    backend = get_gpu_backend()
+    return f"{backend}:{device_id}"
+
+
+def get_device(device_id: int) -> torch.device:
+    """Return a ``torch.device`` for the given device id on the active backend."""
+    return torch.device(get_device_string(device_id))
+
+
+# ---------------------------------------------------------------------------
+# Stream management
+# ---------------------------------------------------------------------------
+
+def get_current_stream() -> Any:
+    """Return the current GPU stream for the active backend."""
+    if get_gpu_backend() == "musa":
+        return _require_musa_module().current_stream()
+    return torch.cuda.current_stream()
+
+
+def create_stream() -> Any:
+    """Create a new GPU stream on the active backend."""
+    if get_gpu_backend() == "musa":
+        return _require_musa_module().Stream()
+    return torch.cuda.Stream()
+
+
+@contextlib.contextmanager
+def stream_context(stream: Any) -> Generator[None, None, None]:
+    """Context manager to execute on the given stream (works for both CUDA and MUSA)."""
+    if get_gpu_backend() == "musa":
+        with _require_musa_module().stream(stream):
+            yield
+    else:
+        with torch.cuda.stream(stream):
+            yield
+
+
+# ---------------------------------------------------------------------------
+# Synchronisation & cache
+# ---------------------------------------------------------------------------
+
+def synchronize(device_id: int | None = None) -> None:
+    """Synchronize the GPU device."""
+    if get_gpu_backend() == "musa":
+        musa = _require_musa_module()
+        if device_id is not None:
+            musa.set_device(device_id)
+        musa.synchronize()
+    else:
+        if device_id is not None:
+            torch.cuda.set_device(device_id)
+        torch.cuda.synchronize()
+
+
+def empty_cache() -> None:
+    """Release all unoccupied cached memory held by the GPU allocator."""
+    if get_gpu_backend() == "musa":
+        _require_musa_module().empty_cache()
+    else:
+        torch.cuda.empty_cache()
+
+
+# ---------------------------------------------------------------------------
+# Initialisation helpers
+# ---------------------------------------------------------------------------
+
+def is_initialized() -> bool:
+    """Return whether the GPU runtime has been initialised."""
+    if get_gpu_backend() == "musa":
+        return getattr(_require_musa_module(), "is_initialized", lambda: False)()
+    return torch.cuda.is_initialized()
+
+
+def init_runtime() -> None:
+    """Explicitly initialise the GPU runtime context."""
+    if get_gpu_backend() == "musa":
+        _require_musa_module().init()
+    else:
+        torch.cuda.init()
+
+
+# ---------------------------------------------------------------------------
+# Tensor device helpers
+# ---------------------------------------------------------------------------
+
+def is_gpu_tensor(tensor: torch.Tensor) -> bool:
+    """Return True if *tensor* lives on the active GPU backend (CUDA or MUSA)."""
+    if tensor.is_cuda:
+        return True
+    if get_gpu_backend() == "musa":
+        return str(tensor.device).startswith("musa")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# IPC handle helpers (ctypes)
+# ---------------------------------------------------------------------------
+
+IPC_HANDLE_SIZE = 64
+
+
+class _IpcMemHandle(ctypes.Structure):
+    """64-byte IPC memory handle — identical layout for both CUDA and MUSA."""
+    _fields_ = [("reserved", ctypes.c_byte * IPC_HANDLE_SIZE)]
+
+
+def _get_runtime_lib() -> ctypes.CDLL:
+    """Return the loaded runtime library (loads lazily)."""
+    _load_runtime()
+    return _runtime_lib  # type: ignore[return-value]
+
+
+def ipc_get_mem_handle(data_ptr: int) -> bytes:
+    """Call cudaIpcGetMemHandle / musaIpcGetMemHandle and return 64-byte handle."""
+    lib = _get_runtime_lib()
+    handle = _IpcMemHandle()
+    if get_gpu_backend() == "musa":
+        result = lib.musaIpcGetMemHandle(ctypes.byref(handle), ctypes.c_void_p(data_ptr))
+        if result != 0:
+            raise RuntimeError(f"musaIpcGetMemHandle failed with error code {result}")
+    else:
+        result = lib.cudaIpcGetMemHandle(ctypes.byref(handle), ctypes.c_void_p(data_ptr))
+        if result != 0:
+            raise RuntimeError(f"cudaIpcGetMemHandle failed with error code {result}")
+    return ctypes.string_at(ctypes.byref(handle), IPC_HANDLE_SIZE)
+
+
+def ipc_open_mem_handle(handle_bytes: bytes) -> int:
+    """Call cudaIpcOpenMemHandle / musaIpcOpenMemHandle and return the device pointer."""
+    lib = _get_runtime_lib()
+    handle = _IpcMemHandle()
+    ctypes.memmove(ctypes.byref(handle), handle_bytes, IPC_HANDLE_SIZE)
+    dev_ptr = ctypes.c_void_p()
+    if get_gpu_backend() == "musa":
+        result = lib.musaIpcOpenMemHandle(
+            ctypes.byref(dev_ptr), handle, ctypes.c_int(1)
+        )
+        if result != 0:
+            raise RuntimeError(f"musaIpcOpenMemHandle failed with error code {result}")
+    else:
+        result = lib.cudaIpcOpenMemHandle(
+            ctypes.byref(dev_ptr), handle, ctypes.c_int(1)
+        )
+        if result != 0:
+            raise RuntimeError(f"cudaIpcOpenMemHandle failed with error code {result}")
+    return dev_ptr.value

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -3,34 +3,13 @@ import os
 import time
 from typing import Callable, Any, Optional, Tuple, Union
 from dataclasses import dataclass
-import ctypes
 
 import torch
 import torch.multiprocessing.reductions as reductions
 import zmq
 
 from flexkv.common.debug import flexkv_logger
-
-
-class cudaIpcMemHandle_t(ctypes.Structure):
-    _fields_ = [("reserved", ctypes.c_byte * 64)]
-
-
-# Load CUDA runtime library
-try:
-    cudart = ctypes.CDLL("libcudart.so")
-except:
-    try:
-        cudart = ctypes.CDLL("libcudart.so.12")
-    except:
-        cudart = ctypes.CDLL("libcudart.so.11")
-
-# CUDA IPC handle size (64 bytes on Linux)
-CUDA_IPC_HANDLE_SIZE = 64
-
-# CUDA error codes
-cudaSuccess = 0
-cudaErrorInvalidValue = 11
+from flexkv.common import gpu_runtime
 
 
 @dataclass
@@ -38,7 +17,6 @@ class TensorSharedHandle:
     rebuild_func: Optional[Callable]
     rebuild_args: Optional[Tuple[Any]]
     device: torch.device
-    # For direct CUDA IPC
     use_direct_ipc: bool = False
     ipc_handle: Optional[bytes] = None
     tensor_shape: Optional[Tuple[int, ...]] = None
@@ -52,17 +30,20 @@ class TensorSharedHandle:
         device_id: int = -1,
         force_direct_ipc: bool = False,
         *,
-        tensor_shape: Optional[Tuple[int, ...]] = None,  # only used when data is bytes
+        tensor_shape: Optional[Tuple[int, ...]] = None,
         tensor_dtype: Optional[
             Union[torch.dtype, str]
-        ] = None,  # only used when data is bytes
-        offset: int = 0,  # offset in bytes from base pointer (for memory pool allocations)
+        ] = None,
+        offset: int = 0,
     ):
         """
         Now we support three ways to construct TensorSharedHandle:
-        If data is a tensor that is managed by torch, we will use the reduce_tensor method to export the TensorSharedHandle.
-        If data is a tensor that is allocated by cudamalloc, we will use the cudaIpcGetMemHandle method to export the TensorSharedHandle.
-        If data is bytes-like, it means the memory has already been shared by CUDA IPC, we will skip the export process to construct the TensorSharedHandle.
+        If data is a tensor that is managed by torch, we will use the reduce_tensor method
+            to export the TensorSharedHandle.
+        If data is a tensor that is allocated by cudamalloc/musaMalloc, we will use the
+            IPC API to export the TensorSharedHandle.
+        If data is bytes-like, it means the memory has already been shared by IPC,
+            we will skip the export process to construct the TensorSharedHandle.
         """
 
         self.use_direct_ipc = False
@@ -91,11 +72,10 @@ class TensorSharedHandle:
         device_id: int,
         force_direct_ipc: bool,
     ) -> None:
-        if not tensor.is_cuda:
-            raise ValueError("Only support CUDA tensor sharing")
+        if not gpu_runtime.is_gpu_tensor(tensor):
+            raise ValueError("Only support GPU tensor sharing (CUDA or MUSA)")
 
         if not force_direct_ipc:
-            ## Try PyTorch's built-in method first
             try:
                 (
                     self.rebuild_func,
@@ -105,7 +85,7 @@ class TensorSharedHandle:
                 if device_id == -1:
                     self.device = tensor_device_id
                 else:
-                    self.device = torch.device(f"cuda:{device_id}")
+                    self.device = gpu_runtime.get_device(device_id)
                     tmp_list = list(self.rebuild_args)
                     tmp_list[6] = device_id
                     self.rebuild_args = tuple(tmp_list)
@@ -114,27 +94,26 @@ class TensorSharedHandle:
                 # )
                 return
             except RuntimeError as e:
-                flexkv_logger.warning(f"PyTorch CUDA IPC export failed: {e}")
-                flexkv_logger.info("Attempting direct CUDA IPC export...")
+                flexkv_logger.warning(f"PyTorch IPC export failed: {e}")
+                flexkv_logger.info("Attempting direct IPC export...")
 
         try:
-            ## Try direct CUDA IPC export
-            self.ipc_handle = self._export_cuda_ipc_handle(tensor)
+            self.ipc_handle = self._export_ipc_handle(tensor)
             self.use_direct_ipc = True
             self.tensor_shape = tuple(tensor.shape)
             self.tensor_dtype = tensor.dtype
             self.tensor_numel = tensor.numel()
             self.device = (
-                tensor.device if device_id == -1 else torch.device(f"cuda:{device_id}")
+                tensor.device if device_id == -1 else gpu_runtime.get_device(device_id)
             )
             self.rebuild_func = None
             self.rebuild_args = None
-            self.offset = 0    ## only used when constructing from direct ipc handle
+            self.offset = 0
             flexkv_logger.info(
-                f"Tensor exported via direct CUDA IPC: tensor.device={tensor.device}, passed device_id={device_id}, final self.device={self.device}"
+                f"Tensor exported via direct IPC: tensor.device={tensor.device}, passed device_id={device_id}, final self.device={self.device}"
             )
         except Exception as e:
-            raise RuntimeError(f"Both PyTorch and direct CUDA IPC export failed: {e}")
+            raise RuntimeError(f"Both PyTorch and direct IPC export failed: {e}") from e
 
     def _init_from_ipc_handle(
         self,
@@ -156,7 +135,7 @@ class TensorSharedHandle:
         resolved_shape = tuple(int(dim) for dim in tensor_shape)
         resolved_dtype = self._ensure_torch_dtype(tensor_dtype)
 
-        self.use_direct_ipc = True # must set to true when constructing from direct ipc handle
+        self.use_direct_ipc = True
         self.ipc_handle = bytes(ipc_handle)
         self.tensor_shape = resolved_shape
         self.tensor_dtype = resolved_dtype
@@ -164,12 +143,11 @@ class TensorSharedHandle:
         for dim in resolved_shape:
             numel *= dim
         self.tensor_numel = numel
-        self.device = torch.device(f"cuda:{device_id}")
+        self.device = gpu_runtime.get_device(device_id)
         self.rebuild_func = None
         self.rebuild_args = None
         self.offset = offset
-        
-  
+
         flexkv_logger.info(
             f"TensorSharedHandle constructed from external IPC handle {self.ipc_handle.hex()} on device {self.device} \
                 with shape {self.tensor_shape} and dtype {self.tensor_dtype}, ptr offset={offset}"
@@ -206,15 +184,15 @@ class TensorSharedHandle:
 
     def get_tensor(self) -> torch.Tensor:
         if self.use_direct_ipc:
-            return self._import_cuda_ipc_handle(
-                self.ipc_handle, self.tensor_shape, self.tensor_dtype, self.device, offset=self.offset
+            return self._import_ipc_handle(
+                self.ipc_handle, self.tensor_shape, self.tensor_dtype, self.device,
+                offset=self.offset
             )
         else:
             return self._import_tensor_handle(
                 self.rebuild_func, self.rebuild_args, self.device
             )
 
-    ## Export tensor handle
     @staticmethod
     def _export_tensor_handle(
         tensor: torch.Tensor,
@@ -223,7 +201,129 @@ class TensorSharedHandle:
         rebuild_func, rebuild_args = reductions.reduce_tensor(tensor)
         return rebuild_func, rebuild_args, device
 
-    ## Import tensor handle
+    @staticmethod
+    def _export_ipc_handle(tensor: torch.Tensor) -> bytes:
+        """Export an IPC handle for the tensor using the active backend (CUDA or MUSA)."""
+        data_ptr = tensor.data_ptr()
+        device = tensor.device
+
+        flexkv_logger.debug(f"Exporting IPC handle: device={device}, data_ptr={hex(data_ptr)}")
+        gpu_runtime.set_device(device.index if device.index is not None else 0)
+
+        handle_bytes = gpu_runtime.ipc_get_mem_handle(data_ptr)
+        flexkv_logger.debug(f"IPC handle exported successfully, first 16 bytes: {handle_bytes.hex()}")
+        return handle_bytes
+
+    @staticmethod
+    def _import_ipc_handle(
+        ipc_handle: bytes,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+        offset: int = 0,
+    ) -> torch.Tensor:
+        """Import a tensor from an IPC handle using the active backend (CUDA or MUSA)."""
+        flexkv_logger.debug(f"Attempting to import IPC handle for device {device}")
+
+        if not gpu_runtime.is_initialized():
+            flexkv_logger.info("Initializing GPU runtime in subprocess")
+            gpu_runtime.init_runtime()
+
+        device_id = device.index if device.index is not None else 0
+        gpu_runtime.set_device(device_id)
+
+        _ = torch.zeros(1, device=device)
+        flexkv_logger.debug(
+            f"GPU context created for device {device_id}, current_device={gpu_runtime.current_device()}"
+        )
+
+        dev_ptr_value = gpu_runtime.ipc_open_mem_handle(ipc_handle)
+
+        data_ptr = dev_ptr_value + offset
+        if offset > 0:
+            flexkv_logger.info(
+                f"_import_ipc_handle: base_gpu_ptr={hex(dev_ptr_value)}, offset={offset}, actual data_ptr={hex(data_ptr)}"
+            )
+
+        flexkv_logger.debug(f"import IPC handle: device={device}, dev_ptr={hex(data_ptr)}")
+
+        tensor = TensorSharedHandle._create_tensor_from_gpu_ptr(
+            data_ptr, shape, dtype, device
+        )
+
+        flexkv_logger.debug(f"Imported tensor with shape {shape} from IPC handle, offset={offset}")
+        return tensor
+
+    @staticmethod
+    def _create_tensor_from_gpu_ptr(
+        data_ptr: int, shape: Tuple[int, ...], dtype: torch.dtype, device: torch.device,
+        strides: Optional[Tuple[int, ...]] = None
+    ) -> torch.Tensor:
+        """
+        Create a PyTorch tensor from a GPU memory pointer (CUDA or MUSA).
+
+        Handles bfloat16 and fp8 via intermediate uint types since
+        __cuda_array_interface__ doesn't support their typestr directly.
+        """
+        TYPESTR_MAP = {
+            torch.float32: "<f4",
+            torch.float64: "<f8",
+            torch.float16: "<f2",
+            torch.int32: "<i4",
+            torch.int64: "<i8",
+            torch.int16: "<i2",
+            torch.uint8: "|u1",
+            torch.int8: "|i1",
+            torch.bool: "|b1",
+            torch.uint16: "<u2",
+        }
+
+        if dtype == torch.bfloat16:
+            class _ArrayInterface:
+                def __init__(self, ptr, shape, strides=None):
+                    self.__cuda_array_interface__ = {
+                        "data": (ptr, False),
+                        "shape": tuple(shape),
+                        "typestr": "<u2",
+                        "version": 3,
+                        "strides": strides,
+                        "descr": [("", "")],
+                    }
+            array_iface = _ArrayInterface(data_ptr, shape, strides)
+            tensor_u16 = torch.as_tensor(array_iface, dtype=torch.uint16, device=device)
+            return tensor_u16.view(torch.bfloat16)
+
+        elif hasattr(torch, 'float8_e4m3fn') and dtype == torch.float8_e4m3fn:
+            class _ArrayInterface:
+                def __init__(self, ptr, shape, strides=None):
+                    self.__cuda_array_interface__ = {
+                        "data": (ptr, False),
+                        "shape": tuple(shape),
+                        "typestr": "|u1",
+                        "version": 3,
+                        "strides": strides,
+                        "descr": [("", "")],
+                    }
+            array_iface = _ArrayInterface(data_ptr, shape, strides)
+            return torch.as_tensor(array_iface, dtype=torch.uint8, device=device).view(torch.float8_e4m3fn)
+
+        else:
+            if dtype not in TYPESTR_MAP:
+                raise ValueError(f"Unsupported dtype for GPU pointer: {dtype}")
+
+            class _ArrayInterface:
+                def __init__(self, ptr, shape, typestr, strides=None):
+                    self.__cuda_array_interface__ = {
+                        "data": (ptr, False),
+                        "shape": tuple(shape),
+                        "typestr": typestr,
+                        "version": 3,
+                        "strides": strides,
+                        "descr": [("", "")],
+                    }
+            array_iface = _ArrayInterface(data_ptr, shape, TYPESTR_MAP[dtype], strides)
+            return torch.as_tensor(array_iface, dtype=dtype, device=device)
+
     @staticmethod
     def _import_tensor_handle(
         rebuild_func: Callable, rebuild_args: Tuple[Any], device: torch.device
@@ -244,205 +344,6 @@ class TensorSharedHandle:
             flexkv_logger.error("Import tensor handle failed: %s", e)
             return torch.empty(0)
 
-    @staticmethod
-    def _create_tensor_from_cuda_ptr(
-        data_ptr: int, shape: Tuple[int, ...], dtype: torch.dtype, device: torch.device, strides: Optional[Tuple[int, ...]] = None
-    ) -> torch.Tensor:
-        """
-        Helper function to create a PyTorch tensor from a CUDA memory pointer.
-        
-        This function handles the special case of bfloat16 by using uint16 as an intermediate
-        type, since PyTorch's __cuda_array_interface__ doesn't support "<e" typestr directly.
-        
-        Args:
-            data_ptr: CUDA memory pointer (integer address)
-            shape: Tensor shape
-            dtype: PyTorch dtype
-            device: Target CUDA device
-            strides: Optional strides (None for C-contiguous)
-        
-        Returns:
-            PyTorch tensor pointing to the CUDA memory (zero-copy)
-        """
-        # Typestr mapping for __cuda_array_interface__
-        TYPESTR_MAP = {
-            torch.float32: "<f4",
-            torch.float64: "<f8",
-            torch.float16: "<f2",
-            torch.int32: "<i4",
-            torch.int64: "<i8",
-            torch.int16: "<i2",
-            torch.uint8: "|u1",
-            torch.int8: "|i1",
-            torch.bool: "|b1",
-            torch.uint16: "<u2"
-        }
-        
-        # For bfloat16, PyTorch's __cuda_array_interface__ doesn't support "<e" directly.
-        # We need to use uint16 ("<u2") and then view as bfloat16 to get correct data.
-        # This is a zero-copy operation - view() only changes the type interpretation.
-        if dtype == torch.bfloat16:
-            class CudaArrayInterface:
-                def __init__(self, ptr, shape, strides=None):
-                    self.__cuda_array_interface__ = {
-                        "data": (ptr, False),  # (data_ptr, read_only)
-                        "shape": tuple(shape),
-                        "typestr": "<u2",  # uint16 (bfloat16 is stored as 16-bit)
-                        "version": 3,
-                        "strides": strides,  # None for C-contiguous
-                        "descr": [("", "")],
-                    }
-            
-            cuda_interface = CudaArrayInterface(data_ptr, shape, strides)
-            # Create as uint16 first, then view as bfloat16 (zero-copy type reinterpretation)
-            tensor_u16 = torch.as_tensor(cuda_interface, dtype=torch.uint16, device=device)
-            return tensor_u16.view(torch.bfloat16)
-
-        elif hasattr(torch, 'float8_e4m3fn') and dtype == torch.float8_e4m3fn:
-            class CudaArrayInterface:
-                def __init__(self, ptr, shape, strides=None):
-                    self.__cuda_array_interface__ = {
-                        "data": (ptr, False),
-                        "shape": tuple(shape),
-                        "typestr": "|u1",  # uint8，跳过不支持的 |f1 
-                        "version": 3,
-                        "strides": strides,
-                        "descr": [("", "")],
-                    }
-            cuda_interface = CudaArrayInterface(data_ptr, shape, strides)
-            # 先作为 uint8 认领，再 view 为 fp8
-            return torch.as_tensor(cuda_interface, dtype=torch.uint8, device=device).view(torch.float8_e4m3fn)
-        else:
-            # For other dtypes, use standard typestr mapping
-            if dtype not in TYPESTR_MAP:
-                raise ValueError(f"Unsupported dtype for CUDA pointer: {dtype}")
-            
-            class CudaArrayInterface:
-                def __init__(self, ptr, shape, typestr, strides=None):
-                    self.__cuda_array_interface__ = {
-                        "data": (ptr, False),  # (data_ptr, read_only)
-                        "shape": tuple(shape),
-                        "typestr": typestr,
-                        "version": 3,
-                        "strides": strides,  # None for C-contiguous
-                        "descr": [("", "")],
-                    }
-            
-            flexkv_logger.debug(f"Creating {dtype} tensor from CUDA ptr")
-            cuda_interface = CudaArrayInterface(data_ptr, shape, TYPESTR_MAP[dtype], strides)
-            return torch.as_tensor(cuda_interface, dtype=dtype, device=device)
-
-    ## Export CUDA IPC handle
-    @staticmethod
-    def _export_cuda_ipc_handle(tensor: torch.Tensor) -> bytes:
-        """
-        Use CUDA IPC API to export the tensor's IPC handle
-        """
-        # Get device pointer
-        data_ptr = tensor.data_ptr()
-        device = tensor.device
-
-        flexkv_logger.debug(
-            f"Exporting CUDA IPC handle: device={device}, data_ptr={hex(data_ptr)}"
-        )
-
-        # Ensure we're on the correct device
-        torch.cuda.set_device(device)
-
-        # Create IPC handle buffer
-        # ipc_handle = ctypes.create_string_buffer(CUDA_IPC_HANDLE_SIZE)
-        ipc_handle = cudaIpcMemHandle_t()
-
-        # Call cudaIpcGetMemHandle
-        result = cudart.cudaIpcGetMemHandle(
-            ctypes.byref(ipc_handle), ctypes.c_void_p(data_ptr)
-        )
-
-        if result != cudaSuccess:
-            error_msg = f"cudaIpcGetMemHandle failed with error code {result} for device {device}, ptr={hex(data_ptr)}"
-            flexkv_logger.error(error_msg)
-            raise RuntimeError(error_msg)
-
-        # Return handle as bytes
-        # handle_bytes = bytes(ipc_handle.raw)
-        handle_bytes = ctypes.string_at(ctypes.byref(ipc_handle), 64)
-        flexkv_logger.debug(
-            f"IPC handle exported successfully, first 16 bytes: {handle_bytes.hex()}"
-        )
-        return handle_bytes
-
-    ## Import CUDA IPC handle
-    @staticmethod
-    def _import_cuda_ipc_handle(
-        ipc_handle: bytes,
-        shape: Tuple[int, ...],
-        dtype: torch.dtype,
-        device: torch.device,
-        offset: int = 0,
-    ) -> torch.Tensor:
-        """
-        Using CUDA IPC API to import the tensor from the IPC handle
-        
-        Args:
-            ipc_handle: CUDA IPC memory handle (bytes)
-            shape: Tensor shape
-            dtype: Tensor dtype
-            device: Target CUDA device
-            offset: Offset in bytes from the base pointer (for memory pool allocations)
-        """
-        # Ensure CUDA is initialized in this process
-        if not torch.cuda.is_initialized():
-            flexkv_logger.info("Initializing CUDA in subprocess")
-            torch.cuda.init()
-
-        # Set device and create a dummy tensor to ensure context is created
-        device_id = device.index if device.index is not None else 0
-        torch.cuda.set_device(device_id)
-
-        # Force CUDA context creation
-        _ = torch.zeros(1, device=device)
-
-        # Create IPC handle buffer
-        ipc_handle_buf = ctypes.create_string_buffer(ipc_handle, CUDA_IPC_HANDLE_SIZE)
-
-        # Rebuild IPC handle
-        handle = cudaIpcMemHandle_t()
-        ctypes.memmove(ctypes.byref(handle), ipc_handle, 64)
-
-        # Open IPC memory handle to get base pointer
-        base_ptr = ctypes.c_void_p()
-        result = cudart.cudaIpcOpenMemHandle(
-            ctypes.byref(base_ptr),
-            handle,
-            ctypes.c_int(1),  # cudaIpcMemLazyEnablePeerAccess = 1
-        )
-        # Print GPU memory address for comparison with C++ side
-
-        if result != cudaSuccess:
-            error_msg = f"cudaIpcOpenMemHandle failed with error code {result} for device {device_id}"
-            flexkv_logger.error(error_msg)
-            flexkv_logger.error(f"IPC handle bytes (full): {ipc_handle.hex()}")
-            flexkv_logger.error(f"Current CUDA device: {torch.cuda.current_device()}")
-            flexkv_logger.error(f"Target device: {device_id}")
-            raise RuntimeError(error_msg)
-
-        # Calculate the actual data pointer: base_ptr + offset
-        data_ptr = base_ptr.value + offset
-        if offset > 0:
-            data_ptr_hex = hex(data_ptr)
-            base_ptr_hex = hex(base_ptr.value)
-            flexkv_logger.info(
-                f"_import_cuda_ipc_handle: Opened IPC handle: device={device}, base_gpu_ptr={base_ptr_hex}, offset={offset}, actual data_ptr={data_ptr_hex}"
-            )
-
-        # Create tensor from pointer using helper function
-        tensor = TensorSharedHandle._create_tensor_from_cuda_ptr(
-            data_ptr, shape, dtype, device
-        )
-
-        flexkv_logger.info(f"Imported tensor with shape {shape} from CUDA IPC handle, dtype={tensor.dtype}, offset={offset}")
-        return tensor
-
 
 def _zmq_test_worker() -> None:
     context = zmq.Context()
@@ -458,7 +359,8 @@ def _zmq_test_worker() -> None:
 if __name__ == "__main__":
     mp.set_start_method("spawn", force=True)
 
-    gpu_tensor = torch.zeros(10, dtype=torch.int64, device="cuda:0")
+    device_str = gpu_runtime.get_device_string(0)
+    gpu_tensor = torch.zeros(10, dtype=torch.int64, device=device_str)
     print(f"Process {os.getpid()}: tensor: {gpu_tensor}")
     gpu_handle = TensorSharedHandle(gpu_tensor, force_direct_ipc=True)
 

--- a/flexkv/integration/tensorrt_llm/trtllm_adapter.py
+++ b/flexkv/integration/tensorrt_llm/trtllm_adapter.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 import traceback
+from flexkv.common import gpu_runtime
 from flexkv.kvmanager import KVManager
 from flexkv.server.client import KVTPClient
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
@@ -528,7 +529,7 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
         flexkv_config.post_init_from_trt_config(config)
         dp_client_id = self.dp_rank
         
-        current_device_id = torch.cuda.current_device() + dp_client_id * flexkv_config.model_config.tp_size
+        current_device_id = gpu_runtime.current_device() + dp_client_id * flexkv_config.model_config.tp_size
         self.flexkv_config = flexkv_config
         
         # For multi-node TP on remote node (node B), worker0 needs to create TransferManagerOnRemote process
@@ -556,7 +557,7 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
         try:
             is_master_node = self.node_rank == 0
             is_first_worker = self.tp_rank % 8 == 0
-            is_multinode_tp = self.flexkv_config.model_config.tp_size > torch.cuda.device_count()
+            is_multinode_tp = self.flexkv_config.model_config.tp_size > gpu_runtime.device_count()
             flexkv_logger.info(f"{is_master_node=}, {is_first_worker=}, {is_multinode_tp=}")
             
             return is_multinode_tp and not is_master_node and is_first_worker

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 
+from flexkv.common import gpu_runtime
 from flexkv.kvmanager import KVManager
 from flexkv.server.client import KVTPClient
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
@@ -676,7 +677,7 @@ class FlexKVWorkerConnector:
         self.launch_remote_transfer_manager = get_tp_group().local_rank == 0 and \
             get_tp_group().rank_in_group != 0
 
-        local_device = torch.cuda.current_device()
+        local_device = gpu_runtime.current_device()
 
         # Determine if server_client_mode (same logic as KVManager)
         server_client_mode = (GLOBAL_CONFIG_FROM_ENV.instance_num > 1 or
@@ -684,7 +685,6 @@ class FlexKVWorkerConnector:
                               GLOBAL_CONFIG_FROM_ENV.server_client_mode)
 
         if server_client_mode:
-            # Assuming Server can see all GPUs, use global device ID
             cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
             if cuda_visible:
                 visible_ids = [int(x.strip()) for x in cuda_visible.split(',') if x.strip()]

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -12,6 +12,7 @@ import nvtx
 import torch
 import numpy as np
 
+from flexkv.common import gpu_runtime
 from flexkv.common.config import CacheConfig, ModelConfig
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.block import hash_token
@@ -109,11 +110,11 @@ class KVTaskManager:
 
         self.is_multinode_tp = False
         self.tp_node_count = 1
-        if self.model_config.tp_size > torch.cuda.device_count():
-            if self.model_config.tp_size != torch.cuda.device_count() * 2:
+        if self.model_config.tp_size > gpu_runtime.device_count():
+            if self.model_config.tp_size != gpu_runtime.device_count() * 2:
                 raise ValueError("Only support 2 nodes TP for now")
             assert self.model_config.dp_size == 1
-            self.tp_node_count = self.model_config.tp_size // torch.cuda.device_count()
+            self.tp_node_count = self.model_config.tp_size // gpu_runtime.device_count()
             self.is_multinode_tp = True
 
         self.cache_engine = GlobalCacheEngine(cache_config, model_config, redis_meta, event_collector)

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -9,6 +9,7 @@ import torch
 import zmq
 import numpy as np
 
+from flexkv.common import gpu_runtime
 from flexkv.common.config import ModelConfig, CacheConfig
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
@@ -255,8 +256,8 @@ class KVTPClient:
         kv_layout: KVCacheLayout,
         override_device_id: Optional[int] = None,
     ) -> None:
-        if not kv_caches or not kv_caches[0].is_cuda:
-            raise ValueError("GPU blocks must be CUDA tensors")
+        if not kv_caches or not gpu_runtime.is_gpu_tensor(kv_caches[0]):
+            raise ValueError("GPU blocks must be CUDA or MUSA tensors")
 
         # Use override_device_id if provided, otherwise use self.device_id
         device_id = override_device_id if override_device_id is not None else self.device_id

--- a/flexkv/storage/allocator.py
+++ b/flexkv/storage/allocator.py
@@ -12,6 +12,7 @@ import torch
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.storage import StorageHandle, AccessHandleType, KVCacheLayout, KVCacheLayoutType
 from flexkv.common.debug import flexkv_logger
+from flexkv.common import gpu_runtime
 
 
 class BaseStorageAllocator(ABC):
@@ -44,8 +45,8 @@ class GPUAllocator(BaseStorageAllocator):
                  layout: KVCacheLayout,
                  dtype: torch.dtype,
                  **kwargs: Any) -> StorageHandle:
-        device_id = kwargs.get("device_id", torch.cuda.current_device())
-        device = f"cuda:{device_id}"
+        device_id = kwargs.get("device_id", gpu_runtime.current_device())
+        device = gpu_runtime.get_device_string(device_id)
         num_chunks = kwargs.get("num_chunks", 1)
 
         total_size = layout.get_total_elements()

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -550,5 +550,6 @@ class TransferEngine:
                 while not self.finished_ops_queue.empty():
                     self.finished_ops_queue.get_nowait()
 
-            torch.cuda.empty_cache()
-            torch.cuda.synchronize()
+            from flexkv.common import gpu_runtime
+            gpu_runtime.empty_cache()
+            gpu_runtime.synchronize()

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -10,23 +10,41 @@ from multiprocessing.connection import Connection
 from threading import Thread
 from typing import List, Any, Dict, Union, Optional, Tuple
 
-import ctypes
 import numpy as np
 import nvtx
 import torch
 import zmq
 import json
 
+from flexkv.common.gpu_backend import get_gpu_backend, get_transfer_kv_blocks_module
+from flexkv.common import gpu_runtime
+
+_transfer_module = get_transfer_kv_blocks_module()
+transfer_kv_blocks = _transfer_module.transfer_kv_blocks
+transfer_kv_blocks_ssd = _transfer_module.transfer_kv_blocks_ssd
+
+if get_gpu_backend() == "musa":
+    try:
+        from flexkv.c_ext_musa import TPTransferThreadGroupMusa as TPTransferThreadGroup
+    except ImportError:
+        from flexkv.c_ext import TPTransferThreadGroup
+    try:
+        from flexkv.c_ext_musa import transfer_kv_blocks_gds, TPGDSTransferThreadGroupMusa as TPGDSTransferThreadGroup
+    except ImportError:
+        try:
+            from flexkv.c_ext import transfer_kv_blocks_gds, TPGDSTransferThreadGroup
+        except ImportError:
+            transfer_kv_blocks_gds = None
+            TPGDSTransferThreadGroup = None
+else:
+    from flexkv.c_ext import TPTransferThreadGroup
+    try:
+        from flexkv.c_ext import transfer_kv_blocks_gds, TPGDSTransferThreadGroup
+    except ImportError:
+        transfer_kv_blocks_gds = None
+        TPGDSTransferThreadGroup = None
+
 from flexkv import c_ext
-
-from flexkv.c_ext import transfer_kv_blocks, transfer_kv_blocks_ssd, TPTransferThreadGroup
-
-# GDS imports are optional (only available when compiled with FLEXKV_ENABLE_GDS=1)
-try:
-    from flexkv.c_ext import transfer_kv_blocks_gds, TPGDSTransferThreadGroup
-except ImportError:
-    transfer_kv_blocks_gds = None
-    TPGDSTransferThreadGroup = None
 
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
@@ -48,21 +66,13 @@ except ImportError:
     shared_transfer_kv_blocks_remote_read = None
 
 
-cudart = ctypes.CDLL('libcudart.so')
-
 def cudaHostRegister(tensor: torch.Tensor) -> None:
-    """Register a CPU tensor with CUDA for pinned memory access"""
-    ptr = tensor.data_ptr()
-    size = tensor.numel() * tensor.element_size()
-    ret = cudart.cudaHostRegister(ctypes.c_void_p(ptr), ctypes.c_size_t(size), 1) # 1 means cudaHostRegisterPortable
-    if ret != 0:
-        raise RuntimeError(f"cudaHostRegister failed with error code {ret}")
+    """Register a CPU tensor for pinned memory access (works with CUDA and MUSA)."""
+    gpu_runtime.host_register(tensor)
 
 def cudaHostUnregister(tensor: torch.Tensor) -> None:
-    """Unregister a CPU tensor from CUDA for pinned memory access"""
-    ptr = tensor.data_ptr()
-    size = tensor.numel() * tensor.element_size()
-    ret = cudart.cudaHostUnregister(ctypes.c_void_p(ptr))
+    """Unregister a CPU tensor from pinned memory (works with CUDA and MUSA)."""
+    gpu_runtime.host_unregister(tensor)
 
 @dataclass
 class WorkerTransferOp:
@@ -349,10 +359,9 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             self.gpu_block_type_ = 2
         else:
             raise ValueError(f"Invalid GPU block type: {len(self.gpu_blocks)}")
-        # set GPU device
         if gpu_device_id != -1:
-            torch.cuda.set_device(gpu_device_id)
-        self.transfer_stream = torch.cuda.Stream()
+            gpu_runtime.set_device(gpu_device_id)
+        self.transfer_stream = gpu_runtime.create_stream()
         self.transfer_num_cta_h2d = transfer_num_cta_h2d
         self.transfer_num_cta_d2h = transfer_num_cta_d2h
         self.use_ce_transfer_h2d = use_ce_transfer_h2d
@@ -425,7 +434,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
 
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
-        with torch.cuda.stream(self.transfer_stream):
+        with gpu_runtime.stream_context(self.transfer_stream):
             start_time = time.time()
             self._transfer_impl(
                 src_block_ids,
@@ -1050,11 +1059,10 @@ class GDSTransferWorker(TransferWorkerBase):
         else:
             raise ValueError(f"Invalid GPU block type: {len(self.gpu_blocks)}")
 
-        # Set GPU device and create stream
         self.gpu_device_id = gpu_device_id
         if gpu_device_id != -1:
-            torch.cuda.set_device(gpu_device_id)
-        self.transfer_stream = torch.cuda.Stream()
+            gpu_runtime.set_device(gpu_device_id)
+        self.transfer_stream = gpu_runtime.create_stream()
 
     def _transfer_impl(
         self,
@@ -1139,7 +1147,7 @@ class GDSTransferWorker(TransferWorkerBase):
 
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
-        with torch.cuda.stream(self.transfer_stream):
+        with gpu_runtime.stream_context(self.transfer_stream):
             start_time = time.time()
             self._transfer_impl(
                 src_block_ids,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "flexkv.c_ext.*"
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+markers = [
+    "musa: marks tests for MUSA backend (deselect with '-m \"not musa\"')",
+]

--- a/requirements-musa.txt
+++ b/requirements-musa.txt
@@ -1,0 +1,7 @@
+setuptools>=61
+torch>=2.5.0
+torch_musa>=2.5.0
+Cython>=3.0.10
+pytest==8.4.0
+pytest-benchmark==5.1.0
+expiring-dict==1.1.2

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,23 @@ import sys
 
 
 from setuptools import find_packages, setup
-from setuptools.command.build_ext import build_ext
-from torch.utils import cpp_extension
+from setuptools.command.build_ext import build_ext as _setuptools_build_ext
+from setuptools.extension import Extension
+
+enable_musa = os.environ.get("FLEXKV_USE_MUSA", "0").strip() == "1"
+
+_has_cuda = (
+    bool(os.environ.get("CUDA_HOME"))
+    or bool(os.environ.get("CUDA_PATH"))
+    or shutil.which("nvcc") is not None
+)
+build_cuda_ext = _has_cuda or not enable_musa
+
+if build_cuda_ext:
+    from torch.utils import cpp_extension as _cpp_ext
+else:
+    _cpp_ext = None
+
 
 def get_version():
     with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
@@ -14,7 +29,6 @@ def get_version():
 build_dir = "build"
 os.makedirs(build_dir, exist_ok=True)
 
-# Check if we're in debug mode using environment variable
 debug = os.environ.get("FLEXKV_DEBUG") == "1"
 if debug:
     print("Running in debug mode - Cython compilation disabled")
@@ -25,125 +39,186 @@ enable_p2p = os.environ.get("FLEXKV_ENABLE_P2P", "0") == "1"
 enable_cputest = os.environ.get("FLEXKV_ENABLE_CPUTEST", "0") == "1"
 # FLEXKV_ENABLE_METRICS=0: build without Prometheus (no prometheus-cpp dependency)
 enable_metrics = os.environ.get("FLEXKV_ENABLE_METRICS", "0") == "1"
-
-# Define C++ extensions (base: no dist/Redis)
-cpp_sources = [
-    "csrc/bindings.cpp",
-    "csrc/transfer.cu",  # Skip CUDA file for now
-    "csrc/hash.cpp",
-    "csrc/tp_transfer_thread_group.cpp",
-    "csrc/transfer_ssd.cpp",
-    "csrc/radix_tree.cpp",
-    "csrc/monitoring/metrics_manager.cpp",  # Monitoring support
-]
-
-hpp_sources = [
-    "csrc/cache_utils.h",
-    "csrc/tp_transfer_thread_group.h",
-    "csrc/transfer_ssd.h",
-    "csrc/radix_tree.h",
-    "csrc/monitoring/metrics_manager.h",  # Monitoring support
-]
-
-# extra_link_args: dist/Redis (libhiredis) only when FLEXKV_ENABLE_P2P=1
-extra_link_args = ["-lcuda", "-lxxhash", "-lpthread", "-lrt", "-luring"]
-if enable_p2p:
-    extra_link_args.append("-lhiredis")
-
-if enable_cputest:
-    extra_link_args.remove("-lcuda")
-    # Set TORCH_CUDA_ARCH_LIST to avoid IndexError when no GPU is available
-    os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0;7.5;8.0;8.6;9.0"
-
-
-# Prometheus libraries only when metrics enabled
-if enable_metrics:
-    extra_link_args.extend(["-lprometheus-cpp-pull", "-lprometheus-cpp-core"])
-else:
-    print("FLEXKV_ENABLE_METRICS=0: building without Prometheus monitoring")
-# If TORCH_CUDA_ARCH_LIST is not set, default to known supported archs
-# to avoid auto-detection failure on newer GPUs (e.g. Blackwell sm_100)
-if not os.environ.get("TORCH_CUDA_ARCH_LIST"):
-    os.environ["TORCH_CUDA_ARCH_LIST"] = "8.0;8.6;9.0"
-
-extra_compile_args = ["-std=c++17", "-O3"]
-if enable_metrics:
-    extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
-include_dirs = [os.path.abspath(os.path.join(build_dir, "include"))]
-
-# Add rpath to find libraries at runtime
 lib_dir = os.path.join(build_dir, "lib")
-if os.path.exists(lib_dir):
-    extra_link_args.extend([f"-Wl,-rpath,{lib_dir}", "-Wl,-rpath,$ORIGIN"])
-    # Also add the current package directory to rpath for installed libraries
-    extra_link_args.append("-Wl,-rpath,$ORIGIN/../lib")
+common_compile_args = ["-std=c++17"]
 
-if enable_cfs:
-    print("ENABLE_CFS = true: compiling and link cfs related content")
-    cpp_sources.append("csrc/pcfs/pcfs.cpp")
-    hpp_sources.append("csrc/pcfs/pcfs.h")
-    extra_link_args.append("-lhifs_client_sdk")
-    extra_compile_args.append("-DFLEXKV_ENABLE_CFS")
-extra_compile_args.append("-DCUDA_AVAILABLE")
+cpp_extensions = []
 
-nvcc_compile_args = ["-O3"]
-if enable_metrics:
-    nvcc_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
-if enable_gds:
-    print("ENABLE_GDS = true: Compiling and linking GDS content")
-    cpp_sources.extend([
-        "csrc/gds/gds_manager.cpp",
-        "csrc/gds/tp_gds_transfer_thread_group.cpp",
-        "csrc/gds/layout_transform.cu",
-    ])
-    hpp_sources.extend([
-        "csrc/gds/gds_manager.h",
-        "csrc/gds/tp_gds_transfer_thread_group.h",
-        "csrc/gds/layout_transform.cuh",
-    ])
-    extra_link_args.append("-lcufile")
-    extra_compile_args.append("-DFLEXKV_ENABLE_GDS")
-    nvcc_compile_args.append("-DFLEXKV_ENABLE_GDS")
-if enable_p2p:
-    print("ENABLE_P2P = true: Compiling and linking distributed (P2P/Redis) content")
-    cpp_sources.extend([
-        "csrc/dist/distributed_radix_tree.cpp",
-        "csrc/dist/local_radix_tree.cpp",
-        "csrc/dist/redis_meta_channel.cpp",
-        "csrc/dist/lease_meta_mempool.cpp",
-    ])
-    extra_compile_args.append("-DFLEXKV_ENABLE_P2P")
-if not enable_gds:
-    print("ENABLE_GDS = false: Skipping GDS code")
-if not enable_p2p:
-    print("ENABLE_P2P = false: Skipping distributed (P2P/Redis) code; no libhiredis or Redis deps required")
+if build_cuda_ext:
+    cpp_sources = [
+        "csrc/bindings.cpp",
+        "csrc/transfer.cu",
+        "csrc/hash.cpp",
+        "csrc/tp_transfer_thread_group.cpp",
+        "csrc/transfer_ssd.cpp",
+        "csrc/radix_tree.cpp",
+        "csrc/monitoring/metrics_manager.cpp",
+    ]
+    hpp_sources = [
+        "csrc/cache_utils.h",
+        "csrc/tp_transfer_thread_group.h",
+        "csrc/transfer_ssd.h",
+        "csrc/radix_tree.h",
+        "csrc/monitoring/metrics_manager.h",
+    ]
+    extra_link_args = ["-lcuda", "-lxxhash", "-lpthread", "-lrt", "-luring"]
+    if enable_p2p:
+        extra_link_args.append("-lhiredis")
+    if enable_cputest:
+        extra_link_args.remove("-lcuda")
+        os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0;7.5;8.0;8.6;9.0"
+    if enable_metrics:
+        extra_link_args.extend(["-lprometheus-cpp-pull", "-lprometheus-cpp-core"])
+    else:
+        print("FLEXKV_ENABLE_METRICS=0: building without Prometheus monitoring")
+    if not os.environ.get("TORCH_CUDA_ARCH_LIST"):
+        os.environ["TORCH_CUDA_ARCH_LIST"] = "8.0;8.6;9.0"
 
-cpp_extensions = [
-    cpp_extension.CUDAExtension(
-        name="flexkv.c_ext",
-        sources=cpp_sources,
-        library_dirs=[os.path.join(build_dir, "lib")],
-        include_dirs=include_dirs,
-        depends=hpp_sources,
-        extra_compile_args={"nvcc": nvcc_compile_args, "cxx": extra_compile_args},
-        extra_link_args=extra_link_args,
-    ),
-]
+    extra_compile_args = list(common_compile_args)
+    if enable_metrics:
+        extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
+    include_dirs = [os.path.abspath(os.path.join(build_dir, "include")), os.path.abspath("third_party/xxHash")]
 
+    if os.path.exists(lib_dir):
+        extra_link_args.extend([f"-Wl,-rpath,{lib_dir}", "-Wl,-rpath,$ORIGIN"])
+        extra_link_args.append("-Wl,-rpath,$ORIGIN/../lib")
+
+    if enable_cfs:
+        print("ENABLE_CFS = true: compiling and link cfs related content")
+        cpp_sources.append("csrc/pcfs/pcfs.cpp")
+        hpp_sources.append("csrc/pcfs/pcfs.h")
+        extra_link_args.append("-lhifs_client_sdk")
+        extra_compile_args.append("-DFLEXKV_ENABLE_CFS")
+    extra_compile_args.append("-DCUDA_AVAILABLE")
+
+    nvcc_compile_args = ["-O3"]
+    if enable_metrics:
+        nvcc_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
+    if enable_gds:
+        print("ENABLE_GDS = true: Compiling and linking GDS content")
+        cpp_sources.extend([
+            "csrc/gds/gds_manager.cpp",
+            "csrc/gds/tp_gds_transfer_thread_group.cpp",
+            "csrc/gds/layout_transform.cu",
+        ])
+        hpp_sources.extend([
+            "csrc/gds/gds_manager.h",
+            "csrc/gds/tp_gds_transfer_thread_group.h",
+            "csrc/gds/layout_transform.cuh",
+        ])
+        extra_link_args.append("-lcufile")
+        extra_compile_args.append("-DFLEXKV_ENABLE_GDS")
+        nvcc_compile_args.append("-DFLEXKV_ENABLE_GDS")
+    if enable_p2p:
+        print("ENABLE_P2P = true: Compiling and linking distributed (P2P/Redis) content")
+        cpp_sources.extend([
+            "csrc/dist/distributed_radix_tree.cpp",
+            "csrc/dist/local_radix_tree.cpp",
+            "csrc/dist/redis_meta_channel.cpp",
+            "csrc/dist/lease_meta_mempool.cpp",
+        ])
+        extra_compile_args.append("-DFLEXKV_ENABLE_P2P")
+    if not enable_gds:
+        print("ENABLE_GDS = false: Skipping GDS code")
+    if not enable_p2p:
+        print("ENABLE_P2P = false: Skipping distributed (P2P/Redis) code; no libhiredis or Redis deps required")
+
+    cpp_extensions.append(
+        _cpp_ext.CUDAExtension(
+            name="flexkv.c_ext",
+            sources=cpp_sources,
+            library_dirs=[os.path.join(build_dir, "lib")],
+            include_dirs=include_dirs,
+            depends=hpp_sources,
+            extra_compile_args={"nvcc": nvcc_compile_args, "cxx": extra_compile_args},
+            extra_link_args=extra_link_args,
+        ),
+    )
+else:
+    print("MUSA-only build: skipping flexkv.c_ext (no CUDA toolkit found)")
+
+if enable_musa:
+    print("FLEXKV_USE_MUSA=1: Adding flexkv.c_ext_musa extension")
+
+    musa_home = os.environ.get("MUSA_HOME", "")
+    has_musa_sdk = bool(musa_home) and os.path.isdir(musa_home)
+    has_mcc = has_musa_sdk and os.path.isfile(os.path.join(musa_home, "bin", "mcc"))
+
+    musa_sources = [
+        "csrc/musa/bindings_musa.cpp",
+        "csrc/transfer_ssd.cpp",
+        "csrc/hash.cpp",
+        "csrc/radix_tree.cpp",
+        "csrc/monitoring/metrics_manager.cpp",
+    ]
+    import torch
+    from torch.utils.cpp_extension import include_paths
+    pytorch_includes = include_paths()
+    musa_include_dirs = [
+        os.path.abspath("csrc"),
+        os.path.abspath("csrc/musa"),
+        os.path.abspath(os.path.join(build_dir, "include")),
+        os.path.abspath("third_party/xxHash"),
+    ]
+    musa_include_dirs.extend(pytorch_includes)
+    musa_compile_args = list(common_compile_args)
+    musa_link_args = ["-lxxhash", "-lpthread", "-lrt", "-luring"]
+    if os.path.exists(lib_dir):
+        musa_link_args.extend([f"-Wl,-rpath,{lib_dir}", "-Wl,-rpath,$ORIGIN"])
+        musa_link_args.append("-Wl,-rpath,$ORIGIN/../lib")
+
+    if enable_cfs:
+        musa_sources.append("csrc/pcfs/pcfs.cpp")
+        musa_compile_args.append("-DFLEXKV_ENABLE_CFS")
+        musa_link_args.append("-lhifs_client_sdk")
+
+    if has_musa_sdk and has_mcc:
+        print(f"  MUSA SDK detected at {musa_home} — building with mcc")
+        musa_compile_args.append("-DFLEXKV_HAS_MUSA_SDK")
+        musa_include_dirs.append(os.path.join(musa_home, "include"))
+        musa_link_args.extend([
+            f"-L{os.path.join(musa_home, 'lib')}",
+            f"-Wl,-rpath,{os.path.join(musa_home, 'lib')}",
+            "-lmusa",
+        ])
+        musa_sources.extend([
+            "csrc/musa/transfer_musa.mu",
+            "csrc/musa/tp_transfer_thread_group_musa.cpp",
+        ])
+        if enable_gds:
+            musa_sources.extend([
+                "csrc/musa/gds/gds_manager_musa.cpp",
+                "csrc/musa/gds/tp_gds_transfer_thread_group_musa.cpp",
+                "csrc/musa/gds/layout_transform_musa.mu",
+            ])
+            musa_compile_args.append("-DFLEXKV_ENABLE_GDS")
+            musa_link_args.append("-lmufile")
+    else:
+        print("  MUSA SDK not found — building C++ stub only (no mcc, no MUSA runtime)")
+
+
+    from torch.utils import cpp_extension
+
+    cpp_extensions.append(
+        cpp_extension.CppExtension(
+            name="flexkv.c_ext_musa",
+            sources=musa_sources,
+            include_dirs=musa_include_dirs,
+            extra_compile_args=musa_compile_args,
+            extra_link_args=musa_link_args,
+        )
+    )
 # Initialize ext_modules with C++ extensions
 ext_modules = cpp_extensions
 
 # Only use Cython in release mode
 if not debug:
-    # Compile Python modules with cythonize
-    # Exclude __init__.py files and test files
     python_files = ["flexkv/**/*.py"]
     excluded_files = ["flexkv/**/__init__.py",
                       "flexkv/**/test_*.py",
                       "flexkv/**/benchmark_*.py",
                       "flexkv/benchmark/**/*.py",
                       "flexkv/benchmark/test_kvmanager.py"]
-    # Import cython when debug is turned off.
     from Cython.Build import cythonize
     cythonized_modules = cythonize(
         python_files,
@@ -155,18 +230,40 @@ if not debug:
             "initializedcheck": False,
             "profile": True,
         },
-        build_dir=build_dir,  # Direct Cython to use the build directory
+        build_dir=build_dir,
     )
-    # Add Cython modules to ext_modules
     ext_modules.extend(cythonized_modules)
     print("Release mode: Including Cython compilation")
 else:
     print("Debug mode: Skipping Cython compilation")
 
-class CustomBuildExt(cpp_extension.BuildExtension):
+_BuildExtBase = _cpp_ext.BuildExtension if _cpp_ext is not None else _setuptools_build_ext
+
+
+class CustomBuildExt(_BuildExtBase):
+    def build_extensions(self):
+        for ext in self.extensions:
+            mu_sources = [s for s in ext.sources if s.endswith(".mu")]
+            if mu_sources:
+                ext.sources = [s for s in ext.sources if not s.endswith(".mu")]
+                musa_home = os.environ.get("MUSA_HOME", "")
+                mcc = os.path.join(musa_home, "bin", "mcc") if musa_home else "mcc"
+                for mu_src in mu_sources:
+                    obj = os.path.splitext(mu_src)[0] + ".o"
+                    obj_path = os.path.join(self.build_temp, obj)
+                    os.makedirs(os.path.dirname(obj_path), exist_ok=True)
+                    inc_flags = []
+                    for d in ext.include_dirs:
+                        inc_flags.extend(["-I", d])
+                    cmd = [mcc, "-c", "-O3","-fPIC", "--std=c++17",
+                           "-DFLEXKV_HAS_MUSA_SDK",
+                           *inc_flags, mu_src, "-o", obj_path]
+                    self.spawn(cmd)
+                    ext.extra_objects.append(obj_path)
+        super().build_extensions()
+
     def run(self):
         super().run()
-        # Copy required shared libraries to the package directory after building
         self.copy_shared_libraries()
 
     def copy_shared_libraries(self):
@@ -176,11 +273,9 @@ class CustomBuildExt(cpp_extension.BuildExtension):
             print(f"Warning: Source library directory {source_lib_dir} does not exist")
             return
 
-        # Create lib directory in the package
         package_lib_dir = os.path.join("flexkv", "lib")
         os.makedirs(package_lib_dir, exist_ok=True)
 
-        # Copy all .so files
         for file in os.listdir(source_lib_dir):
             if file.endswith(".so") or file.endswith(".so.*"):
                 source_file = os.path.join(source_lib_dir, file)
@@ -190,7 +285,26 @@ class CustomBuildExt(cpp_extension.BuildExtension):
                     print(f"Copied {source_file} to {dest_file}")
 
 with open("requirements.txt") as f:
-    install_requires = f.read().splitlines()
+    install_requires = [
+        line for line in f.read().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+if enable_musa and not _has_cuda:
+    install_requires = [
+        r for r in install_requires
+        if not r.strip().lower().startswith("nvtx")
+    ]
+
+if _cpp_ext is not None:
+    _cmdclass = {
+        "build_ext": CustomBuildExt.with_options(
+            include_dirs=os.path.join(build_dir, "include"),
+            no_python_abi_suffix=True,
+            build_temp=os.path.join(build_dir, "temp"),
+        )
+    }
+else:
+    _cmdclass = {"build_ext": CustomBuildExt}
 
 setup(
     name="flexkv",
@@ -202,14 +316,8 @@ setup(
     },
     include_package_data=True,
     install_requires=install_requires,
-    ext_modules=ext_modules,  # Now contains both C++ and Cython modules as needed
-    cmdclass={
-        "build_ext": CustomBuildExt.with_options(
-            include_dirs=os.path.join(build_dir, "include"),  # Include directory for xxhash
-            no_python_abi_suffix=True,
-            build_temp=os.path.join(build_dir, "temp"),  # Temporary build files
-        )
-    },
-    #python_requires=">=3.8",
+    ext_modules=ext_modules,
+    cmdclass=_cmdclass,
     python_requires=">=3.6",
 )
+

--- a/tests/test_gpu_backend_dispatch.py
+++ b/tests/test_gpu_backend_dispatch.py
@@ -1,0 +1,67 @@
+"""
+Tests for GPU backend selection (CUDA vs MUSA).
+Ensures the correct extension module is used and CUDA path is unchanged when only CUDA is available.
+"""
+import os
+import pytest
+
+
+def test_get_gpu_backend_returns_cuda_or_musa():
+    """get_gpu_backend() returns either 'cuda' or 'musa'."""
+    from flexkv.common.gpu_backend import get_gpu_backend
+    backend = get_gpu_backend()
+    assert backend in ("cuda", "musa")
+
+
+def test_cuda_available_uses_c_ext_by_default():
+    """When CUDA is available and no override, get_transfer_kv_blocks_module returns c_ext."""
+    import torch
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    env_orig = os.environ.get("FLEXKV_GPU_BACKEND")
+    try:
+        if "FLEXKV_GPU_BACKEND" in os.environ:
+            del os.environ["FLEXKV_GPU_BACKEND"]
+        from flexkv.common.gpu_backend import get_gpu_backend, get_transfer_kv_blocks_module
+        backend = get_gpu_backend()
+        mod = get_transfer_kv_blocks_module()
+        assert backend == "cuda"
+        assert mod.__name__ == "flexkv.c_ext"
+        assert hasattr(mod, "transfer_kv_blocks")
+    finally:
+        if env_orig is not None:
+            os.environ["FLEXKV_GPU_BACKEND"] = env_orig
+        elif "FLEXKV_GPU_BACKEND" in os.environ:
+            del os.environ["FLEXKV_GPU_BACKEND"]
+
+
+def test_musa_override_selects_c_ext_musa_when_built():
+    """When FLEXKV_GPU_BACKEND=musa and c_ext_musa is built, that module is used."""
+    env_orig = os.environ.get("FLEXKV_GPU_BACKEND")
+    try:
+        os.environ["FLEXKV_GPU_BACKEND"] = "musa"
+        from flexkv.common.gpu_backend import get_gpu_backend, get_transfer_kv_blocks_module
+        backend = get_gpu_backend()
+        assert backend == "musa"
+        try:
+            mod = get_transfer_kv_blocks_module()
+            # Module may be c_ext_musa if built, or c_ext if fallback
+            assert mod.__name__ in ("flexkv.c_ext_musa", "flexkv.c_ext")
+            assert hasattr(mod, "transfer_kv_blocks")
+        except ImportError:
+            # Both extensions not built, skip assertion about module
+            pytest.skip("Neither flexkv.c_ext_musa nor flexkv.c_ext is available")
+    finally:
+        if env_orig is not None:
+            os.environ["FLEXKV_GPU_BACKEND"] = env_orig
+        elif "FLEXKV_GPU_BACKEND" in os.environ:
+            del os.environ["FLEXKV_GPU_BACKEND"]
+
+
+def test_c_ext_musa_importable_when_built():
+    """If flexkv.c_ext_musa is built, it can be imported and has transfer_kv_blocks."""
+    try:
+        import flexkv.c_ext_musa as musa_ext
+        assert hasattr(musa_ext, "transfer_kv_blocks")
+    except ImportError:
+        pytest.skip("flexkv.c_ext_musa not built (FLEXKV_USE_MUSA=1 and build completed)")

--- a/tests/test_gpu_runtime.py
+++ b/tests/test_gpu_runtime.py
@@ -1,0 +1,171 @@
+"""
+Tests for flexkv.common.gpu_runtime — backend-agnostic GPU runtime abstraction.
+"""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestGpuRuntimeBackendDetection:
+    """Verify gpu_runtime loads the correct shared library based on backend."""
+
+    def test_import(self):
+        from flexkv.common import gpu_runtime
+        assert hasattr(gpu_runtime, "host_register")
+        assert hasattr(gpu_runtime, "host_unregister")
+        assert hasattr(gpu_runtime, "get_current_stream")
+        assert hasattr(gpu_runtime, "set_device")
+        assert hasattr(gpu_runtime, "synchronize")
+        assert hasattr(gpu_runtime, "device_count")
+        assert hasattr(gpu_runtime, "current_device")
+        assert hasattr(gpu_runtime, "get_device_string")
+        assert hasattr(gpu_runtime, "create_stream")
+        assert hasattr(gpu_runtime, "stream_context")
+        assert hasattr(gpu_runtime, "empty_cache")
+        assert hasattr(gpu_runtime, "is_gpu_tensor")
+        assert hasattr(gpu_runtime, "ipc_get_mem_handle")
+        assert hasattr(gpu_runtime, "ipc_open_mem_handle")
+
+
+class TestGpuRuntimeMusaPath:
+    """Test that MUSA backend path is selected when FLEXKV_GPU_BACKEND=musa."""
+
+    def setup_method(self):
+        import flexkv.common.gpu_runtime as mod
+        mod._runtime_lib = None
+        mod._backend = ""
+
+    @patch.dict(os.environ, {"FLEXKV_GPU_BACKEND": "musa"})
+    @patch("ctypes.CDLL")
+    def test_loads_musart(self, mock_cdll):
+        import flexkv.common.gpu_runtime as mod
+        mod._runtime_lib = None
+        mod._backend = ""
+        mock_lib = MagicMock()
+        mock_cdll.return_value = mock_lib
+        mod._load_runtime()
+        mock_cdll.assert_called_with("libmusart.so")
+        assert mod._backend == "musa"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("ctypes.CDLL")
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    def test_loads_cudart(self, mock_backend, mock_cdll):
+        import flexkv.common.gpu_runtime as mod
+        mod._runtime_lib = None
+        mod._backend = ""
+        mock_lib = MagicMock()
+        mock_cdll.return_value = mock_lib
+        mod._load_runtime()
+        mock_cdll.assert_called_with("libcudart.so")
+        assert mod._backend == "cuda"
+
+
+class TestGpuRuntimeStreamDevice:
+    """Test stream/device helpers dispatch correctly."""
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    @patch("torch.cuda.current_stream")
+    def test_get_current_stream_cuda(self, mock_stream, mock_backend):
+        from flexkv.common.gpu_runtime import get_current_stream
+        sentinel = object()
+        mock_stream.return_value = sentinel
+        result = get_current_stream()
+        assert result is sentinel
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    @patch("torch.cuda.set_device")
+    def test_set_device_cuda(self, mock_set, mock_backend):
+        from flexkv.common.gpu_runtime import set_device
+        set_device(3)
+        mock_set.assert_called_once_with(3)
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    @patch("torch.cuda.device_count", return_value=4)
+    def test_device_count_cuda(self, mock_count, mock_backend):
+        from flexkv.common.gpu_runtime import device_count
+        assert device_count() == 4
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    @patch("torch.cuda.current_device", return_value=2)
+    def test_current_device_cuda(self, mock_cur, mock_backend):
+        from flexkv.common.gpu_runtime import current_device
+        assert current_device() == 2
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    @patch("torch.cuda.empty_cache")
+    def test_empty_cache_cuda(self, mock_ec, mock_backend):
+        from flexkv.common.gpu_runtime import empty_cache
+        empty_cache()
+        mock_ec.assert_called_once()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="cuda")
+    def test_get_device_string_cuda(self, mock_backend):
+        from flexkv.common.gpu_runtime import get_device_string
+        assert get_device_string(0) == "cuda:0"
+        assert get_device_string(3) == "cuda:3"
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_get_device_string_musa(self, mock_backend):
+        from flexkv.common.gpu_runtime import get_device_string
+        assert get_device_string(0) == "musa:0"
+        assert get_device_string(1) == "musa:1"
+
+
+class TestMusaUnavailableRaisesError:
+    """When backend is 'musa' but torch.musa is absent, functions must raise."""
+
+    def _remove_torch_musa(self):
+        """Patch torch so that torch.musa does not exist."""
+        import torch as _torch
+        return patch.object(_torch, "musa", new=None, create=True)
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_get_current_stream_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import get_current_stream
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                get_current_stream()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_set_device_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import set_device
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                set_device(0)
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_synchronize_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import synchronize
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                synchronize()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_device_count_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import device_count
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                device_count()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_current_device_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import current_device
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                current_device()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_empty_cache_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import empty_cache
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                empty_cache()
+
+    @patch("flexkv.common.gpu_runtime.get_gpu_backend", return_value="musa")
+    def test_create_stream_raises(self, _mock_backend):
+        with self._remove_torch_musa():
+            from flexkv.common.gpu_runtime import create_stream
+            with pytest.raises(RuntimeError, match="torch.musa is not available"):
+                create_stream()
+

--- a/tests/test_musa_build.py
+++ b/tests/test_musa_build.py
@@ -1,0 +1,58 @@
+"""
+Tests for MUSA build configuration.
+When FLEXKV_USE_MUSA=1, the build should include flexkv.c_ext_musa.
+"""
+import os
+import pytest
+
+# Import from flexkv.build_config (used by setup.py and tests)
+from flexkv.build_config import get_cpp_extension_names
+
+
+def test_default_build_includes_only_c_ext():
+    """Without FLEXKV_USE_MUSA, only flexkv.c_ext is in the extension list."""
+    env_orig = os.environ.get("FLEXKV_USE_MUSA")
+    try:
+        if "FLEXKV_USE_MUSA" in os.environ:
+            del os.environ["FLEXKV_USE_MUSA"]
+        names = get_cpp_extension_names()
+        assert names == ["flexkv.c_ext"]
+    finally:
+        if env_orig is not None:
+            os.environ["FLEXKV_USE_MUSA"] = env_orig
+        elif "FLEXKV_USE_MUSA" in os.environ:
+            del os.environ["FLEXKV_USE_MUSA"]
+
+
+@pytest.mark.parametrize("value", ["1"])
+def test_musa_build_includes_c_ext_musa(value):
+    """With FLEXKV_USE_MUSA=1, flexkv.c_ext_musa is in the extension list."""
+    env_orig = os.environ.get("FLEXKV_USE_MUSA")
+    try:
+        os.environ["FLEXKV_USE_MUSA"] = value
+        names = get_cpp_extension_names()
+        assert "flexkv.c_ext_musa" in names
+    finally:
+        if env_orig is not None:
+            os.environ["FLEXKV_USE_MUSA"] = env_orig
+        elif "FLEXKV_USE_MUSA" in os.environ:
+            del os.environ["FLEXKV_USE_MUSA"]
+
+
+def test_musa_disabled_omits_c_ext_musa():
+    """With FLEXKV_USE_MUSA=0 or unset, c_ext_musa is not in the list."""
+    for value in ("0", "", "false"):
+        env_orig = os.environ.get("FLEXKV_USE_MUSA")
+        try:
+            if value:
+                os.environ["FLEXKV_USE_MUSA"] = value
+            elif "FLEXKV_USE_MUSA" in os.environ:
+                del os.environ["FLEXKV_USE_MUSA"]
+            names = get_cpp_extension_names()
+            assert "flexkv.c_ext_musa" not in names
+            assert "flexkv.c_ext" in names
+        finally:
+            if env_orig is not None:
+                os.environ["FLEXKV_USE_MUSA"] = env_orig
+            elif "FLEXKV_USE_MUSA" in os.environ:
+                del os.environ["FLEXKV_USE_MUSA"]

--- a/tests/test_transfer_musa.py
+++ b/tests/test_transfer_musa.py
@@ -1,0 +1,215 @@
+"""
+Tests for MUSA transfer path — Phase 2.
+Run with: pytest tests/test_transfer_musa.py -v -m musa
+Skip when c_ext_musa is not built or MUSA device is not available.
+"""
+import os
+import pytest
+
+try:
+    import flexkv.c_ext_musa as musa_ext
+    MUSA_EXT_AVAILABLE = hasattr(musa_ext, "transfer_kv_blocks")
+except ImportError:
+    musa_ext = None
+    MUSA_EXT_AVAILABLE = False
+
+HAS_MUSA_SDK = getattr(musa_ext, "HAS_MUSA_SDK", False) if musa_ext else False
+
+
+def _musa_device_available():
+    try:
+        import torch
+        musa = getattr(torch, "musa", None)
+        return musa is not None and musa.is_available()
+    except Exception:
+        return False
+
+
+MUSA_DEVICE_AVAILABLE = _musa_device_available()
+
+
+# ---------------------------------------------------------------------------
+# 1. Import / build verification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.musa
+class TestMusaExtImport:
+    """Verify the c_ext_musa extension can be imported and has correct attributes."""
+
+    def test_extension_importable(self):
+        if not MUSA_EXT_AVAILABLE:
+            pytest.skip("flexkv.c_ext_musa not built (build with FLEXKV_USE_MUSA=1)")
+        assert hasattr(musa_ext, "transfer_kv_blocks")
+
+    def test_has_musa_sdk_attribute(self):
+        if not MUSA_EXT_AVAILABLE:
+            pytest.skip("flexkv.c_ext_musa not built")
+        assert hasattr(musa_ext, "HAS_MUSA_SDK")
+
+    @pytest.mark.skipif(not MUSA_EXT_AVAILABLE, reason="extension not built")
+    def test_sdk_flag_matches_env(self):
+        """When MUSA_HOME points to a real SDK, HAS_MUSA_SDK should be True."""
+        musa_home = os.environ.get("MUSA_HOME", "")
+        if musa_home and os.path.isdir(musa_home):
+            assert musa_ext.HAS_MUSA_SDK is True
+        else:
+            assert musa_ext.HAS_MUSA_SDK is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Stub transfer (no device required)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.musa
+@pytest.mark.skipif(
+    HAS_MUSA_SDK,
+    reason="Stub tests require extension built without MUSA SDK (no-op path); with SDK, real kernel runs and needs valid GPU pointers",
+)
+class TestMusaTransferStub:
+    """Call transfer_kv_blocks in stub mode — must not crash."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_ext(self):
+        if not MUSA_EXT_AVAILABLE:
+            pytest.skip("flexkv.c_ext_musa not built")
+
+    def _make_dummy_args(self, num_blocks=2, num_layers=1, chunk_size=256):
+        import torch
+        gpu_block_ids = torch.zeros(num_blocks, dtype=torch.int64)
+        cpu_block_ids = torch.zeros(num_blocks, dtype=torch.int64)
+        cpu_tensor = torch.zeros(
+            chunk_size * num_blocks * 2 * num_layers, dtype=torch.int64
+        )
+        gpu_tensor_ptrs = torch.zeros(1, dtype=torch.int64)
+        return dict(
+            gpu_block_id_tensor=gpu_block_ids,
+            gpu_tensor_ptrs_tensor=gpu_tensor_ptrs,
+            gpu_kv_stride_in_bytes=0,
+            gpu_block_stride_in_bytes=0,
+            gpu_layer_stride_in_bytes=0,
+            cpu_block_id_tensor=cpu_block_ids,
+            cpu_tensor=cpu_tensor,
+            cpu_kv_stride_in_bytes=chunk_size * 8,
+            cpu_layer_stride_in_bytes=chunk_size * 8,
+            cpu_block_stride_in_bytes=chunk_size * 8,
+            chunk_size_in_bytes=chunk_size * 8,
+            start_layer_id=0,
+            num_layers=num_layers,
+        )
+
+    def test_host_to_device_no_crash(self):
+        args = self._make_dummy_args()
+        musa_ext.transfer_kv_blocks(**args, is_host_to_device=True)
+
+    def test_device_to_host_no_crash(self):
+        args = self._make_dummy_args()
+        musa_ext.transfer_kv_blocks(**args, is_host_to_device=False)
+
+    def test_ce_transfer_no_crash(self):
+        args = self._make_dummy_args()
+        musa_ext.transfer_kv_blocks(**args, use_ce_transfer=True)
+
+    def test_mla_mode_no_crash(self):
+        args = self._make_dummy_args()
+        musa_ext.transfer_kv_blocks(**args, is_mla=True)
+
+    @pytest.mark.parametrize("block_type", [0, 1, 2])
+    def test_all_backend_types(self, block_type):
+        args = self._make_dummy_args()
+        musa_ext.transfer_kv_blocks(**args, gpu_block_type=block_type)
+
+    def test_multi_layer(self):
+        args = self._make_dummy_args(num_blocks=4, num_layers=3, chunk_size=128)
+        musa_ext.transfer_kv_blocks(**args)
+
+
+# ---------------------------------------------------------------------------
+# 3. Real MUSA device transfer (requires MUSA SDK + device)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.musa
+@pytest.mark.skipif(
+    not (HAS_MUSA_SDK and MUSA_DEVICE_AVAILABLE),
+    reason="Requires MUSA SDK build and MUSA device",
+)
+class TestMusaTransferDevice:
+    """Correctness tests that run on an actual MUSA device."""
+
+    def test_h2d_d2h_roundtrip_vllm(self):
+        """Write data H→D then read D→H and verify parity (VLLM backend)."""
+        import torch
+
+        num_blocks = 2
+        num_layers = 1
+        num_kv = 2  # K and V
+        block_size = 64
+        chunk_bytes = block_size * 8
+
+        # CPU layout: [layer][kv][block]; strides in bytes
+        cpu_block_stride = chunk_bytes
+        cpu_kv_stride = num_blocks * cpu_block_stride
+        cpu_layer_stride = num_kv * cpu_kv_stride
+
+        cpu_src = torch.arange(
+            num_blocks * num_layers * num_kv * block_size, dtype=torch.int64
+        ).pin_memory()
+        cpu_dst = torch.zeros_like(cpu_src).pin_memory()
+
+        # VLLM layout: [K_block0, K_block1, V_block0, V_block1] per layer
+        gpu_block_stride = chunk_bytes
+        gpu_kv_stride = num_blocks * chunk_bytes
+        gpu_tensors = [
+            torch.zeros(num_kv * num_blocks * block_size, dtype=torch.int64, device="musa")
+            for _ in range(num_layers)
+        ]
+        gpu_ptrs = torch.tensor(
+            [t.data_ptr() for t in gpu_tensors], dtype=torch.int64
+        )
+
+        block_ids = torch.arange(num_blocks, dtype=torch.int64)
+
+        # Use CE transfer (memcpy) — kernel path uses __ldg which cannot read host memory
+        musa_ext.transfer_kv_blocks(
+            block_ids, gpu_ptrs,
+            gpu_kv_stride, gpu_block_stride, 0,
+            block_ids, cpu_src,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride,
+            chunk_bytes, 0, num_layers,
+            is_host_to_device=True, use_ce_transfer=True, gpu_block_type=0,
+        )
+
+        musa_ext.transfer_kv_blocks(
+            block_ids, gpu_ptrs,
+            gpu_kv_stride, gpu_block_stride, 0,
+            block_ids, cpu_dst,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride,
+            chunk_bytes, 0, num_layers,
+            is_host_to_device=False, use_ce_transfer=True, gpu_block_type=0,
+        )
+
+        assert torch.equal(cpu_src, cpu_dst), "H→D→H roundtrip data mismatch"
+
+
+# ---------------------------------------------------------------------------
+# 4. Signature parity with CUDA extension
+# ---------------------------------------------------------------------------
+
+@pytest.mark.musa
+class TestMusaCudaSignatureParity:
+    """Ensure c_ext_musa.transfer_kv_blocks accepts the same kwargs as c_ext."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_ext(self):
+        if not MUSA_EXT_AVAILABLE:
+            pytest.skip("flexkv.c_ext_musa not built")
+
+    def test_same_parameter_names(self):
+        import inspect
+        try:
+            import flexkv.c_ext as cuda_ext
+        except ImportError:
+            pytest.skip("flexkv.c_ext (CUDA) not available for comparison")
+        cuda_sig = inspect.signature(cuda_ext.transfer_kv_blocks)
+        musa_sig = inspect.signature(musa_ext.transfer_kv_blocks)
+        assert list(cuda_sig.parameters.keys()) == list(musa_sig.parameters.keys())
+


### PR DESCRIPTION
### Description

This PR adds support for MUSA as an alternative backend to CUDA in FlexKV.

#### Summary

- **Backend abstraction:** Introduces `gpu_backend.py` and `gpu_runtime.py` so Python code uses a single dispatch layer instead of scattered `torch.cuda` calls. This keeps the CUDA path unchanged and allows MUSA to be added without `#ifdef` in existing CUDA sources.

- **MUSA C++ extension:** Adds a parallel MUSA implementation under `csrc/musa/`:
  - Transfer kernels (`transfer_musa.mu`)
  - GDS manager and layout transform for MUSA
  - Thread groups for transfer and GDS
  - Python bindings (`bindings_musa.cpp`)

- **Build system:** Adds `build_config.py` and updates `setup.py` to support conditional MUSA builds via `FLEXKV_USE_MUSA=1`. CUDA and MUSA extensions can be built independently.

- **Integration:** Updates `memory_handle.py`, `worker.py`, `allocator.py`, and the vLLM/TensorRT-LLM adapters to use the GPU runtime abstraction.

- **Documentation:** Adds `docs/musa/musa_support_system_design.md` and `docs/musa/musa_test_plan.md`.

- **Tests:** Adds tests for backend dispatch, GPU runtime, MUSA build, and MUSA transfer.

#### Design principles

- Same API shape as CUDA (musa* types/functions, mcc compiler)
- No changes to existing CUDA code paths
- Backend abstraction first, then MUSA wiring

#### Testing

- `tests/test_gpu_backend_dispatch.py` – backend selection
<img width="1563" height="449" alt="image" src="https://github.com/user-attachments/assets/024588d6-4536-4912-9ac6-f16c7547ef04" />

- `tests/test_gpu_runtime.py` – runtime abstraction
<img width="1557" height="727" alt="image" src="https://github.com/user-attachments/assets/3c196004-2ed4-49a2-834d-eda85d5bc6e8" />

- `tests/test_musa_build.py` – MUSA build (when `FLEXKV_USE_MUSA=1`)
<img width="1557" height="421" alt="image" src="https://github.com/user-attachments/assets/772baefd-c1b2-4a97-bcfb-46db30fb4e74" />

- `tests/test_transfer_musa.py` – MUSA transfer behavior
<img width="1555" height="602" alt="image" src="https://github.com/user-attachments/assets/609d2c16-cd5f-4a53-8b07-a553a142c270" />
