### PR TITLE
[bugfix] Fix multiple bugs in distributed KV transfer (P2P SSD / RDMA)

### DIFF
--- a/flexkv/transfer/utils.py
+++ b/flexkv/transfer/utils.py
@@ -217,16 +217,17 @@ class RDMATaskInfo:
             "data_size": self.data_size,
         }
 
-    def from_dict(self, data: dict) -> "RDMATaskInfo":
-        return RDMATaskInfo(
-            task_id = data.get("task_id", 0),
+    @classmethod
+    def from_dict(cls, data: dict) -> "RDMATaskInfo":
+        return cls(
+            task_id=data.get("task_id", 0),
             local_engine_addr=data.get("local_engine_addr", ""),
             peer_engine_addr=data.get("peer_engine_addr", ""),
-            peer_zmq_addr = data.get("peer_zmq_addr", ""),
-            src_ptr=data.get("src_ptrs", []),
-            dst_ptr=data.get("dst_ptrs", []),
+            peer_zmq_addr=data.get("peer_zmq_addr", ""),
+            src_ptrs=data.get("src_ptrs", []),
+            dst_ptrs=data.get("dst_ptrs", []),
             src_block_ids=data.get("src_block_ids"),
             dst_block_ids=data.get("dst_block_ids"),
-            data_lens = data.get("data_lens", []),
+            data_lens=data.get("data_lens", []),
             data_size=int(data.get("data_size", 0)),
         )

--- a/flexkv/transfer/utils.py
+++ b/flexkv/transfer/utils.py
@@ -101,14 +101,19 @@ class RemoteSSD2HMetaInfo:
     task_id: int
     cpu_block_ids: List[int]
     ssd_block_ids: List[int]
-    peer_engine_addr: str # the mooncake engine address of the node that initiates the transfer, used for write data back to the node.
+    peer_engine_addr: str  # mooncake engine addr of the node that initiates the transfer,
+                           # used for write data back to the node.
     peer_cpu_base_ptr: int # the cpu buffer base ptr of the peer node, used for calculating the dst ptrs.
     peer_zmq_status_addr: str
     data_size: int
     layer_id: int
     layer_granularity: int
-    
-    def __init__(self, task_id, cpu_block_ids, ssd_block_ids, peer_engine_addr, peer_cpu_base_ptr, peer_zmq_status_addr, data_size, layer_id, layer_granularity):
+
+    def __init__(
+        self, task_id, cpu_block_ids, ssd_block_ids, peer_engine_addr,
+        peer_cpu_base_ptr, peer_zmq_status_addr, data_size, layer_id,
+        layer_granularity
+    ):
         self.task_id = task_id
         self.cpu_block_ids = cpu_block_ids
         self.ssd_block_ids = ssd_block_ids
@@ -144,7 +149,7 @@ class RemoteSSD2HMetaInfo:
             "layer_id": self.layer_id,
             "layer_granularity": self.layer_granularity,
         }
-        
+
 class NodeMetaInfo:
     """Node information for flexkv sub-nodes"""
 
@@ -181,10 +186,11 @@ class NodeMetaInfo:
             cpu_bufer_base_ptr=data.get("cpu_buffer_ptr"),
             ssd_bufer_base_ptr=data.get("ssd_buffer_ptr"),
         )
-        
+
 class RDMATaskInfo:
     def __init__(
-        self, task_id: int, local_engine_addr: str, peer_engine_addr: str, peer_zmq_addr: str, src_ptrs: List[int], dst_ptrs: List[int], 
+        self, task_id: int, local_engine_addr: str, peer_engine_addr: str,
+        peer_zmq_addr: str, src_ptrs: List[int], dst_ptrs: List[int],
         src_block_ids: List[int], dst_block_ids: List[int], data_lens: List[int], data_size: int
     ):
         self.task_id = task_id
