### PR TITLE
[bugfix] Fix multiple P2P bugs in distributed KV cache

### DIFF
--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -202,21 +202,26 @@ size_t LocalRadixTree::local_block_report(size_t max_batch) {
   if (channel == nullptr || max_batch == 0) return 0;
   size_t processed = 0;
   bool ret;
-  NewBlockMeta* node_ptr = nullptr;
-  // 1) publish new block metas
-  while (processed < max_batch && new_block_queue.pop(node_ptr)) {
-    publish_node_blocks(node_ptr);
-    delete node_ptr; // release the temporary copied node
-    processed++;
-    if (processed >= max_batch) {
-      std::cout << "[WARN] local_block_report: processed >= max_batch, processed: " 
-      << processed << ", max_batch: " << max_batch 
-      << ", new_block_queue size: " << new_block_queue.size() << std::endl;
+
+  // Priority 1: delete evicted blocks from Redis FIRST.
+  // This prevents stale RDMA reads from recycled memory addresses.
+  // Previously this was step 3 and could starve under heavy new-block publish load.
+  std::unique_ptr<std::deque<int64_t>> evicted_q_ptr;
+  while (processed < max_batch && evicted_blocks_queue.pop(evicted_q_ptr)) {
+    if (evicted_q_ptr) {
+      ret = channel->delete_blockmeta_batch(node_id, evicted_q_ptr.get());
+      if (!ret) {
+        std::cerr << "[ERROR] local_block_report: delete_blockmeta_batch failed. block hashes: " << evicted_q_ptr->front() << std::endl;
+      }
+      for (auto hash : *evicted_q_ptr) {
+        normal_block_hashes.remove(hash);
+      }
     }
+    evicted_q_ptr.reset();
+    processed++;
   }
 
-  // 2) update state to ABOUT_TO_EVICT for queued hashes
-  // Consume at most (max_batch - processed) items from about_to_evict_blocks_queue
+  // Priority 2: update state to ABOUT_TO_EVICT for queued hashes
   size_t budget = (max_batch > processed) ? (max_batch - processed) : 0;
   std::unique_ptr<std::deque<int64_t>> about_q_ptr;
   while (budget > 0 && about_to_evict_blocks_queue.pop(about_q_ptr)) {
@@ -232,36 +237,16 @@ size_t LocalRadixTree::local_block_report(size_t max_batch) {
     about_q_ptr.reset();
     processed++;
     budget--;
-    if (budget == 0) {
-      std::cout << "[WARN] local_block_report: budget is 0, budget: " 
-      << " max_batch: " << max_batch 
-      << ", processed: " << processed
-      << ", about_to_evict_blocks_queue size: " << about_to_evict_blocks_queue.size() << std::endl;
-    }
   }
 
-  // 3) delete evicted blocks
+  // Priority 3: publish new block metas (lowest priority — new blocks can wait)
+  NewBlockMeta* node_ptr = nullptr;
   budget = (max_batch > processed) ? (max_batch - processed) : 0;
-  std::unique_ptr<std::deque<int64_t>> evicted_q_ptr;
-  while (budget > 0 && evicted_blocks_queue.pop(evicted_q_ptr)) {
-    if (evicted_q_ptr) {
-      ret = channel->delete_blockmeta_batch(node_id, evicted_q_ptr.get());
-      if (!ret) {
-        std::cerr << "[ERROR] local_block_report: delete_blockmeta_batch failed. block hashes: " << evicted_q_ptr->front() << std::endl;
-      }
-      for (auto hash : *evicted_q_ptr) {
-        normal_block_hashes.remove(hash);
-      }
-    }
-    evicted_q_ptr.reset();
+  while (budget > 0 && new_block_queue.pop(node_ptr)) {
+    publish_node_blocks(node_ptr);
+    delete node_ptr;
     processed++;
     budget--;
-    if (budget == 0) {
-      std::cout << "[WARN] local_block_report: budget is 0, budget: " 
-      << " max_batch: " << max_batch 
-      << ", processed: " << processed
-      << ", evicted_blocks_queue size: " << evicted_blocks_queue.size() << std::endl;
-    }
   }
 
   return processed;
@@ -664,7 +649,14 @@ int LocalRadixTree::evict(torch::Tensor &evicted_blocks, int num_evicted) {
 }
 
 int LocalRadixTree::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted_block_hashes, int num_evicted) {
-  return 0;
+  // Call the primary evict (two-arg) which does the real work.
+  // It pushes hashes into evicted_blocks_queue for async Redis cleanup.
+  // Note: evicted_block_hashes is NOT populated here because extracting
+  // from the lock-free queue is unsafe while the background worker runs.
+  // Callers that need hashes (e.g. Dynamo event collector) should use
+  // CRadixTreeCacheEngine's evict which handles hashes natively.
+  // This stub exists to satisfy the virtual interface.
+  return evict(evicted_blocks, num_evicted);
 }
 
 // Delegate wrappers to base CRadixTreeIndex
@@ -711,28 +703,66 @@ void LocalRadixTree::set_ready(CRadixNode *node, bool ready, int ready_length) {
 }
 
 size_t LocalRadixTree::drain_pending_queues() {
-  size_t dropped = 0;
-  {
-    std::unique_ptr<std::deque<int64_t>> ptr;
-    while (evicted_blocks_queue.pop(ptr)) {
-      if (ptr) dropped += ptr->size();
-      ptr.reset();
+  // Flush all pending queues to Redis synchronously.
+  // Critical: evicted blocks MUST be deleted from Redis before their
+  // memory is recycled, otherwise another node could RDMA-read stale data.
+  size_t processed = 0;
+  if (channel != nullptr) {
+    // 1) Delete evicted blocks from Redis
+    {
+      std::unique_ptr<std::deque<int64_t>> ptr;
+      while (evicted_blocks_queue.pop(ptr)) {
+        if (ptr && !ptr->empty()) {
+          channel->delete_blockmeta_batch(node_id, ptr.get());
+          for (auto hash : *ptr) {
+            normal_block_hashes.remove(hash);
+          }
+          processed += ptr->size();
+        }
+        ptr.reset();
+      }
+    }
+    // 2) Update about-to-evict states
+    {
+      std::unique_ptr<std::deque<int64_t>> ptr;
+      while (about_to_evict_blocks_queue.pop(ptr)) {
+        if (ptr && !ptr->empty()) {
+          channel->update_block_state_batch(node_id, ptr.get(), NODE_STATE_ABOUT_TO_EVICT);
+          for (auto hash : *ptr) {
+            normal_block_hashes.remove(hash);
+          }
+          processed += ptr->size();
+        }
+        ptr.reset();
+      }
+    }
+    // 3) Publish new blocks
+    {
+      NewBlockMeta* node_ptr = nullptr;
+      while (new_block_queue.pop(node_ptr)) {
+        if (node_ptr) {
+          publish_node_blocks(node_ptr);
+          delete node_ptr;
+          processed++;
+        }
+      }
+    }
+  } else {
+    // No channel — just drop everything
+    {
+      std::unique_ptr<std::deque<int64_t>> ptr;
+      while (evicted_blocks_queue.pop(ptr)) { ptr.reset(); }
+    }
+    {
+      std::unique_ptr<std::deque<int64_t>> ptr;
+      while (about_to_evict_blocks_queue.pop(ptr)) { ptr.reset(); }
+    }
+    {
+      NewBlockMeta* ptr = nullptr;
+      while (new_block_queue.pop(ptr)) { if (ptr) delete ptr; }
     }
   }
-  {
-    std::unique_ptr<std::deque<int64_t>> ptr;
-    while (about_to_evict_blocks_queue.pop(ptr)) {
-      if (ptr) dropped += ptr->size();
-      ptr.reset();
-    }
-  }
-  {
-    NewBlockMeta* ptr = nullptr;
-    while (new_block_queue.pop(ptr)) {
-      if (ptr) delete ptr;
-    }
-  }
-  return dropped;
+  return processed;
 }
 
 } // namespace flexkv

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -164,8 +164,13 @@ class RedisNodeInfo:
         
         # register cleanup function on exit
         atexit.register(self._cleanup_on_exit)
-        signal.signal(signal.SIGINT, self._signal_handler)
-        signal.signal(signal.SIGTERM, self._signal_handler)
+        # Only register signal handlers in the main process — in subprocess
+        # workers (e.g. PEER2CPUTransferWorker) this would override vLLM's
+        # process management signals and can cause shutdown hangs.
+        import multiprocessing
+        if multiprocessing.current_process().name == "MainProcess":
+            signal.signal(signal.SIGINT, self._signal_handler)
+            signal.signal(signal.SIGTERM, self._signal_handler)
     
     def __del__(self) -> None:
         """destructor, ensure cleanup is performed when object is destroyed"""
@@ -350,10 +355,16 @@ class RedisNodeInfo:
 
                 if self._node_id is not None:
                     node_key = f"node:{self._node_id}"
-                    # Renew TTL
-                    heartbeat_client.expire(node_key, self.node_ttl_seconds)
-                    # Also update the timestamp field
-                    heartbeat_client.hset(node_key, "timestamp", str(int(time.time())))
+                    # Renew TTL; expire() returns 1 if the key exists, 0 if not.
+                    # Only update timestamp if the key still exists — otherwise
+                    # hset() would recreate an expired key WITHOUT a TTL, causing
+                    # other nodes to see a zombie node with stale RDMA addresses.
+                    ttl_renewed = heartbeat_client.expire(node_key, self.node_ttl_seconds)
+                    if ttl_renewed:
+                        heartbeat_client.hset(node_key, "timestamp", str(int(time.time())))
+                    else:
+                        print(f"[RedisNodeInfo] WARNING: node key {node_key} expired/missing, "
+                              f"skipping hset to avoid resurrection")
 
             except Exception:
                 # Connection lost, reset client so it reconnects next iteration
@@ -722,6 +733,10 @@ class RedisMeta:
             return True
         return False
 
+    # TTL for meta:<node_id> keys — set to 5x the node TTL so that meta
+    # survives normal heartbeat jitter but auto-expires after a crash.
+    META_TTL_MULTIPLIER: int = 5
+
     def regist_node_meta(self, node_id: int, addr: str, zmq_addr: str, cpu_buffer_ptr: int, ssd_buffer_ptr: int) -> None:
         """Register node meta information as a Redis hash.
 
@@ -737,6 +752,11 @@ class RedisMeta:
             "cpu_buffer_ptr": int(cpu_buffer_ptr),
             "ssd_buffer_ptr": int(ssd_buffer_ptr),
         })
+        # Set TTL on meta key so it auto-expires after node crash.
+        # The heartbeat in regist_node_meta_renew_ttl() will keep it alive.
+        meta_ttl = self.nodeinfo.node_ttl_seconds * self.META_TTL_MULTIPLIER
+        if meta_ttl > 0:
+            r.expire(key, meta_ttl)
 
     def get_node_meta(self, node_id: int) -> dict:
         """Get node meta information from Redis.
@@ -770,6 +790,11 @@ class RedisMeta:
 
     def set_node_id(self, node_id: int):
         self._node_id = int(node_id)
+        # Also propagate to nodeinfo so that its heartbeat thread can
+        # renew the node:<id> TTL (previously nodeinfo._node_id stayed None,
+        # making the heartbeat thread a no-op in worker subprocesses).
+        if self.nodeinfo is not None:
+            self.nodeinfo._node_id = int(node_id)
 
     def load_pcfs_file_nodeids(self) -> Dict[int, List[int]]:
         """Load all PCFS file node IDs grouped by node id from Redis.

--- a/flexkv/mooncakeEngineWrapper.py
+++ b/flexkv/mooncakeEngineWrapper.py
@@ -45,7 +45,7 @@ class MoonCakeTransferEngineWrapper:
         self.mooncake_addr = f"{self.engine_ip}:{self.engien_port}"
         flexkv_logger.info(f"Mooncake listen on: {self.mooncake_addr}")
 
-        supported_backend = ["redis"]
+        supported_backend = ["redis", "http"]
         self.metadata_backend = self.config.metadata_backend.lower()
         if self.metadata_backend not in supported_backend:
             raise ValueError(

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -325,7 +325,7 @@ class TransferEngine:
                 cache_config = self.cache_config,
                 ssd_kv_layout = self._ssd_handle.kv_layout if self._ssd_handle else None,
                 ssd_files = self._ssd_handle.get_file_list() if self._ssd_handle else None,
-                num_blocks_per_file = self._ssd_handle.num_blocks_per_file if self._ssd_handle else None,
+                num_blocks_per_file = self._ssd_handle.num_blocks_per_file if self._ssd_handle else 0,
                 mooncake_config_path = getattr(self.cache_config, 'mooncake_config_path', None) or os.environ.get("MOONCAKE_CONFIG_PATH"),
             )
             # NOTE: now peerH2H and peerSSD2H op use the same worker

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -786,7 +786,13 @@ class CPURemoteTransferWorker(TransferWorkerBase):
             raise ValueError(f"num_remote_blocks_per_file {self.num_remote_blocks_per_file} "
                              f"is not divisible by round_robin {self.round_robin}")
 
-        self.block_size = cpu_kv_layout.get_chunk_size()
+        # For multi-group layouts, get_chunk_size() is not valid.
+        # CPURemoteTransferWorker uses LAYERFIRST which is single-group only,
+        # but guard for safety.
+        if cpu_kv_layout.layer_groups is not None:
+            self.block_size = cpu_kv_layout.get_block_stride()
+        else:
+            self.block_size = cpu_kv_layout.get_chunk_size()
         self.dtype = dtype
 
         self.is_mla = cpu_kv_layout.is_mla
@@ -1379,7 +1385,12 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self.cpu_layer_ptrs = self._get_layer_ptrs(cpu_blocks)
         self.num_layers = cpu_kv_layout.num_layer
         self.num_cpu_blocks = cpu_kv_layout.num_block
-        self.block_size = cpu_kv_layout.get_chunk_size()
+        # For multi-group layouts (e.g. gemma4), get_chunk_size() is invalid;
+        # use get_block_stride() which works for both single and multi-group BLOCKFIRST.
+        if cpu_kv_layout.layer_groups is not None:
+            self.block_size = cpu_kv_layout.get_block_stride()
+        else:
+            self.block_size = cpu_kv_layout.get_chunk_size()
         self.dtype = dtype
         self.cpu_kv_layout = cpu_kv_layout
         self.remote_kv_layout = remote_kv_layout
@@ -1406,9 +1417,19 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 self.cache_config.redis_port,
                 self.cache_config.redis_password,
                 self.cache_config.local_ip,
-                node_ttl_seconds=self.cache_config.node_ttl_seconds,
+                node_ttl_seconds=getattr(self.cache_config, 'node_ttl_seconds', 0),
             )
             self.redis_meta_client.set_node_id(self.cache_config.distributed_node_id)
+
+            # Connect nodeinfo so the listener/heartbeat threads start and
+            # current_node_id_set is populated — required for is_node_active()
+            # checks during P2P transfers.
+            if not self.redis_meta_client.nodeinfo.connect():
+                flexkv_logger.warning(
+                    "PEER2CPUTransferWorker: failed to connect RedisNodeInfo listener"
+                )
+            else:
+                self.redis_meta_client.nodeinfo.scan_active_nodes()
 
             # Persistent NodeMetaInfo Pool for skip redis operation when getting
             # NodeMetaInfo according to node_id
@@ -1604,6 +1625,11 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         )
         return transfer_finished
 
+    # Timeout for a single RDMA batch transfer (seconds).
+    # Prevents indefinite blocking when a remote node becomes unreachable
+    # but its node:<id> TTL hasn't expired yet.
+    RDMA_TRANSFER_TIMEOUT_SECONDS = 30
+
     def _batch_transfer_impl(self,
         task_info: RDMATaskInfo,
         transfer_type: TransferType,
@@ -1611,9 +1637,20 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         layer_granularity: int,
         **kwargs,):
         if transfer_type == TransferType.PEERH2H:
-            ret = self.mooncake_transfer_engine.batch_transfer_sync_read(
-                task_info.peer_engine_addr, task_info.src_ptrs, task_info.dst_ptrs, task_info.data_lens
-            )
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(
+                    self.mooncake_transfer_engine.batch_transfer_sync_read,
+                    task_info.peer_engine_addr, task_info.src_ptrs, task_info.dst_ptrs, task_info.data_lens
+                )
+                try:
+                    ret = future.result(timeout=self.RDMA_TRANSFER_TIMEOUT_SECONDS)
+                except concurrent.futures.TimeoutError:
+                    flexkv_logger.error(
+                        f"RDMA batch transfer to {task_info.peer_engine_addr} timed out "
+                        f"after {self.RDMA_TRANSFER_TIMEOUT_SECONDS}s"
+                    )
+                    return False
             if ret != 0:
                 flexkv_logger.error(f"RDMA transfer failed with error code: {ret}")
                 return False
@@ -2064,7 +2101,14 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             # step1: get the remote meta info
             src_meta = self.get_node_meta(node_id)
             if src_meta is None:
-                return [] # NOTE: if we miss part of meta data, then we should abort this request
+                # Skip this node's blocks instead of aborting all nodes.
+                # In multi-node P2P, one dead node should not prevent fetching
+                # blocks from other healthy nodes.
+                flexkv_logger.warning(
+                    f"[PEER2CPUTransferWorker] Skipping node {node_id}: "
+                    f"meta unavailable, will skip {len(segments)} segment(s)"
+                )
+                continue
             peer_engine_addr = src_meta.engine_addr
             src_ptr_list = []
             dst_ptr_list = []


### PR DESCRIPTION
- Heartbeat hset can resurrect expired node key: check expire() return before hset to avoid creating zombie node without TTL
- meta:<node_id> has no TTL: add TTL (3x node TTL) so meta auto-expires after node crash
- Signal handlers override in subprocess: only register SIGINT/SIGTERM handlers in MainProcess
- set_node_id() not propagated to nodeinfo: sync node_id to nodeinfo._node_id
- _dist_cpu_op_parser all-or-nothing: skip failed nodes with continue instead of return []
- RDMA transfer no timeout: wrap batch_transfer_sync_read with ThreadPoolExecutor timeout
- evict 3-arg overload is no-op: delegate to 2-arg evict
- local_block_report batch budget starvation: prioritize evict deletion over new block publish
- drain_pending_queues drops data: actually execute Redis operations when channel is available
- transfer_engine num_blocks_per_file: use 0 instead of None to avoid Cython type error
- mooncakeEngineWrapper: support "http" metadata backend