### PR TITLE
refactor: align multi-node TP topology with framework (nnodes/node_rank) and unify eventfd socket path

### DIFF
--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -36,6 +36,24 @@ class ModelConfig:
     pp_size: int = 1
     pp_rank: int = 0
 
+    # topology configs
+    #   nnodes        : number of physical machines spanned by one replica
+    #                   (== server_args.nnodes in SGLang)
+    #   node_rank     : index of this machine within ``nnodes``
+    #                   (== server_args.node_rank in SGLang).  Used by
+    #                   KVTaskEngine's multi-node topology derivation and
+    #                   for logging; NOT embedded in the layerwise UDS
+    #                   socket path (UDS endpoints are kernel-local).
+    nnodes: int = 1
+    node_rank: int = 0
+
+    # Multi-node bootstrap: master node's IP for TransferManager rendezvous.
+    # ``None`` falls back to ``FLEXKV_MASTER_HOST`` env var (default
+    # ``"localhost"``) inside ``resolve_master_host_and_ports``.  Set this
+    # from the framework's own launch config (e.g. sglang's
+    # ``--dist-init-addr``) to avoid exposing an extra env knob.
+    master_host: Optional[str] = None
+
     # NSA context parallelism: when True, layerwise transfer sends full
     # (unpartitioned) KV cache to every rank instead of head-sliced data.
     is_nsa_cp: bool = False

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -127,10 +127,13 @@ class FlexKVConfig:
         pp_rank: int = 0,
         dp_size: int = 1,
         dp_rank: int = 0,
+        nnodes: int = 1,
+        node_rank: int = 0,
         is_nsa_cp: bool = False,
         cp_size: int = 1,
         cp_rank: int = 0,
         kv_cache_dtype: Optional[str] = None,
+        master_host: Optional[str] = None,
     ):
         """
         Initialize FlexKVConfig fields from sglang config.
@@ -143,9 +146,13 @@ class FlexKVConfig:
             pp_rank: pipeline parallel rank (default 0)
             dp_size: data parallel size (default 1, no DP)
             dp_rank: data parallel rank (default 0)
+            nnodes: number of nodes (aligned with server_args.nnodes, default 1)
+            node_rank: index of this node (aligned with server_args.node_rank, default 0)
             is_nsa_cp: whether NSA context parallelism is enabled
             cp_size: context parallel size (default 1, no CP)
             cp_rank: context parallel rank (default 0)
+            kv_cache_dtype: KV cache dtype (default None, use model dtype)
+            master_host: master host for multi-node setup (default None, use localhost)
         """
         # cache config: use page_size as tokens_per_block so that FlexKV's
         # CPU radix tree manages blocks at page granularity, ensuring that
@@ -250,6 +257,14 @@ class FlexKVConfig:
         self.model_config.pp_rank = int(pp_rank)
         self.model_config.is_nsa_cp = is_nsa_cp
         self.model_config.cp_size = int(cp_size if cp_size is not None else 1)
+        # Topology: nnodes + node_rank (aligned with sglang server_args).
+        # ``gpus_per_node`` is no longer stored on model_config; KVTaskEngine
+        # derives it locally as (tp_size * pp_size) // nnodes.
+        self.model_config.nnodes = max(1, int(nnodes))
+        self.model_config.node_rank = int(node_rank)
+        # Multi-node bootstrap: master host (derived from sglang --dist-init-addr).
+        # ``None`` here falls back to FLEXKV_MASTER_HOST env var downstream.
+        self.model_config.master_host = master_host
         update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
 
         # Each PP rank needs its own IPC ports so that their

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -9,7 +9,6 @@ import copy
 import os
 from expiring_dict import ExpiringDict
 import nvtx