@@ -200,8 +206,8 @@ class RDMATaskInfo:
     def to_dict(self) -> dict:
         return {
             "task_id": self.task_id,
-            "local_engine_addr": self.local_engine_addr,  
-            "peer_engine_addr": self.peer_engine_addr, 
+            "local_engine_addr": self.local_engine_addr,
+            "peer_engine_addr": self.peer_engine_addr,
             "peer_zmq_addr": self.peer_zmq_addr,
             "src_ptrs": self.src_ptrs,
             "dst_ptrs": self.dst_ptrs,
@@ -217,8 +223,8 @@ class RDMATaskInfo:
             local_engine_addr=data.get("local_engine_addr", ""),
             peer_engine_addr=data.get("peer_engine_addr", ""),
             peer_zmq_addr = data.get("peer_zmq_addr", ""),
-            src_ptr=data.get("src_ptr", []),
-            dst_ptr=data.get("dst_ptr", []),
+            src_ptr=data.get("src_ptrs", []),
+            dst_ptr=data.get("dst_ptrs", []),
             src_block_ids=data.get("src_block_ids"),
             dst_block_ids=data.get("dst_block_ids"),
             data_lens = data.get("data_lens", []),

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1828,6 +1828,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             f"Node {self.cache_config.distributed_node_id} Listening on {self.zmq_listen_addr}"
         )
         while not self.zmq_server.shutdown_event.is_set():
+            recv_meta = None
+            failure_msg = None
             try:
                 ## step1: recv and parse the message into meta info
                 try:

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1658,8 +1658,12 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         if transfer_type == TransferType.PEERH2H:
             # remote cpu to local cpu transfer by one-side rdma read
             for i in range(len(task_info.src_ptrs)):
-                ret = self.mooncake_transfer_engine.transfer_sync_read(task_info.peer_zmq_addr, task_info.src_ptrs[i],
-                                                                       task_info.dst_ptrs[i], task_info.data_lens[i])
+                ret = self.mooncake_transfer_engine.transfer_sync_read(
+                    task_info.peer_engine_addr,
+                    task_info.src_ptrs[i],
+                    task_info.dst_ptrs[i],
+                    task_info.data_lens[i],
+                )
                 if ret != 0:
                     flexkv_logger.error(f"transfer_sync_write failed with error code: {ret}")
                     return False

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1967,6 +1967,14 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 nvtx.end_range(nvtx_range)
             except Exception as e:
                 flexkv_logger.error(f"Unexpected error in ssd_handle_loop: {e}")
