### PR TITLE
feat: add SLRU eviction policy with strategy pattern refactor

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -555,14 +555,17 @@ PYBIND11_MODULE(c_ext, m) {
 
   py::class_<flexkv::CRadixTreeIndex>(m, "CRadixTreeIndex")
       .def(py::init([](int tokens_per_block, unsigned int max_num_blocks,
-                       int hit_reward_seconds, std::string eviction_policy) {
+                       int hit_reward_seconds, std::string eviction_policy,
+                       int protected_threshold) {
              auto policy = flexkv::parse_eviction_policy(eviction_policy);
              return new flexkv::CRadixTreeIndex(
-                 tokens_per_block, max_num_blocks, hit_reward_seconds, policy);
+                 tokens_per_block, max_num_blocks, hit_reward_seconds, policy,
+                 protected_threshold);
            }),
            py::arg("tokens_per_block"), py::arg("max_num_blocks") = 1000000,
            py::arg("hit_reward_seconds") = 0,
-           py::arg("eviction_policy") = "lru")
+           py::arg("eviction_policy") = "lru",
+           py::arg("protected_threshold") = 2)
       .def("is_empty", &flexkv::CRadixTreeIndex::is_empty)
       .def("reset", &flexkv::CRadixTreeIndex::reset)
       .def("lock", &flexkv::CRadixTreeIndex::lock, py::arg("node"))
@@ -804,14 +807,15 @@ PYBIND11_MODULE(c_ext, m) {
   py::class_<flexkv::LocalRadixTree, flexkv::CRadixTreeIndex>(m,
                                                               "LocalRadixTree")
       .def(py::init<int, unsigned int, uint32_t, uint32_t, uint32_t, uint32_t,
-                    uint32_t, uint32_t, uint32_t, std::string>(),
+                    uint32_t, uint32_t, uint32_t, std::string, int>(),
            py::arg("tokens_per_block"), py::arg("max_num_blocks") = 1000000u,
            py::arg("lease_ttl_ms") = 100000, py::arg("renew_lease_ms") = 0,
            py::arg("refresh_batch_size") = 256, py::arg("idle_sleep_ms") = 10,
            py::arg("safety_ttl_ms") = 100,
            py::arg("swap_block_threshold") = 1024,
            py::arg("hit_reward_seconds") = 0,
-           py::arg("eviction_policy") = "lru")
+           py::arg("eviction_policy") = "lru",
+           py::arg("protected_threshold") = 2)
       .def("set_meta_channel", &flexkv::LocalRadixTree::set_meta_channel,
            py::arg("channel"))
       .def("start", &flexkv::LocalRadixTree::start, py::arg("channel"))

--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -47,9 +47,9 @@ LocalRadixTree::LocalRadixTree(int tokens_per_block, unsigned int max_num_blocks
   uint32_t ttl_ms, uint32_t renew_ms,
   uint32_t batch_sz, uint32_t idle_sleep_ms,
   uint32_t safety_ttl_ms, uint32_t swap_block_threshold, uint32_t hit_reward_seconds,
-  std::string eviction_policy)
+  std::string eviction_policy, int protected_threshold)
   : CRadixTreeIndex(tokens_per_block, max_num_blocks, hit_reward_seconds,
-      parse_eviction_policy(eviction_policy)), 
+      parse_eviction_policy(eviction_policy), protected_threshold), 
   channel(nullptr), node_id(0),
   lease_ttl_ms(ttl_ms), refresh_batch_size(batch_sz),
   lease_pool(max_num_blocks),

--- a/csrc/dist/local_radix_tree.h
+++ b/csrc/dist/local_radix_tree.h
@@ -85,7 +85,8 @@ public:
                  uint32_t safety_ttl_ms = 100,
                  uint32_t swap_block_threshold = 1024,
                  uint32_t hit_reward_seconds = 0,
-                 std::string eviction_policy = "lru");
+                 std::string eviction_policy = "lru",
+                 int protected_threshold = 2);
   ~LocalRadixTree();
 
   void set_meta_channel(RedisMetaChannel *ch);
@@ -134,6 +135,3 @@ public:
 };
 
 } // namespace flexkv
-
-
-

--- a/csrc/eviction_strategy.cpp
+++ b/csrc/eviction_strategy.cpp
@@ -1,0 +1,161 @@
+#include "eviction_strategy.h"
+#include "radix_tree.h"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace flexkv {
+
+// ===========================================================================
+// parse_eviction_policy
+// ===========================================================================
+
+EvictionPolicy parse_eviction_policy(const std::string &name) {
+  if (name == "lru")
+    return EvictionPolicy::LRU;
+  if (name == "lfu")
+    return EvictionPolicy::LFU;
+  if (name == "fifo")
+    return EvictionPolicy::FIFO;
+  if (name == "mru")
+    return EvictionPolicy::MRU;
+  if (name == "filo")
+    return EvictionPolicy::FILO;
+  if (name == "slru")
+    return EvictionPolicy::SLRU;
+  throw std::invalid_argument(
+      "Unknown eviction policy: '" + name +
+      "'. "
+      "Supported policies: 'lru', 'lfu', 'slru', 'fifo', 'mru', 'filo'.");
+}
+
+// ===========================================================================
+// LRUStrategy
+// ===========================================================================
+
+bool LRUStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  return a->get_time() > b->get_time();
+}
+
+std::string LRUStrategy::priority_repr(CRadixNode *node) const {
+  return std::to_string(node->get_time());
+}
+
+// ===========================================================================
+// LFUStrategy
+// ===========================================================================
+
+bool LFUStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  if (a->get_hit_count() != b->get_hit_count()) {
+    return a->get_hit_count() > b->get_hit_count();
+  }
+  return a->get_last_access_time() > b->get_last_access_time();
+}
+
+std::string LFUStrategy::priority_repr(CRadixNode *node) const {
+  std::ostringstream oss;
+  oss << "(" << node->get_hit_count() << ", " << node->get_last_access_time()
+      << ")";
+  return oss.str();
+}
+
+// ===========================================================================
+// FIFOStrategy
+// ===========================================================================
+
+bool FIFOStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  return a->get_creation_time() > b->get_creation_time();
+}
+
+std::string FIFOStrategy::priority_repr(CRadixNode *node) const {
+  return std::to_string(node->get_creation_time());
+}
+
+// ===========================================================================
+// MRUStrategy
+// ===========================================================================
+
+bool MRUStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  // MRU: most recently used is evicted first, so the node with the
+  // LARGEST last_access_time has the LOWEST priority (evicted first).
+  // In the max-heap, the node that should be evicted last (smallest
+  // last_access_time) should have higher priority.
+  return a->get_last_access_time() < b->get_last_access_time();
+}
+
+std::string MRUStrategy::priority_repr(CRadixNode *node) const {
+  // Negate to reflect that larger access time = lower priority
+  std::ostringstream oss;
+  oss << "-" << node->get_last_access_time();
+  return oss.str();
+}
+
+// ===========================================================================
+// FILOStrategy
+// ===========================================================================
+
+bool FILOStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  // FILO: newest node is evicted first, so the node with the LARGEST
+  // creation_time has the LOWEST priority.
+  return a->get_creation_time() < b->get_creation_time();
+}
+
+std::string FILOStrategy::priority_repr(CRadixNode *node) const {
+  std::ostringstream oss;
+  oss << "-" << node->get_creation_time();
+  return oss.str();
+}
+
+// ===========================================================================
+// SLRUStrategy
+// ===========================================================================
+
+bool SLRUStrategy::compare(CRadixNode *a, CRadixNode *b) const {
+  bool a_protected = a->get_hit_count() >= protected_threshold_;
+  bool b_protected = b->get_hit_count() >= protected_threshold_;
+
+  // Protected segment nodes have higher priority (evicted later).
+  // Probationary segment (not protected) is evicted first.
+  if (a_protected != b_protected) {
+    // Exactly one of the two is Protected; that one has the higher priority.
+    return a_protected && !b_protected;
+  }
+
+  // Within the same segment, use LRU ordering by last_access_time.
+  return a->get_last_access_time() > b->get_last_access_time();
+}
+
+std::string SLRUStrategy::priority_repr(CRadixNode *node) const {
+  int segment = (node->get_hit_count() >= protected_threshold_) ? 1 : 0;
+  std::ostringstream oss;
+  oss << "(segment=" << segment
+      << ", last_access_time=" << node->get_last_access_time() << ")";
+  return oss.str();
+}
+
+// ===========================================================================
+// Factory function
+// ===========================================================================
+
+std::unique_ptr<IEvictionStrategy>
+create_eviction_strategy(EvictionPolicy policy, int protected_threshold) {
+  switch (policy) {
+  case EvictionPolicy::LRU:
+    return std::make_unique<LRUStrategy>();
+  case EvictionPolicy::LFU:
+    return std::make_unique<LFUStrategy>();
+  case EvictionPolicy::FIFO:
+    return std::make_unique<FIFOStrategy>();
+  case EvictionPolicy::MRU:
+    return std::make_unique<MRUStrategy>();
+  case EvictionPolicy::FILO:
+    return std::make_unique<FILOStrategy>();
+  case EvictionPolicy::SLRU:
+    return std::make_unique<SLRUStrategy>(protected_threshold);
+  default:
+    // Fallback to LRU for unknown policies
+    return std::make_unique<LRUStrategy>();
+  }
+}
+
+} // namespace flexkv