-import torch
 import numpy as np
 
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
@@ -21,7 +20,7 @@ from flexkv.cache.cache_engine import GlobalCacheEngine, DEFAULT_CACHE_STRATEGY,
 from flexkv.transfer_manager import TransferManagerHandle, TransferManagerOnRemote
 from flexkv.common.request import KVResponseStatus, KVResponse
 from flexkv.transfer_manager import (
-    get_master_host_and_ports_from_env,
+    resolve_master_host_and_ports,
     get_trtllm_subprocess_host_and_ports_from_env
 )
 from flexkv.cache.redis_meta import RedisMeta
@@ -107,27 +106,61 @@ class KVTaskManager:
         self.model_config = model_config
         self._check_config(model_config, cache_config)
 
-        self.is_multinode_tp = False
-        self.tp_node_count = 1
-        if self.model_config.tp_size > torch.cuda.device_count():
-            if self.model_config.tp_size != torch.cuda.device_count() * 2:
-                raise ValueError("Only support 2 nodes TP for now")
-            assert self.model_config.dp_size == 1
-            self.tp_node_count = self.model_config.tp_size // torch.cuda.device_count()
-            self.is_multinode_tp = True
+        # ---- Multi-node topology ----
+        nnodes = self.model_config.nnodes
+        pp_size = self.model_config.pp_size
+        tp_size = self.model_config.tp_size
+
+        total_gpus = tp_size * pp_size
+        if total_gpus % nnodes != 0:
+            raise ValueError(
+                f"[KVTaskEngine] cannot derive gpus_per_node: "
+                f"tp*pp={total_gpus} not divisible by nnodes={nnodes}"
+            )
+        gpus_per_node = total_gpus // nnodes
+
+        self.nnodes_per_tp_group = max(
+            (tp_size + gpus_per_node - 1) // gpus_per_node, 1
+        )
+        if self.nnodes_per_tp_group > 2:
+            raise ValueError(
+                f"Only support 2-nodes TP for now, but got "
+                f"nnodes_per_tp_group={self.nnodes_per_tp_group} "
+                f"(tp_size={tp_size}, gpus_per_node={gpus_per_node})"
+            )
+
+        if tp_size % self.nnodes_per_tp_group != 0:
+            raise ValueError(
+                f"[KVTaskEngine] tp_size={tp_size} not divisible by "
+                f"nnodes_per_tp_group={self.nnodes_per_tp_group}"
+            )
+        tp_size_per_node = tp_size // self.nnodes_per_tp_group
+
+        flexkv_logger.info(
+            f"[KVTaskEngine] topology: "
+            f"nnodes={nnodes}, "
+            f"node_rank={self.model_config.node_rank}, "
+            f"gpus_per_node={gpus_per_node}, "
+            f"tp_size={tp_size}, "
+            f"pp_size={pp_size}, "
+            f"dp_size={self.model_config.dp_size}, "
+            f"nnodes_per_tp_group={self.nnodes_per_tp_group}, "
+            f"tp_size_per_node={tp_size_per_node}, "
+            f"master_host={self.model_config.master_host!r}"
+        )
 
         self.cache_engine = GlobalCacheEngine(cache_config, model_config, redis_meta, event_collector)
 
         model_config_for_transfer = copy.deepcopy(self.model_config)
-        if self.is_multinode_tp:
-            model_config_for_transfer.tp_size //= self.tp_node_count
+        if self.nnodes_per_tp_group > 1:
+            model_config_for_transfer.tp_size //= self.nnodes_per_tp_group
             if not self.model_config.use_mla:
-                model_config_for_transfer.num_kv_heads //= self.tp_node_count
+                model_config_for_transfer.num_kv_heads //= self.nnodes_per_tp_group
             # When NSA CP is active, cp_size mirrors tp_size and must also
             # be divided so that TransferEngine's _eventfd_group_size matches
             # the number of local GPUs on each node.
             if model_config_for_transfer.is_nsa_cp and model_config_for_transfer.cp_size > 1:
-                model_config_for_transfer.cp_size //= self.tp_node_count
+                model_config_for_transfer.cp_size //= self.nnodes_per_tp_group
 
         combine_with_trtllm = os.getenv("FLEXKV_WITH_TRTLLM", "0") == "1"
         if not combine_with_trtllm:
@@ -155,8 +188,10 @@ class KVTaskManager:
             ]
             self.transfer_handles[0]._handle.send_config_to_remotes()
 
-        if self.is_multinode_tp:
-            master_host, master_ports = get_master_host_and_ports_from_env()
+        if self.nnodes_per_tp_group > 1:
+            master_host, master_ports = resolve_master_host_and_ports(
+                master_host=self.model_config.master_host
+            )
             self.transfer_handles.append(TransferManagerHandle(
                 model_config_for_transfer,
                 self.cache_config,

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -1,34 +1,57 @@
-import copy
-import torch.multiprocessing as mp
-import threading
 import time
 import os
 import socket
 import struct
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from torch.multiprocessing import Queue as MPQueue, Pipe as MPPipe
+from torch.multiprocessing import Queue as MPQueue
 from multiprocessing.connection import Connection
-from threading import Thread
 from typing import List, Any, Dict, Union, Optional, Tuple
 
-import ctypes
-import numpy as np
-import nvtx
 import torch
-
-from flexkv import c_ext
 
 from flexkv.c_ext import LayerwiseTransferGroup
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
-from flexkv.common.transfer import TransferOp, TransferType, PartitionBlockType
-from flexkv.common.transfer import get_nvtx_range_color
-from flexkv.common.config import CacheConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.config import ModelConfig, GLOBAL_CONFIG_FROM_ENV
 
-from flexkv.transfer.worker_op import WorkerTransferOp, WorkerLayerwiseTransferOp
+from flexkv.transfer.worker_op import WorkerLayerwiseTransferOp
 from flexkv.transfer.worker import TransferWorkerBase, cudaHostRegister
+
+
+def build_layerwise_eventfd_socket_path(model_config: ModelConfig) -> str:
+    """Construct the LayerwiseWorker's UDS socket path.
+
+    Disambiguated by ``(pp_rank, dp_rank)`` so multiple PP stages and DP
+    replicas on the same host each get their own endpoint.
+
+    We deliberately do NOT embed ``node_rank`` in the path: Unix domain
+    sockets are kernel-local, so two FlexKV instances on different
+    physical hosts cannot collide even when ``/tmp`` happens to be on a
+    shared filesystem (NFS and friends propagate the inode, not the
+    socket endpoint).  Deployments that stack multiple containers on one
+    host with a shared ``/tmp`` should disambiguate via the
+    ``FLEXKV_LAYERWISE_EVENTFD_SOCKET`` env var (e.g. embed ``$HOSTNAME``
+    or the container id in the base path).
+
+    Must stay in sync with the sglang-side consumer at
+    ``sglang.srt.mem_cache.storage.flexkv.flexkv_connector``, which
+    imports this helper directly so the two ends cannot drift.  Both
+    sides derive the path from the same ``ModelConfig`` fields, so no
+    env-var plumbing between processes is required.
+    """
+    base = os.environ.get(
+        'FLEXKV_LAYERWISE_EVENTFD_SOCKET',
+        '/tmp/flexkv_layerwise_eventfd.sock',
+    )
+    suffix = ""
+    if model_config.pp_size > 1:
+        suffix += f"_pp{model_config.pp_rank}"
+    if model_config.dp_size > 1:
+        suffix += f"_dp{model_config.dp_rank}"
+    if not suffix:
+        return base
+    root, ext = os.path.splitext(base)
+    return f"{root}{suffix}{ext}"
 
 
 def _recv_fds(sock: socket.socket, num_fds: int) -> Tuple[List[int], bytes]:
@@ -68,6 +91,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                  pp_size: int,
                  dp_size: int,
                  dp_rank: int,
+                 layerwise_eventfd_socket: str,
                  num_blocks_per_file: int,
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
@@ -108,6 +132,11 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         self.dp_group_id = dp_group_id
         self.dp_size = dp_size if dp_size > 0 else 1
         self.dp_rank = dp_rank
+        # Pre-computed UDS socket path.  Both ends (this worker and the
+        # sglang connector) derive the path from the same ModelConfig
+        # fields (pp_rank / dp_rank / node_rank / is_multinode_tp), so no
+        # env-var plumbing between processes is required.
+        self.layerwise_eventfd_socket = layerwise_eventfd_socket
         self.is_nsa_cp = is_nsa_cp
 
         # initialize GPU storage
@@ -314,23 +343,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                                        max_retries: int = 180,
                                        retry_interval: float = 1.0) -> torch.Tensor:
         """Receive eventfds from SGLang via Unix socket (FlexKV as server)."""
-        base_socket_path = os.environ.get('FLEXKV_LAYERWISE_EVENTFD_SOCKET', '/tmp/flexkv_layerwise_eventfd.sock')
-        sock_suffix = ""
-        if int(self.pp_size) > 1:
-            sock_suffix += f"_pp{int(self.pp_rank)}"
-        if int(self.dp_size) > 1:
-            sock_suffix += f"_dp{int(self.dp_rank)}"
-        # Multi-node TP: add _node{id} suffix to match sglang connector's
-        # socket path.  The sglang connector sets FLEXKV_NODE_ID when it
-        # detects cross-node TP; the subprocess inherits this env var.
-        _node_id_str = os.environ.get("FLEXKV_NODE_ID")
-        if _node_id_str is not None:
-            sock_suffix += f"_node{_node_id_str}"
-        if sock_suffix:
-            root, ext = os.path.splitext(base_socket_path)
-            socket_path = f"{root}{sock_suffix}{ext}"
-        else:
-            socket_path = base_socket_path
+        socket_path = self.layerwise_eventfd_socket
 
         rank_parts = []
         if int(self.tp_group_size) > 1:

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -18,18 +18,17 @@ import time
 import multiprocessing as mp
 import selectors
 import os
-from queue import Queue
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import contextlib
 import nvtx
 import numpy as np
+import torch
 
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.storage import StorageHandle
-from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType, CompletedOp, LayerwiseTransferOp
+from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType, CompletedOp
 from flexkv.common.transfer import get_nvtx_range_color
-from flexkv.common.storage import KVCacheLayoutType
 from flexkv.transfer.scheduler import TransferScheduler
 from flexkv.transfer.worker import (
     WorkerHandle,
@@ -41,7 +40,10 @@ from flexkv.transfer.worker import (
     tpGDSTransferWorker,
     PEER2CPUTransferWorker,
 )
-from flexkv.transfer.layerwise import LayerwiseTransferWorker
+from flexkv.transfer.layerwise import (
+    LayerwiseTransferWorker,
+    build_layerwise_eventfd_socket_path,
+)
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.ring_buffer import SharedOpPool
 
@@ -193,8 +195,8 @@ class TransferEngine:
                         dtype=gpu_handles[0].dtype,
                         tp_group_size=self.tp_size,
                         dp_group_id=dp_client_id,
-                        is_nsa_cp=getattr(self.model_config, "is_nsa_cp", False),
-                        cp_size=getattr(self.model_config, "cp_size", 1),
+                        is_nsa_cp=self.model_config.is_nsa_cp,
+                        cp_size=self.model_config.cp_size,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -237,8 +239,8 @@ class TransferEngine:
                     dtype=gpu_handles[0].dtype,
                     tp_group_size=self.tp_size,
                     dp_group_id=dp_client_id,
-                    is_nsa_cp=getattr(self.model_config, "is_nsa_cp", False),
-                    cp_size=getattr(self.model_config, "cp_size", 1),
+                    is_nsa_cp=self.model_config.is_nsa_cp,
+                    cp_size=self.model_config.cp_size,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -345,10 +347,14 @@ class TransferEngine:
             ssd_files = {} if self._ssd_handle is None else self._ssd_handle.get_file_list()
             ssd_kv_layout = None if self._ssd_handle is None else self._ssd_handle.kv_layout
             num_blocks_per_file = 0 if self._ssd_handle is None else self._ssd_handle.num_blocks_per_file
-            _is_nsa_cp = getattr(self.model_config, 'is_nsa_cp', False)
-            _cp_size = getattr(self.model_config, 'cp_size', 1)
+            _is_nsa_cp = self.model_config.is_nsa_cp
+            _cp_size = self.model_config.cp_size
             # For CP, each CP rank connects via eventfd; for TP, each TP rank connects.
             _eventfd_group_size = _cp_size if _is_nsa_cp and _cp_size > 1 else self.tp_size
+
+            _layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
+                self.model_config
+            )
 
             # Prepare indexer handles for fused layerwise transfer
             has_indexer_for_layerwise = (
@@ -380,6 +386,7 @@ class TransferEngine:
                     pp_size=self.model_config.pp_size,
                     dp_size=self.model_config.dp_size,
                     dp_rank=dp_client_id,
+                    layerwise_eventfd_socket=_layerwise_eventfd_socket,
                     num_blocks_per_file=num_blocks_per_file,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
@@ -470,8 +477,8 @@ class TransferEngine:
                             dtype=indexer_gpu_handles_list[0].dtype,
                             tp_group_size=self.tp_size,
                             dp_group_id=dp_client_id,
-                            is_nsa_cp=getattr(self.model_config, "is_nsa_cp", False),
-                            cp_size=getattr(self.model_config, "cp_size", 1),
+                            is_nsa_cp=self.model_config.is_nsa_cp,
+                            cp_size=self.model_config.cp_size,
                             use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                             use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -514,8 +521,8 @@ class TransferEngine:
                         dtype=indexer_gpu_handles_list[0].dtype,
                         tp_group_size=self.tp_size,
                         dp_group_id=dp_client_id,
-                        is_nsa_cp=getattr(self.model_config, "is_nsa_cp", False),
-                        cp_size=getattr(self.model_config, "cp_size", 1),
+                        is_nsa_cp=self.model_config.is_nsa_cp,
+                        cp_size=self.model_config.cp_size,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -228,10 +228,30 @@ class TransferManager:
         if hasattr(self, 'transfer_engine'):
             self.transfer_engine.shutdown()
 
-def get_master_host_and_ports_from_env() -> Tuple[str, Tuple[str, str, str]]:
-    master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
+def resolve_master_host_and_ports(
+    master_host: Optional[str] = None,
+) -> Tuple[str, Tuple[str, str, str]]:
+    """Resolve the (master_host, master_ports) tuple for multi-node transfer.
+
+    ``master_host`` resolution order:
+        1. explicit ``master_host`` argument (when provided by the caller,
+           e.g. via sglang ``--dist-init-addr``);
+        2. ``FLEXKV_MASTER_HOST`` env var (used by framework-agnostic
+           launchers such as TRT-LLM's ``multi_node_launch.sh``);
+        3. ``"localhost"`` default.
+
+    ``master_ports`` always comes from ``FLEXKV_MASTER_PORTS`` (or default),
+    because changing ports rarely warrants a host-aware plumbing change.
+    """
+    if master_host is None:
+        master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
     master_ports = os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558")
     master_ports = tuple(master_ports.split(","))
+    flexkv_logger.info(
+        f"[TransferManager] resolved master endpoint: "
+        f"host={master_host!r} (source={'arg' if master_host is not None else 'env/default'}), "
+        f"ports={master_ports}"
+    )
     return "tcp://" + master_host, master_ports
 
 def get_trtllm_subprocess_host_and_ports_from_env() -> Tuple[str, Tuple[str, str, str]]:
@@ -244,9 +264,11 @@ class TransferManagerOnRemote(TransferManager):
     """
     TransferManager for remote mode, used for multi-node tensor parallelism.
     """
-    def __init__(self, mode: str = "Default"):
+    def __init__(self, mode: str = "Default", master_host: Optional[str] = None):
         if mode == "Default":
-            self.master_host, self.master_ports = get_master_host_and_ports_from_env()
+            self.master_host, self.master_ports = resolve_master_host_and_ports(
+                master_host=master_host
+            )
         elif mode == "TrtllmSubprocess":
             self.master_host, self.master_ports = get_trtllm_subprocess_host_and_ports_from_env()
         else:
@@ -842,20 +864,20 @@ class TranserManagerMultiNodeHandle(TransferManagerHandleBase):
         try:
             command_addr = f"{self.master_host}:{self.master_ports[0]}"
             self.command_socket.bind(command_addr)
-            flexkv_logger.debug(f"Master bound command port at {command_addr}")
+            flexkv_logger.info(f"Master bound command port at {command_addr}")
 
             result_addr = f"{self.master_host}:{self.master_ports[1]}"
             self.result_socket.bind(result_addr)
-            flexkv_logger.debug(f"Master bound result port at {result_addr}")
+            flexkv_logger.info(f"Master bound result port at {result_addr}")
 
             query_addr = f"{self.master_host}:{self.master_ports[2]}"
             self.query_socket.bind(query_addr)
-            flexkv_logger.debug(f"Master bound query port at {query_addr}")
+            flexkv_logger.info(f"Master bound query port at {query_addr}")
 
             self.result_socket.setsockopt(zmq.RCVTIMEO, 0)
 
             self._connected = True
-            flexkv_logger.debug("Master transfer manager ready for remote connections")
+            flexkv_logger.info("Master transfer manager ready for remote connections")
 
         except Exception as e:
             flexkv_logger.error(f"Master failed to bind ports: {e}")


### PR DESCRIPTION
## Summary

Replace device_count()-based probing and `FLEXKV_MASTER_HOST` / `FLEXKV_NODE_ID` / `FLEXKV_LOCAL_GPU_COUNT` env-var plumbing with explicit `ModelConfig` fields driven by the framework (sglang `server_args` / TRT-LLM launcher), so FlexKV and its callers cannot drift on the multi-node layout.

## Newly-derived variables

| Name | Formula |
|---|---|
| `gpus_per_node` | `(tp_size * pp_size) // nnodes` |
| `nnodes_per_tp_group` | `max(ceil(tp_size / gpus_per_node), 1)` (hard-capped at 2) |
| `tp_size_per_node` | `tp_size // nnodes_per_tp_group` |
| `local_tp_rank` | `tp_rank % tp_size_per_node` |
| `flexkv_master_host` | `server_args.dist_init_addr.split(":")[0]` if `nnodes > 1` else `None` |

## Renamed variables

| Old | New |
|---|---|
| `self.rank` | `self.is_sync_leader` |
| `self.tp_cpu_group` / `self.cp_cpu_group` (branched) | `self.sync_group` |
| `self.tp_size` / `self.cp_size` (branched for sync) | `self.sync_size` |
| `self.src_rank` | `self.sync_src` |
| `self.global_rank` | `self.world_rank` |
| `self.tp_node_count` (FlexKV) | `self.nnodes_per_tp_group` |
| `self.node_tp_size` | `self.tp_size_per_node` |
| `self.node_tp_rank` | `self.local_tp_rank` |
| `self.node_id` | `node_rank` (from `server_args.node_rank`) |
| `self.is_multinode_tp` | `nnodes_per_tp_group > 1` |
| `FLEXKV_MASTER_HOST` (env-only) | `ModelConfig.master_host` (explicit, env as fallback) |
| `FLEXKV_LOCAL_GPU_COUNT` (env) | `gpus_per_node` (derived, see above) |
| `FLEXKV_NODE_ID` (env) | `server_args.node_rank` / `ModelConfig.node_rank` |
> Note: the renames in the bottom rows that touch `BaseKVConnector` / `server_args._*` / `kvcache` live on the sglang side and are tracked by the companion sglang PR; they are listed here for review continuity.