+                # Send failure notify so the peer doesn't block waiting forever
+                try:
+                    if recv_meta is not None:
+                        self.zmq_server.send_transfer_status(
+                            recv_meta.peer_zmq_status_addr, failure_msg
+                        )
+                except Exception:
+                    pass
                 time.sleep(0.001)
 
     def copy_ssd_data_to_dram(

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -37,7 +37,14 @@ from flexkv.common.config import CacheConfig, GLOBAL_CONFIG_FROM_ENV, MooncakeTr
 from flexkv.mooncakeEngineWrapper import MoonCakeTransferEngineWrapper
 from flexkv.transfer.zmqHelper import NotifyMsg, NotifyStatus, SSDZMQServer, SSDZMQClient
 from flexkv.cache.redis_meta import RedisMeta
-from flexkv.transfer.utils import group_blocks_by_node_and_segment, group_blocks_by_node, split_contiguous_blocks, RemoteSSD2HMetaInfo, NodeMetaInfo, RDMATaskInfo
+from flexkv.transfer.utils import (
+    group_blocks_by_node_and_segment,
+    group_blocks_by_node,
+    split_contiguous_blocks,
+    RemoteSSD2HMetaInfo,
+    NodeMetaInfo,
+    RDMATaskInfo,
+)
 try:
     from flexkv.c_ext import (
         transfer_kv_blocks_remote,
@@ -894,7 +901,11 @@ class CPURemoteTransferWorker(TransferWorkerBase):
 
                 # Calculate block_id_in_file using the same logic as C++
                 # This should match the C++ implementation in pcfs.cpp
-                block_id_in_file = int(((remote_block_id_list[i] / self.round_robin) / total_file_num) * self.round_robin + (remote_block_id_list[i] % self.round_robin))
+                block_id_in_file = int(
+                    ((remote_block_id_list[i] / self.round_robin) / total_file_num)
+                    * self.round_robin
+                    + (remote_block_id_list[i] % self.round_robin)
+                )
 
                 cfs_blocks_partition[fid].append(block_id_in_file)
                 cpu_blocks_partition[fid].append(cpu_block_id_list[i].item())
@@ -1236,7 +1247,11 @@ class tpGDSTransferWorker(TransferWorkerBase):
         # SSD layout calculations
         self.ssd_layer_stride_in_bytes = ssd_kv_layout_per_file.get_layer_stride() * self.dtype.itemsize
         self.ssd_kv_stride_in_bytes = ssd_kv_layout_per_file.get_kv_stride() * self.dtype.itemsize
-        self.ssd_tp_stride_in_bytes = self.ssd_block_stride_in_bytes // self.tp_group_size if not self.is_mla else self.ssd_block_stride_in_bytes
+        self.ssd_tp_stride_in_bytes = (
+            self.ssd_block_stride_in_bytes // self.tp_group_size
+            if not self.is_mla
+            else self.ssd_block_stride_in_bytes
+        )
 
         # Resolve pointers in Python (where storage is valid); pass them to C++ so we avoid
         # "Tensor that doesn't have storage" when C++ calls .data_ptr() on tensors passed
@@ -1397,7 +1412,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             # NodeMetaInfo according to node_id
             # assuming that every flexkv progress has unique node id
             self.node_metas: Dict[int, NodeMetaInfo] = {}
-            assert self.redis_meta_client != None
+            assert self.redis_meta_client is not None
 
 
             # step2: initialize mooncake transfer engine for the whole flexkv
@@ -1410,7 +1425,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 self.mooncake_config
             )
             assert (
-                self.mooncake_transfer_engine != None
+                self.mooncake_transfer_engine is not None
             ), "PEER2CPUTransferWorker: initilaize mooncake transfer engine failed"
 
             # step3: register local cpu buffer to mooncake transfer engine
@@ -1423,13 +1438,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             assert (
                 regist_buffer_status == 0
             ), "PEER2CPUTransferWorker: regist cpu buffer to mooncake transfer engine"
-
-            # step4: regist node info into redis server
-            self.regist_node_meta(
-                self.cpu_blocks.data_ptr(),
-                self.cpu_blocks.data_ptr(),
-                self.zmq_listen_addr,
-            )
 
         ## when enable p2p ssd, we need start a zmq server to recive the meta info from remote node,
         # and allocate a cpu buffer for ssd to cpu copy
@@ -1501,6 +1509,21 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             except Exception as e:
                 flexkv_logger.error(f"Error setting ssd ioctx: {e}\n")
                 raise RuntimeError("SSD Worker init failed") from e
+
+        ## step4: regist node info into redis server
+        ## Must be done after P2P SSD init so we can register the correct
+        ## ssd_buffer_base_ptr (tmp_cpu_buffer) when P2P SSD is enabled.
+        if self.cache_config.enable_kv_sharing:
+            ssd_buffer_ptr = (
+                self.tmp_cpu_buffer.data_ptr()
+                if self.cache_config.enable_p2p_ssd
+                else 0
+            )
+            self.regist_node_meta(
+                self.cpu_blocks.data_ptr(),
+                ssd_buffer_ptr,
+                self.zmq_listen_addr,
+            )
 
         ## unique task id counter for remote ssd to cpu transfer task
         self.remote_ssd_task_id_counter = 0
@@ -1614,7 +1637,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             )
             if not ret:
                 flexkv_logger.error(
-                    f"Wait remote ssd to cpu transfer task {task_info.task_id} notify from {task_info.peer_engine_addr} failed with error code: {ret}"
+                    f"Wait remote ssd to cpu transfer task {task_info.task_id} "
+                    f"notify from {task_info.peer_engine_addr} failed with error code: {ret}"
                 )
                 return False
         else:
@@ -1671,7 +1695,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             )
             if not ret:
                 flexkv_logger.error(
-                    f"Wait remote ssd to cpu transfer task {task_info.task_id} notify from {task_info.peer_engine_addr} failed with error code: {ret}"
+                    f"Wait remote ssd to cpu transfer task {task_info.task_id} "
+                    f"notify from {task_info.peer_engine_addr} failed with error code: {ret}"
                 )
                 return False
 