--- a/csrc/eviction_strategy.h
+++ b/csrc/eviction_strategy.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace flexkv {
+
+// Forward declaration — full definition in radix_tree.h
+class CRadixNode;
+
+// ---------------------------------------------------------------------------
+// EvictionPolicy enum — defines the supported cache eviction policies.
+// ---------------------------------------------------------------------------
+enum class EvictionPolicy { LRU, LFU, FIFO, MRU, FILO, SLRU };
+
+EvictionPolicy parse_eviction_policy(const std::string &name);
+
+// ---------------------------------------------------------------------------
+// IEvictionStrategy — abstract interface for cache eviction comparison logic.
+//
+// Each concrete strategy encapsulates the comparison semantics for a specific
+// eviction policy (LRU, LFU, SLRU, etc.), eliminating the need for magic
+// numbers or bit-shift tricks when expressing multi-dimensional priorities.
+// ---------------------------------------------------------------------------
+class IEvictionStrategy {
+public:
+  virtual ~IEvictionStrategy() = default;
+
+  // Compare two nodes for the priority_queue used during eviction.
+  // Returns true if node `a` has HIGHER priority than `b` (i.e., `a` should
+  // be evicted LATER). The priority_queue is a max-heap, so the node with the
+  // LOWEST priority (most eligible for eviction) ends up at the top.
+  virtual bool compare(CRadixNode *a, CRadixNode *b) const = 0;
+
+  // Return a human-readable representation of the node's eviction priority.
+  // This replaces the old get_priority() → double approach, which could not
+  // naturally express multi-dimensional priorities without magic numbers.
+  virtual std::string priority_repr(CRadixNode *node) const = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Concrete strategy implementations
+// ---------------------------------------------------------------------------
+
+// LRU: Least Recently Used — evict the node with the smallest grace_time.
+class LRUStrategy final : public IEvictionStrategy {
+public:
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+};
+
+// LFU: Least Frequently Used — evict the node with the fewest hits;
+// break ties by last_access_time (LRU within same frequency).
+class LFUStrategy final : public IEvictionStrategy {
+public:
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+};
+
+// FIFO: First In First Out — evict the oldest node by creation_time.
+class FIFOStrategy final : public IEvictionStrategy {
+public:
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+};
+
+// MRU: Most Recently Used — evict the node with the largest last_access_time.
+class MRUStrategy final : public IEvictionStrategy {
+public:
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+};
+
+// FILO: First In Last Out — evict the newest node by creation_time.
+class FILOStrategy final : public IEvictionStrategy {
+public:
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+};
+
+// SLRU: Segmented LRU — nodes are classified into Probationary (segment=0)
+// and Protected (segment=1) based on hit_count vs protected_threshold.
+// Probationary nodes are evicted before Protected ones; within the same
+// segment, LRU ordering by last_access_time is used.
+class SLRUStrategy final : public IEvictionStrategy {
+public:
+  explicit SLRUStrategy(int protected_threshold)
+      : protected_threshold_(protected_threshold) {}
+
+  bool compare(CRadixNode *a, CRadixNode *b) const override;
+  std::string priority_repr(CRadixNode *node) const override;
+
+private:
+  int protected_threshold_;
+};
+
+// ---------------------------------------------------------------------------
+// Factory function
+// ---------------------------------------------------------------------------
+
+// Create the appropriate strategy instance for the given eviction policy.
+// For SLRU, protected_threshold is required to determine segment membership.
+std::unique_ptr<IEvictionStrategy>
+create_eviction_strategy(EvictionPolicy policy, int protected_threshold = 2);
+
+} // namespace flexkv

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -45,42 +45,7 @@ static std::optional<HashType> get_hash_safe(
 }
 
 bool CRadixNode::Compare::operator()(CRadixNode *a, CRadixNode *b) {
-  auto policy = a->get_index()->get_eviction_policy();
-  switch (policy) {
-    case EvictionPolicy::LRU:
-      return a->get_time() > b->get_time();
-    case EvictionPolicy::LFU:
-      if (a->get_hit_count() != b->get_hit_count()) {
-        return a->get_hit_count() > b->get_hit_count();
-      }
-      return a->get_last_access_time() > b->get_last_access_time();
-    case EvictionPolicy::FIFO:
-      return a->get_creation_time() > b->get_creation_time();
-    case EvictionPolicy::MRU:
-      return a->get_last_access_time() < b->get_last_access_time();
-    case EvictionPolicy::FILO:
-      return a->get_creation_time() < b->get_creation_time();
-    default:
-      return a->get_time() > b->get_time();
-  }
-}
-
-double CRadixNode::get_priority() {
-  auto policy = index->get_eviction_policy();
-  switch (policy) {
-    case EvictionPolicy::LRU:
-      return (double)grace_time;
-    case EvictionPolicy::LFU:
-      return (double)hit_count;
-    case EvictionPolicy::FIFO:
-      return (double)creation_time;
-    case EvictionPolicy::MRU:
-      return -(double)last_access_time;
-    case EvictionPolicy::FILO:
-      return -(double)creation_time;
-    default:
-      return (double)grace_time;
-  }
+  return a->get_index()->get_strategy()->compare(a, b);
 }
 
 CRadixNode::CRadixNode(CRadixTreeIndex *index, bool ready, int lock_cnt, bool enable_block_node_ids) {

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <execinfo.h>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <torch/extension.h>
@@ -11,27 +12,9 @@
 
 #include "cache_utils.h"
 #include "dist/lease_meta_mempool.h" // for flexkv::LeaseMeta
+#include "eviction_strategy.h"
 
 namespace flexkv {
-
-enum class EvictionPolicy { LRU, LFU, FIFO, MRU, FILO };
-
-inline EvictionPolicy parse_eviction_policy(const std::string &name) {
-  if (name == "lru")
-    return EvictionPolicy::LRU;
-  if (name == "lfu")
-    return EvictionPolicy::LFU;
-  if (name == "fifo")
-    return EvictionPolicy::FIFO;
-  if (name == "mru")
-    return EvictionPolicy::MRU;
-  if (name == "filo")
-    return EvictionPolicy::FILO;
-  throw std::invalid_argument(
-      "Unknown eviction policy: '" + name +
-      "'. "
-      "Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo'.");
-}
 
 class CRadixTreeIndex;
 
@@ -64,8 +47,6 @@ public:
   struct Compare {
     bool operator()(CRadixNode *a, CRadixNode *b);
   };
-
-  double get_priority();
 
   bool get_leaf_state() { return on_leaf; }
 
@@ -127,7 +108,13 @@ public:
     } else {
       grace_time = now_time + reward_us;
     }
-    hit_count++;
+    // Saturating increment: clamp at INT_MAX to prevent overflow into negatives.
+    // For SLRU the absolute value is irrelevant once >= protected_threshold,
+    // but wrapping around would incorrectly demote a long-lived hot node back
+    // to the Probationary segment. For LFU it preserves monotonic ordering.
+    if (hit_count < std::numeric_limits<int>::max()) {
+      hit_count++;
+    }
   }
 
   CRadixNode *get_parent() { return parent; }
@@ -252,24 +239,25 @@ protected:
   int tokens_per_block;
   int node_count;
   int hit_reward_seconds;
-  EvictionPolicy eviction_policy;
+  std::unique_ptr<IEvictionStrategy> strategy_;
 
 public:
   CRadixTreeIndex(int tokens_per_block, int max_num_blocks = 1000000,
                   int hit_reward_seconds = 0,
-                  EvictionPolicy eviction_policy = EvictionPolicy::LRU) {
+                  EvictionPolicy eviction_policy = EvictionPolicy::LRU,
+                  int protected_threshold = 2) {
     this->tokens_per_block = tokens_per_block;
     this->max_num_blocks = max_num_blocks;
     this->node_count = 0;
     this->hit_reward_seconds = hit_reward_seconds;
-    this->eviction_policy = eviction_policy;
+    this->strategy_ = create_eviction_strategy(eviction_policy, protected_threshold);
 
     root = new CRadixNode(this, true, 0);
     node_list.push_back(root);
     root->set_node_list_it(std::prev(node_list.end()));
   }
 
-  EvictionPolicy get_eviction_policy() { return eviction_policy; }
+  const IEvictionStrategy *get_strategy() const { return strategy_.get(); }
 
   virtual ~CRadixTreeIndex() {
     leaf_list.clear();

--- a/docs/eviction_policy/README_en.md
+++ b/docs/eviction_policy/README_en.md
@@ -16,6 +16,7 @@ When GPU KV cache memory is full, FlexKV evicts (removes) cached blocks from the
 |--------|-------------|----------------|
 | `lru` | Least Recently Used | Evicts the **least recently accessed** nodes first |
 | `lfu` | Least Frequently Used | Evicts the **least frequently accessed** nodes first; ties broken by LRU |
+| `slru` | Segmented Least Recently Used | Splits nodes into probationary and protected segments; evicts **least recently accessed** nodes in the probationary segment first |
 | `fifo` | First In First Out | Evicts the **oldest inserted** nodes first |
 | `mru` | Most Recently Used | Evicts the **most recently accessed** nodes first |
 | `filo` | First In Last Out | Evicts the **most recently inserted** nodes first |
@@ -48,7 +49,7 @@ Or using JSON:
 export FLEXKV_EVICTION_POLICY=lru
 ```
 
-Supported values: `lru`, `lfu`, `fifo`, `mru`, `filo`.
+Supported values: `lru`, `lfu`, `slru`, `fifo`, `mru`, `filo`.
 
 ---
 
@@ -61,7 +62,8 @@ In addition to `eviction_policy` itself, FlexKV provides the following configura
 | `eviction_policy` | `FLEXKV_EVICTION_POLICY` | str | `lru` | Eviction policy, see [Supported Eviction Policies](#supported-eviction-policies) for available values |
 | `evict_start_threshold` | `FLEXKV_EVICT_START_THRESHOLD` | float | `0.7` | Cache utilization threshold to trigger proactive eviction. When cache usage reaches this ratio, FlexKV begins proactively evicting nodes. For example, `0.7` means eviction starts when cache is 70% full; setting to `1.0` means eviction only occurs when cache is completely full |
 | `evict_ratio` | `FLEXKV_EVICT_RATIO` | float | `0.05` | Minimum eviction ratio per eviction round. For example, `0.05` means at least 5% of total blocks are evicted each round, reducing overhead from frequent small evictions. Setting to `0.0` evicts only the minimum blocks needed to satisfy the current request |
-| `hit_reward_seconds` | `FLEXKV_HIT_REWARD_SECONDS` | int | `0` | Hit reward in seconds, only effective for the LRU policy. Each cache hit adds the specified seconds to the node's effective access time (stackable), making frequently hit nodes harder to evict. Set to `0` for standard LRU behavior |
+| `hit_reward_seconds` | `FLEXKV_HIT_REWARD_SECONDS` | int | `0` | Hit reward in seconds, only effective for the LRU policy. Each cache hit adds the specified seconds to the node's effective access time (stackable), making frequently hit nodes harder to evict. Set to `0` for standard LRU behavior. Note: this parameter has no effect on other policies (LFU/SLRU/FIFO/MRU/FILO) |
+| `slru_protected_threshold` | `FLEXKV_SLRU_PROTECTED_THRESHOLD` | int | `2` | Protected threshold for the SLRU policy. Nodes with hit count reaching this value are promoted to the protected segment and become harder to evict. Only effective for the SLRU policy |
 
 ### Configuration Examples
 
@@ -139,3 +141,25 @@ hit_reward_seconds: 10
 - **Priority Value**: `-creation_time`
 - **Behavior**: The most recently inserted nodes are evicted first. This is the reverse of FIFO.
 - **Best For**: Scenarios where older cached content is more valuable and should be preserved longer.
+
+### SLRU (Segmented Least Recently Used)
+
+- **Priority Value**: `(is_protected, last_access_time)`
+- **Behavior**: Logically splits cached nodes into two segments:
+  - **Probationary segment**: Nodes with `hit_count < protected_threshold` (default 2). Newly inserted nodes enter this segment by default.
+  - **Protected segment**: Nodes with `hit_count >= protected_threshold`. Nodes that are accessed multiple times are automatically promoted to this segment.
+  
+  During eviction, nodes in the Probationary segment are evicted first; within the same segment, LRU ordering applies (least recently accessed nodes are evicted first). Protected segment nodes are only evicted after all Probationary segment nodes have been evicted.
+- **Best For**: Mixed workloads with both frequently reused system prompts and large volumes of one-shot queries. SLRU effectively resists cache scan pollution, preventing large batches of one-time requests from flushing out frequently used cache entries.
+- **Note**: SLRU orders same-segment nodes by `last_access_time`, so `hit_reward_seconds` (which only affects `grace_time`) has no effect on SLRU.
+
+**Configuration**:
+```bash
+export FLEXKV_EVICTION_POLICY=slru
+export FLEXKV_SLRU_PROTECTED_THRESHOLD=2  # Optional, default is 2
+```
+Or in a config file:
+```yml
+eviction_policy: slru
+slru_protected_threshold: 2
+```

--- a/docs/eviction_policy/README_zh.md
+++ b/docs/eviction_policy/README_zh.md
@@ -16,6 +16,7 @@
 |------|------|----------|
 | `lru` | 最近最少使用 | 优先驱逐**最久未被访问**的节点 |
 | `lfu` | 最不经常使用 | 优先驱逐**命中次数最少**的节点；次数相同时按 LRU 排序 |
+| `slru` | 分段最近最少使用 | 将节点分为试用段和保护段，优先驱逐试用段中**最久未访问**的节点 |
 | `fifo` | 先进先出 | 优先驱逐**最早插入**的节点 |
 | `mru` | 最近最多使用 | 优先驱逐**最近刚被访问**的节点 |
 | `filo` | 先进后出 | 优先驱逐**最近插入**的节点 |
@@ -48,7 +49,7 @@ eviction_policy: lru
 export FLEXKV_EVICTION_POLICY=lru
 ```
 
-可选值：`lru`、`lfu`、`fifo`、`mru`、`filo`。
+可选值：`lru`、`lfu`、`slru`、`fifo`、`mru`、`filo`。
 
 ---
 
@@ -61,7 +62,8 @@ export FLEXKV_EVICTION_POLICY=lru
 | `eviction_policy` | `FLEXKV_EVICTION_POLICY` | str | `lru` | 驱逐策略，可选值见上方[支持的驱逐策略](#支持的驱逐策略) |
 | `evict_start_threshold` | `FLEXKV_EVICT_START_THRESHOLD` | float | `0.7` | 触发主动驱逐的缓存利用率阈值。当缓存占用比例达到该值时，FlexKV 开始主动驱逐节点。例如 `0.7` 表示缓存占用达到 70% 时即开始驱逐；设为 `1.0` 则仅在缓存满时才驱逐 |
 | `evict_ratio` | `FLEXKV_EVICT_RATIO` | float | `0.05` | 每次驱逐的最小淘汰比例。例如 `0.05` 表示每次至少淘汰总 block 数的 5%，以减少频繁小量驱逐带来的开销。设为 `0.0` 则仅淘汰满足当前需求所需的最少 block 数 |
-| `hit_reward_seconds` | `FLEXKV_HIT_REWARD_SECONDS` | int | `0` | 命中奖励秒数，仅对 LRU 策略生效。每次缓存命中时向节点的有效访问时间叠加指定秒数（可累积），使命中越多的节点越难被驱逐。设为 `0` 时为标准 LRU 行为 |
+| `hit_reward_seconds` | `FLEXKV_HIT_REWARD_SECONDS` | int | `0` | 命中奖励秒数，仅对 LRU 策略生效。每次缓存命中时向节点的有效访问时间叠加指定秒数（可累积），使命中越多的节点越难被驱逐。设为 `0` 时为标准 LRU 行为。注意：该参数对其他策略（LFU/SLRU/FIFO/MRU/FILO）不生效 |
+| `slru_protected_threshold` | `FLEXKV_SLRU_PROTECTED_THRESHOLD` | int | `2` | SLRU 策略的保护阈值。节点命中次数达到该值后进入保护段，不易被驱逐。仅对 SLRU 策略生效 |
 
 ### 配置示例
 
@@ -139,3 +141,25 @@ hit_reward_seconds: 10
 - **优先级值**：`-creation_time`
 - **行为**：最近插入的节点最先被驱逐，是 FIFO 的反向策略。
 - **适用场景**：较旧的缓存内容更有价值、需要更长时间保留的场景。
+
+### SLRU（分段最近最少使用）
+
+- **优先级值**：`(is_protected, last_access_time)`
+- **行为**：将缓存节点逻辑上分为两个段：
+  - **Probationary（试用段）**：`hit_count < protected_threshold`（默认 2）的节点。新插入的节点默认进入此段。
+  - **Protected（保护段）**：`hit_count >= protected_threshold` 的节点。被多次访问的节点自动晋升到此段。
+  
+  驱逐时优先淘汰 Probationary 段中的节点；同段内按 LRU 规则（最久未访问的先淘汰）。Protected 段的节点只有在 Probationary 段全部被淘汰后才会被驱逐。
+- **适用场景**：混合工作负载场景，既有高频复用的 system prompt，又有大量一次性查询。SLRU 能有效抵抗缓存扫描污染（cache scan pollution），避免大量一次性请求冲刷掉高频缓存。
+- **注意**：SLRU 同段内按 `last_access_time` 排序，因此 `hit_reward_seconds`（仅作用于 `grace_time`）对 SLRU 不生效。
+
+**配置方式**：
+```bash
+export FLEXKV_EVICTION_POLICY=slru
+export FLEXKV_SLRU_PROTECTED_THRESHOLD=2  # 可选，默认值为 2
+```
+或在配置文件中：
+```yml
+eviction_policy: slru
+slru_protected_threshold: 2
+```

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -42,7 +42,7 @@ from flexkv.integration.dynamo.collector import KVEventCollector
 from flexkv.metrics import FlexKVMetricsCollector, init_global_collector, get_global_collector
 
 DEVICE_TYPE: List[str] = ['CPU', 'GPU', 'SSD', 'REMOTE']
-_VALID_EVICTION_POLICIES = {'lru', 'lfu', 'fifo', 'mru', 'filo'}
+_VALID_EVICTION_POLICIES = {'lru', 'lfu', 'slru', 'fifo', 'mru', 'filo'}
 
 class CacheEngineAccel:
     def __init__(self,
@@ -54,7 +54,8 @@ class CacheEngineAccel:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 protected_threshold: int = 2):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -65,10 +66,14 @@ class CacheEngineAccel:
         if eviction_policy not in _VALID_EVICTION_POLICIES:
             raise ValueError(f"Invalid eviction_policy: '{eviction_policy}'. "
                               f"Supported policies: {sorted(_VALID_EVICTION_POLICIES)}")
+        if not isinstance(protected_threshold, int) or protected_threshold < 1:
+            raise ValueError(f"Invalid protected_threshold: {protected_threshold}. "
+                              f"protected_threshold must be an integer >= 1")
 
         self.device_type = device_type
 
-        self.index = CRadixTreeIndex(tokens_per_block, num_total_blocks, hit_reward_seconds, eviction_policy)
+        self.index = CRadixTreeIndex(tokens_per_block, num_total_blocks, hit_reward_seconds, eviction_policy,
+                                     protected_threshold)
 
         self.mempool = Mempool(num_total_blocks=num_total_blocks)
 
@@ -223,7 +228,8 @@ class CacheEngine:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 protected_threshold: int = 2):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -234,10 +240,14 @@ class CacheEngine:
         if eviction_policy not in _VALID_EVICTION_POLICIES:
             raise ValueError(f"Invalid eviction_policy: '{eviction_policy}'. "
                               f"Supported policies: {sorted(_VALID_EVICTION_POLICIES)}")
+        if not isinstance(protected_threshold, int) or protected_threshold < 1:
+            raise ValueError(f"Invalid protected_threshold: {protected_threshold}. "
+                              f"protected_threshold must be an integer >= 1")
 
         self.device_type = device_type
 
-        self.index = RadixTreeIndex(tokens_per_block=tokens_per_block, hit_reward_seconds=hit_reward_seconds, eviction_policy=eviction_policy)
+        self.index = RadixTreeIndex(tokens_per_block=tokens_per_block, hit_reward_seconds=hit_reward_seconds, eviction_policy=eviction_policy,
+                                       protected_threshold=protected_threshold)
 
         self.mempool = Mempool(num_total_blocks=num_total_blocks)
 
@@ -376,6 +386,7 @@ class GlobalCacheEngine:
         self.evict_start_threshold = GLOBAL_CONFIG_FROM_ENV.evict_start_threshold
         self.hit_reward_seconds = GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds
         self.eviction_policy = GLOBAL_CONFIG_FROM_ENV.eviction_policy
+        self.protected_threshold = GLOBAL_CONFIG_FROM_ENV.slru_protected_threshold
 
         # Initialize metrics collector for cache engine monitoring (before creating CacheEngines)
         self._metrics_collector = get_global_collector()
@@ -398,74 +409,92 @@ class GlobalCacheEngine:
             if cache_config.enable_p2p_cpu:
                 self.cpu_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.CPU, meta=self.redis_meta) #TODO
             elif self.index_accel:
-                self.cpu_cache_engine = CacheEngineAccel(DeviceType.CPU,
-                                                cache_config.num_cpu_blocks,
-                                                cache_config.tokens_per_block,
-                                                self.evict_ratio,
-                                                self.hit_reward_seconds,
-                                                self.evict_start_threshold,
-                                                self.eviction_policy,
-                                                event_collector,
-                                                self._metrics_collector)
+                self.cpu_cache_engine = CacheEngineAccel(
+                    device_type=DeviceType.CPU,
+                    num_total_blocks=cache_config.num_cpu_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=event_collector,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             else:
-                self.cpu_cache_engine = CacheEngine(DeviceType.CPU,
-                                                cache_config.num_cpu_blocks,
-                                                cache_config.tokens_per_block,
-                                                self.evict_ratio,
-                                                self.hit_reward_seconds,
-                                                self.evict_start_threshold,
-                                                self.eviction_policy,
-                                                event_collector,
-                                                self._metrics_collector)
+                self.cpu_cache_engine = CacheEngine(
+                    device_type=DeviceType.CPU,
+                    num_total_blocks=cache_config.num_cpu_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=event_collector,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
         if cache_config.enable_ssd:
             if cache_config.enable_p2p_ssd:
                 self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta) #TODO
             elif self.index_accel:
-                self.ssd_cache_engine = CacheEngineAccel(DeviceType.SSD,
-                                                cache_config.num_ssd_blocks,
-                                                cache_config.tokens_per_block,
-                                                self.evict_ratio,
-                                                self.hit_reward_seconds,
-                                                self.evict_start_threshold,
-                                                self.eviction_policy,
-                                                event_collector,
-                                                self._metrics_collector)
+                self.ssd_cache_engine = CacheEngineAccel(
+                    device_type=DeviceType.SSD,
+                    num_total_blocks=cache_config.num_ssd_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=event_collector,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             else:
-                self.ssd_cache_engine = CacheEngine(DeviceType.SSD,
-                                                cache_config.num_ssd_blocks,
-                                                cache_config.tokens_per_block,
-                                                self.evict_ratio,
-                                                self.hit_reward_seconds,
-                                                self.evict_start_threshold,
-                                                self.eviction_policy,
-                                                event_collector,
-                                                self._metrics_collector)
+                self.ssd_cache_engine = CacheEngine(
+                    device_type=DeviceType.SSD,
+                    num_total_blocks=cache_config.num_ssd_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=event_collector,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
         if cache_config.enable_remote:
             if cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
                 self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta)
             elif self.index_accel:
-                self.remote_cache_engine = CacheEngineAccel(DeviceType.REMOTE,
-                                                   cache_config.num_remote_blocks,
-                                                   cache_config.tokens_per_block,
-                                                   self.evict_ratio,
-                                                   self.hit_reward_seconds,
-                                                   self.evict_start_threshold,
-                                                   self.eviction_policy,
-                                                   None,
-                                                   self._metrics_collector)
+                self.remote_cache_engine = CacheEngineAccel(
+                    device_type=DeviceType.REMOTE,
+                    num_total_blocks=cache_config.num_remote_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=None,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             else:
-                self.remote_cache_engine = CacheEngine(DeviceType.REMOTE,
-                                                   cache_config.num_remote_blocks,
-                                                   cache_config.tokens_per_block,
-                                                   self.evict_ratio,
-                                                   self.hit_reward_seconds,
-                                                   self.evict_start_threshold,
-                                                   self.eviction_policy,
-                                                   None,
-                                                   self._metrics_collector)
+                self.remote_cache_engine = CacheEngine(
+                    device_type=DeviceType.REMOTE,
+                    num_total_blocks=cache_config.num_remote_blocks,
+                    tokens_per_block=cache_config.tokens_per_block,
+                    evict_ratio=self.evict_ratio,
+                    hit_reward_seconds=self.hit_reward_seconds,
+                    evict_start_threshold=self.evict_start_threshold,
+                    eviction_policy=self.eviction_policy,
+                    event_collector=None,
+                    metrics_collector=self._metrics_collector,
+                    protected_threshold=self.protected_threshold,
+                )
             self.cache_engines[DeviceType.REMOTE] = self.remote_cache_engine
 
         #TODO move this to kvmanager.start()

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -135,7 +135,7 @@ class RadixNode:
         self.children.clear()
 
 class RadixTreeIndex:
-    def __init__(self, tokens_per_block: int, max_num_blocks: int = 1000000, hit_reward_seconds: int = 0, eviction_policy: str = "lru"):
+    def __init__(self, tokens_per_block: int, max_num_blocks: int = 1000000, hit_reward_seconds: int = 0, eviction_policy: str = "lru", protected_threshold: int = 2):
         self.root_node: RadixNode = RadixNode(block_hashes=np.array([], dtype=np.int64),
                                               physical_blocks=np.array([], dtype=np.int64),
                                               is_ready=True,
@@ -150,6 +150,7 @@ class RadixTreeIndex:
 
         self.hit_reward_seconds = hit_reward_seconds
         self.eviction_policy = eviction_policy
+        self.protected_threshold = protected_threshold
 
     def reset(self) -> None:
         self.root_node = RadixNode(block_hashes=np.array([], dtype=np.int64),
@@ -180,6 +181,9 @@ class RadixTreeIndex:
                     current_node.grace_time = now + self.hit_reward_seconds
                 else:
                     current_node.grace_time += self.hit_reward_seconds
+                # Python int is unbounded, so no overflow concern here.
+                # For SLRU the value only matters via comparison against
+                # protected_threshold; for LFU it preserves monotonic ordering.
                 current_node.hit_count += 1
             child_hash = sequence.get_hash(prefix_blocks_num + current_node.size())
             if child_hash in current_node.children:
@@ -325,12 +329,15 @@ class RadixTreeIndex:
             return node.creation_time
         elif self.eviction_policy == "mru":
             return -node.last_access_time
+        elif self.eviction_policy == "slru":
+            is_protected = 1 if node.hit_count >= self.protected_threshold else 0
+            return (is_protected, node.last_access_time)
         elif self.eviction_policy == "filo":
             return -node.creation_time
         else:
             raise ValueError(
                 f"Unknown eviction policy: {self.eviction_policy}. "
-                f"Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo'."
+                f"Supported policies: 'lru', 'lfu', 'slru', 'fifo', 'mru', 'filo'."
             )
 
     def lock(self, node: RadixNode) -> None:

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -121,6 +121,7 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     evict_start_threshold=float(os.getenv('FLEXKV_EVICT_START_THRESHOLD', 0.7)),
     hit_reward_seconds=int(os.getenv('FLEXKV_HIT_REWARD_SECONDS', 0)),
     eviction_policy=os.getenv('FLEXKV_EVICTION_POLICY', 'lru'),
+    slru_protected_threshold=int(os.getenv('FLEXKV_SLRU_PROTECTED_THRESHOLD', 2)),
 
     enable_mps=bool(int(os.getenv('FLEXKV_ENABLE_MPS', 1))),
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ cpp_sources = [
     "csrc/tp_transfer_thread_group.cpp",
     "csrc/transfer_ssd.cpp",
     "csrc/radix_tree.cpp",
+    "csrc/eviction_strategy.cpp",
     "csrc/monitoring/metrics_manager.cpp",  # Monitoring support
 ]
 
@@ -64,6 +65,7 @@ hpp_sources = [
     "csrc/tp_transfer_thread_group.h",
     "csrc/transfer_ssd.h",
     "csrc/radix_tree.h",
+    "csrc/eviction_strategy.h",
     "csrc/monitoring/metrics_manager.h",  # Monitoring support
 ]
 

--- a/tests/test_cache_engine.py
+++ b/tests/test_cache_engine.py
@@ -73,9 +73,10 @@ def _cfg(**overrides) -> dict:
         # --- Valid configurations ---
         # Default valid config
         (_cfg(), False),
-        # Explicit eviction policies – all 5 should be valid
+        # Explicit eviction policies – all 6 should be valid
         (_cfg(eviction_policy='lru'), False),
         (_cfg(eviction_policy='lfu'), False),
+        (_cfg(eviction_policy='slru'), False),
         (_cfg(eviction_policy='fifo'), False),
         (_cfg(eviction_policy='mru'), False),
         (_cfg(eviction_policy='filo'), False),
@@ -115,6 +116,16 @@ def _cfg(**overrides) -> dict:
         (_cfg(device_type='Unknown'), True),
         (_cfg(device_type=999), True),
         (_cfg(device_type=None), True),
+
+        # --- Valid: protected_threshold (only meaningful for SLRU, but accepted for all) ---
+        (_cfg(eviction_policy='slru', protected_threshold=1), False),
+        (_cfg(eviction_policy='slru', protected_threshold=5), False),
+
+        # --- Invalid: protected_threshold ---
+        (_cfg(protected_threshold=0), True),
+        (_cfg(protected_threshold=-1), True),
+        (_cfg(protected_threshold=1.5), True),
+        (_cfg(protected_threshold=None), True),
     ],
 )
 def test_config_init(engine_cls, config: dict, should_raise: bool):
@@ -499,6 +510,10 @@ def test_eviction_policy(engine_cls):
     # LFU: evict lowest hit count (D=2) → D
     _assert_only_evicted(run_test('lfu'), 'D')
 
+    # SLRU: with default protected_threshold=2, all nodes have hit_count>=2
+    # so all are in Protected segment; within same segment, LRU → B evicted
+    _assert_only_evicted(run_test('slru'), 'B')
+
     # FIFO: evict earliest inserted → A
     _assert_only_evicted(run_test('fifo'), 'A')
 
@@ -538,9 +553,9 @@ def test_eviction_policy_edge_cases(engine_cls):
 
 
 # ---- Verify all 5 policies are accepted without error ----
-@pytest.mark.parametrize("policy", ['lru', 'lfu', 'fifo', 'mru', 'filo'])
+@pytest.mark.parametrize("policy", ['lru', 'lfu', 'slru', 'fifo', 'mru', 'filo'])
 def test_eviction_policy_valid_creation(engine_cls, policy: str):
-    """All five policies should be accepted and produce a working engine."""
+    """All six policies should be accepted and produce a working engine."""
     engine = _create_engine(engine_cls, policy)
     seqs = _make_seqs(2)
     engine.insert(seqs[0], engine.take(1), is_ready=True)
@@ -581,6 +596,7 @@ def test_eviction_policy_consecutive(engine_cls):
     expected_eviction_order = {
         'lru':  ['B', 'C', 'D'],
         'lfu':  ['D', 'C', 'B'],
+        'slru': ['B', 'C', 'D'],  # all Protected (hit>=2), same-segment LRU
         'fifo': ['A', 'B', 'C'],
         'mru':  ['A', 'D', 'C'],
         'filo': ['D', 'C', 'B'],
@@ -665,6 +681,7 @@ def test_eviction_policy_batch(engine_cls):
     expected_evicted = {
         'lru':  {'B', 'C'},
         'lfu':  {'D', 'C'},
+        'slru': {'B', 'C'},  # all Protected (hit>=2), same-segment LRU
         'fifo': {'A', 'B'},
         'mru':  {'A', 'D'},
         'filo': {'D', 'C'},
@@ -756,3 +773,320 @@ def test_eviction_policy_reinsert_after_eviction(engine_cls):
     assert engine.match(seqs[2]).num_matched_blocks == 0, (
         "C should be evicted to make room for re-inserted B"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests – SLRU-specific eviction behavior
+# ---------------------------------------------------------------------------
+
+def _create_slru_engine(engine_cls, protected_threshold: int = 2,
+                        num_total_blocks: int = _EVICT_NUM_TOTAL_BLOCKS):
+    """Helper to create an SLRU engine with a given protected_threshold.
+
+    Passes protected_threshold directly as a constructor argument,
+    consistent with how hit_reward_seconds is passed.
+    """
+    return engine_cls(
+        device_type=DEFAULT_DEVICE_TYPE,
+        num_total_blocks=num_total_blocks,
+        tokens_per_block=_EVICT_TOKENS_PER_BLOCK,
+        evict_ratio=_EVICT_RATIO,
+        eviction_policy='slru',
+        protected_threshold=protected_threshold,
+    )
+
+
+def test_slru_protected_node_retained(engine_cls):
+    """SLRU: nodes in the Protected segment should be retained over
+    Probationary nodes, regardless of access time.
+
+    Setup (protected_threshold=5):
+      Insert A, B, C, D.
+      Access A×10 (Protected), B×1, C×1, D×1 (all Probationary).
+      Insert E → should evict a Probationary node (B, oldest access).
+      A must survive because it is in the Protected segment.
+    """
+    seqs = _make_seqs(5)
+    engine = _create_slru_engine(engine_cls, protected_threshold=5)
+
+    # Insert A, B, C, D
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # Access A 10 times → hit_count >= 5 → Protected
+    for _ in range(10):
+        engine.match(seqs[0])
+    time.sleep(0.002)
+
+    # Access B, C, D once each → hit_count < 5 → Probationary
+    # B accessed first (oldest), then C, then D
+    engine.match(seqs[1])
+    time.sleep(0.002)
+    engine.match(seqs[2])
+    time.sleep(0.002)
+    engine.match(seqs[3])
+    time.sleep(0.002)
+
+    # Insert E → triggers eviction of 1 block
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # A (Protected) must survive
+    assert result['A'] == 1, (
+        f"A (Protected) should survive, got result: {result}"
+    )
+    # B (Probationary, oldest access) should be evicted
+    assert result['B'] == 0, (
+        f"B (Probationary, oldest access) should be evicted, got result: {result}"
+    )
+    # E should survive (just inserted)
+    assert result['E'] == 1, (
+        f"E should survive, got result: {result}"
+    )
+
+
+def test_slru_same_segment_lru_order(engine_cls):
+    """SLRU: within the same segment, nodes are evicted in LRU order
+    (oldest last_access_time first).
+
+    Setup (protected_threshold=100, so all nodes stay Probationary):
+      Insert A, B, C, D.
+      Access in order: A → B → C → D (D most recent).
+      Insert E → evicts A (oldest access in Probationary segment).
+    """
+    seqs = _make_seqs(5)
+    engine = _create_slru_engine(engine_cls, protected_threshold=100)
+
+    # Insert A, B, C, D
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # Access in order: A, B, C, D
+    for i in range(4):
+        engine.match(seqs[i])
+        time.sleep(0.002)
+
+    # Insert E → triggers eviction
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # A (oldest access) should be evicted
+    _assert_only_evicted(result, 'A')
+
+
+def test_slru_custom_protected_threshold(engine_cls):
+    """SLRU: verify that a custom protected_threshold correctly determines
+    which nodes are in the Protected vs Probationary segment.
+
+    Setup (protected_threshold=3):
+      Insert A, B, C, D.
+      Access A×5, B×3, then D×1, then C×2 (D accessed before C so that D
+      has the oldest last_access_time among the Probationary nodes).
+      → A (hit=5>=3, Protected), B (hit=3>=3, Protected),
+        D (hit=1<3, Probationary, oldest access),
+        C (hit=2<3, Probationary, newer access).
+      Insert E → evicts D (Probationary with oldest last_access_time).
+    """
+    seqs = _make_seqs(5)
+    engine = _create_slru_engine(engine_cls, protected_threshold=3)
+
+    # Insert A, B, C, D
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # Access pattern: A×5, B×3 → both Protected (hit >= 3).
+    for _ in range(5):
+        engine.match(seqs[0])
+    time.sleep(0.002)
+    for _ in range(3):
+        engine.match(seqs[1])
+    time.sleep(0.002)
+    # D is accessed first (older last_access_time), then C.
+    # Both remain Probationary since their hit_count stays < 3.
+    engine.match(seqs[3])
+    time.sleep(0.002)
+    for _ in range(2):
+        engine.match(seqs[2])
+    time.sleep(0.002)
+
+    # Insert E → triggers eviction
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # A and B are Protected → must survive
+    assert result['A'] == 1, f"A (Protected) should survive, got result: {result}"
+    assert result['B'] == 1, f"B (Protected) should survive, got result: {result}"
+    # D (Probationary, oldest access) should be evicted
+    assert result['D'] == 0, f"D (Probationary, oldest access) should be evicted, got result: {result}"
+    # C (Probationary, newer access) should survive
+    assert result['C'] == 1, f"C (Probationary, newer access) should survive, got result: {result}"
+    # E should survive
+    assert result['E'] == 1, f"E should survive, got result: {result}"
+
+
+def test_slru_batch_eviction_cross_segment(engine_cls):
+    """SLRU batch eviction: when evicting 2 blocks, both Probationary nodes
+    should be evicted before any Protected node.
+
+    Setup (protected_threshold=3, evict_ratio=0.5 → evict 2 blocks):
+      Insert A, B, C, D.
+      Access A×5, B×5 (Protected), C×1, D×1 (Probationary).
+      Insert E → evicts C and D (both Probationary).
+    """
+    seqs = _make_seqs(5)
+    engine = engine_cls(
+        device_type=DEFAULT_DEVICE_TYPE,
+        num_total_blocks=_EVICT_NUM_TOTAL_BLOCKS,
+        tokens_per_block=_EVICT_TOKENS_PER_BLOCK,
+        evict_ratio=0.5,  # Evict 2 blocks at once
+        eviction_policy='slru',
+        protected_threshold=3,
+    )
+
+    # Insert A, B, C, D
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # Access A×5, B×5 → Protected; C×1, D×1 → Probationary
+    for _ in range(5):
+        engine.match(seqs[0])
+        engine.match(seqs[1])
+    time.sleep(0.002)
+    engine.match(seqs[2])
+    time.sleep(0.002)
+    engine.match(seqs[3])
+    time.sleep(0.002)
+
+    # Insert E → triggers eviction of 2 blocks
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # A and B (Protected) must survive
+    assert result['A'] == 1, f"A (Protected) should survive, got result: {result}"
+    assert result['B'] == 1, f"B (Protected) should survive, got result: {result}"
+    # C and D (Probationary) should be evicted
+    assert result['C'] == 0, f"C (Probationary) should be evicted, got result: {result}"
+    assert result['D'] == 0, f"D (Probationary) should be evicted, got result: {result}"
+    # E should survive
+    assert result['E'] == 1, f"E should survive, got result: {result}"
+
+
+def test_slru_threshold_one_promotes_on_first_hit(engine_cls):
+    """SLRU boundary: with protected_threshold=1, a single match should be
+    enough to promote a node to the Protected segment.
+
+    Setup (protected_threshold=1, num_total_blocks=4, evict_ratio=0.25):
+      Insert A, B, C, D (fills cache).
+      match A, B, C once each → A/B/C.hit_count = 1 → Protected.
+      D is never matched → D.hit_count = 0 → Probationary.
+      Insert E → triggers eviction; D (only Probationary) must be evicted.
+    """
+    seqs = _make_seqs(5)
+    engine = _create_slru_engine(engine_cls, protected_threshold=1)
+
+    # Insert A, B, C, D — fills cache (4/4)
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # Match A, B, C once → their hit_count becomes 1 → Protected segment.
+    # D is intentionally not matched → stays in Probationary (hit_count=0).
+    engine.match(seqs[0])
+    time.sleep(0.002)
+    engine.match(seqs[1])
+    time.sleep(0.002)
+    engine.match(seqs[2])
+    time.sleep(0.002)
+
+    # Insert E → triggers eviction of 1 block; D (only Probationary) must go.
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # A, B, C are Protected (hit_count >= 1) → must survive.
+    assert result['A'] == 1, f"A (Protected) should survive, got result: {result}"
+    assert result['B'] == 1, f"B (Protected) should survive, got result: {result}"
+    assert result['C'] == 1, f"C (Protected) should survive, got result: {result}"
+    # D is the only Probationary node → evicted.
+    assert result['D'] == 0, f"D (Probationary) should be evicted, got result: {result}"
+    # E just inserted → survives.
+    assert result['E'] == 1, f"E should survive, got result: {result}"
+
+
+def test_slru_all_protected_falls_back_to_lru(engine_cls):
+    """SLRU: when every candidate is in the Protected segment, eviction
+    falls back to pure LRU within that segment — the least recently
+    accessed Protected node is evicted.
+
+    Setup (protected_threshold=1, num_total_blocks=4, evict_ratio=0.25):
+      Insert A, B, C, D.
+      match A, match B, match C, match D → all hit_count=1 → Protected.
+      Re-access A, C, D (fresher) but leave B as the oldest access.
+      Insert E → evicts B (oldest last_access_time among all-Protected).
+    """
+    seqs = _make_seqs(5)
+    engine = _create_slru_engine(engine_cls, protected_threshold=1)
+
+    # Insert A, B, C, D
+    for seq in seqs[:4]:
+        engine.insert(seq, engine.take(1), is_ready=True)
+        time.sleep(0.002)
+
+    # First-round match → all promote to Protected (hit_count >= 1)
+    for seq in seqs[:4]:
+        engine.match(seq)
+        time.sleep(0.002)
+
+    # Re-access A, C, D (in this order). B is left untouched → oldest
+    # last_access_time among the Protected segment.
+    engine.match(seqs[0])
+    time.sleep(0.002)
+    engine.match(seqs[2])
+    time.sleep(0.002)
+    engine.match(seqs[3])
+    time.sleep(0.002)
+
+    # Insert E → evicts the LRU-within-Protected node, which is B.
+    engine.insert(seqs[4], engine.take(1), is_ready=True)
+
+    labels = ['A', 'B', 'C', 'D', 'E']
+    result = {
+        labels[i]: engine.match(seqs[i]).num_matched_blocks
+        for i in range(5)
+    }
+
+    # B must be evicted (oldest access among all-Protected → same-segment LRU).
+    assert result['B'] == 0, f"B should be evicted (same-segment LRU), got result: {result}"
+    # Others must survive.
+    assert result['A'] == 1, f"A should survive, got result: {result}"
+    assert result['C'] == 1, f"C should survive, got result: {result}"
+    assert result['D'] == 1, f"D should survive, got result: {result}"
+    assert result['E'] == 1, f"E should survive, got result: {result}"


### PR DESCRIPTION
## Summary

This PR adds **Segmented LRU (SLRU)** as a new eviction policy and refactors the eviction-comparison logic from a `switch`-case in `CRadixNode::Compare` into a dedicated `IEvictionStrategy` hierarchy.

SLRU resists cache scan pollution by splitting cached nodes into two logical segments:
- **Probationary**: `hit_count < protected_threshold` (default `2`). Newly inserted nodes start here.
- **Protected**: `hit_count >= protected_threshold`. Nodes promoted after being accessed enough times.

During eviction, Probationary nodes are evicted first; within the same segment, classic LRU (`last_access_time`) ordering applies. This is particularly useful for mixed workloads where a few hot prefixes (e.g. system prompts) coexist with large volumes of one-shot queries.

## Why the strategy-pattern refactor

The previous `Compare` did a `switch` on `EvictionPolicy` and combined with a `double get_priority()` that could not cleanly express multi-dimensional keys (SLRU's priority is the pair `(is_protected, last_access_time)`, not a flat double). Replacing it with `IEvictionStrategy` removes magic numbers / bit tricks and makes adding future policies trivial.

## Key changes

### C++ core
- New `csrc/eviction_strategy.{h,cpp}`: abstract `IEvictionStrategy` + 6 concrete strategies (`LRU / LFU / FIFO / MRU / FILO / SLRU`) + factory `create_eviction_strategy(policy, protected_threshold)`.
- `CRadixNode::Compare::operator()` now delegates to `strategy->compare(a, b)`.
- `double get_priority()` replaced by `std::string priority_repr(node)` on the strategy (supports multi-dimensional keys).
- `EvictionPolicy` enum moved into `eviction_strategy.h`.
- `update_time()` saturates `hit_count` at `INT_MAX` to prevent int overflow from silently demoting long-lived hot nodes back to Probationary.
- `CRadixTreeIndex` now stores only `strategy_` as the single source of truth; redundant `eviction_policy` / `protected_threshold` fields and their unused getters are removed.

### Python layer
- `RadixTreeIndex._get_eviction_priority` gains the `"slru"` branch with key `(is_protected, last_access_time)`.
- `CacheEngine` / `CacheEngineAccel` accept a new `protected_threshold` kwarg with validation (`int >= 1`); the eviction-policy whitelist is extended with `"slru"`.
- `GlobalCacheEngine` reads `FLEXKV_SLRU_PROTECTED_THRESHOLD` from env and forwards it into every per-device `CacheEngine`. All 6 call sites were migrated to keyword arguments for robustness against future signature drift.

### Bindings / build
- `pybind11` bindings for `CRadixTreeIndex` and `LocalRadixTree` accept `eviction_policy` + `protected_threshold` with sensible defaults (`"lru"`, `2`).
- `setup.py` picks up `csrc/eviction_strategy.{h,cpp}`.

### Docs
- `docs/eviction_policy/README_{en,zh}.md`:
  - SLRU added to the policy table + per-policy parameters table (`slru_protected_threshold` / `FLEXKV_SLRU_PROTECTED_THRESHOLD`).
  - Dedicated SLRU section describing segments and best-fit workloads.
  - Note: `hit_reward_seconds` has no effect on SLRU (SLRU orders same-segment nodes by `last_access_time`, while `hit_reward_seconds` only affects `grace_time`).

### Tests (`tests/test_cache_engine.py`)
- SLRU added to all parameterized policy tests (creation, consecutive eviction, batch eviction, valid-creation).
- New SLRU-specific tests:
  - `test_slru_protected_node_retained`: Protected nodes outlive Probationary ones regardless of access time.
  - `test_slru_batch_eviction_cross_segment`: batch eviction drains all Probationary before touching Protected.
  - `test_slru_custom_protected_threshold`: custom threshold correctly classifies nodes; same-segment LRU wins the tie.
  - `test_slru_threshold_one_promotes_on_first_hit`: `protected_threshold=1` boundary — a single hit promotes to Protected.
  - `test_slru_all_protected_falls_back_to_lru`: when every candidate is Protected, eviction falls back to same-segment LRU.
- `test_config_init` parameterization extended with invalid `protected_threshold` cases (`0`, `-1`, `1.5`, `None`).

## Backward compatibility

- All existing policies (`lru / lfu / fifo / mru / filo`) keep their exact previous semantics.
- `protected_threshold` is a new optional parameter with default `2`; existing callers that don't pass it are unaffected.
- Public C++ type hierarchy change: `CRadixTreeIndex` no longer exposes `get_eviction_policy()` / `get_protected_threshold()`. A grep across the repo confirmed no external caller used them. If downstream users do, `get_strategy()->priority_repr(node)` covers the diagnostic use case.

## Configuration

```bash
export FLEXKV_EVICTION_POLICY=slru
export FLEXKV_SLRU_PROTECTED_THRESHOLD=2   # optional, default 2
```

Or in YAML:

```yml
eviction_policy: slru
slru_protected_threshold: 2
```

## Test plan

- `pytest tests/test_cache_engine.py` — 183 tests all pass, covering both `CacheEngine` (pure Python) and `CacheEngineAccel` (C++ accel) paths.