@@ -1687,7 +1712,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
     ) -> List[RDMATaskInfo]:
         """
         parse the transfer op to a list of RDMATaskInfo
-        1. group the blocks by remote node id, each segment is a list of continuous blocks (segment is the smallest transmission unit)
+        1. group the blocks by remote node id, each segment is a list of
+           continuous blocks (segment is the smallest transmission unit)
         2. using corresponding distributed op parser to parse the op and create RDMATaskInfo for each segment
         5. return the list of RDMATaskInfo
         Parameters:
@@ -1706,7 +1732,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
 
         src_block_node_ids = transfer_op.src_block_node_ids
 
-        # step1: group the blocks by remote node id and remote block source type, each segment is a list of continuous blocks
+        # step1: group the blocks by remote node id and remote block source type,
+        # each segment is a list of continuous blocks
         #flexkv_logger.info(
         #    f"[PEER2CPUTransferWorker] src_block_ids: {src_block_ids} \n \
         #                        dst_block_ids: {dst_block_ids} \n \
@@ -1771,7 +1798,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             task_info_list.append(
                 RDMATaskInfo(
                     ssd_task_id,
-                    self.mooncake_transfer_engine.get_engine_addr(),  ## for ssd transfer, peer engine addr refers to local mooncake engine
+                    self.mooncake_transfer_engine.get_engine_addr(),
+                    # for ssd transfer, peer engine addr refers to local mooncake engine
                     peer_engine_addr,
                     peer_zmq_addr,
                     None,
@@ -1821,10 +1849,16 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
 
                 self.zmq_server.listen_socket.send(b"OK")
 
-                failure_msg = NotifyMsg(mooncake_engine_addr=self.mooncake_transfer_engine.get_engine_addr(),
-                                                task_id=recv_meta.task_id, status = NotifyStatus.FAIL) ## used when transfer fails
-                success_msg = NotifyMsg(mooncake_engine_addr=self.mooncake_transfer_engine.get_engine_addr(),
-                                                task_id=recv_meta.task_id, status = NotifyStatus.SUCCESS) ## used when transfer fails
+                failure_msg = NotifyMsg(
+                    mooncake_engine_addr=self.mooncake_transfer_engine.get_engine_addr(),
+                    task_id=recv_meta.task_id,
+                    status=NotifyStatus.FAIL,
+                )
+                success_msg = NotifyMsg(
+                    mooncake_engine_addr=self.mooncake_transfer_engine.get_engine_addr(),
+                    task_id=recv_meta.task_id,
+                    status=NotifyStatus.SUCCESS,
+                )
 
                 # step2: ckeck the recieved info, early return if check error
                 nvtx_range = nvtx.start_range(message="ssd_handle_loop. check and load_data", color="orange")
@@ -1836,17 +1870,21 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                         self.zmq_server.send_transfer_status(recv_meta.peer_zmq_status_addr, failure_msg)
                         continue
 
-                # TODO: we need to support dynamic temp buffer or split the ssd transfer request if number of ssd blocks is larger than num_tmp_cpu_blocks
-                # now we just refuse this transfer by returning a failure status
+                # TODO: we need to support dynamic temp buffer or split the ssd
+                # transfer request if number of ssd blocks is larger than
+                # num_tmp_cpu_blocks. Now we just refuse this transfer by
+                # returning a failure status.
                 if len(recv_meta.ssd_block_ids)>self.cache_config.num_tmp_cpu_blocks:
                     flexkv_logger.warning(
-                            f"The number of ssd_block_ids is larger than {self.cache_config.num_tmp_cpu_blocks},  can not do transfer now"
+                            f"The number of ssd_block_ids is larger than "
+                            f"{self.cache_config.num_tmp_cpu_blocks}, can not do transfer now"
                         )
                     self.zmq_server.send_transfer_status(recv_meta.peer_zmq_status_addr, failure_msg)
                     continue
 
                 ## step3: do copy data from ssd to cpu
-                # NOTE: this block ids is a corresponding relationship with self.tmp_cpu_buffer, for every transfer req we reuse the local cpu buffer
+                # NOTE: this block ids is a corresponding relationship with
+                # self.tmp_cpu_buffer, for every transfer req we reuse the local cpu buffer
                 local_cpu_buffer_block_ids = torch.arange(0, len(recv_meta.ssd_block_ids), dtype = torch.int64)
                 local_cpu_start_idx = 0
 
@@ -1869,7 +1907,9 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                         all_copy_complete = False
                         break
                     # get corresponding temp cpu block ids
-                    local_cpu_buffer_block_ids_per_seg = local_cpu_buffer_block_ids[local_cpu_start_idx: local_cpu_start_idx+len(ssd_block_ids_per_seg)]
+                    local_cpu_buffer_block_ids_per_seg = local_cpu_buffer_block_ids[
+                        local_cpu_start_idx: local_cpu_start_idx + len(ssd_block_ids_per_seg)
+                    ]
                     local_cpu_start_idx += len(ssd_block_ids_per_seg)
 
                     layer_id = recv_meta.layer_id
@@ -1912,7 +1952,9 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                     self.zmq_server.send_transfer_status(recv_meta.peer_zmq_status_addr, failure_msg)
                     continue
 
-                if not self.write_data_back_to_peer(recv_meta.peer_engine_addr, src_ptr_list, dst_ptr_list, data_size_list):
+                if not self.write_data_back_to_peer(
+                    recv_meta.peer_engine_addr, src_ptr_list, dst_ptr_list, data_size_list
+                ):
                     self.zmq_server.send_transfer_status(recv_meta.peer_zmq_status_addr, failure_msg)
                     flexkv_logger.error("Failed to write data back to peer")
                     continue
@@ -1959,9 +2001,13 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         dst_ptr_list: List[int],
         data_size_list: List[int]
     ):
-        flexkv_logger.info(f"Write data back to peer from src: {src_ptr_list} to {dst_ptr_list}")
-        ret = self.mooncake_transfer_engine.batch_transfer_sync_write(peer_address, src_ptr_list, dst_ptr_list, data_size_list)
-        return True if ret == 0 else False
+        flexkv_logger.info(
+            f"Write data back to peer from src: {src_ptr_list} to {dst_ptr_list}"
+        )
+        ret = self.mooncake_transfer_engine.batch_transfer_sync_write(
+            peer_address, src_ptr_list, dst_ptr_list, data_size_list
+        )
+        return ret == 0
 
 
     #============================== distrbuted cpu related ==========================
@@ -2034,11 +2080,13 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 assert len(data_size_list) == len(src_ptr_list) and len(data_size_list) == len(dst_ptr_list)
 
             flexkv_logger.info(
-                f"[PEER2CPUTransferWorker]: remote cpu op parser src_ptr_list: {src_ptr_list}, dst_ptr_list: {dst_ptr_list} "
+                f"[PEER2CPUTransferWorker]: remote cpu op parser "
+                f"src_ptr_list: {src_ptr_list}, dst_ptr_list: {dst_ptr_list} "
             )
             # step3: create RDMATaskInfo for each segment
             # NOTE: block wise layout: only one start ptr for each segment
-            #       layer wise layout: multiple start ptrs for each segment, the number of start ptrs equals to layer_granularity * kv_dim
+            #       layer wise layout: multiple start ptrs for each segment,
+            #       the number of start ptrs equals to layer_granularity * kv_dim
 
             task_info_list.append(
                   RDMATaskInfo(
@@ -2068,9 +2116,11 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         """
         Get the cpu buffer block start ptrs for the given cpu blocks.
         We have two layout types in flexkv, layerwise and blockwise.
-        1) For layerwise layout,although the cpu blocks are continous, we need to calculate the start ptrs for each layer and each kv dim. So
+        1) For layerwise layout, although the cpu blocks are continous, we need to
+        calculate the start ptrs for each layer and each kv dim. So
         the number of start ptrs equals to layer_granularity * kv_dim.
-        2) For blockwise layout, the cpu blocks are continuous, so we only need to calculate the start ptr for the first block. So
+        2) For blockwise layout, the cpu blocks are continuous, so we only need to
+        calculate the start ptr for the first block. So
         the number of start ptrs is 1.
         3) For other layout types, raise error.
 
@@ -2080,7 +2130,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             layer_start_id (int): the start layer id, only used for layerwise layout
             layer_granularity (int): the number of layers to be transferred, only used for layerwise layout
         Returns:
-            Tuple(List[int], int): the list of cpu buffer block start ptrs and data size per block (used for calculate total data size)
+            Tuple(List[int], int): the list of cpu buffer block start ptrs and
+                data size per block (used for calculate total data size)
         """
 
         # assuming that remote cpu buffer layout is the same as local cpu buffer layout
@@ -2124,8 +2175,12 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         return  src_block_ptrs, data_size_per_block
 
     ### redis client helper functions
-    def regist_node_meta(self, cpu_buffer_base_ptr: int, ssd_buffer_base_ptr: int, zmq_addr: str):
-        self.redis_meta_client.regist_node_meta(self.redis_meta_client.get_node_id(), self.mooncake_transfer_engine.get_engine_addr(),
+    def regist_node_meta(
+        self, cpu_buffer_base_ptr: int, ssd_buffer_base_ptr: int, zmq_addr: str
+    ):
+        self.redis_meta_client.regist_node_meta(
+            self.redis_meta_client.get_node_id(),
+            self.mooncake_transfer_engine.get_engine_addr(),
                                                 zmq_addr, cpu_buffer_base_ptr, ssd_buffer_base_ptr)
         #NOTE: maybe useless
         node_meta_info = NodeMetaInfo(

--- a/flexkv/transfer/zmqHelper.py
+++ b/flexkv/transfer/zmqHelper.py
@@ -19,7 +19,7 @@ class NotifyMsg:
         self.mooncake_engine_addr = mooncake_engine_addr
         self.task_id = task_id
         self.status = status
-        
+
     def to_string(self):
         return json.dumps({
             "mooncake_engine_addr": self.mooncake_engine_addr,
@@ -29,7 +29,7 @@ class NotifyMsg:
     @classmethod
     def from_string(cls, s):
         data = json.loads(s)
-        status = NotifyStatus[data["status"]] 
+        status = NotifyStatus[data["status"]]
         return cls(mooncake_engine_addr = data["mooncake_engine_addr"], task_id = data["task_id"], status = status)
 
 
@@ -37,13 +37,13 @@ class SSDZMQServer:
     def __init__(self, ip: str, port: int, ssd_handle_loop = None):
         if ssd_handle_loop is None:
             raise ValueError("ssd_handle_loop must be provided externally")
-        
+
         self.zmq_context = zmq.Context()
         ## listening the ssd meta info
         self.meta_addr = f"tcp://{ip}:{port}"
         self.listen_socket = self.zmq_context.socket(zmq.REP)
         self.listen_socket.bind(self.meta_addr)
-        
+
         self.shutdown_event = threading.Event()
         self.ssd_handle_loop = ssd_handle_loop
         self.thread = threading.Thread(target=self.ssd_handle_loop, daemon=True)
@@ -52,7 +52,7 @@ class SSDZMQServer:
 
     def get_addr(self):
         return self.meta_addr
-    
+
     def start(self):
         self.thread.start()
 
@@ -62,9 +62,9 @@ class SSDZMQServer:
             self.listen_socket.close(0)
             self.zmq_context.term()
         except Exception as e:
-            flexkv_logger.error(f"Error when closing ZMQ: {e}")    
+            flexkv_logger.error(f"Error when closing ZMQ: {e}")
         self.thread.join()
-        
+
     def send_transfer_status(self, peer_status_addr: str, status_msg: NotifyMsg):
         req_socket = self.zmq_context.socket(zmq.PUSH)
         req_socket.setsockopt(zmq.SNDTIMEO, 1000)  ## time out 1s
@@ -87,27 +87,30 @@ class SSDZMQServer:
             # other exception
             req_socket.close()
             flexkv_logger.error(f"Error sending transfer status to {peer_status_addr}: {e}")
-            return False   
-    
-                
+            return False
+
+
 class SSDZMQClient:
+    RECV_TIMEOUT_MS = 5000  # timeout for receiving transfer notifications
+
     def __init__(self, ip: str, port: int):
         self.zmq_context = zmq.Context()
         self.zmq_status_addr = f"tcp://{ip}:{port}"
         self.status_socket = self.zmq_context.socket(zmq.PULL)
-        self.status_socket.bind(self.zmq_status_addr) 
-    
+        self.status_socket.setsockopt(zmq.RCVTIMEO, self.RECV_TIMEOUT_MS)
+        self.status_socket.bind(self.zmq_status_addr)
+
     def get_addr(self):
         return self.zmq_status_addr
-    
+
     def send_meta_info(self, meta_info: RemoteSSD2HMetaInfo, peer_zmq_addr: str):
         req_socket = self.zmq_context.socket(zmq.REQ)
         req_socket.setsockopt(zmq.SNDTIMEO, 1000)  ## time out 1s
         try:
             req_socket.connect(peer_zmq_addr)
             req_socket.send(json.dumps(meta_info.to_dict()).encode("utf-8"))
-            reply = req_socket.recv()  
-            
+            reply = req_socket.recv()
+
             if reply != b"OK":
                 return False
             flexkv_logger.info(f"Meta info sent to {peer_zmq_addr}, waiting for transfer status")
@@ -129,22 +132,26 @@ class SSDZMQClient:
             return False
 
     def wait_transfer_notify(self, peer_addr: str, task_id: int):
-        timeout = 5.0 # timeout after 5 seconds
+        timeout_s = self.RECV_TIMEOUT_MS / 1000.0
         start_time = time.time()
         transfer_status = False
         while True:
-            notify = self.status_socket.recv().decode("utf-8")
+            try:
+                # recv() blocks until a message arrives or RCVTIMEO expires, raising zmq.Again on timeout
+                notify = self.status_socket.recv().decode("utf-8")
+            except zmq.Again:
+                flexkv_logger.warning(f"Timeout waiting for notify: {peer_addr}, task={task_id}")
+                return False
             msg = NotifyMsg.from_string(notify)
-            
+
             if msg.mooncake_engine_addr == peer_addr and msg.task_id == task_id:
                 flexkv_logger.info(f"Received notify: {msg.mooncake_engine_addr}, {msg.task_id}, {msg.status}")
                 if msg.status == NotifyStatus.SUCCESS:
                     transfer_status = True
                 break
-            if time.time() - start_time > timeout:
+            if time.time() - start_time > timeout_s:
                 flexkv_logger.warning(f"Timeout waiting for notify: {peer_addr}, task={task_id}")
                 return False
-            time.sleep(0.01) # sleep for 10 ms to avoid busy waiting
         return transfer_status
 
     def shutdown(self):
@@ -152,4 +159,4 @@ class SSDZMQClient:
             self.status_socket.close(0)
             self.zmq_context.term()
         except Exception as e:
-            flexkv_logger.error(f"Error when closing ZMQ: {e}")    
+            flexkv_logger.error(f"Error when closing ZMQ: {e}")


### PR DESCRIPTION
## Summary
- Fix `wait_transfer_notify` infinite blocking: set `zmq.RCVTIMEO` on the PULL socket and unify timeout into `RECV_TIMEOUT_MS` constant
- Fix wrong `ssd_buffer_base_ptr` in `regist_node_meta`: move registration after P2P SSD init so `tmp_cpu_buffer` ptr is used instead of CPU buffer ptr
- Fix `_transfer_impl` passing `peer_zmq_addr` (ZMQ address) instead of `peer_engine_addr` (Mooncake engine address) to `transfer_sync_read`
- Fix missing failure notification in `ssd_handle_loop`: when an exception occurs after ZMQ "OK" reply, send `failure_msg` so the peer doesn't block until timeout
- Fix incorrect key names in `RDMATaskInfo.from_dict` (`src_ptr`/`dst_ptr` → `src_ptrs`/`dst_ptrs`)
- Clean up all pre-existing ruff lint warnings in `worker.py` (E501, E711, SIM210)