### PR TITLE
feat: add Pipeline Parallelism support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,20 @@ target_include_directories(xxhash PUBLIC
 install(FILES ${XXHASH_HEADERS} DESTINATION include)
 
 # ==================== prometheus-cpp Library ====================
-# Option to enable/disable monitoring (env FLEXKV_ENABLE_METRICS=0 or -DFLEXKV_ENABLE_MONITORING=OFF)
-set(_FLEXKV_MONITORING_DEFAULT ON)
+# Step 1: Auto-detect default from directory existence
+if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/third_party/prometheus-cpp")
+    set(_FLEXKV_MONITORING_DEFAULT ON)
+else()
+    set(_FLEXKV_MONITORING_DEFAULT OFF)
+    message(STATUS "third_party/prometheus-cpp not found, Prometheus monitoring defaults to OFF")
+endif()
+
+# Step 2: Environment variable override (FLEXKV_ENABLE_METRICS=1/0)
 if(DEFINED ENV{FLEXKV_ENABLE_METRICS})
-  if("$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "0" OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "OFF"
+  if("$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "1" OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "ON"
+      OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "YES" OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "TRUE")
+    set(_FLEXKV_MONITORING_DEFAULT ON)
+  elseif("$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "0" OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "OFF"
       OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "NO" OR "$ENV{FLEXKV_ENABLE_METRICS}" STREQUAL "FALSE")
     set(_FLEXKV_MONITORING_DEFAULT OFF)
   endif()

--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,11 @@ fi
 echo "=== Building in ${BUILD_TYPE} mode ==="
 
 # Install submodules
-git submodule update --init --recursive
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git submodule update --init --recursive
+else
+  echo "WARNING: Not a git repository, skipping submodule update. If submodules are missing, please clone the repo instead of copying."
+fi
 
 mkdir -p build
 cd build

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -419,14 +419,14 @@ PYBIND11_MODULE(c_ext, m) {
   py::class_<flexkv::LayerwiseTransferGroup>(m, "LayerwiseTransferGroup")
       .def(py::init<int, const std::vector<std::vector<torch::Tensor>> &,
                     torch::Tensor &, std::map<int, std::vector<std::string>> &,
-                    int, int, torch::Tensor &, torch::Tensor &, torch::Tensor &,
+                    int, torch::Tensor &, torch::Tensor &, torch::Tensor &,
                     torch::Tensor &, int, int, torch::Tensor &, int,
                     const std::vector<std::vector<torch::Tensor>> &,
                     torch::Tensor, torch::Tensor, torch::Tensor,
                     torch::Tensor, torch::Tensor,
                     std::map<int, std::vector<std::string>>>(),
            py::arg("num_gpus"), py::arg("gpu_blocks"), py::arg("cpu_blocks"),
-           py::arg("ssd_files"), py::arg("dp_group_id"), py::arg("num_layers"),
+           py::arg("ssd_files"), py::arg("num_layers"),
            py::arg("gpu_kv_strides_tensor"),
            py::arg("gpu_block_strides_tensor"),
            py::arg("gpu_layer_strides_tensor"),
@@ -510,13 +510,13 @@ PYBIND11_MODULE(c_ext, m) {
           py::init<std::map<int, std::vector<std::string>> &, int, int, int>());
 
   py::class_<flexkv::TPTransferThreadGroup>(m, "TPTransferThreadGroup")
-      .def(py::init<int, const std::vector<int64_t> &, int, int64_t, int, int,
+      .def(py::init<int, const std::vector<int64_t> &, int, int64_t, int,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
                     const std::vector<int64_t> &>(),
            py::arg("num_gpus"), py::arg("gpu_block_ptrs_flat"),
            py::arg("num_tensors_per_gpu"), py::arg("cpu_blocks_ptr"),
-           py::arg("dp_group_id"), py::arg("num_layers"),
+           py::arg("num_layers"),
            py::arg("gpu_kv_strides_in_bytes"),
            py::arg("gpu_block_strides_in_bytes"),
            py::arg("gpu_layer_strides_in_bytes"),
@@ -529,19 +529,19 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("cpu_block_stride_in_bytes"),
            py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_num_cta"),
            py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
-           py::arg("layer_id"), py::arg("layer_granularity"), py::arg("is_mla"),
-           py::arg("is_nsa_cp") = false);
+           py::arg("layer_id"), py::arg("layer_granularity"), py::arg("is_mla")
+           );
 
 #ifdef FLEXKV_ENABLE_GDS
   py::class_<flexkv::TPGDSTransferThreadGroup>(m, "TPGDSTransferThreadGroup")
       .def(py::init<int, const std::vector<int64_t> &, int,
-                    std::map<int, std::vector<std::string>> &, int, int,
+                    std::map<int, std::vector<std::string>> &, int,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
                     const std::vector<int64_t> &>(),
            py::arg("num_gpus"), py::arg("gpu_block_ptrs_flat"),
            py::arg("num_tensors_per_gpu"), py::arg("ssd_files"),
-           py::arg("dp_group_id"), py::arg("num_layers"),
+           py::arg("num_layers"),
            py::arg("gpu_kv_strides_in_bytes"),
            py::arg("gpu_block_strides_in_bytes"),
            py::arg("gpu_layer_strides_in_bytes"),

--- a/csrc/gds/tp_gds_transfer_thread_group.cpp
+++ b/csrc/gds/tp_gds_transfer_thread_group.cpp
@@ -9,7 +9,6 @@ TPGDSTransferThreadGroup::TPGDSTransferThreadGroup(
     const std::vector<int64_t> &gpu_block_ptrs_flat,
     int num_tensors_per_gpu,
     std::map<int, std::vector<std::string>> &ssd_files, 
-    int dp_group_id,
     int num_layers,
     const std::vector<int64_t> &gpu_kv_strides_in_bytes,
     const std::vector<int64_t> &gpu_block_strides_in_bytes,
@@ -19,7 +18,6 @@ TPGDSTransferThreadGroup::TPGDSTransferThreadGroup(
   
   num_gpus_ = num_gpus;
   num_tensors_per_gpu_ = num_tensors_per_gpu;
-  dp_group_id_ = dp_group_id;
   
   // per-GPU layout parameters
   gpu_kv_strides_in_bytes_ = new int64_t[num_gpus];

--- a/csrc/gds/tp_gds_transfer_thread_group.h
+++ b/csrc/gds/tp_gds_transfer_thread_group.h
@@ -27,7 +27,6 @@ public:
       const std::vector<int64_t> &gpu_block_ptrs_flat,
       int num_tensors_per_gpu,
       std::map<int, std::vector<std::string>> &ssd_files, 
-      int dp_group_id,
       int num_layers,
       const std::vector<int64_t> &gpu_kv_strides_in_bytes,
       const std::vector<int64_t> &gpu_block_strides_in_bytes,
@@ -54,7 +53,6 @@ private:
   std::future<void> enqueue_for_gpu(int gpu_idx, Task task);
 
   int num_gpus_;
-  int dp_group_id_;
   std::vector<int> gpu_device_ids_;
   void **gpu_blocks_;
   int num_tensors_per_gpu_;

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -61,7 +61,7 @@ static void CUDART_CB layer_done_host_callback(void *userData) {
 LayerwiseTransferGroup::LayerwiseTransferGroup(
     int num_gpus, const std::vector<std::vector<torch::Tensor>> &gpu_blocks,
     torch::Tensor &cpu_blocks,
-    std::map<int, std::vector<std::string>> &ssd_files, int dp_group_id,
+    std::map<int, std::vector<std::string>> &ssd_files,
     int num_layers, torch::Tensor &gpu_kv_strides_tensor,
     torch::Tensor &gpu_block_strides_tensor,
     torch::Tensor &gpu_layer_strides_tensor,
@@ -146,8 +146,6 @@ LayerwiseTransferGroup::LayerwiseTransferGroup(
   }
 
   cpu_blocks_ = cpu_blocks.data_ptr();
-
-  dp_group_id_ = dp_group_id;
 
   // Get GPU device IDs from tensors (like tp_transfer_thread_group.cpp)
   gpu_device_ids_.resize(num_gpus_);

--- a/csrc/layerwise.h
+++ b/csrc/layerwise.h
@@ -22,7 +22,7 @@ public:
   LayerwiseTransferGroup(
       int num_gpus, const std::vector<std::vector<torch::Tensor>> &gpu_blocks,
       torch::Tensor &cpu_blocks,
-      std::map<int, std::vector<std::string>> &ssd_files, int dp_group_id,
+      std::map<int, std::vector<std::string>> &ssd_files,
       int num_layers, torch::Tensor &gpu_kv_strides_tensor,
       torch::Tensor &gpu_block_strides_tensor,
       torch::Tensor &gpu_layer_strides_tensor,

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -22,7 +22,7 @@ namespace flexkv {
 
 TPTransferThreadGroup::TPTransferThreadGroup(
     int num_gpus, const std::vector<int64_t> &gpu_block_ptrs_flat,
-    int num_tensors_per_gpu, int64_t cpu_blocks_ptr, int dp_group_id,
+    int num_tensors_per_gpu, int64_t cpu_blocks_ptr,
     int num_layers, const std::vector<int64_t> &gpu_kv_strides_in_bytes,
     const std::vector<int64_t> &gpu_block_strides_in_bytes,
     const std::vector<int64_t> &gpu_layer_strides_in_bytes,
@@ -30,7 +30,6 @@ TPTransferThreadGroup::TPTransferThreadGroup(
     const std::vector<int64_t> &gpu_device_ids) {
   num_gpus_ = num_gpus;
   num_tensors_per_gpu_ = num_tensors_per_gpu;
-  dp_group_id_ = dp_group_id;
 
   gpu_kv_strides_in_bytes_ = new int64_t[num_gpus];
   gpu_block_strides_in_bytes_ = new int64_t[num_gpus];
@@ -156,8 +155,7 @@ void TPTransferThreadGroup::tp_group_transfer(
     const int64_t cpu_block_stride_in_bytes,
     const int64_t cpu_tp_stride_in_bytes, const int transfer_num_cta,
     const bool is_host_to_device, const bool use_ce_transfer,
-    const int layer_id, const int layer_granularity, const bool is_mla,
-    const bool is_nsa_cp) {
+    const int layer_id, const int layer_granularity, const bool is_mla) {
 
   std::atomic<bool> failed{false};
   std::string error_msg;

--- a/csrc/tp_transfer_thread_group.h
+++ b/csrc/tp_transfer_thread_group.h
@@ -38,7 +38,7 @@ public:
   TPTransferThreadGroup(int num_gpus,
                         const std::vector<int64_t> &gpu_block_ptrs_flat,
                         int num_tensors_per_gpu, int64_t cpu_blocks_ptr,
-                        int dp_group_id, int num_layers,
+                        int num_layers,
                         const std::vector<int64_t> &gpu_kv_strides_in_bytes,
                         const std::vector<int64_t> &gpu_block_strides_in_bytes,
                         const std::vector<int64_t> &gpu_layer_strides_in_bytes,
@@ -56,15 +56,13 @@ public:
                          const int transfer_num_cta,
                          const bool is_host_to_device,
                          const bool use_ce_transfer, const int layer_id,
-                         const int layer_granularity, const bool is_mla,
-                         const bool is_nsa_cp);
+                         const int layer_granularity, const bool is_mla);
 
 private:
   using Task = std::function<void()>;
   std::future<void> enqueue_for_gpu(int gpu_idx, Task task);
 
   int num_gpus_;
-  int dp_group_id_;
   std::vector<int> gpu_device_ids_;
   void **gpu_blocks_;
   void *cpu_blocks_;

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -398,7 +398,7 @@ class GlobalCacheEngine:
 
         if cache_config.enable_cpu:
             if cache_config.enable_p2p_cpu:
-                self.cpu_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.CPU, meta=self.redis_meta, pp_rank=self.model_config.pp_rank, pp_size=self.model_config.pp_size) #TODO
+                self.cpu_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.CPU, meta=self.redis_meta)
             elif self.index_accel:
                 self.cpu_cache_engine = CacheEngineAccel(DeviceType.CPU,
                                                 cache_config.num_cpu_blocks,
@@ -422,7 +422,7 @@ class GlobalCacheEngine:
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
         if cache_config.enable_ssd:
             if cache_config.enable_p2p_ssd:
-                self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta, pp_rank=self.model_config.pp_rank, pp_size=self.model_config.pp_size) #TODO
+                self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta)
             elif self.index_accel:
                 self.ssd_cache_engine = CacheEngineAccel(DeviceType.SSD,
                                                 cache_config.num_ssd_blocks,
@@ -447,7 +447,7 @@ class GlobalCacheEngine:
         if cache_config.enable_remote:
             if cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
-                self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta, pp_rank=self.model_config.pp_rank, pp_size=self.model_config.pp_size)
+                self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta)
             elif self.index_accel:
                 self.remote_cache_engine = CacheEngineAccel(DeviceType.REMOTE,
                                                    cache_config.num_remote_blocks,
@@ -532,14 +532,15 @@ class GlobalCacheEngine:
             slot_mapping: np.ndarray,
             layer_num: int = -1,
             layer_granularity: int = -1,
-            dp_id: int = 0,
+            dp_rank: int = 0,
+            pp_rank: int = 0,
             temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY,
             namespace: Optional[List[str]] = None) \
                  -> Tuple[TransferOpGraph, np.ndarray, Callable, Dict, int]:
         self._check_input(token_ids, token_mask, slot_mapping)
 
         if layer_num == -1:
-            layer_num = self.model_config.num_layers
+            layer_num = self.model_config.num_layers_per_pp_stage
         if layer_granularity == -1:
             layer_granularity = layer_num
 
@@ -561,7 +562,7 @@ class GlobalCacheEngine:
 
         if aligned_length == 0 or not token_mask.any():
             transfer_graph = TransferOpGraph.create_empty_graph()
-            transfer_graph.bind_to_dp_group(dp_id)
+            transfer_graph.bind_to_worker(dp_rank, pp_rank)
             return_mask = np.zeros_like(token_mask, dtype=np.bool_)
             callback = partial(self._transfer_callback, node_to_unlock={}, buffer_to_free={})
             return transfer_graph, return_mask, callback, {}, -1
@@ -616,7 +617,7 @@ class GlobalCacheEngine:
         #                                                                         finished_ops_ids=finished_ops_ids,
         #                                                                         layer_num=layer_num,
         #                                                                         layer_granularity=layer_granularity)
-        transfer_graph.bind_to_dp_group(dp_id)
+        transfer_graph.bind_to_worker(dp_rank, pp_rank)
 
         for device_type in node_to_unlock:
             self.cache_engines[device_type].lock_node(node_to_unlock[device_type][0])
@@ -1073,14 +1074,15 @@ class GlobalCacheEngine:
             token_mask: np.ndarray,
             slot_mapping: np.ndarray,
             layer_num : int = -1,
-            dp_id: int = 0,
+            dp_rank: int = 0,
+            pp_rank: int = 0,
             temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY,
             namespace: Optional[List[str]] = None) \
                 -> Tuple[TransferOpGraph, np.ndarray, Callable, Dict, int]:
         self._check_input(token_ids, token_mask, slot_mapping)
 
         if layer_num == -1:
-            layer_num = self.model_config.num_layers
+            layer_num = self.model_config.num_layers_per_pp_stage
         # ignore the last incomplete block
         aligned_length = (token_ids.shape[0] // self.tokens_per_block) * self.tokens_per_block
         aligned_token_ids = token_ids[:aligned_length]
@@ -1131,7 +1133,7 @@ class GlobalCacheEngine:
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
         return_mask[(block_start_idx + skipped_gpu_blocks)* self.tokens_per_block:
                     (block_start_idx + skipped_gpu_blocks + num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
-        transfer_graph.bind_to_dp_group(dp_id)
+        transfer_graph.bind_to_worker(dp_rank, pp_rank)
 
         for device_type in node_to_unlock:
             self.cache_engines[device_type].lock_node(node_to_unlock[device_type][0])

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple, TYPE_CHECKING, List, Dict
 
+import time
 import numpy as np
 import torch
 
@@ -37,9 +38,7 @@ class HierarchyLRCacheEngine:
                  evict_start_threshold: float = 1.0,
                  hit_reward_seconds: int = 0,
                  eviction_policy: str = "lru",
-                 meta: Optional[RedisMeta] = None,
-                 pp_rank: int = 0,
-                 pp_size: int = 1) -> None:
+                 meta: Optional[RedisMeta] = None) -> None:
         if num_total_blocks <= 0:
             raise ValueError(f"Invalid num_total_blocks: {num_total_blocks}")
         if tokens_per_block <= 0 or (tokens_per_block & (tokens_per_block - 1)) != 0:
@@ -92,8 +91,6 @@ class HierarchyLRCacheEngine:
         self.num_total_blocks = num_total_blocks
         self.evict_ratio = evict_ratio
         self.evict_start_threshold = evict_start_threshold
-        self.pp_rank = pp_rank
-        self.pp_size = pp_size
         
         # cumulative statistics: for analyzing distributed KV reuse benefits
         self._stats_total_queried_tokens = 0       # total tokens queried
@@ -116,12 +113,8 @@ class HierarchyLRCacheEngine:
         else:
             raise ValueError(f"Invalid device type: {self.device_type}")
 
-        if self.pp_size > 1:
-            local_ch_block_key = f"{base_key}:pp{self.pp_rank}"
-            remote_ch_block_key = f"{base_key}:pp{self.pp_rank}"
-        else:
-            local_ch_block_key = base_key
-            remote_ch_block_key = base_key
+        local_ch_block_key = base_key
+        remote_ch_block_key = base_key
         self.remote_ch = self._meta.get_redis_meta_channel(remote_ch_block_key)
         self.local_ch = self._meta.get_redis_meta_channel(local_ch_block_key)
                 # Load and store mapping of node_id -> file_nodeids from Redis
@@ -161,7 +154,6 @@ class HierarchyLRCacheEngine:
         num_blocks = sequence_meta.num_blocks
 
         # Query both local and remote
-        import time
         t0 = time.perf_counter()
         mr_local = self.local_index.match_prefix(block_hashes_t, int(num_blocks), True)
         t1 = time.perf_counter()
@@ -452,7 +444,7 @@ class HierarchyLRCacheEngine:
 
     #TODO pfcs may not work now
     @classmethod
-    def pcfs_ce_from_cache_config(cls, cache_config: "CacheConfig", node_id: int, meta: Optional[RedisMeta] = None, pp_rank: int = 0, pp_size: int = 1) -> "HierarchyLRCacheEngine":
+    def pcfs_ce_from_cache_config(cls, cache_config: "CacheConfig", node_id: int, meta: Optional[RedisMeta] = None) -> "HierarchyLRCacheEngine":
         """Create a PCFSCacheEngine from CacheConfig.
 
         This replaces RemotePCFSCacheEngine. It wires both local and remote
@@ -531,16 +523,14 @@ class HierarchyLRCacheEngine:
             local_safety_ttl_ms=int(GLOBAL_CONFIG_FROM_ENV.safety_ttl_ms),
             eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
             meta=meta,
-            pp_rank=pp_rank,
-            pp_size=pp_size,
         )
 
     #TODO is this enough for peercpu and peerssd?
     @classmethod
-    def from_cache_config(cls, cache_config: "CacheConfig", node_id: int, device_type: DeviceType, meta: Optional[RedisMeta] = None, pp_rank: int = 0, pp_size: int = 1) -> "HierarchyLRCacheEngine":
+    def from_cache_config(cls, cache_config: "CacheConfig", node_id: int, device_type: DeviceType, meta: Optional[RedisMeta] = None) -> "HierarchyLRCacheEngine":
 
         if device_type == DeviceType.REMOTE:
-            return cls.pcfs_ce_from_cache_config(cache_config, node_id, meta, pp_rank=pp_rank, pp_size=pp_size)
+            return cls.pcfs_ce_from_cache_config(cache_config, node_id, meta)
         else:
             # select correct blocks configuration based on device_type
             if device_type == DeviceType.CPU:
@@ -574,7 +564,5 @@ class HierarchyLRCacheEngine:
                 hit_reward_seconds=int(GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds),
                 eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
                 meta=meta,
-                pp_rank=pp_rank,
-                pp_size=pp_size,
             )
             raise ValueError("Invalid device type: {cache_config.device_type}")

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -680,14 +680,13 @@ class RedisMeta:
         # rpush returns the new length of the list
         return int(r.rpush(f"pcfs:{nid}", *values))
 
-    def regist_buffer(self, mrs: Iterable[object], pp_rank: int = 0, pp_size: int = 1) -> int:
+    def regist_buffer(self, mrs: Iterable[object]) -> int:
         """Register RDMA memory regions in Redis.
 
         Each element in mrs can be one of:
           - dict with keys {"buffer_ptr": ..., "buffer_size": ...}
           - tuple/list (buffer_ptr, buffer_size)
-        Stored as hash: key = buffer:<node_id>[:pp<pp_rank>]:<buffer_ptr>, field "buffer_size" = <buffer_size>.
-        When pp_size > 1, pp_rank is included in the key for isolation.
+        Stored as hash: key = buffer:<node_id>:<buffer_ptr>, field "buffer_size" = <buffer_size>.
         Returns the number of regions processed.
         """
         nid = self.get_node_id()
@@ -704,27 +703,21 @@ class RedisMeta:
                 continue
             if ptr is None or size is None:
                 continue
-            if pp_size > 1:
-                key = f"buffer:{nid}:pp{pp_rank}:{int(ptr)}"
-            else:
-                key = f"buffer:{nid}:{int(ptr)}"
+            key = f"buffer:{nid}:{int(ptr)}"
             pipe.hset(key, mapping={"buffer_size": int(size)})
             processed += 1
         if processed:
             pipe.execute()
         return processed
 
-    def unregist_buffer(self, buffer_ptr: Union[int, str], pp_rank: int = 0, pp_size: int = 1) -> bool:
+    def unregist_buffer(self, buffer_ptr: Union[int, str]) -> bool:
         """Unregister a previously registered RDMA memory region by buffer_ptr.
 
-        Looks up key buffer:<node_id>[:pp<pp_rank>]:<buffer_ptr> and deletes it if present.
+        Looks up key buffer:<node_id>:<buffer_ptr> and deletes it if present.
         Returns True if the key existed and was deleted, otherwise False.
         """
         nid = self.get_node_id()
-        if pp_size > 1:
-            key = f"buffer:{nid}:pp{pp_rank}:{int(buffer_ptr)}"
-        else:
-            key = f"buffer:{nid}:{int(buffer_ptr)}"
+        key = f"buffer:{nid}:{int(buffer_ptr)}"
         r = self._client()
         exists = bool(r.exists(key))
         if exists:
@@ -732,40 +725,31 @@ class RedisMeta:
             return True
         return False
 
-    def regist_node_meta(self, node_id: int, addr: str, zmq_addr: str, cpu_buffer_ptr: int, ssd_buffer_ptr: int, pp_rank: int = 0, pp_size: int = 1) -> None:
+    def regist_node_meta(self, node_id: int, addr: str, zmq_addr: str, cpu_buffer_ptr: int, ssd_buffer_ptr: int) -> None:
         """Register node meta information as a Redis hash.
 
-        Key: meta:<node_id>[:pp<pp_rank>]
-        When pp_size > 1, pp_rank is included in the key for PP rank isolation.
+        Key: meta:<node_id>
         Fields: node_id (int), addr (str), cpu_buffer_ptr (int), ssd_buffer_ptr (int)
         """
         r = self._client()
-        if pp_size > 1:
-            key = f"meta:{int(node_id)}:pp{pp_rank}"
-        else:
-            key = f"meta:{int(node_id)}"
+        key = f"meta:{int(node_id)}"
         r.hset(key, mapping={
             "node_id": int(node_id),
             "addr": str(addr),
             "zmq_addr": str(zmq_addr),
             "cpu_buffer_ptr": int(cpu_buffer_ptr),
             "ssd_buffer_ptr": int(ssd_buffer_ptr),
-            "pp_rank": int(pp_rank),
-            "pp_size": int(pp_size),
         })
 
-    def get_node_meta(self, node_id: int, pp_rank: int = 0, pp_size: int = 1) -> dict:
+    def get_node_meta(self, node_id: int) -> dict:
         """Get node meta information from Redis.
 
-        Reads key meta:<node_id>[:pp<pp_rank>] and returns a dict with fields:
+        Reads key meta:<node_id> and returns a dict with fields:
         node_id (int), addr (str), cpu_buffer_ptr (int), ssd_buffer_ptr (int).
         Returns empty dict if the key does not exist.
         """
         r = self._client()
-        if pp_size > 1:
-            key = f"meta:{int(node_id)}:pp{pp_rank}"
-        else:
-            key = f"meta:{int(node_id)}"
+        key = f"meta:{int(node_id)}"
         data = r.hgetall(key)
         if not data:
             return {}
@@ -780,16 +764,10 @@ class RedisMeta:
         out["ssd_buffer_ptr"] = int(sb) if sb is not None and sb != "" else 0
         return out
 
-    def unregist_node_meta(self, node_id: int, pp_rank: int = 0, pp_size: int = 1) -> bool:
-        """Unregister node meta by node_id. Returns True if deleted.
-        
-        When pp_size > 1, only deletes the key for the specified pp_rank.
-        """
+    def unregist_node_meta(self, node_id: int) -> bool:
+        """Unregister node meta by node_id. Returns True if deleted."""
         r = self._client()
-        if pp_size > 1:
-            key = f"meta:{int(node_id)}:pp{pp_rank}"
-        else:
-            key = f"meta:{int(node_id)}"
+        key = f"meta:{int(node_id)}"
         return bool(r.delete(key))
 
 

--- a/flexkv/cache/transfer_pattern.py
+++ b/flexkv/cache/transfer_pattern.py
@@ -61,7 +61,8 @@ def convert_read_graph_to_layer_wise_graph(
                 layer_id=i * layer_granularity,
                 layer_granularity=layer_granularity,
                 # Inherit these fields directly
-                dp_id=op.dp_id,
+                dp_rank=op.dp_rank,
+                pp_rank=op.pp_rank,
             )
             new_graph.add_transfer_op(new_op)
             split_op_ids.append(new_op.op_id)

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -1,6 +1,7 @@
 import os
 import json
-from dataclasses import dataclass
+import yaml
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Optional, List, Union, Dict, Any
 from argparse import Namespace
@@ -29,21 +30,40 @@ class ModelConfig:
     use_mla: bool = False
     dtype: torch.dtype = torch.bfloat16
 
-    # parallel configs
+    # ------------------------------------------------------------------
+    # Parallel configs
+    # ------------------------------------------------------------------
     tp_size: int = 1
-    dp_size: int = 1
-    dp_rank: int = 0
+    tp_rank: int = 0
+
     pp_size: int = 1
     pp_rank: int = 0
 
-    # topology configs
-    #   nnodes        : number of physical machines spanned by one replica
-    #                   (== server_args.nnodes in SGLang)
-    #   node_rank     : index of this machine within ``nnodes``
-    #                   (== server_args.node_rank in SGLang).  Used by
-    #                   KVTaskEngine's multi-node topology derivation and
-    #                   for logging; NOT embedded in the layerwise UDS
-    #                   socket path (UDS endpoints are kernel-local).
+    dp_size: int = 1
+    dp_rank: int = 0
+
+    # pp_start_layer / pp_end_layer: [start, end) layer indices for this PP stage.
+    pp_start_layer: int = 0
+    pp_end_layer: int = -1   # -1 → lazily resolved to num_layers
+
+    # ------------------------------------------------------------------
+    # Attention-level parallel configs
+    # ------------------------------------------------------------------
+    # enable_dp_attention: whether DP-attention is enabled (sglang
+    # ``--enable-dp-attention`` or TRT-LLM ``enable_attention_dp``).
+    # When True, the physical TP group is split into
+    # attn_tp × attn_cp × attn_dp.
+    enable_dp_attention: bool = False
+
+    # attn_cp_size / attn_cp_rank: context-parallel size/rank.
+    attn_cp_size: int = 1
+    attn_cp_rank: int = 0
+
+    # ------------------------------------------------------------------
+    # Topology configs
+    # ------------------------------------------------------------------
+    # nnodes: number of physical machines spanned by one replica
+    # node_rank: index of this machine within ``nnodes``
     nnodes: int = 1
     node_rank: int = 0
 
@@ -54,15 +74,144 @@ class ModelConfig:
     # ``--dist-init-addr``) to avoid exposing an extra env knob.
     master_host: Optional[str] = None
 
-    # NSA context parallelism: when True, layerwise transfer sends full
-    # (unpartitioned) KV cache to every rank instead of head-sliced data.
+    # NSA context parallelism: when True, every rank in the CP group holds
+    # identical (full) KV cache.  FlexKV treats CP ranks the same as TP ranks
+    # in MLA mode.
     is_nsa_cp: bool = False
-    cp_size: int = 1
+
+    # ------------------------------------------------------------------
+    # Freeze mechanism: after post_init, ModelConfig must not be mutated
+    # ------------------------------------------------------------------
+    _frozen: bool = field(default=False, init=False, repr=False)
+
+    def freeze(self) -> None:
+        """Lock the config so that any subsequent __setattr__ raises an error.
+        """
+        object.__setattr__(self, '_frozen', True)
+        flexkv_logger.info(
+            f"[FlexKV] ModelConfig FROZEN — primitive vars are now immutable. "
+            f"Derived: attn_tp_size={self.attn_tp_size}, attn_tp_rank={self.attn_tp_rank}, "
+            f"tp_size_per_node={self.tp_size_per_node}, "
+            f"nnodes_per_pp_rank={self.nnodes_per_pp_rank}, "
+            f"nnodes_per_tp_group={self.nnodes_per_tp_group}, "
+            f"total_gpus={self.total_gpus}, "
+            f"gpus_per_node={self.gpus_per_node}, "
+            f"num_kv_heads_per_node={self.num_kv_heads_per_node}, "
+            f"tp_rank_per_node={self.tp_rank_per_node}, "
+            f"local_rank={self.local_rank}"
+        )
+
+    def __setattr__(self, name: str, value) -> None:
+        if name == '_frozen':
+            return object.__setattr__(self, name, value)
+        if getattr(self, '_frozen', False):
+            raise AttributeError(
+                f"ModelConfig is frozen — cannot set '{name}'. "
+                f"All primitive fields must be set during post_init_from_*(), "
+                f"after which freeze() is called.  Derived fields (attn_tp_size, "
+                f"attn_tp_rank) are @property "
+                f"and cannot be set at all."
+            )
+        object.__setattr__(self, name, value)
+
+    # ------------------------------------------------------------------
+    # Derived topology properties
+    # ------------------------------------------------------------------
+    @property
+    def total_gpus(self) -> int:
+        """Total GPUs across all nodes for one FlexKV instance."""
+        return self.dp_size * self.tp_size * self.pp_size
+
+    @property
+    def gpus_per_node(self) -> int:
+        """Total GPUs on this node (across all DP, PP stages and TP groups)."""
+        return self.total_gpus // self.nnodes
+
+    @property
+    def nnodes_per_pp_rank(self) -> int:
+        """Number of nodes spanned by one PP stage."""
+        return max(self.nnodes // self.pp_size, 1)
+
+    @property
+    def nnodes_per_tp_group(self) -> int:
+        """Number of nodes spanned by one TP group."""
+        return self.nnodes_per_pp_rank
+
+    @property
+    def tp_size_per_node(self) -> int:
+        """Number of TP ranks on this node within one TP group."""
+        return self.tp_size // self.nnodes_per_tp_group
+
+    @property
+    def tp_rank_per_node(self) -> int:
+        """TP rank index within the local node (within one TP group)."""
+        return self.tp_rank % self.tp_size_per_node
+
+    @property
+    def local_rank(self) -> int:
+        """Local GPU device index within the node (a.k.a. ``LOCAL_RANK`` in
+        PyTorch distributed / sglang / vllm).
+
+        Matches the standard Megatron-style rank layout:
+            global_rank = dp_rank * pp_size * tp_size + pp_rank * tp_size + tp_rank
+
+        When DP-attention is enabled, DP replicas share the same physical
+        GPUs, so the DP dimension is not reflected in the device index.
+        The formula then reduces to:
+            local_rank = pp_rank_per_node * tp_size_per_node + tp_rank_per_node
+
+        When DP-attention is disabled, each DP replica has its own GPUs:
+            local_rank = (dp_rank_per_node * pp_size_per_node + pp_rank_per_node)
+                         * tp_size_per_node + tp_rank_per_node
+        where the ``_per_node`` values are derived inline from the global ranks
+        and topology.
+        """
+        pp_size_per_node = max(self.pp_size // self.nnodes, 1)
+        pp_rank_per_node = self.pp_rank % pp_size_per_node
+        if self.enable_dp_attention:
+            return pp_rank_per_node * self.tp_size_per_node + self.tp_rank_per_node
+        dp_size_per_node = self.gpus_per_node // (pp_size_per_node * self.tp_size_per_node)
+        dp_rank_per_node = self.dp_rank % dp_size_per_node
+        return (dp_rank_per_node * pp_size_per_node + pp_rank_per_node) * self.tp_size_per_node + self.tp_rank_per_node
+
+    @property
+    def attn_tp_size(self) -> int:
+        """Attention-level TP size derived from tp / attn_dp / attn_cp."""
+        attn_dp = max(1, self.dp_size) if self.enable_dp_attention else 1
+        cp = max(1, self.attn_cp_size)
+        return max(1, max(1, self.tp_size) // (attn_dp * cp))
+
+    @property
+    def attn_tp_rank(self) -> int:
+        """Attention-level TP rank derived from tp_rank / attn_tp_size."""
+        return self.tp_rank % max(1, self.attn_tp_size)
+
+    @property
+    def num_kv_heads_per_node(self) -> int:
+        """Number of KV heads visible to a single node."""
+        if self.use_mla:
+            return self.num_kv_heads
+        return self.num_kv_heads * self.tp_size_per_node // max(1, self.attn_tp_size)
+
+    @property
+    def kv_dim(self) -> int:
+        """KV dimension: 1 for MLA (no head split), 2 for standard (head split)."""
+        return 1 if self.use_mla else 2
+
+    @property
+    def num_layers_per_pp_stage(self) -> int:
+        """Number of layers managed by this PP stage."""
+        end = self.pp_end_layer if self.pp_end_layer >= 0 else self.num_layers
+        return end - self.pp_start_layer
 
     @property
     def token_size_in_bytes(self) -> int:
-        kv_dim = 1 if self.use_mla else 2
-        return self.num_layers * self.num_kv_heads * self.head_size * kv_dim * self.dtype.itemsize
+        return self.num_layers * self.num_kv_heads * self.head_size * self.kv_dim * self.dtype.itemsize
+
+    @property
+    def token_size_in_bytes_per_pp_stage(self) -> int:
+        """Token size in bytes for one PP stage (used by data plane)."""
+        return self.num_layers_per_pp_stage * self.num_kv_heads * self.head_size * self.kv_dim * self.dtype.itemsize
 
 @dataclass
 class CacheConfig:
@@ -229,10 +378,6 @@ def parse_path_list(path_str: str) -> List[str]:
     return paths
 
 def load_user_config_from_file(config_file: str) -> UserConfig:
-    import json
-    import yaml
-    from dataclasses import fields
-
     # read json config file or yaml config file
     if config_file.endswith('.json'):
         with open(config_file) as f:
@@ -275,7 +420,7 @@ def convert_to_block_num(size_in_GB: float, block_size_in_bytes: int) -> int:
 def update_default_config_from_user_config(model_config: ModelConfig,
                                            cache_config: CacheConfig,
                                            user_config: UserConfig) -> None:
-    block_size_in_bytes = model_config.token_size_in_bytes * cache_config.tokens_per_block
+    block_size_in_bytes = model_config.token_size_in_bytes_per_pp_stage * cache_config.tokens_per_block
 
     assert user_config.cpu_cache_gb > 0
     assert user_config.ssd_cache_gb >= 0

--- a/flexkv/common/tracer.py
+++ b/flexkv/common/tracer.py
@@ -195,7 +195,8 @@ class FlexKVTracer:
                      slot_mapping: Union[torch.Tensor, np.ndarray],
                      token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
                      layer_granularity: int = -1,
-                     dp_id: int = 0,
+                     dp_rank: int = 0,
+                     pp_rank: int = 0,
                      **kwargs):
         """Record a request operation"""
         if not self.enabled:
@@ -211,7 +212,8 @@ class FlexKVTracer:
             "slot_mapping": self._convert_tensor_to_list(slot_mapping),
             "token_mask": self._convert_tensor_to_list(token_mask) if token_mask is not None else None,
             "layer_granularity": layer_granularity,
-            "dp_id": dp_id,
+            "dp_rank": dp_rank,
+            "pp_rank": pp_rank,
             "token_ids_shape": list(token_ids.shape),
             "slot_mapping_shape": list(slot_mapping.shape),
             "token_mask_shape": list(token_mask.shape) if token_mask is not None else None,

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -9,6 +9,17 @@ from flexkv.common.debug import flexkv_logger
 
 
 @dataclass(frozen=True)
+class WorkerKey:
+    """Immutable, hashable key that uniquely identifies a worker by (dp_rank, pp_rank).
+
+    Used as dict keys in TransferEngine's worker maps and TransferManager's
+    GPU grouping instead of raw ``Tuple[int, int]`` to avoid ambiguity.
+    """
+    dp_rank: int
+    pp_rank: int
+
+
+@dataclass(frozen=True)
 class CompletedOp:
     graph_id: int
     op_id: int
@@ -91,7 +102,8 @@ class TransferOp:
     # this will keep the full info
     successors: Set[int] = field(default_factory=set)
     status: TransferOpStatus = TransferOpStatus.PENDING
-    dp_id: int = 0
+    dp_rank: int = 0
+    pp_rank: int = 0
     # used for get block ids inner worker process
     src_slot_id: int = -1
     dst_slot_id: int = -1
@@ -137,7 +149,8 @@ class LayerwiseTransferOp(TransferOp):
                 dst_block_ids_disk2h: np.ndarray,
                 layer_id: int = 0,
                 layer_granularity: int = 1,
-                dp_id: int = 0,
+                dp_rank: int = 0,
+                pp_rank: int = 0,
                 counter_id: int = 0,
                 indexer_src_block_ids: Optional[np.ndarray] = None,
                 indexer_dst_block_ids: Optional[np.ndarray] = None) -> None:
@@ -158,7 +171,8 @@ class LayerwiseTransferOp(TransferOp):
             dst_block_ids=np.array([], dtype=np.int64),
             layer_id=layer_id,
             layer_granularity=layer_granularity,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
         )
 
     def __post_init__(self) -> None:
@@ -289,13 +303,30 @@ class TransferOpGraph:
             assert op.src_block_ids.size == op.dst_block_ids.size, \
                 f"src_block_ids.size={op.src_block_ids.size}, dst_block_ids.size={op.dst_block_ids.size}"
 
+    def clear_gpu_blocks(self) -> None:
+        """Clear GPU block_ids from the graph.
+        """
+        for op_id in self._gpu_transfer_op_id:
+            op = self._op_map[op_id]
+            # Replace with empty arrays; set_gpu_blocks() will fill them later
+            if op.src_block_ids.size > 0:
+                op.src_block_ids = np.array([], dtype=op.src_block_ids.dtype)
+            if op.dst_block_ids.size > 0:
+                op.dst_block_ids = np.array([], dtype=op.dst_block_ids.dtype)
+
     @property
     def num_ops(self) -> int:
         return len(self._op_map)
 
-    def bind_to_dp_group(self, dp_id: int) -> None:
+    def bind_to_worker(self, dp_rank: int, pp_rank: int) -> None:
+        """Bind all ops in this graph to the specified DP group and PP stage.
+
+        Both fields are always set together because they jointly determine
+        which worker (GPU) handles the transfer.
+        """
         for op in self._op_map.values():
-            op.dp_id = dp_id
+            op.dp_rank = dp_rank
+            op.pp_rank = pp_rank
 
     def visualize(self) -> str:
         """
@@ -351,7 +382,7 @@ class TransferOpGraph:
                 dst_str = format_blocks(op.dst_block_ids)
                 lines.append(f"║     ├─ src_blocks:   {src_str}".ljust(71) + "║")
                 lines.append(f"║     ├─ dst_blocks:   {dst_str}".ljust(71) + "║")
-                lines.append(f"║     └─ layer_id={op.layer_id}, dp_id={op.dp_id}".ljust(71) + "║")
+                lines.append(f"║     └─ layer_id={op.layer_id}, dp_rank={op.dp_rank}, pp_rank={op.pp_rank}".ljust(71) + "║")
             else:
                 lines.append("║     └─ (VIRTUAL - no blocks)".ljust(71) + "║")
 
@@ -395,7 +426,8 @@ def _merge_ops(ops: List[TransferOp], transfer_type: TransferType,
         dst_block_ids=dst_blocks,
         layer_id=ops[0].layer_id,
         layer_granularity=ops[0].layer_granularity,
-        dp_id=ops[0].dp_id,
+        dp_rank=ops[0].dp_rank,
+        pp_rank=ops[0].pp_rank,
     )
     if callbacks:
         if len(callbacks) == 1:
@@ -481,7 +513,8 @@ def merge_to_batch_graph(batch_id: int,
                     else np.array([], dtype=np.int64),
                 layer_id=0,
                 layer_granularity=1,
-                dp_id=ops_by_type[TransferType.H2D][0].dp_id,
+                dp_rank=ops_by_type[TransferType.H2D][0].dp_rank,
+                pp_rank=ops_by_type[TransferType.H2D][0].pp_rank,
                 counter_id=counter_id,
                 # Indexer maps 1:1 with main KV blocks, use same block_ids
                 # CPU side (src) and GPU side (dst) for H2D direction

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -16,6 +16,28 @@ if TYPE_CHECKING:
 
 logger = flexkv_logger
 
+
+def _parse_dtype_str(dtype_str: str) -> torch.dtype:
+    """Convert a dtype string (e.g. 'fp8', 'bfloat16', 'fp8_e4m3') to torch.dtype.
+
+    Shared by sglang / vllm / TRT-LLM integration adapters so that dtype
+    parsing logic is defined in exactly one place.
+    """
+    dtype_map = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp32": torch.float32,
+        "bf16": torch.bfloat16,
+        "fp8": torch.float8_e4m3fn,
+        "float8": torch.float8_e4m3fn,
+        "e4m3": torch.float8_e4m3fn,
+        "fp8_e4m3": torch.float8_e4m3fn,
+    }
+    return dtype_map.get(dtype_str.lower(), torch.bfloat16)
+
+
 @dataclass
 class FlexKVConfig:
     enable_flexkv: bool = True
@@ -106,6 +128,17 @@ class FlexKVConfig:
         self.model_config.dp_size = vllm_config.parallel_config.data_parallel_size
         self.model_config.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self.model_config.pp_rank = getattr(vllm_config.parallel_config, 'pipeline_parallel_rank', 0)
+
+        if self.model_config.pp_size > 1:
+            from vllm.distributed.utils import get_pp_indices as vllm_get_pp_indices
+            start_layer, end_layer = vllm_get_pp_indices(
+                self.model_config.num_layers, self.model_config.pp_rank, self.model_config.pp_size
+            )
+            self.model_config.pp_start_layer = start_layer
+            self.model_config.pp_end_layer = end_layer
+        else:
+            self.model_config.pp_start_layer = 0
+            self.model_config.pp_end_layer = self.model_config.num_layers
         if self.model_config.use_mla:
             self.model_config.num_kv_heads = 1
         else:
@@ -117,57 +150,66 @@ class FlexKVConfig:
         hf_config = getattr(vllm_config.model_config, 'hf_config', None)
         self._detect_indexer_config_from_hf(hf_config, source="vllm")
 
+        logger.info(
+            f"[FlexKV vllm] Primitive vars set: tp_size={self.model_config.tp_size}, "
+            f"dp_size={self.model_config.dp_size}, dp_rank={self.model_config.dp_rank}, "
+            f"pp_size={self.model_config.pp_size}, pp_rank={self.model_config.pp_rank}, "
+            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
+            f"attn_cp_size={self.model_config.attn_cp_size}, "
+            f"attn_cp_rank={self.model_config.attn_cp_rank}"
+        )
+        logger.info(
+            f"[FlexKV vllm] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
+            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
+            f"local_rank={self.model_config.local_rank}"
+        )
+
+        # Freeze model_config — no further mutations allowed
+        self.model_config.freeze()
+
     def post_init_from_sglang_config(
         self,
         sglang_config,
-        tp_size: int,
-        page_size: int,
-        num_local_layers: int = 0,
-        pp_size: int = 1,
-        pp_rank: int = 0,
-        dp_size: int = 1,
-        dp_rank: int = 0,
-        nnodes: int = 1,
-        node_rank: int = 0,
-        is_nsa_cp: bool = False,
-        cp_size: int = 1,
-        cp_rank: int = 0,
-        kv_cache_dtype: Optional[str] = None,
-        master_host: Optional[str] = None,
+        server_args,
+        page_size: int = 64,
+        tp_rank: Optional[int] = 0,
+        pp_rank: Optional[int] = 0,
+        dp_rank: Optional[int] = 0,
+        attn_cp_rank: Optional[int] = 0,
     ):
         """
         Initialize FlexKVConfig fields from sglang config.
         Args:
             sglang_config: sglang.srt.configs.model_config.ModelConfig-like object
-            tp_size: tensor parallel size used by sglang
+            server_args: sglang ServerArgs — source of tp_size, dp_size,
+                nnodes, node_rank, enable_dp_attention, attn_cp_size,
+                is_nsa_cp, kv_cache_dtype, dist_init_addr
             page_size: KV block size (tokens per block) used by sglang
-            num_local_layers: number of layers on this PP rank (0 means no PP, use total layers)
-            pp_size: pipeline parallel size (default 1, no PP)
-            pp_rank: pipeline parallel rank (default 0)
-            dp_size: data parallel size (default 1, no DP)
-            dp_rank: data parallel rank (default 0)
-            nnodes: number of nodes (aligned with server_args.nnodes, default 1)
-            node_rank: index of this node (aligned with server_args.node_rank, default 0)
-            is_nsa_cp: whether NSA context parallelism is enabled
-            cp_size: context parallel size (default 1, no CP)
-            cp_rank: context parallel rank (default 0)
-            kv_cache_dtype: KV cache dtype (default None, use model dtype)
-            master_host: master host for multi-node setup (default None, use localhost)
+            tp_rank: physical tensor parallel rank (runtime, from process group)
+            pp_rank: pipeline parallel rank (runtime, from process group)
+            dp_rank: data parallel rank (runtime, from process group)
+            attn_cp_rank: attention-level context parallel rank (runtime)
         """
+        # Extract parallelism params from server_args
+        tp_size = server_args.tp_size
+        pp_size = server_args.pp_size
+        dp_size = server_args.dp_size
+        nnodes = server_args.nnodes
+        node_rank = server_args.node_rank
+        enable_dp_attention = server_args.enable_dp_attention
+        attn_cp_size = server_args.attn_cp_size
+        is_nsa_cp = getattr(server_args, 'enable_nsa_prefill_context_parallel', False)
+        kv_cache_dtype = getattr(server_args, 'kv_cache_dtype', None)
+
         # cache config: use page_size as tokens_per_block so that FlexKV's
         # CPU radix tree manages blocks at page granularity, ensuring that
         # hash generation, matching, insertion and eviction are all page-aligned.
         self.cache_config.tokens_per_block = page_size
 
-        total_layers = int(getattr(sglang_config, "num_hidden_layers", 0))
-        self.model_config.num_layers = int(num_local_layers) if num_local_layers > 0 else total_layers
+        self.model_config.num_layers = int(getattr(sglang_config, "num_hidden_layers", 0))
 
-        attn_arch = getattr(sglang_config, "attention_arch", None)
-        use_mla = False
-        if hasattr(attn_arch, "name"):
-            use_mla = (attn_arch.name.upper() == "MLA")
-        elif isinstance(attn_arch, str):
-            use_mla = (attn_arch.upper() == "MLA")
+        from sglang.srt.configs.model_config import AttentionArch
+        use_mla = getattr(sglang_config, "attention_arch", None) == AttentionArch.MLA
 
         if use_mla:
             kv_lora_rank = int(getattr(sglang_config, "kv_lora_rank", 0))
@@ -196,21 +238,6 @@ class FlexKVConfig:
         # to the sglang model dtype.  sglang's ModelConfig.dtype is the *model
         # weight* dtype (e.g. bfloat16), which may differ from the KV cache
         # dtype (e.g. fp8_e4m3 when --kv-cache-dtype fp8_e4m3 is used).
-        def _parse_dtype_str(dtype_str: str) -> torch.dtype:
-            dtype_map = {
-                "float16": torch.float16,
-                "float32": torch.float32,
-                "bfloat16": torch.bfloat16,
-                "fp16": torch.float16,
-                "fp32": torch.float32,
-                "bf16": torch.bfloat16,
-                "fp8": torch.float8_e4m3fn,
-                "float8": torch.float8_e4m3fn,
-                "e4m3": torch.float8_e4m3fn,
-                "fp8_e4m3": torch.float8_e4m3fn,
-            }
-            return dtype_map.get(dtype_str.lower(), torch.bfloat16)
-
         user_dtype_str = self.user_config.kv_cache_dtype
         if user_dtype_str is not None:
             self.model_config.dtype = _parse_dtype_str(user_dtype_str)
@@ -251,47 +278,34 @@ class FlexKVConfig:
         self.model_config.use_mla = use_mla
 
         self.model_config.tp_size = int(tp_size)
+        self.model_config.tp_rank = int(tp_rank)
         self.model_config.dp_size = int(dp_size if dp_size is not None else 1)
         self.model_config.dp_rank = int(dp_rank if dp_rank is not None else 0)
         self.model_config.pp_size = int(pp_size)
         self.model_config.pp_rank = int(pp_rank)
+
+        if pp_size > 1:
+            from sglang.srt.distributed.utils import get_pp_indices as sglang_get_pp_indices
+            start_layer, end_layer = sglang_get_pp_indices(
+                self.model_config.num_layers, self.model_config.pp_rank, self.model_config.pp_size
+            )
+            self.model_config.pp_start_layer = start_layer
+            self.model_config.pp_end_layer = end_layer
+        else:
+            self.model_config.pp_start_layer = 0
+            self.model_config.pp_end_layer = self.model_config.num_layers
+        self.model_config.enable_dp_attention = bool(enable_dp_attention)
+        self.model_config.attn_cp_size = int(attn_cp_size)
+        self.model_config.attn_cp_rank = int(attn_cp_rank)
         self.model_config.is_nsa_cp = is_nsa_cp
-        self.model_config.cp_size = int(cp_size if cp_size is not None else 1)
-        # Topology: nnodes + node_rank (aligned with sglang server_args).
-        # ``gpus_per_node`` is no longer stored on model_config; KVTaskEngine
-        # derives it locally as (tp_size * pp_size) // nnodes.
         self.model_config.nnodes = max(1, int(nnodes))
         self.model_config.node_rank = int(node_rank)
         # Multi-node bootstrap: master host (derived from sglang --dist-init-addr).
         # ``None`` here falls back to FLEXKV_MASTER_HOST env var downstream.
+        _dist_init_addr = getattr(server_args, 'dist_init_addr', None)
+        master_host = _dist_init_addr.split(":")[0] if _dist_init_addr and int(nnodes) > 1 else None
         self.model_config.master_host = master_host
         update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
-
-        # Each PP rank needs its own IPC ports so that their
-        # KVManager / TransferManager instances do not collide on the same
-        # ZMQ endpoint.  DP ranks share the same KVServer (only DP0 creates
-        # it), so they must use the same IPC port.
-        _dp_rank = int(dp_rank if dp_rank is not None else 0)
-        port_suffix = ""
-        if int(pp_size) > 1:
-            port_suffix += f"_pp{int(pp_rank)}"
-        if port_suffix:
-            self.server_recv_port = f"{self.server_recv_port}{port_suffix}"
-            self.gpu_register_port = f"{self.server_recv_port}_gpu_register"
-
-        rank_parts = []
-        if int(tp_size) > 1:
-            rank_parts.append("tp_rank=0")
-        if int(pp_size) > 1:
-            rank_parts.append(f"pp_rank={int(pp_rank)}")
-        if int(self.model_config.dp_size) > 1:
-            rank_parts.append(f"dp_rank={_dp_rank}")
-        rank_label = f" [{', '.join(rank_parts)}]" if rank_parts else ""
-        logger.info(
-            f"[FlexKV] IPC ports configured{rank_label}: "
-            f"server_recv_port={self.server_recv_port}, "
-            f"gpu_register_port={self.gpu_register_port}"
-        )
 
         hf_config = getattr(sglang_config, 'hf_config', None)
         self._detect_indexer_config_from_hf(hf_config, source="sglang")
@@ -305,6 +319,29 @@ class FlexKVConfig:
                 f"tokens_per_block={self.cache_config.tokens_per_block}"
             )
 
+        # Log primitive and derived variables for verification
+        logger.info(
+            f"[FlexKV sglang] Primitive vars set: tp_size={self.model_config.tp_size}, "
+            f"tp_rank={self.model_config.tp_rank}, dp_size={self.model_config.dp_size}, "
+            f"dp_rank={self.model_config.dp_rank}, pp_size={self.model_config.pp_size}, "
+            f"pp_rank={self.model_config.pp_rank}, "
+            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
+            f"attn_cp_size={self.model_config.attn_cp_size}, "
+            f"attn_cp_rank={self.model_config.attn_cp_rank}, "
+            f"is_nsa_cp={self.model_config.is_nsa_cp}, "
+            f"nnodes={self.model_config.nnodes}, node_rank={self.model_config.node_rank}"
+        )
+        logger.info(
+            f"[FlexKV sglang] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
+            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
+            f"tp_rank_per_node={self.model_config.tp_rank_per_node}, "
+            f"tp_size_per_node={self.model_config.tp_size_per_node}, "
+            f"local_rank={self.model_config.local_rank}"
+        )
+
+        # Freeze model_config — no further mutations allowed
+        self.model_config.freeze()
+
     def post_init_from_trt_config(
         self,
         config,
@@ -313,21 +350,6 @@ class FlexKVConfig:
         # Convert dtype string to torch.dtype
         dtype_str = config.pytorch_backend_config.kv_cache_dtype
         flexkv_logger.info(f"[FlexKVConfig] dtype_str from TRT config: {dtype_str}")
-
-        # Helper function to convert dtype string to torch.dtype
-        def _parse_dtype_str(dtype_str: str) -> torch.dtype:
-            dtype_map = {
-                "float16": torch.float16,
-                "float32": torch.float32,
-                "bfloat16": torch.bfloat16,
-                "fp16": torch.float16,
-                "fp32": torch.float32,
-                "bf16": torch.bfloat16,
-                "fp8": torch.float8_e4m3fn,
-                "float8": torch.float8_e4m3fn,
-                "e4m3": torch.float8_e4m3fn,
-            }
-            return dtype_map.get(dtype_str.lower(), torch.bfloat16)
 
         if dtype_str == "auto":
             # When dtype_str is "auto", try to get kv_cache_dtype from user_config first
@@ -362,6 +384,14 @@ class FlexKVConfig:
         self.model_config.pp_size = getattr(config.mapping, 'pp_size', 1)
         self.model_config.pp_rank = getattr(config.mapping, 'pp_rank', 0)
 
+        if self.model_config.pp_size > 1:
+            layers_range = config.mapping.pp_layers(self.model_config.num_layers)
+            self.model_config.pp_start_layer = layers_range[0]
+            self.model_config.pp_end_layer = layers_range[-1] + 1
+        else:
+            self.model_config.pp_start_layer = 0
+            self.model_config.pp_end_layer = self.model_config.num_layers
+
         # self.model_config (model configs part)
         try:
             model_path = getattr(config, 'hf_model_dir', None)
@@ -392,3 +422,23 @@ class FlexKVConfig:
             flexkv_logger.error(f"Failed to load config from {model_path}: {e}")
         # Update cache config with user config after model config is initialized
         update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
+
+        # Log primitive and derived variables for verification
+        flexkv_logger.info(
+            f"[FlexKV TRT-LLM] Primitive vars set: tp_size={self.model_config.tp_size}, "
+            f"tp_rank={self.model_config.tp_rank}, dp_size={self.model_config.dp_size}, "
+            f"dp_rank={self.model_config.dp_rank}, pp_size={self.model_config.pp_size}, "
+            f"pp_rank={self.model_config.pp_rank}, "
+            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
+            f"attn_cp_size={self.model_config.attn_cp_size}, "
+            f"attn_cp_rank={self.model_config.attn_cp_rank}, "
+            f"nnodes={self.model_config.nnodes}, node_rank={self.model_config.node_rank}"
+        )
+        flexkv_logger.info(
+            f"[FlexKV TRT-LLM] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
+            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
+            f"local_rank={self.model_config.local_rank}"
+        )
+
+        # Freeze model_config — no further mutations allowed
+        self.model_config.freeze()

--- a/flexkv/integration/tensorrt_llm/trtllm_adapter.py
+++ b/flexkv/integration/tensorrt_llm/trtllm_adapter.py
@@ -45,7 +45,7 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         self.flexkv_manager = KVManager(model_config=self.model_config,
                                         cache_config=self.cache_config,
                                         server_recv_port=flexkv_config.server_recv_port,
-                                        dp_client_id=self.dp_rank)
+                                        dp_client_id=self.model_config.dp_rank)
         self.flexkv_manager.start()
         # self.dp_client = KVDPClient(self.server_recv_port, self.model_config)
 
@@ -209,6 +209,8 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         task_id, matched_mask = self.flexkv_manager.get_match(
             token_ids=np_token_ids,
             token_mask=np_token_mask,
+            dp_rank=self.flexkv_config.model_config.dp_rank,
+            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
         num_new_matched_tokens = matched_mask.sum().item()
@@ -366,6 +368,8 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         
         task_id, unmatched_mask = self.flexkv_manager.put_match(
             token_ids=np_token_ids,
+            dp_rank=self.flexkv_config.model_config.dp_rank,
+            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
 
@@ -538,26 +542,30 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
             self.remote_process = TransferManagerOnRemote.create_process()
             flexkv_logger.info(f"TransferManagerOnRemote process created, PID: {self.remote_process.pid}")
         
-        flexkv_logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, dp_client_id: {dp_client_id}")
-        self.tp_client = KVTPClient(flexkv_config.gpu_register_port, dp_client_id, current_device_id)
+        flexkv_logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, dp_rank: {dp_rank}")
+        self.tp_client = KVTPClient(flexkv_config.gpu_register_port, dp_rank=dp_rank, pp_rank=0, device_id=current_device_id)
         flexkv_logger.info("Finish init FlexKVWorkerConnector")
     
     def _need_to_create_remote_process(self) -> bool:
         """Check if need to create TransferManagerOnRemote process.
         
         Returns True when all of the following conditions are met:
-        - Multi-node TP is detected (tp_size > gpus_per_node)
+        - Multi-node TP is detected (nnodes_per_tp_group > 1)
         - Current node is not master node (node_rank > 0)
-        - Current worker is worker0 in TP group (tp_rank == 0)
+        - Current worker is worker0 in the local TP group (tp_rank_per_node == 0)
         
         Returns:
             bool: True if need to create TransferManagerOnRemote process, False otherwise.
         """
         try:
             is_master_node = self.node_rank == 0
-            is_first_worker = self.tp_rank % 8 == 0
-            is_multinode_tp = self.flexkv_config.model_config.tp_size > torch.cuda.device_count()
-            flexkv_logger.info(f"{is_master_node=}, {is_first_worker=}, {is_multinode_tp=}")
+            is_first_worker = self.flexkv_config.model_config.tp_rank_per_node == 0
+            is_multinode_tp = self.flexkv_config.model_config.nnodes_per_tp_group > 1
+            flexkv_logger.info(
+                f"{is_master_node=}, {is_first_worker=}, {is_multinode_tp=}, "
+                f"nnodes_per_tp_group={self.flexkv_config.model_config.nnodes_per_tp_group}, "
+                f"tp_rank_per_node={self.flexkv_config.model_config.tp_rank_per_node}"
+            )
             
             return is_multinode_tp and not is_master_node and is_first_worker
         except Exception as e:

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -336,6 +336,8 @@ class FlexKVSchedulerConnector:
         task_id, matched_mask = self.flexkv_manager.get_match(
             token_ids=np_token_ids,
             token_mask=np_token_mask,
+            dp_rank=self.flexkv_config.model_config.dp_rank,
+            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
         num_new_matched_tokens = matched_mask.sum().item()
@@ -484,6 +486,8 @@ class FlexKVSchedulerConnector:
         namespace = self._extract_namespace(request)
         task_id, unmatched_mask = self.flexkv_manager.put_match(
             token_ids=np_token_ids,
+            dp_rank=self.flexkv_config.model_config.dp_rank,
+            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
 
@@ -704,7 +708,10 @@ class FlexKVWorkerConnector:
         logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, "
                     f"server_client_mode={server_client_mode}, dp_client_id={dp_client_id}, "
                     f"client_id={client_id}, device_id={device_id}")
-        self.tp_client = KVTPClient(flexkv_config.gpu_register_port, client_id, device_id)
+        self.tp_client = KVTPClient(flexkv_config.gpu_register_port,
+                                    dp_rank=client_id,
+                                    pp_rank=self.flexkv_config.model_config.pp_rank,
+                                    device_id=device_id)
         logger.info("Finish init FlexKVWorkerConnector")
 
     def register_to_server(self, kv_caches: dict[str, torch.Tensor]):

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -151,7 +151,8 @@ class KVManager:
                   slot_mapping: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
                   layer_granularity: int = -1,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> int:
         if isinstance(token_ids, torch.Tensor):
@@ -165,13 +166,15 @@ class KVManager:
                                                slot_mapping,
                                                token_mask,
                                                layer_granularity,
+                                               pp_rank=pp_rank,
                                                namespace=namespace)
         else:
             task_id, _ = self.kv_task_engine.get_async(token_ids,
                                                        slot_mapping,
                                                        token_mask,
                                                        layer_granularity,
-                                                       dp_id,
+                                                       dp_rank,
+                                                       pp_rank=pp_rank,
                                                        namespace=namespace)
         return task_id
 
@@ -179,7 +182,8 @@ class KVManager:
                   token_ids: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
                   layer_granularity: int = -1,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   namespace: Optional[List[str]] = None,
                   ) -> Tuple[int, np.ndarray]:
@@ -191,13 +195,15 @@ class KVManager:
             task_id, mask = self.dp_client.get_match(token_ids,
                                                      token_mask,
                                                      layer_granularity,
+                                                     pp_rank=pp_rank,
                                                      cpu_only=cpu_only,
                                                      namespace=namespace)
         else:
             task_id, mask = self.kv_task_engine.get_match(token_ids,
                                                           token_mask,
                                                           layer_granularity,
-                                                          dp_id,
+                                                          dp_rank,
+                                                          pp_rank=pp_rank,
                                                           cpu_only=cpu_only,
                                                           namespace=namespace)
         return task_id, mask
@@ -206,7 +212,8 @@ class KVManager:
                   token_ids: Union[torch.Tensor, np.ndarray],
                   slot_mapping: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> int:
         if isinstance(token_ids, torch.Tensor):
@@ -216,15 +223,16 @@ class KVManager:
         if isinstance(token_mask, torch.Tensor):
             token_mask = token_mask.numpy()
         if self.server_client_mode:
-            task_id = self.dp_client.put_async(token_ids, slot_mapping, token_mask, namespace=namespace)
+            task_id = self.dp_client.put_async(token_ids, slot_mapping, token_mask, pp_rank=pp_rank, namespace=namespace)
         else:
-            task_id, _ = self.kv_task_engine.put_async(token_ids, slot_mapping, token_mask, dp_id, namespace=namespace)
+            task_id, _ = self.kv_task_engine.put_async(token_ids, slot_mapping, token_mask, dp_rank, pp_rank=pp_rank, namespace=namespace)
         return task_id
 
     def put_match(self,
                   token_ids: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> Tuple[int, np.ndarray]:
         if isinstance(token_ids, torch.Tensor):
@@ -232,21 +240,22 @@ class KVManager:
         if isinstance(token_mask, torch.Tensor):
             token_mask = token_mask.numpy()
         if self.server_client_mode:
-            task_id, mask = self.dp_client.put_match(token_ids, token_mask, namespace=namespace)
+            task_id, mask = self.dp_client.put_match(token_ids, token_mask, pp_rank=pp_rank, namespace=namespace)
         else:
-            task_id, mask = self.kv_task_engine.put_match(token_ids, token_mask, dp_id, namespace=namespace)
+            task_id, mask = self.kv_task_engine.put_match(token_ids, token_mask, dp_rank, pp_rank=pp_rank, namespace=namespace)
         return task_id, mask
 
     def prefetch_async(self,
                        token_ids: np.ndarray,
-                       dp_id: int = 0,
+                       dp_rank: int = 0,
+                       pp_rank: int = 0,
                        namespace: Optional[List[str]] = None) -> int:
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
         if self.server_client_mode:
-            task_id = self.dp_client.prefetch_async(token_ids, namespace=namespace)
+            task_id = self.dp_client.prefetch_async(token_ids, pp_rank=pp_rank, namespace=namespace)
         else:
-            task_id = self.kv_task_engine.prefetch_async(token_ids, dp_id=dp_id, namespace=namespace)
+            task_id = self.kv_task_engine.prefetch_async(token_ids, dp_rank=dp_rank, pp_rank=pp_rank, namespace=namespace)
         return task_id
 
     def launch(self,

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -25,6 +25,7 @@ from flexkv.transfer_manager import (
 )
 from flexkv.cache.redis_meta import RedisMeta
 from flexkv.integration.dynamo.collector import KVEventCollector
+from flexkv.transfer_manager import TransferManagerMultiNodeHandle
 
 class TaskStatus(Enum):
     # slot mapping is not ready
@@ -60,13 +61,15 @@ class KVTask:
     token_ids: np.ndarray
     slot_mapping: np.ndarray
     token_mask: Optional[np.ndarray]
-    dp_id: int
 
     # cache engine return
     graph: TransferOpGraph
     return_mask: Union[np.ndarray, list[np.ndarray]]
     callback: Optional[Union[Callable, List[Callable]]]
     op_callback_dict: Dict[int, Callable]
+
+    dp_rank: int = 0
+    pp_rank: int = 0
 
     # batch: points to the batch task id if this task was merged into a batch
     batch_task_id: Optional[int] = None
@@ -151,21 +154,10 @@ class KVTaskManager:
 
         self.cache_engine = GlobalCacheEngine(cache_config, model_config, redis_meta, event_collector)
 
-        model_config_for_transfer = copy.deepcopy(self.model_config)
-        if self.nnodes_per_tp_group > 1:
-            model_config_for_transfer.tp_size //= self.nnodes_per_tp_group
-            if not self.model_config.use_mla:
-                model_config_for_transfer.num_kv_heads //= self.nnodes_per_tp_group
-            # When NSA CP is active, cp_size mirrors tp_size and must also
-            # be divided so that TransferEngine's _eventfd_group_size matches
-            # the number of local GPUs on each node.
-            if model_config_for_transfer.is_nsa_cp and model_config_for_transfer.cp_size > 1:
-                model_config_for_transfer.cp_size //= self.nnodes_per_tp_group
-
         combine_with_trtllm = os.getenv("FLEXKV_WITH_TRTLLM", "0") == "1"
         if not combine_with_trtllm:
             self.transfer_handles = [TransferManagerHandle(
-                model_config_for_transfer,
+                self.model_config,
                 self.cache_config,
                 mode="process",
                 gpu_register_port=gpu_register_port
@@ -178,7 +170,7 @@ class KVTaskManager:
             self.remote_process = TransferManagerOnRemote.create_process(mode="TrtllmSubprocess")
             self.transfer_handles = [
                 TransferManagerHandle(
-                    model_config_for_transfer,
+                    self.model_config,
                     self.cache_config,
                     mode="remote",
                     gpu_register_port=gpu_register_port,
@@ -188,12 +180,12 @@ class KVTaskManager:
             ]
             self.transfer_handles[0]._handle.send_config_to_remotes()
 
-        if self.nnodes_per_tp_group > 1:
+        if self.model_config.nnodes > 1:
             master_host, master_ports = resolve_master_host_and_ports(
                 master_host=self.model_config.master_host
             )
             self.transfer_handles.append(TransferManagerHandle(
-                model_config_for_transfer,
+                self.model_config,
                 self.cache_config,
                 mode="remote",
                 gpu_register_port=gpu_register_port,
@@ -246,7 +238,8 @@ class KVTaskManager:
                         slot_mapping: np.ndarray,
                         token_mask: Optional[np.ndarray] = None,
                         layer_granularity: int = -1,
-                        dp_id: int = 0,
+                        dp_rank: int = 0,
+                        pp_rank: int = 0,
                         is_fake_slot_mapping: bool = False,
                         temp_cache_strategy=DEFAULT_CACHE_STRATEGY,
                         namespace: Optional[List[str]] = None,
@@ -258,9 +251,10 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=token_mask,
             slot_mapping=slot_mapping,
-            layer_num=self.model_config.num_layers,
+            layer_num=self.model_config.num_layers_per_pp_stage,
             layer_granularity=layer_granularity,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
             temp_cache_strategy=temp_cache_strategy,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
@@ -272,7 +266,8 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -285,7 +280,8 @@ class KVTaskManager:
                         token_ids: np.ndarray,
                         slot_mapping: np.ndarray,
                         token_mask: Optional[np.ndarray] = None,
-                        dp_id: int = 0,
+                        dp_rank: int = 0,
+                        pp_rank: int = 0,
                         is_fake_slot_mapping: bool = False,
                         namespace: Optional[List[str]] = None,
                         ) -> None:
@@ -296,8 +292,9 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=token_mask,
             slot_mapping=slot_mapping,
-            layer_num=self.model_config.num_layers,
-            dp_id=dp_id,
+            layer_num=self.model_config.num_layers_per_pp_stage,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
             task_id=task_id,
@@ -308,7 +305,8 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -318,6 +316,7 @@ class KVTaskManager:
     def create_prefetch_task(self,
                             task_id: int,
                             token_ids: np.ndarray,
+                            pp_rank: int = 0,
                             namespace: Optional[List[str]] = None,
                             ) -> None:
         if task_id in self.tasks:
@@ -332,7 +331,9 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=fake_token_mask,
             slot_mapping=fake_slot_mapping,
-            layer_num=self.model_config.num_layers,
+            layer_num=self.model_config.num_layers_per_pp_stage,
+            dp_rank=0,  # dp_rank irrelevant: prefetch only uploads to CPU (ignore_gpu=True)
+            pp_rank=pp_rank,
             temp_cache_strategy=temp_cache_strategy,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
@@ -344,7 +345,8 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=fake_slot_mapping,  # ignore slot_mapping for prefetch
             token_mask=fake_token_mask,  # ignore token_mask for prefetch
-            dp_id=0,  # ignore dp_id for prefetch
+            dp_rank=0,  # ignore dp_rank for prefetch
+            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -361,7 +363,21 @@ class KVTaskManager:
         nvtx.mark(f"launch task: task_id={task_id}, graph_id={transfer_graph.graph_id}")
         if transfer_graph.num_ops > 0:
             for transfer_handle in self.transfer_handles:
-                transfer_handle.submit(transfer_graph)
+                # For remote handles: deepcopy graph and clear GPU blocks when
+                # it's a cross-machine PP handle (different PP stages have
+                # different GPU block_ids).  Cross-machine TP handles share
+                # the same slot_mapping, so no clear is needed.
+                if isinstance(transfer_handle._handle, TransferManagerMultiNodeHandle):
+                    if self.model_config.nnodes > 1 and self.model_config.pp_size > 1:
+                        # Cross-machine PP: each PP rank has different GPU blocks
+                        graph_copy = copy.deepcopy(transfer_graph)
+                        graph_copy.clear_gpu_blocks()
+                        transfer_handle.submit(graph_copy, task_end_op_id=self.tasks[task_id].task_end_op_id)
+                    else:
+                        # Cross-machine TP: same slot_mapping across TP ranks
+                        transfer_handle.submit(transfer_graph, task_end_op_id=self.tasks[task_id].task_end_op_id)
+                else:
+                    transfer_handle.submit(transfer_graph, task_end_op_id=self.tasks[task_id].task_end_op_id)
 
     def _update_tasks(self, timeout: float = 0.001) -> None:
         completed_ops = self._get_completed_ops(timeout)
@@ -498,7 +514,7 @@ class KVTaskManager:
                     raise ValueError("remote_file_size must not None if use file_size model")
                 if model_config.use_mla:
                     kv_size = (
-                        model_config.num_layers
+                        model_config.num_layers_per_pp_stage
                         * cache_config.tokens_per_block
                         * model_config.num_kv_heads
                         * model_config.head_size
@@ -506,7 +522,7 @@ class KVTaskManager:
                     )
                 else:
                     kv_size = (
-                        model_config.num_layers
+                        model_config.num_layers_per_pp_stage
                         * 2
                         * cache_config.tokens_per_block
                         * model_config.num_kv_heads
@@ -535,7 +551,8 @@ class KVTaskEngine(KVTaskManager):
                   slot_mapping: np.ndarray,
                   token_mask: Optional[np.ndarray] = None,
                   layer_granularity: int = -1,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         # self._sync_prefetch(token_ids, namespace)
@@ -544,7 +561,8 @@ class KVTaskEngine(KVTaskManager):
                                                     is_fake_slot_mapping=False,
                                                     token_mask=token_mask,
                                                     layer_granularity=layer_granularity,
-                                                    dp_id=dp_id,
+                                                    dp_rank=dp_rank,
+                                                    pp_rank=pp_rank,
                                                     task_id=task_id,
                                                     namespace=namespace)
         # trace get request
@@ -555,7 +573,8 @@ class KVTaskEngine(KVTaskManager):
             slot_mapping=slot_mapping,
             token_mask=token_mask,
             layer_granularity=layer_granularity,
-            dp_id=dp_id
+            dp_rank=dp_rank,
+            pp_rank=pp_rank
         )
         self._launch_task(task_id)
         return task_id, return_mask
@@ -564,14 +583,16 @@ class KVTaskEngine(KVTaskManager):
                   token_ids: np.ndarray,
                   slot_mapping: np.ndarray,
                   token_mask: Optional[np.ndarray] = None,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         task_id, return_mask = self._put_match_impl(token_ids,
                                                     slot_mapping,
                                                     is_fake_slot_mapping=False,
                                                     token_mask=token_mask,
-                                                    dp_id=dp_id,
+                                                    dp_rank=dp_rank,
+                                                    pp_rank=pp_rank,
                                                     task_id=task_id,
                                                     namespace=namespace)
         # trace put request
@@ -582,7 +603,8 @@ class KVTaskEngine(KVTaskManager):
             slot_mapping=slot_mapping,
             token_mask=token_mask,
             layer_granularity=-1,  # put has no layer_granularity parameter
-            dp_id=dp_id
+            dp_rank=dp_rank,
+            pp_rank=pp_rank
         )
         self._launch_task(task_id)
         return task_id, return_mask
@@ -687,7 +709,8 @@ class KVTaskEngine(KVTaskManager):
                   token_ids: np.ndarray,
                   token_mask: Optional[np.ndarray] = None,
                   layer_granularity: int = -1,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
@@ -701,7 +724,8 @@ class KVTaskEngine(KVTaskManager):
                                                            is_fake_slot_mapping=True,
                                                            token_mask=token_mask,
                                                            layer_granularity=layer_granularity,
-                                                           dp_id=dp_id,
+                                                           dp_rank=dp_rank,
+                                                           pp_rank=pp_rank,
                                                            cpu_only=cpu_only,
                                                            task_id=task_id,
                                                            namespace=namespace)
@@ -713,7 +737,8 @@ class KVTaskEngine(KVTaskManager):
             slot_mapping=fake_slot_mapping,
             token_mask=token_mask,
             layer_granularity=layer_granularity,
-            dp_id=dp_id
+            dp_rank=dp_rank,
+            pp_rank=pp_rank
         )
         nvtx.pop_range()
         return result_task_id, return_mask
@@ -724,14 +749,15 @@ class KVTaskEngine(KVTaskManager):
                   is_fake_slot_mapping: bool = False,
                   token_mask: Optional[np.ndarray] = None,
                   layer_granularity: int = -1,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         if token_mask is None:
             token_mask = np.ones_like(token_ids)
         if layer_granularity == -1:
-            layer_granularity = self.model_config.num_layers
+            layer_granularity = self.model_config.num_layers_per_pp_stage
         if task_id == -1:
             task_id = self._gen_task_id()
         temp_cache_strategy = DEFAULT_CACHE_STRATEGY
@@ -743,7 +769,8 @@ class KVTaskEngine(KVTaskManager):
                              slot_mapping,
                              token_mask,
                              layer_granularity,
-                             dp_id,
+                             dp_rank,
+                             pp_rank=pp_rank,
                              is_fake_slot_mapping=is_fake_slot_mapping,
                              temp_cache_strategy=temp_cache_strategy,
                              namespace=namespace)
@@ -754,7 +781,8 @@ class KVTaskEngine(KVTaskManager):
     def put_match(self,
                   token_ids: np.ndarray,
                   token_mask: Optional[np.ndarray] = None,
-                  dp_id: int = 0,
+                  dp_rank: int = 0,
+                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         fake_slot_mapping = np.zeros_like(token_ids)
@@ -762,7 +790,8 @@ class KVTaskEngine(KVTaskManager):
                                                            fake_slot_mapping,
                                                            is_fake_slot_mapping=True,
                                                            token_mask=token_mask,
-                                                           dp_id=dp_id,
+                                                           dp_rank=dp_rank,
+                                                           pp_rank=pp_rank,
                                                            task_id=task_id,
                                                            namespace=namespace)
         # trace put match request
@@ -773,7 +802,8 @@ class KVTaskEngine(KVTaskManager):
             slot_mapping=fake_slot_mapping,
             token_mask=token_mask,
             layer_granularity=-1,  # put has no layer_granularity parameter
-            dp_id=dp_id
+            dp_rank=dp_rank,
+            pp_rank=pp_rank
         )
         return result_task_id, return_mask
 
@@ -782,7 +812,8 @@ class KVTaskEngine(KVTaskManager):
                         slot_mapping: np.ndarray,
                         is_fake_slot_mapping: bool = False,
                         token_mask: Optional[np.ndarray] = None,
-                        dp_id: int = 0,
+                        dp_rank: int = 0,
+                        pp_rank: int = 0,
                         task_id: int = -1,
                         namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         if token_mask is None:
@@ -794,7 +825,8 @@ class KVTaskEngine(KVTaskManager):
                              token_ids,
                              slot_mapping,
                              token_mask,
-                             dp_id,
+                             dp_rank,
+                             pp_rank=pp_rank,
                              is_fake_slot_mapping=is_fake_slot_mapping,
                              namespace=namespace)
         self._process_empty_graph(task_id)
@@ -803,13 +835,14 @@ class KVTaskEngine(KVTaskManager):
 
     def prefetch_async(self,
                        token_ids: np.ndarray,
-                       dp_id: int = 0,
+                       dp_rank: int = 0,
+                       pp_rank: int = 0,
                        task_id: int = -1,
                        namespace: Optional[List[str]] = None) -> int:
         if task_id == -1:
             task_id = self._gen_task_id()
         nvtx.push_range(f"prefetch match: task_id={task_id}", color=get_nvtx_default_color())
-        self.create_prefetch_task(task_id, token_ids, namespace=namespace)
+        self.create_prefetch_task(task_id, token_ids, pp_rank=pp_rank, namespace=namespace)
         self._process_empty_graph(task_id)
         nvtx.pop_range()
         # trace prefetch async request
@@ -820,7 +853,8 @@ class KVTaskEngine(KVTaskManager):
             slot_mapping=np.zeros_like(token_ids),
             token_mask=np.ones_like(token_ids),
             layer_granularity=-1,
-            dp_id=dp_id
+            dp_rank=dp_rank,
+            pp_rank=pp_rank
         )
         self._launch_task(task_id)
         return task_id
@@ -864,7 +898,8 @@ class KVTaskEngine(KVTaskManager):
             task_end_op_id=task_end_op_id,
             task_end_op_finished=False,
             status=TaskStatus.READY,
-            dp_id=self.tasks[task_ids[0]].dp_id,
+            dp_rank=self.tasks[task_ids[0]].dp_rank,
+            pp_rank=self.tasks[task_ids[0]].pp_rank,
             graph=batch_task_graph,
             return_mask=return_masks,
             callback=callbacks,

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -94,6 +94,7 @@ class KVDPClient:
         token_ids: np.ndarray,
         slot_mapping: np.ndarray,
         token_mask: Optional[np.ndarray],
+        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
         req = PutRequest(self.dp_client_id,
@@ -101,6 +102,7 @@ class KVDPClient:
                          slot_mapping,
                          token_mask if token_mask is not None else None,
                          self._get_task_id(),
+                         pp_rank,
                          namespace)
         self.send_to_server.send_pyobj(req)
         return req.task_id
@@ -109,12 +111,14 @@ class KVDPClient:
         self,
         token_ids: np.ndarray,
         token_mask: Optional[np.ndarray],
+        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> Optional[Tuple[int, np.ndarray]]:
         req = PutMatchRequest(self.dp_client_id,
                               token_ids,
                               token_mask if token_mask is not None else None,
                               self._get_task_id(),
+                              pp_rank,
                               namespace)
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
@@ -127,9 +131,10 @@ class KVDPClient:
     def prefetch_async(
         self,
         token_ids: np.ndarray,
+        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
-        req = PrefetchRequest(self.dp_client_id, token_ids, self._get_task_id(), namespace)
+        req = PrefetchRequest(self.dp_client_id, token_ids, self._get_task_id(), pp_rank, namespace)
         self.send_to_server.send_pyobj(req)
         return req.task_id
 
@@ -139,6 +144,7 @@ class KVDPClient:
         slot_mapping: np.ndarray,
         token_mask: Optional[np.ndarray],
         layer_granularity: int,
+        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
         req = GetRequest(self.dp_client_id,
@@ -147,6 +153,7 @@ class KVDPClient:
                          token_mask if token_mask is not None else None,
                          self._get_task_id(),
                          layer_granularity,
+                         pp_rank,
                          namespace)
         self.send_to_server.send_pyobj(req)
         return req.task_id
@@ -156,6 +163,7 @@ class KVDPClient:
         token_ids: np.ndarray,
         token_mask: Optional[np.ndarray],
         layer_granularity: int,
+        pp_rank: int = 0,
         cpu_only: bool = False,
         namespace: Optional[List[str]] = None,
     ) -> Optional[Tuple[int, np.ndarray]]:
@@ -165,6 +173,7 @@ class KVDPClient:
                               layer_granularity,
                               cpu_only,
                               self._get_task_id(),
+                              pp_rank,
                               namespace)
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
@@ -239,7 +248,8 @@ class KVTPClient:
     def __init__(
         self,
         gpu_register_port: str,
-        dp_client_id: int,
+        dp_rank: int,
+        pp_rank: int,
         device_id: int,
     ):
         # Init inter-process communication
@@ -248,11 +258,39 @@ class KVTPClient:
             context, zmq.SocketType.PUSH, gpu_register_port, False
         )
 
-        self.dp_client_id = dp_client_id
+        self.dp_rank = dp_rank
+        self.pp_rank = pp_rank
         self.device_id = device_id
 
-        flexkv_logger.info(f"KVTPClient {device_id} of KVDPClient {self.dp_client_id} Initialized! "
-                           f"(gpu_register_port={gpu_register_port})")
+        flexkv_logger.info(f"KVTPClient {device_id} of DP {self.dp_rank} Initialized! "
+                           f"(gpu_register_port={gpu_register_port}, dp_rank={dp_rank}, pp_rank={pp_rank})")
+
+    def set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
+        """Send set_slot_mapping message to TransferManagerOnRemote via existing ZMQ channel.
+
+        Reuses the same PUSH socket (send_to_server) that connects to
+        TransferManagerOnRemote's command_socket — no separate IPC socket needed.
+        """
+        message = {
+            'type': 'set_slot_mapping',
+            'task_id': task_id,
+            'slot_mapping': slot_mapping,
+        }
+        try:
+            self.send_to_server.send_pyobj(message, flags=zmq.NOBLOCK)
+            flexkv_logger.debug(
+                f"KVTPClient {self.device_id}: set_slot_mapping sent for task_id={task_id}"
+            )
+        except zmq.Again:
+            flexkv_logger.warning(
+                f"KVTPClient {self.device_id}: zmq.Again when sending set_slot_mapping, "
+                f"retrying with blocking send..."
+            )
+            self.send_to_server.send_pyobj(message)
+            flexkv_logger.info(
+                f"KVTPClient {self.device_id}: set_slot_mapping sent (blocking retry) "
+                f"for task_id={task_id}"
+            )
 
     def register_to_server(
         self,
@@ -281,7 +319,8 @@ class KVTPClient:
                 indexer_handles.append(TensorSharedHandle(tensor, device_id))
 
         register_req = RegisterTPClientRequest(
-            self.dp_client_id,
+            self.dp_rank,
+            self.pp_rank,
             device_id,
             handles,
             kv_layout,
@@ -293,7 +332,7 @@ class KVTPClient:
             self.send_to_server.send_pyobj(register_req, flags=zmq.NOBLOCK)
             flexkv_logger.info(
                 f"KVTPClient {device_id}: registration message sent "
-                f"(dp_client_id={self.dp_client_id}, num_kv_caches={len(kv_caches)})")
+                f"(dp_rank={self.dp_rank}, num_kv_caches={len(kv_caches)})")
         except zmq.Again:
             flexkv_logger.error(
                 f"KVTPClient {device_id}: zmq.Again when sending registration "

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -18,7 +18,8 @@ class RegisterDPClientRequest:
 
 @dataclass
 class RegisterTPClientRequest:
-    dp_client_id: int
+    dp_rank: int
+    pp_rank: int
     device_id: int
     handles: List[TensorSharedHandle]
     gpu_layout: KVCacheLayout
@@ -37,6 +38,7 @@ class PutRequest:
     slot_mapping: np.ndarray
     token_mask: Optional[np.ndarray]
     task_id: int = -1
+    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 
@@ -48,6 +50,7 @@ class GetRequest:
     token_mask: Optional[np.ndarray]
     task_id: int = -1
     layer_granularity: int = -1
+    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 @dataclass
@@ -55,6 +58,7 @@ class PrefetchRequest:
     dp_client_id: int
     token_ids: np.ndarray
     task_id: int = -1
+    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 @dataclass
@@ -63,6 +67,7 @@ class PutMatchRequest:
     token_ids: np.ndarray
     token_mask: Optional[np.ndarray]
     task_id: int = -1
+    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 @dataclass
@@ -73,6 +78,7 @@ class GetMatchRequest:
     layer_granularity: int
     cpu_only: bool = False
     task_id: int = -1
+    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 @dataclass
@@ -131,3 +137,4 @@ class ShutdownRequest:
 @dataclass
 class CheckRunningRequest:
     dp_client_id: int
+

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -376,7 +376,8 @@ class KVServer:
             slot_mapping=req.slot_mapping,
             token_mask=req.token_mask,
             layer_granularity=req.layer_granularity,
-            dp_id=req.dp_client_id,
+            dp_rank=req.dp_client_id,
+            pp_rank=req.pp_rank,
             namespace=req.namespace,
         )
 
@@ -386,7 +387,8 @@ class KVServer:
             token_ids=req.token_ids,
             slot_mapping=req.slot_mapping,
             token_mask=req.token_mask,
-            dp_id=req.dp_client_id,
+            dp_rank=req.dp_client_id,
+            pp_rank=req.pp_rank,
             task_id=req.task_id,
             namespace=req.namespace,
         )
@@ -397,7 +399,8 @@ class KVServer:
             token_ids=req.token_ids,
             token_mask=req.token_mask,
             layer_granularity=req.layer_granularity,
-            dp_id=req.dp_client_id,
+            dp_rank=req.dp_client_id,
+            pp_rank=req.pp_rank,
             cpu_only=req.cpu_only,
             task_id=req.task_id,
             namespace=req.namespace,
@@ -411,7 +414,8 @@ class KVServer:
         req_id, mask = self.kv_task_engine.put_match(
             token_ids=req.token_ids,
             token_mask=req.token_mask,
-            dp_id=req.dp_client_id,
+            dp_rank=req.dp_client_id,
+            pp_rank=req.pp_rank,
             task_id=req.task_id,
             namespace=req.namespace,
         )
@@ -423,7 +427,8 @@ class KVServer:
         """Handle Prefetch request"""
         task_id = self.kv_task_engine.prefetch_async(
             token_ids=req.token_ids,
-            dp_id=req.dp_client_id,
+            dp_rank=req.dp_client_id,
+            pp_rank=req.pp_rank,
             task_id=req.task_id,
             namespace=req.namespace,
         )

--- a/flexkv/storage/storage_engine.py
+++ b/flexkv/storage/storage_engine.py
@@ -38,10 +38,10 @@ class StorageEngine:
         if self._cache_config.enable_cpu:
             self._cpu_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
-                num_layer=self._model_config.num_layers,
+                num_layer=self._model_config.num_layers_per_pp_stage,
                 num_block=self._cache_config.num_cpu_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
-                num_head=self._model_config.num_kv_heads,
+                num_head=self._model_config.num_kv_heads_per_node,
                 head_size=self._model_config.head_size,
                 is_mla=self._model_config.use_mla
             )
@@ -56,7 +56,7 @@ class StorageEngine:
                 # tokens_per_block is 1 (one indexer entry per page).
                 indexer_cpu_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
-                    num_layer=self._model_config.num_layers,
+                    num_layer=self._model_config.num_layers_per_pp_stage,
                     num_block=self._cache_config.num_cpu_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,
@@ -75,10 +75,10 @@ class StorageEngine:
                 raise ValueError(f"SSD layout type must be the same as CPU layout type: {self._cpu_layout.type}")
             self._ssd_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.ssd_layout_type,
-                num_layer=self._model_config.num_layers,
+                num_layer=self._model_config.num_layers_per_pp_stage,
                 num_block=self._cache_config.num_ssd_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
-                num_head=self._model_config.num_kv_heads,
+                num_head=self._model_config.num_kv_heads_per_node,
                 head_size=self._model_config.head_size,
                 is_mla=self._model_config.use_mla
             )
@@ -92,7 +92,7 @@ class StorageEngine:
             if self._indexer_config is not None:
                 indexer_ssd_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.ssd_layout_type,
-                    num_layer=self._model_config.num_layers,
+                    num_layer=self._model_config.num_layers_per_pp_stage,
                     num_block=self._cache_config.num_ssd_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,
@@ -113,10 +113,10 @@ class StorageEngine:
                 raise ValueError(f"Remote layout type must be the same as CPU layout type: {self._cpu_layout.type}")
             self._remote_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
-                num_layer=self._model_config.num_layers,
+                num_layer=self._model_config.num_layers_per_pp_stage,
                 num_block=self._cache_config.num_remote_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
-                num_head=self._model_config.num_kv_heads,
+                num_head=self._model_config.num_kv_heads_per_node,
                 head_size=self._model_config.head_size,
                 is_mla=self._model_config.use_mla
             )
@@ -130,7 +130,7 @@ class StorageEngine:
             if self._indexer_config is not None:
                 indexer_remote_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
-                    num_layer=self._model_config.num_layers,
+                    num_layer=self._model_config.num_layers_per_pp_stage,
                     num_block=self._cache_config.num_remote_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -19,36 +19,26 @@ from flexkv.transfer.worker_op import WorkerLayerwiseTransferOp
 from flexkv.transfer.worker import TransferWorkerBase, cudaHostRegister
 
 
-def build_layerwise_eventfd_socket_path(model_config: ModelConfig) -> str:
+def build_layerwise_eventfd_socket_path(
+    pp_rank: int,
+    dp_rank: int,
+    pp_size: int = 1,
+    dp_size: int = 1,
+) -> str:
     """Construct the LayerwiseWorker's UDS socket path.
 
     Disambiguated by ``(pp_rank, dp_rank)`` so multiple PP stages and DP
     replicas on the same host each get their own endpoint.
-
-    We deliberately do NOT embed ``node_rank`` in the path: Unix domain
-    sockets are kernel-local, so two FlexKV instances on different
-    physical hosts cannot collide even when ``/tmp`` happens to be on a
-    shared filesystem (NFS and friends propagate the inode, not the
-    socket endpoint).  Deployments that stack multiple containers on one
-    host with a shared ``/tmp`` should disambiguate via the
-    ``FLEXKV_LAYERWISE_EVENTFD_SOCKET`` env var (e.g. embed ``$HOSTNAME``
-    or the container id in the base path).
-
-    Must stay in sync with the sglang-side consumer at
-    ``sglang.srt.mem_cache.storage.flexkv.flexkv_connector``, which
-    imports this helper directly so the two ends cannot drift.  Both
-    sides derive the path from the same ``ModelConfig`` fields, so no
-    env-var plumbing between processes is required.
     """
     base = os.environ.get(
         'FLEXKV_LAYERWISE_EVENTFD_SOCKET',
         '/tmp/flexkv_layerwise_eventfd.sock',
     )
     suffix = ""
-    if model_config.pp_size > 1:
-        suffix += f"_pp{model_config.pp_rank}"
-    if model_config.dp_size > 1:
-        suffix += f"_dp{model_config.dp_rank}"
+    if pp_size > 1:
+        suffix += f"_pp{pp_rank}"
+    if dp_size > 1:
+        suffix += f"_dp{dp_rank}"
     if not suffix:
         return base
     root, ext = os.path.splitext(base)
@@ -87,11 +77,6 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                  ssd_kv_layout: KVCacheLayout,
                  dtype: torch.dtype,
                  tp_group_size: int,
-                 dp_group_id: int,
-                 pp_rank: int,
-                 pp_size: int,
-                 dp_size: int,
-                 dp_rank: int,
                  layerwise_eventfd_socket: str,
                  num_blocks_per_file: int,
                  use_ce_transfer_h2d: bool = False,
@@ -99,7 +84,6 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                  h2d_cta_num: int = 4,
                  d2h_cta_num: int = 4,
                  enable_eventfd: bool = True,
-                 is_nsa_cp: bool = False,
                  indexer_gpu_blocks: Optional[List[List[TensorSharedHandle]]] = None,
                  indexer_cpu_blocks: Optional[Union[torch.Tensor, HugePageTensorHandle]] = None,
                  indexer_gpu_kv_layouts: Optional[List[KVCacheLayout]] = None,
@@ -110,8 +94,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                  indexer_num_blocks_per_file: int = 0) -> None:
         flexkv_logger.debug(
             f"[LayerwiseWorker] __init__ started: worker_id={worker_id}, "
-            f"tp_group_size={tp_group_size}, dp_group_id={dp_group_id}, "
-            f"pp_rank={pp_rank}, pp_size={pp_size}, "
+            f"tp_group_size={tp_group_size}, "
             f"enable_eventfd={enable_eventfd}, "
             f"num_gpu_blocks={[len(b) for b in gpu_blocks]}")
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
@@ -129,17 +112,11 @@ class LayerwiseTransferWorker(TransferWorkerBase):
 
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
-        self.pp_rank = pp_rank
-        self.pp_size = pp_size if pp_size > 0 else 1
-        self.dp_group_id = dp_group_id
-        self.dp_size = dp_size if dp_size > 0 else 1
-        self.dp_rank = dp_rank
         # Pre-computed UDS socket path.  Both ends (this worker and the
         # sglang connector) derive the path from the same ModelConfig
         # fields (pp_rank / dp_rank / node_rank / is_multinode_tp), so no
         # env-var plumbing between processes is required.
         self.layerwise_eventfd_socket = layerwise_eventfd_socket
-        self.is_nsa_cp = is_nsa_cp
 
         # initialize GPU storage
         self.num_layers = gpu_kv_layouts[0].num_layer
@@ -183,17 +160,11 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         self.cpu_kv_stride_in_bytes = cpu_kv_layout.get_kv_stride() * self.dtype.itemsize
         self.cpu_layer_stride_in_bytes = cpu_kv_layout.get_layer_stride() * self.dtype.itemsize
         # TP-divided CPU strides (for CPU->GPU, each rank reads its own portion)
-        if self.is_nsa_cp:
-            # CP: no head partitioning, every rank gets the full KV cache
-            cpu_kv_layout_tp = cpu_kv_layout
-            self.cpu_tp_stride_in_bytes = 0
+        if cpu_kv_layout.type == KVCacheLayoutType.BLOCKFIRST and not self.is_mla:
+            cpu_kv_layout_tp = cpu_kv_layout.div_head(self.tp_group_size)
         else:
-            # TP: partition by heads, each rank reads a different head slice
-            if cpu_kv_layout.type == KVCacheLayoutType.BLOCKFIRST and not self.is_mla:
-                cpu_kv_layout_tp = cpu_kv_layout.div_head(self.tp_group_size)
-            else:
-                cpu_kv_layout_tp = cpu_kv_layout
-            self.cpu_tp_stride_in_bytes = self.cpu_block_stride_in_bytes // self.tp_group_size
+            cpu_kv_layout_tp = cpu_kv_layout
+        self.cpu_tp_stride_in_bytes = self.cpu_block_stride_in_bytes // self.tp_group_size
         self.h2d_cpu_kv_stride_in_bytes = cpu_kv_layout_tp.get_kv_stride() * self.dtype.itemsize
         self.h2d_cpu_layer_stride_in_bytes = cpu_kv_layout_tp.get_layer_stride() * self.dtype.itemsize
 
@@ -330,7 +301,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
 
         self.layerwise_transfer_group = LayerwiseTransferGroup(
             self.num_gpus, self.gpu_blocks, cpu_blocks, ssd_files,
-            dp_group_id, self.num_layers,
+            self.num_layers,
             gpu_kv_strides_tensor, gpu_block_strides_tensor,
             gpu_layer_strides_tensor, gpu_chunk_sizes_tensor,
             GLOBAL_CONFIG_FROM_ENV.iouring_entries,
@@ -347,15 +318,6 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                                        retry_interval: float = 1.0) -> torch.Tensor:
         """Receive eventfds from SGLang via Unix socket (FlexKV as server)."""
         socket_path = self.layerwise_eventfd_socket
-
-        rank_parts = []
-        if int(self.tp_group_size) > 1:
-            rank_parts.append("tp_rank=0")
-        if int(self.pp_size) > 1:
-            rank_parts.append(f"pp_rank={int(self.pp_rank)}")
-        if int(self.dp_size) > 1:
-            rank_parts.append(f"dp_rank={int(self.dp_rank)}")
-        rank_label = f" [{', '.join(rank_parts)}]" if rank_parts else ""
 
         def cleanup_socket():
             try:
@@ -374,11 +336,11 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             server_sock.listen(tp_group_size * 3)
             os.chmod(socket_path, 0o777)
             flexkv_logger.info(
-                f"[LayerwiseWorker] Eventfd server created{rank_label}: "
+                f"[LayerwiseWorker] Eventfd server created: "
                 f"socket={socket_path}, waiting for {tp_group_size} connection(s)")
         except Exception as e:
             flexkv_logger.error(
-                f"[LayerwiseWorker] Failed to bind/listen on {socket_path}{rank_label}: {e}")
+                f"[LayerwiseWorker] Failed to bind/listen on {socket_path}: {e}")
             server_sock.close()
             return torch.empty(0, dtype=torch.int32)
 
@@ -397,7 +359,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             while len(all_rank_eventfds) < tp_group_size:
                 if time.time() > total_deadline:
                     flexkv_logger.error(
-                        f"[LayerwiseWorker] Deadline exceeded on {socket_path}{rank_label}, "
+                        f"[LayerwiseWorker] Deadline exceeded on {socket_path}, "
                         f"received {len(all_rank_eventfds)}/{tp_group_size} ranks")
                     break
 
@@ -410,41 +372,34 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                     flexkv_logger.info(
                         f"[LayerwiseWorker] Accepted connection "
                         f"{conn_idx} (registered {len(all_rank_eventfds)}/{tp_group_size}) "
-                        f"on {socket_path}{rank_label}")
+                        f"on {socket_path}")
                 except socket.timeout:
                     flexkv_logger.warning(
-                        f"[LayerwiseWorker] Timeout waiting for connection on {socket_path}{rank_label}, "
+                        f"[LayerwiseWorker] Timeout waiting for connection on {socket_path}, "
                         f"registered {len(all_rank_eventfds)}/{tp_group_size}, retrying...")
                     continue
 
                 try:
                     with conn:
-                        # Accept both 16-byte (legacy: tp_rank, tp_size, num_layers, num_counters)
-                        # and 24-byte (new: tp_rank, tp_size, cp_rank, cp_size, num_layers, num_counters)
-                        metadata = conn.recv(24)
+                        # Receive 16-byte metadata: tp_rank_per_node, tp_size_per_node,
+                        # num_layers, num_counters
+                        metadata = conn.recv(16)
                         if len(metadata) < 16:
                             flexkv_logger.error(
-                                f"[LayerwiseWorker] Incomplete metadata on {socket_path}{rank_label}: "
-                                f"{len(metadata)} bytes")
+                                f"[LayerwiseWorker] Incomplete metadata on {socket_path}: "
+                                f"expected 16 bytes, got {len(metadata)}")
                             continue
 
-                        if len(metadata) >= 24:
-                            tp_rank, _, cp_rank, cp_size, recv_num_layers, recv_num_counters = \
-                                struct.unpack("iiiiii", metadata[:24])
-                        else:
-                            tp_rank, _, recv_num_layers, recv_num_counters = \
-                                struct.unpack("iiii", metadata[:16])
-                            cp_rank, cp_size = 0, 1
+                        rank_key, tp_size_per_node_recv, recv_num_layers, recv_num_counters = \
+                            struct.unpack("iiii", metadata[:16])
 
-                        # Use cp_rank as the connection key when CP is active,
-                        # otherwise use tp_rank
-                        rank_key = cp_rank if cp_size > 1 else tp_rank
                         if not all_rank_eventfds:
                             num_layers, num_counters = recv_num_layers, recv_num_counters
 
                         flexkv_logger.debug(
                             f"[LayerwiseWorker] Connection {conn_idx}: "
-                            f"tp_rank={tp_rank}, cp_rank={cp_rank}, cp_size={cp_size}, "
+                            f"tp_rank_per_node={rank_key}, "
+                            f"tp_size_per_node={tp_size_per_node_recv}, "
                             f"num_layers={recv_num_layers}, "
                             f"num_counters={recv_num_counters}")
 
@@ -455,7 +410,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                             rank_eventfds[counter_id] = fds
                             flexkv_logger.debug(
                                 f"[LayerwiseWorker] Received counter_id={counter_id}, "
-                                f"num_fds={len(fds)} from rank_key={rank_key}")
+                                f"num_fds={len(fds)} from tp_rank_per_node={rank_key}")
 
                         all_rank_eventfds[rank_key] = rank_eventfds
                         # Send ACK to client so it knows the fds were received
@@ -464,8 +419,8 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                         except Exception:
                             pass
                         flexkv_logger.info(
-                            f"[LayerwiseWorker] Received all eventfds from rank_key={rank_key} "
-                            f"(tp_rank={tp_rank}, cp_rank={cp_rank}) on {socket_path}")
+                            f"[LayerwiseWorker] Received all eventfds from tp_rank_per_node={rank_key} "
+                            f"on {socket_path}")
                 except Exception as e:
                     # Send NACK so client knows to retry
                     try:
@@ -474,19 +429,19 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                         pass
                     flexkv_logger.warning(
                         f"[LayerwiseWorker] Failed to receive eventfds from connection {conn_idx} "
-                        f"on {socket_path}{rank_label}: {e}. "
+                        f"on {socket_path}: {e}. "
                         f"Client will retry, continuing accept loop...")
                     continue
         except Exception as e:
             flexkv_logger.error(
-                f"[LayerwiseWorker] Fatal error in accept loop on {socket_path}{rank_label}: {e}")
+                f"[LayerwiseWorker] Fatal error in accept loop on {socket_path}: {e}")
         finally:
             server_sock.close()
             cleanup_socket()
 
         if not all_rank_eventfds:
             flexkv_logger.warning(
-                f"[LayerwiseWorker] No connections received on {socket_path}{rank_label}")
+                f"[LayerwiseWorker] No connections received on {socket_path}")
             return torch.empty(0, dtype=torch.int32)
 
         # Build tensor: [num_counters, tp_size, num_layers]
@@ -498,9 +453,9 @@ class LayerwiseTransferWorker(TransferWorkerBase):
 
         tensor = torch.tensor(eventfds_list, dtype=torch.int32)
         flexkv_logger.info(
-            f"[LayerwiseWorker] Eventfd setup complete{rank_label}: "
+            f"[LayerwiseWorker] Eventfd setup complete: "
             f"socket={socket_path}, tensor_shape={tensor.shape}, "
-            f"counters={num_counters}, tp_size={tp_group_size}, layers={num_layers}"
+            f"counters={num_counters}, tp_size_per_rank={tp_group_size}, layers={num_layers}"
         )
         return tensor
 
@@ -621,7 +576,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         kv_dim = 2 if not self.is_mla else 1
         transfer_size = self.cpu_chunk_size_in_bytes * self.num_layers * num_h2d_blocks * kv_dim
 
-        if self.is_nsa_cp or self.is_mla:
+        if self.is_mla:
             transfer_size *= self.tp_group_size
 
         self._log_transfer_performance(

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -18,7 +18,7 @@ import time
 import multiprocessing as mp
 import selectors
 import os
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import contextlib
 import nvtx
@@ -27,7 +27,7 @@ import torch
 
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.storage import StorageHandle
-from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType, CompletedOp
+from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType, CompletedOp, WorkerKey
 from flexkv.common.transfer import get_nvtx_range_color
 from flexkv.transfer.scheduler import TransferScheduler
 from flexkv.transfer.worker import (
@@ -87,13 +87,13 @@ def free_op_from_buffer(op: TransferOp, pin_buffer: SharedOpPool) -> None:
 
 class TransferEngine:
     def __init__(self,
-        gpu_handles: Dict[int, List[StorageHandle]],
+        gpu_handles: Dict[WorkerKey, List[StorageHandle]],
         model_config: ModelConfig,
         cache_config: CacheConfig,
         cpu_handle: Optional[StorageHandle] = None,
         ssd_handle: Optional[StorageHandle] = None,
         remote_handle: Optional[StorageHandle] = None,
-        indexer_gpu_handles: Optional[Dict[int, List[StorageHandle]]] = None,
+        indexer_gpu_handles: Optional[Dict[WorkerKey, List[StorageHandle]]] = None,
         indexer_cpu_handle: Optional[StorageHandle] = None,
         indexer_ssd_handle: Optional[StorageHandle] = None,
         indexer_remote_handle: Optional[StorageHandle] = None):
@@ -101,7 +101,7 @@ class TransferEngine:
         Initialize transfer engine
 
         Args:
-            gpu_handles: Dict mapping dp_client_id -> list of GPU handles for that TP group
+            gpu_handles: Dict mapping WorkerKey(dp_rank, pp_rank) -> list of GPU handles for that TP group
             cpu_handle: CPU handle
             ssd_handle: Optional SSD handle
             remote_handle: Optional remote handle
@@ -123,7 +123,7 @@ class TransferEngine:
 
         # Create shutdown pipe for zero-latency selector
         self.shutdown_read_fd, self.shutdown_write_fd = os.pipe()
-        self.gpu_handle_groups = gpu_handles  # dp_client_id -> list of GPU handles for that TP group
+        self.gpu_handle_groups = gpu_handles  # WorkerKey -> list of GPU handles for that TP group
         self._cpu_handle = cpu_handle
         self._ssd_handle = ssd_handle
         self._remote_handle = remote_handle
@@ -143,7 +143,7 @@ class TransferEngine:
         self.op_id_to_nvtx_range: Dict[int, str] = {}
 
         # self.dp_size = model_config.dp_size
-        self.tp_size = model_config.tp_size
+        self.tp_size_per_node = model_config.tp_size_per_node
         self.num_gpu_groups = len(self.gpu_handle_groups)
         self._running = False
         self._has_indexer = False
@@ -151,10 +151,14 @@ class TransferEngine:
         self._indexer_op_to_parent_op: Dict[int, int] = {}
         self._indexer_op_map: Dict[int, TransferOp] = {}
 
+        # Same-node PP layerwise fan-out: replica op_id → parent op_id
+        self._pp_replica_to_parent_op: Dict[int, int] = {}
+        self._pp_replica_op_map: Dict[int, TransferOp] = {}
+
     def _init_workers(self) -> None:
         if self._running:
             return
-        self._worker_map: Dict[TransferType, Union[WorkerHandle, List[WorkerHandle]]] = {}
+        self._worker_map: Dict[TransferType, Union[WorkerHandle, Dict[WorkerKey, WorkerHandle]]] = {}
 
         assert self._cpu_handle is not None
         _enable_layerwise = GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer
@@ -163,9 +167,9 @@ class TransferEngine:
         
         # H2D worker
         if not _enable_layerwise:
-            if self.tp_size == 1:
-                self.h2d_workers: List[WorkerHandle] = [
-                    GPUCPUTransferWorker.create_worker(
+            if self.tp_size_per_node == 1:
+                self.h2d_workers: Dict[WorkerKey, WorkerHandle] = {
+                    worker_key: GPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self.finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -180,11 +184,11 @@ class TransferEngine:
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                     )
-                    for _, gpu_handles in self.gpu_handle_groups.items()
-                ]
+                    for worker_key, gpu_handles in self.gpu_handle_groups.items()
+                }
             else:
-                self.h2d_workers = [
-                    tpGPUCPUTransferWorker.create_worker(
+                self.h2d_workers = {
+                    worker_key: tpGPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self.finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -193,23 +197,20 @@ class TransferEngine:
                         gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                         cpu_kv_layout=self._cpu_handle.kv_layout,
                         dtype=gpu_handles[0].dtype,
-                        tp_group_size=self.tp_size,
-                        dp_group_id=dp_client_id,
-                        is_nsa_cp=self.model_config.is_nsa_cp,
-                        cp_size=self.model_config.cp_size,
+                        tp_group_size=self.tp_size_per_node,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                     )
-                    for dp_client_id, gpu_handles in self.gpu_handle_groups.items()
-                ]
+                    for worker_key, gpu_handles in self.gpu_handle_groups.items()
+                }
             self._worker_map[TransferType.H2D] = self.h2d_workers
 
         # D2H worker
-        if self.tp_size == 1:
-            self.d2h_workers: List[WorkerHandle] = [
-                GPUCPUTransferWorker.create_worker(
+        if self.tp_size_per_node == 1:
+            self.d2h_workers: Dict[WorkerKey, WorkerHandle] = {
+                worker_key: GPUCPUTransferWorker.create_worker(
                     mp_ctx=self.mp_ctx,
                     finished_ops_queue=self.finished_ops_queue,
                     op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -224,11 +225,11 @@ class TransferEngine:
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                 )
-                for _, gpu_handles in self.gpu_handle_groups.items()
-            ]
+                for worker_key, gpu_handles in self.gpu_handle_groups.items()
+            }
         else:
-            self.d2h_workers = [
-                tpGPUCPUTransferWorker.create_worker(
+            self.d2h_workers = {
+                worker_key: tpGPUCPUTransferWorker.create_worker(
                     mp_ctx=self.mp_ctx,
                     finished_ops_queue=self.finished_ops_queue,
                     op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -237,17 +238,14 @@ class TransferEngine:
                     gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     dtype=gpu_handles[0].dtype,
-                    tp_group_size=self.tp_size,
-                    dp_group_id=dp_client_id,
-                    is_nsa_cp=self.model_config.is_nsa_cp,
-                    cp_size=self.model_config.cp_size,
+                    tp_group_size=self.tp_size_per_node,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                 )
-                for dp_client_id, gpu_handles in self.gpu_handle_groups.items()
-            ]
+                for worker_key, gpu_handles in self.gpu_handle_groups.items()
+            }
         self._worker_map[TransferType.D2H] = self.d2h_workers
 
         if self._ssd_handle is not None and self._cpu_handle is not None:
@@ -308,9 +306,9 @@ class TransferEngine:
             self._worker_map[TransferType.H2REMOTE] = self.remotecpu_write_worker
             self._worker_map[TransferType.REMOTE2H] = self.remotecpu_read_worker
         if self.cache_config.enable_gds:
-            if self.tp_size == 1:
-                self.gds_workers = [
-                    GDSTransferWorker.create_worker(
+            if self.tp_size_per_node == 1:
+                self.gds_workers: Dict[WorkerKey, WorkerHandle] = {
+                    worker_key: GDSTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self.finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -322,11 +320,11 @@ class TransferEngine:
                         dtype=self._ssd_handle.dtype,
                         gpu_device_id=gpu_handles[0].gpu_device_id,
                     )
-                    for _, gpu_handles in self.gpu_handle_groups.items()
-                ]
+                    for worker_key, gpu_handles in self.gpu_handle_groups.items()
+                }
             else:
-                self.gds_workers = [
-                    tpGDSTransferWorker.create_worker(
+                self.gds_workers = {
+                    worker_key: tpGDSTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self.finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -336,25 +334,16 @@ class TransferEngine:
                         gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                         ssd_kv_layout=self._ssd_handle.kv_layout,
                         dtype=self._ssd_handle.dtype,
-                        tp_group_size=self.tp_size,
-                        dp_group_id=dp_client_id,
+                        tp_group_id=self.tp_size_per_node,
                     )
-                    for dp_client_id, gpu_handles in self.gpu_handle_groups.items()
-                ]
+                    for worker_key, gpu_handles in self.gpu_handle_groups.items()
+                }
             self._worker_map[TransferType.DISK2D] = self.gds_workers
             self._worker_map[TransferType.D2DISK] = self.gds_workers
         if GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer:
             ssd_files = {} if self._ssd_handle is None else self._ssd_handle.get_file_list()
             ssd_kv_layout = None if self._ssd_handle is None else self._ssd_handle.kv_layout
             num_blocks_per_file = 0 if self._ssd_handle is None else self._ssd_handle.num_blocks_per_file
-            _is_nsa_cp = self.model_config.is_nsa_cp
-            _cp_size = self.model_config.cp_size
-            # For CP, each CP rank connects via eventfd; for TP, each TP rank connects.
-            _eventfd_group_size = _cp_size if _is_nsa_cp and _cp_size > 1 else self.tp_size
-
-            _layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
-                self.model_config
-            )
 
             # Prepare indexer handles for fused layerwise transfer
             has_indexer_for_layerwise = (
@@ -362,12 +351,18 @@ class TransferEngine:
                 self._indexer_cpu_handle is not None
             )
 
-            self.layerwise_workers = []
-            for dp_client_id, gpu_handles in self.gpu_handle_groups.items():
-                # Resolve indexer handles for this dp_client_id
+            self.layerwise_workers: Dict[WorkerKey, WorkerHandle] = {}
+            for worker_key, gpu_handles in self.gpu_handle_groups.items():
+                _layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
+                    pp_rank=worker_key.pp_rank,
+                    dp_rank=worker_key.dp_rank,
+                    pp_size=self.model_config.pp_size,
+                    dp_size=self.model_config.dp_size,
+                )
+                # Resolve indexer handles for this WorkerKey
                 idx_handles = None
                 if has_indexer_for_layerwise:
-                    idx_handles = self._indexer_gpu_handles.get(dp_client_id)
+                    idx_handles = self._indexer_gpu_handles.get(worker_key)
 
                 worker = LayerwiseTransferWorker.create_worker(
                     mp_ctx=self.mp_ctx,
@@ -380,19 +375,13 @@ class TransferEngine:
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     ssd_kv_layout=ssd_kv_layout,
                     dtype=gpu_handles[0].dtype,
-                    tp_group_size=_eventfd_group_size,
-                    dp_group_id=dp_client_id,
-                    pp_rank=self.model_config.pp_rank,
-                    pp_size=self.model_config.pp_size,
-                    dp_size=self.model_config.dp_size,
-                    dp_rank=dp_client_id,
+                    tp_group_size=self.tp_size_per_node,
                     layerwise_eventfd_socket=_layerwise_eventfd_socket,
                     num_blocks_per_file=num_blocks_per_file,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     h2d_cta_num=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     d2h_cta_num=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
-                    is_nsa_cp=_is_nsa_cp,
                     indexer_gpu_blocks=[h.get_tensor_handle_list() for h in idx_handles] if idx_handles else None,
                     indexer_cpu_blocks=self._indexer_cpu_handle.get_worker_tensor() if idx_handles else None,
                     indexer_gpu_kv_layouts=[h.kv_layout for h in idx_handles] if idx_handles else None,
@@ -402,11 +391,11 @@ class TransferEngine:
                     indexer_ssd_kv_layout=self._indexer_ssd_handle.kv_layout if (idx_handles and self._indexer_ssd_handle) else None,
                     indexer_num_blocks_per_file=self._indexer_ssd_handle.num_blocks_per_file if (idx_handles and self._indexer_ssd_handle) else 0,
                 )
-                self.layerwise_workers.append(worker)
+                self.layerwise_workers[worker_key] = worker
 
                 flexkv_logger.debug(
-                    f"[TransferEngine] Created layerwise worker for dp_client_id={dp_client_id}: "
-                    f"tp_size={self.tp_size}, has_indexer={idx_handles is not None}, "
+                    f"[TransferEngine] Created layerwise worker for {worker_key}: "
+                    f"tp_size_per_node={self.tp_size_per_node}, has_indexer={idx_handles is not None}, "
                     f"has_ssd={len(ssd_files) > 0}")
 
             self._worker_map[TransferType.LAYERWISE] = self.layerwise_workers
@@ -442,12 +431,12 @@ class TransferEngine:
         if (self._indexer_gpu_handles is not None
                 and self._indexer_cpu_handle is not None):
             self._indexer_finished_ops_queue = self.mp_ctx.Queue()
-            self._indexer_worker_map: Dict[TransferType, Union[WorkerHandle, List[WorkerHandle]]] = {}
+            self._indexer_worker_map: Dict[TransferType, Union[WorkerHandle, Dict[WorkerKey, WorkerHandle]]] = {}
             # H2D indexer worker
             if not _enable_layerwise:
-                if self.tp_size == 1:
-                    self._indexer_h2d_workers = [
-                        GPUCPUTransferWorker.create_worker(
+                if self.tp_size_per_node == 1:
+                    self._indexer_h2d_workers: Dict[WorkerKey, WorkerHandle] = {
+                        worker_key: GPUCPUTransferWorker.create_worker(
                             mp_ctx=self.mp_ctx,
                             finished_ops_queue=self._indexer_finished_ops_queue,
                             op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -462,11 +451,11 @@ class TransferEngine:
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                             transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                         )
-                        for _, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
-                    ]
+                        for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
+                    }
                 else:
-                    self._indexer_h2d_workers = [
-                        tpGPUCPUTransferWorker.create_worker(
+                    self._indexer_h2d_workers = {
+                        worker_key: tpGPUCPUTransferWorker.create_worker(
                             mp_ctx=self.mp_ctx,
                             finished_ops_queue=self._indexer_finished_ops_queue,
                             op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -475,23 +464,20 @@ class TransferEngine:
                             gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                             cpu_kv_layout=self._indexer_cpu_handle.kv_layout,
                             dtype=indexer_gpu_handles_list[0].dtype,
-                            tp_group_size=self.tp_size,
-                            dp_group_id=dp_client_id,
-                            is_nsa_cp=self.model_config.is_nsa_cp,
-                            cp_size=self.model_config.cp_size,
+                            tp_group_size=self.tp_size_per_node,
                             use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                             use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                             transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                         )
-                        for dp_client_id, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
-                    ]
+                        for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
+                    }
                 self._indexer_worker_map[TransferType.H2D] = self._indexer_h2d_workers
 
             # D2H indexer worker
-            if self.tp_size == 1:
-                self._indexer_d2h_workers = [
-                    GPUCPUTransferWorker.create_worker(
+            if self.tp_size_per_node == 1:
+                self._indexer_d2h_workers: Dict[WorkerKey, WorkerHandle] = {
+                    worker_key: GPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self._indexer_finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -506,11 +492,11 @@ class TransferEngine:
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                     )
-                    for _, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
-                ]
+                    for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
+                }
             else:
-                self._indexer_d2h_workers = [
-                    tpGPUCPUTransferWorker.create_worker(
+                self._indexer_d2h_workers = {
+                    worker_key: tpGPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
                         finished_ops_queue=self._indexer_finished_ops_queue,
                         op_buffer_tensor=self.pin_buffer.get_buffer(),
@@ -519,17 +505,14 @@ class TransferEngine:
                         gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                         cpu_kv_layout=self._indexer_cpu_handle.kv_layout,
                         dtype=indexer_gpu_handles_list[0].dtype,
-                        tp_group_size=self.tp_size,
-                        dp_group_id=dp_client_id,
-                        is_nsa_cp=self.model_config.is_nsa_cp,
-                        cp_size=self.model_config.cp_size,
+                        tp_group_size=self.tp_size_per_node,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
                     )
-                    for dp_client_id, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
-                ]
+                    for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
+                }
             self._indexer_worker_map[TransferType.D2H] = self._indexer_d2h_workers
             if self._indexer_ssd_handle is not None and self._indexer_cpu_handle is not None:
                 # H2DISK indexer worker
@@ -590,7 +573,7 @@ class TransferEngine:
                 self._indexer_worker_map[TransferType.REMOTE2H] = self._indexer_remote2h_worker
                 flexkv_logger.info("TransferEngine: indexer Remote workers initialized")
             if self.cache_config.enable_gds and self._indexer_ssd_handle is not None:
-                if self.tp_size == 1:
+                if self.tp_size_per_node == 1:
                     self._indexer_gds_workers = [
                         GDSTransferWorker.create_worker(
                             mp_ctx=self.mp_ctx,
@@ -618,10 +601,9 @@ class TransferEngine:
                             gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                             ssd_kv_layout=self._indexer_ssd_handle.kv_layout,
                             dtype=self._indexer_ssd_handle.dtype,
-                            tp_group_size=self.tp_size,
-                            dp_group_id=dp_client_id,
+                            tp_group_size=self.tp_size_per_node,
                         )
-                        for dp_client_id, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
+                        for _, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     ]
                 self._indexer_worker_map[TransferType.DISK2D] = self._indexer_gds_workers
                 self._indexer_worker_map[TransferType.D2DISK] = self._indexer_gds_workers
@@ -662,27 +644,27 @@ class TransferEngine:
             raise ValueError("No workers initialized, please check the config")
         # Wait for all main KV workers to ready
         for transfer_type, worker in self._worker_map.items():
-            if isinstance(worker, List):
-                for w in worker:
-                    flexkv_logger.info(f"waiting for {transfer_type.name} worker {w.worker_id} to ready")
+            if isinstance(worker, dict):
+                for w in worker.values():
+                    flexkv_logger.debug(f"waiting for {transfer_type.name} worker {w.worker_id} to ready")
                     w.ready_event.wait()
-                    flexkv_logger.info(f"{transfer_type.name} worker {w.worker_id} is ready")
+                    flexkv_logger.debug(f"{transfer_type.name} worker {w.worker_id} is ready")
             else:
-                flexkv_logger.info(f"waiting for {transfer_type.name} worker {worker.worker_id} to ready")
+                flexkv_logger.debug(f"waiting for {transfer_type.name} worker {worker.worker_id} to ready")
                 worker.ready_event.wait()
-                flexkv_logger.info(f"{transfer_type.name} worker {worker.worker_id} is ready")
+                flexkv_logger.debug(f"{transfer_type.name} worker {worker.worker_id} is ready")
         # Wait for all indexer workers to ready
         if self._has_indexer:
             for transfer_type, worker in self._indexer_worker_map.items():
-                if isinstance(worker, List):
-                    for w in worker:
-                        flexkv_logger.info(f"waiting for indexer {transfer_type.name} worker {w.worker_id} to ready")
+                if isinstance(worker, dict):
+                    for w in worker.values():
+                        flexkv_logger.debug(f"waiting for indexer {transfer_type.name} worker {w.worker_id} to ready")
                         w.ready_event.wait()
-                        flexkv_logger.info(f"indexer {transfer_type.name} worker {w.worker_id} is ready")
+                        flexkv_logger.debug(f"indexer {transfer_type.name} worker {w.worker_id} is ready")
                 else:
-                    flexkv_logger.info(f"waiting for indexer {transfer_type.name} worker {worker.worker_id} to ready")
+                    flexkv_logger.debug(f"waiting for indexer {transfer_type.name} worker {worker.worker_id} to ready")
                     worker.ready_event.wait()
-                    flexkv_logger.info(f"indexer {transfer_type.name} worker {worker.worker_id} is ready")
+                    flexkv_logger.debug(f"indexer {transfer_type.name} worker {worker.worker_id} is ready")
         # Startup assertions: verify layerwise mode worker map consistency
         if _enable_layerwise:
             assert TransferType.H2D not in self._worker_map, \
@@ -760,10 +742,28 @@ class TransferEngine:
                         while True:
                             try:
                                 op_id = self.finished_ops_queue.get_nowait()
-                                op = self.op_id_to_op[op_id]
-                                op.pending_count -= 1
-                                if op.pending_count == 0:
-                                    self._finalize_op(op, finished_ops)
+                                # Check if this is a PP-replica op (same-node PP fan-out)
+                                if op_id in self._pp_replica_to_parent_op:
+                                    # PP-replica op: decrement parent's pending_count
+                                    replica_op = self._pp_replica_op_map.pop(op_id)
+                                    parent_op_id = self._pp_replica_to_parent_op.pop(op_id)
+                                    parent_op = self.op_id_to_op[parent_op_id]
+                                    parent_op.pending_count -= 1
+                                    # Clean up replica from op_id_to_op and NVTX
+                                    del self.op_id_to_op[op_id]
+                                    if op_id in self.op_id_to_nvtx_range:
+                                        nvtx.end_range(self.op_id_to_nvtx_range[op_id])
+                                        self.op_id_to_nvtx_range.pop(op_id)
+                                    if parent_op.pending_count == 0:
+                                        self._finalize_op(parent_op, finished_ops)
+                                    flexkv_logger.debug(
+                                        f"[TransferEngine] PP replica op {op_id} completed, "
+                                        f"parent op {parent_op_id} pending_count={parent_op.pending_count}")
+                                else:
+                                    op = self.op_id_to_op[op_id]
+                                    op.pending_count -= 1
+                                    if op.pending_count == 0:
+                                        self._finalize_op(op, finished_ops)
                             except queue.Empty:
                                 break
                         nvtx.end_range(nvtx_r2)
@@ -834,7 +834,7 @@ class TransferEngine:
         free_op_from_buffer(op, self.pin_buffer)
         # Compute transfer metrics for this completed op
         num_blocks = len(op.src_block_ids) if op.src_block_ids is not None else 0
-        num_bytes = num_blocks * self.cache_config.tokens_per_block * self.model_config.token_size_in_bytes
+        num_bytes = num_blocks * self.cache_config.tokens_per_block * self.model_config.token_size_in_bytes_per_pp_stage
         transfer_type_str = op.transfer_type.value if op.transfer_type != TransferType.VIRTUAL else None
         self.completed_queue.put(CompletedOp(
             graph_id=op.graph_id,
@@ -845,6 +845,85 @@ class TransferEngine:
         ))
         finished_ops.append(op)
         del self.op_id_to_op[op.op_id]
+
+    def _assign_layerwise_op_to_workers(self, op: TransferOp) -> None:
+        """Fan-out a LAYERWISE op to all PP-stage layerwise workers on the same dp_rank.
+
+        In cross-node PP, the remote TransferManagerOnRemote handles this by
+        rebinding WorkerKey.  In same-node PP there is no remote TM, so we
+        replicate the op here for every PP-stage worker under the same dp_rank.
+
+        Replicas are tracked via ``_pp_replica_to_parent_op`` so that their
+        completion decrements the parent op's ``pending_count`` (identical to
+        how indexer ops are tracked).
+        """
+        from flexkv.common.transfer import LayerwiseTransferOp
+        assert isinstance(op, LayerwiseTransferOp)
+
+        worker_map = self._worker_map[TransferType.LAYERWISE]
+        assert isinstance(worker_map, dict), \
+            "LAYERWISE worker map must be a Dict[WorkerKey, WorkerHandle]"
+
+        # Find all layerwise workers sharing the same dp_rank
+        sibling_keys = [wk for wk in worker_map if wk.dp_rank == op.dp_rank]
+
+        if not sibling_keys:
+            raise ValueError(
+                f"No layerwise worker found for dp_rank={op.dp_rank}, pp_rank={op.pp_rank}")
+
+        # Submit to the original pp_rank's worker
+        primary_key = WorkerKey(dp_rank=op.dp_rank, pp_rank=op.pp_rank)
+        if primary_key in worker_map:
+            worker_map[primary_key].submit_transfer(op)
+        else:
+            # Original worker not found — this shouldn't happen, but handle gracefully
+            raise ValueError(
+                f"No layerwise worker found for primary key {primary_key}")
+
+        # If there's only one worker for this dp_rank, no fan-out needed
+        if len(sibling_keys) <= 1:
+            return
+
+        # Create replicas for every other pp_rank under the same dp_rank
+        for wk in sibling_keys:
+            if wk == primary_key:
+                continue
+
+            # Create a replica LayerwiseTransferOp with the target pp_rank
+            replica = LayerwiseTransferOp(
+                graph_id=op.graph_id,
+                src_block_ids_h2d=op.src_block_ids_h2d.copy(),
+                dst_block_ids_h2d=op.dst_block_ids_h2d.copy(),
+                src_block_ids_disk2h=op.src_block_ids_disk2h.copy(),
+                dst_block_ids_disk2h=op.dst_block_ids_disk2h.copy(),
+                layer_id=op.layer_id,
+                layer_granularity=op.layer_granularity,
+                dp_rank=op.dp_rank,
+                pp_rank=wk.pp_rank,
+                counter_id=op.counter_id,
+                indexer_src_block_ids=op.indexer_src_block_ids.copy(),
+                indexer_dst_block_ids=op.indexer_dst_block_ids.copy(),
+            )
+
+            # Track replica → parent so that completion decrements parent's pending_count
+            self._pp_replica_to_parent_op[replica.op_id] = op.op_id
+            self._pp_replica_op_map[replica.op_id] = replica
+            op.pending_count += 1
+
+            # Register in op_id_to_op so scheduler can find it on completion
+            self.op_id_to_op[replica.op_id] = replica
+            self.op_id_to_nvtx_range[replica.op_id] = nvtx.start_range(
+                f"schedule LAYERWISE_REPLICA op_id: {replica.op_id}, "
+                f"graph_id: {replica.graph_id}, pp_rank={wk.pp_rank}",
+                color=get_nvtx_range_color(replica.graph_id))
+
+            worker_map[wk].submit_transfer(replica)
+
+            flexkv_logger.debug(
+                f"[TransferEngine] === Layerwise PP Replica Dispatched ==="
+                f"\n  parent_op_id={op.op_id}, replica_op_id={replica.op_id}"
+                f"\n  dp_rank={op.dp_rank}, pp_rank={wk.pp_rank}"
+                f"\n  pending_count={op.pending_count}")
 
     def _assign_op_to_worker(self, op: TransferOp) -> None:
         self.op_id_to_nvtx_range[op.op_id] = nvtx.start_range(f"schedule {op.transfer_type.name} "
@@ -857,6 +936,18 @@ class TransferEngine:
             return
         if op.transfer_type not in self._worker_map:
             raise ValueError(f"Unsupported transfer type: {op.transfer_type}")
+
+        # --- Same-node PP fan-out for LAYERWISE ops ---
+        # In cross-node PP, TransferManagerOnRemote rebinds WorkerKey so that
+        # PP1+ workers receive the op.  In same-node PP, only one local
+        # TransferManager exists, so we fan-out here: for every layerwise
+        # worker that shares the same dp_rank but has a different pp_rank, we
+        # create a replica op with the correct pp_rank.
+        if op.transfer_type == TransferType.LAYERWISE:
+            self._assign_layerwise_op_to_workers(op)
+            return
+
+        worker_key = WorkerKey(dp_rank=op.dp_rank, pp_rank=op.pp_rank)
 
         if self._has_indexer and op.transfer_type in self._indexer_worker_map:
             # Indexer maps 1:1 with main KV blocks, use block_ids directly.
@@ -874,7 +965,8 @@ class TransferEngine:
                     dst_block_ids=dst_page_ids,
                     layer_id=op.layer_id,
                     layer_granularity=op.layer_granularity,
-                    dp_id=op.dp_id,
+                    dp_rank=op.dp_rank,
+                    pp_rank=op.pp_rank,
                 )
                 register_op_to_buffer(indexer_op, self.pin_buffer)
                 self._indexer_op_to_parent_op[indexer_op.op_id] = op.op_id
@@ -884,18 +976,18 @@ class TransferEngine:
                 flexkv_logger.debug(
                     f"[TransferEngine] === Indexer Op Dispatched (non-layerwise) ==="
                     f"\n  parent_op_id={op.op_id}, indexer_op_id={indexer_op.op_id}"
-                    f"\n  type={op.transfer_type.name}, dp_id={op.dp_id}"
+                    f"\n  type={op.transfer_type.name}, dp_rank={op.dp_rank}, pp_rank={op.pp_rank}"
                     f"\n  num_pages={num_pages}, pending_count={op.pending_count}")
 
                 indexer_worker = self._indexer_worker_map[op.transfer_type]
-                if isinstance(indexer_worker, List):
-                    indexer_worker[op.dp_id].submit_transfer(indexer_op)
+                if isinstance(indexer_worker, dict):
+                    indexer_worker[worker_key].submit_transfer(indexer_op)
                 else:
                     indexer_worker.submit_transfer(indexer_op)
 
         worker = self._worker_map[op.transfer_type]
-        if isinstance(worker, List):
-            worker[op.dp_id].submit_transfer(op)
+        if isinstance(worker, dict):
+            worker[worker_key].submit_transfer(op)
         else:
             worker.submit_transfer(op)
 
@@ -964,15 +1056,15 @@ class TransferEngine:
             # shutdown indexer workers first
             if self._has_indexer:
                 for worker in self._indexer_worker_map.values():
-                    if isinstance(worker, List):
-                        for w in worker:
+                    if isinstance(worker, dict):
+                        for w in worker.values():
                             w.shutdown()
                     else:
                         worker.shutdown()
             # shutdown main KV workers
             for worker in self._worker_map.values():
-                if isinstance(worker, List):
-                    for w in worker:
+                if isinstance(worker, dict):
+                    for w in worker.values():
                         w.shutdown()
                 else:
                     worker.shutdown()

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -419,9 +419,6 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
                  cpu_kv_layout: KVCacheLayout,
                  dtype: torch.dtype,
                  tp_group_size: int,
-                 dp_group_id: int,
-                 is_nsa_cp: bool = False,
-                 cp_size: int = 1,
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
                  transfer_num_cta_h2d: int = 4,
@@ -440,12 +437,9 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         self.gpu_blocks = imported_gpu_blocks
         self.dtype = dtype # note this should be quantized data type
         self.is_mla = gpu_kv_layouts[0].is_mla
-        self.is_nsa_cp = is_nsa_cp
-        self.cp_size = cp_size
 
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
-        self.dp_group_id = dp_group_id
 
         flexkv_logger.info(f"Pinning CPU Memory: {cpu_blocks.numel() * cpu_blocks.element_size() / (1024 ** 3):.2f} GB")
         cudaHostRegister(cpu_blocks)
@@ -497,7 +491,6 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             gpu_block_ptrs_flat,
             num_tensors_per_gpu,
             cpu_blocks_ptr,
-            dp_group_id,
             self.num_layers,
             self.gpu_kv_strides_in_bytes,
             self.gpu_block_strides_in_bytes,
@@ -551,7 +544,6 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             layer_id,
             layer_granularity,
             self.is_mla,
-            self.is_nsa_cp and self.cp_size > 1,
         )
 
 
@@ -1145,7 +1137,6 @@ class tpGDSTransferWorker(TransferWorkerBase):
         ssd_kv_layout: KVCacheLayout,
         dtype: torch.dtype,
         tp_group_size: int,
-        dp_group_id: int,
     ) -> None:
         """
         Initialize TP GDS Transfer Worker
@@ -1161,7 +1152,6 @@ class tpGDSTransferWorker(TransferWorkerBase):
             ssd_kv_layout: Layout of SSD KV cache
             dtype: Data type
             tp_group_size: Size of tensor parallel group
-            dp_group_id: Data parallel group ID
         """
         # Initialize base class first
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
@@ -1182,7 +1172,6 @@ class tpGDSTransferWorker(TransferWorkerBase):
         self.is_mla = gpu_kv_layouts[0].is_mla
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
-        self.dp_group_id = dp_group_id
 
         # Layout information
         self.num_layers = gpu_kv_layouts[0].num_layer
@@ -1205,7 +1194,7 @@ class tpGDSTransferWorker(TransferWorkerBase):
         # SSD layout calculations
         self.ssd_layer_stride_in_bytes = ssd_kv_layout_per_file.get_layer_stride() * self.dtype.itemsize
         self.ssd_kv_stride_in_bytes = ssd_kv_layout_per_file.get_kv_stride() * self.dtype.itemsize
-        self.ssd_tp_stride_in_bytes = self.ssd_block_stride_in_bytes // self.tp_group_size if not self.is_mla else self.ssd_block_stride_in_bytes
+        self.ssd_tp_stride_in_bytes = self.ssd_block_stride_in_bytes // self.tp_size_per_node if not self.is_mla else self.ssd_block_stride_in_bytes
 
         # Resolve pointers in Python (where storage is valid); pass them to C++ so we avoid
         # "Tensor that doesn't have storage" when C++ calls .data_ptr() on tensors passed
@@ -1224,7 +1213,6 @@ class tpGDSTransferWorker(TransferWorkerBase):
             gpu_block_ptrs_flat,
             num_tensors_per_gpu,
             ssd_files,
-            dp_group_id,
             self.num_layers,
             self.gpu_kv_strides_in_bytes,
             self.gpu_block_strides_in_bytes,

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -19,7 +19,7 @@ import subprocess
 import pickle
 import sys
 
-from flexkv.common.transfer import TransferOpGraph, CompletedOp
+from flexkv.common.transfer import TransferOpGraph, CompletedOp, WorkerKey
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
@@ -43,12 +43,12 @@ class TransferManager:
         # Multi-instance support: get instance_num from environment
         self.instance_num = GLOBAL_CONFIG_FROM_ENV.instance_num
         
-        # Calculate total expected GPUs across all instances
-        self.expected_gpus = self.instance_num * model_config.tp_size * model_config.dp_size
+        # Calculate total expected GPUs on this node across all instances
+        self.expected_gpus = self.instance_num * model_config.gpus_per_node
 
         self.all_gpu_layouts: Dict[int, KVCacheLayout] = {}
         self.all_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> gpu_blocks
-        self.gpu_client_mapping: Dict[int, int] = {}  # device_id -> dp_client_id
+        self.gpu_worker_key_mapping: Dict[int, WorkerKey] = {}  # device_id -> WorkerKey(dp_rank, pp_rank)
 
         # Indexer GPU registration data
         self.all_indexer_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> indexer_gpu_blocks
@@ -72,7 +72,7 @@ class TransferManager:
             try:
                 self.all_gpu_blocks[device_id] = req.handles
                 self.all_gpu_layouts[device_id] = req.gpu_layout
-                self.gpu_client_mapping[device_id] = req.dp_client_id
+                self.gpu_worker_key_mapping[device_id] = WorkerKey(dp_rank=req.dp_rank, pp_rank=req.pp_rank)
                 # Store indexer GPU data if present
                 if req.indexer_handles is not None:
                     self.all_indexer_gpu_blocks[device_id] = req.indexer_handles
@@ -87,8 +87,9 @@ class TransferManager:
         try:
             flexkv_logger.info(f"GPU tensor registration server started on port {self.gpu_register_port}, "
                                f"expected {self.expected_gpus} GPUs to register "
-                               f"(instance_num={self.instance_num}, tp={self.model_config.tp_size}, "
-                               f"dp={self.model_config.dp_size})")
+                               f"(instance_num={self.instance_num}, gpus_per_node={self.model_config.gpus_per_node}, "
+                               f"total_gpus={self.model_config.total_gpus}, pp_rank={self.model_config.pp_rank}, "
+                               f"node_rank={self.model_config.node_rank}, nnodes={self.model_config.nnodes})")
             last_log_time = time.time()
             while len(self.all_gpu_blocks) < self.expected_gpus:
                 try:
@@ -109,7 +110,8 @@ class TransferManager:
                     continue
 
                 if isinstance(req, RegisterTPClientRequest):
-                    flexkv_logger.info(f"Received GPU blocks registration request: {type(req)}")
+                    flexkv_logger.info(f"Received GPU blocks registration request: {type(req)}, "
+                                       f"device_id={req.device_id}, dp_rank={req.dp_rank}")
                     self._handle_gpu_blocks_registration(req)
                     flexkv_logger.info(f"GPU {req.device_id} registered successfully, "
                                        f"waiting for {self.expected_gpus - len(self.all_gpu_blocks)} GPUs to register")
@@ -153,13 +155,13 @@ class TransferManager:
                 indexer_dtype=indexer_dtype,
             )
         
-        # Group GPU handles by dp_client_id
-        grouped_gpu_handles: Dict[int, List] = {}
+        # Group GPU handles by WorkerKey
+        grouped_gpu_handles: Dict[WorkerKey, List] = {}
         for device_id in sorted(self.all_gpu_blocks.keys()):
-            dp_client_id = self.gpu_client_mapping[device_id]
-            if dp_client_id not in grouped_gpu_handles:
-                grouped_gpu_handles[dp_client_id] = []
-            grouped_gpu_handles[dp_client_id].append(
+            worker_key = self.gpu_worker_key_mapping[device_id]
+            if worker_key not in grouped_gpu_handles:
+                grouped_gpu_handles[worker_key] = []
+            grouped_gpu_handles[worker_key].append(
                 self.storage_engine.get_storage_handle(DeviceType.GPU, device_id))
         
         cpu_handle = self.storage_engine.get_storage_handle(DeviceType.CPU) \
@@ -172,15 +174,15 @@ class TransferManager:
             else None
         )
 
-        indexer_gpu_handles: Optional[Dict[int, List]] = None
+        indexer_gpu_handles: Optional[Dict[WorkerKey, List]] = None
         if self.storage_engine.has_storage_handle(DeviceType.CPU, is_indexer=True):
             indexer_gpu_handles = {}
             for device_id in sorted(self.all_gpu_blocks.keys()):
                 if self.storage_engine.has_storage_handle(DeviceType.GPU, device_id, is_indexer=True):
-                    dp_client_id = self.gpu_client_mapping[device_id]
-                    if dp_client_id not in indexer_gpu_handles:
-                        indexer_gpu_handles[dp_client_id] = []
-                    indexer_gpu_handles[dp_client_id].append(
+                    worker_key = self.gpu_worker_key_mapping[device_id]
+                    if worker_key not in indexer_gpu_handles:
+                        indexer_gpu_handles[worker_key] = []
+                    indexer_gpu_handles[worker_key].append(
                         self.storage_engine.get_storage_handle(DeviceType.GPU, device_id, is_indexer=True))
         indexer_cpu_handle = (
             self.storage_engine.get_storage_handle(DeviceType.CPU, is_indexer=True)
@@ -210,7 +212,23 @@ class TransferManager:
             indexer_ssd_handle=indexer_ssd_handle,
             indexer_remote_handle=indexer_remote_handle,
         )
-        flexkv_logger.info("Initialized TransferEngine successfully")
+
+        # Derive local (dp_rank, pp_rank) from GPU registrations rather than
+        # model_config.  In cross-node PP, TransferManagerOnRemote receives
+        # model_config from the PP0 master (pp_rank=0), but local GPUs
+        # register with their true pp_rank (e.g. pp_rank=1).
+        worker_keys = set(self.gpu_worker_key_mapping.values())
+        self._local_dp_rank = self.model_config.dp_rank
+        self._local_pp_rank = self.model_config.pp_rank
+        if len(worker_keys) == 1:
+            wk = next(iter(worker_keys))
+            self._local_dp_rank = wk.dp_rank
+            self._local_pp_rank = wk.pp_rank
+
+        flexkv_logger.info(f"Initialized TransferEngine successfully, "
+                           f"grouped_gpu_handles keys={list(grouped_gpu_handles.keys())}, "
+                           f"num_gpu_groups={len(grouped_gpu_handles)}, "
+                           f"local_dp_rank={self._local_dp_rank}, local_pp_rank={self._local_pp_rank}")
 
     def submit(self, transfer_graph: TransferOpGraph) -> None:
         self.transfer_engine.submit_transfer_graph(transfer_graph)
@@ -289,6 +307,11 @@ class TransferManagerOnRemote(TransferManager):
         self._active_graphs: Dict[int, int] = {}
         self._active_graphs_lock = threading.Lock()
 
+        # Pending matching for cross-node PP: graph arrives before or after slot_mapping
+        self._pending_graphs: Dict[int, TransferOpGraph] = {}
+        self._pending_slot_mappings: Dict[int, np.ndarray] = {}
+        self._pending_lock = threading.Lock()
+
         self._worker_thread: threading.Thread | None = None
 
         self._connect_to_master_transfer_manager()
@@ -352,21 +375,21 @@ class TransferManagerOnRemote(TransferManager):
                                 task_end_op_id = message.get('task_end_op_id', -1)
 
                                 if graph is not None:
-                                    graph_id = graph.graph_id
-
-                                    with self._active_graphs_lock:
-                                        self._active_graphs[graph_id] = task_end_op_id
-
-                                    self.submit(graph)
+                                    self._handle_submit(graph, task_end_op_id)
                                 else:
                                     flexkv_logger.warning("Received submit message without graph")
                             elif msg_type == 'submit_batch':
                                 graphs = message.get('graphs', [])
                                 for graph in graphs:
+                                    self._rebind_graph_to_local_worker(graph)
                                     graph_id = graph.graph_id
                                     with self._active_graphs_lock:
                                         self._active_graphs[graph_id] = -1
                                     self.submit(graph)
+                            elif msg_type == 'set_slot_mapping':
+                                task_id = message.get('task_id')
+                                slot_mapping = message.get('slot_mapping')
+                                self._handle_set_slot_mapping(task_id, slot_mapping)
                             else:
                                 flexkv_logger.warning(f"Unexpected command message: {message}")
                         else:
@@ -415,11 +438,90 @@ class TransferManagerOnRemote(TransferManager):
         poller.unregister(self.command_socket)
         poller.unregister(self.query_socket)
 
+    def _handle_set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
+        """Handle set_slot_mapping message from FlexKVConnector.
+
+        When the graph (with cleared GPU blocks) arrived earlier, we can immediately
+        set_gpu_blocks and submit.  Otherwise, store the slot_mapping and wait
+        for the graph to arrive later.
+        """
+        with self._pending_lock:
+            if task_id in self._pending_graphs:
+                # Graph already arrived, set GPU blocks and submit
+                graph = self._pending_graphs.pop(task_id)
+                graph.set_gpu_blocks(slot_mapping)
+                self._rebind_graph_to_local_worker(graph)
+                self.submit(graph)
+                flexkv_logger.debug(
+                    f"[TransferManagerOnRemote] set_slot_mapping: "
+                    f"graph for task_id={task_id} submitted (graph arrived first)"
+                )
+            else:
+                # Graph not yet arrived, store slot_mapping for later matching
+                self._pending_slot_mappings[task_id] = slot_mapping
+                flexkv_logger.debug(
+                    f"[TransferManagerOnRemote] set_slot_mapping: "
+                    f"slot_mapping stored for task_id={task_id}, waiting for graph"
+                )
+
+    def _handle_submit(self, graph: TransferOpGraph, task_end_op_id: int = -1) -> None:
+        """Handle submit message with pending matching support.
+
+        If slot_mapping already arrived, set_gpu_blocks and submit immediately.
+        Otherwise, store graph in pending_graphs for later matching.
+        """
+        task_id = graph.graph_id  # Use graph_id as task_id for matching
+        with self._pending_lock:
+            if task_id in self._pending_slot_mappings:
+                # slot_mapping already arrived, set GPU blocks and submit
+                slot_mapping = self._pending_slot_mappings.pop(task_id)
+                graph.set_gpu_blocks(slot_mapping)
+                self._rebind_graph_to_local_worker(graph)
+                flexkv_logger.debug(
+                    f"[TransferManagerOnRemote] submit: "
+                    f"graph for task_id={task_id} submitted (slot_mapping arrived first)"
+                )
+            else:
+                # slot_mapping not yet arrived, store graph for later matching
+                self._pending_graphs[task_id] = graph
+                flexkv_logger.debug(
+                    f"[TransferManagerOnRemote] submit: "
+                    f"graph stored for task_id={task_id}, waiting for slot_mapping"
+                )
+                return  # Don't submit yet, wait for slot_mapping
+
+        # Submit graph to transfer engine
+        with self._active_graphs_lock:
+            self._active_graphs[graph.graph_id] = task_end_op_id
+        self.submit(graph)
+
+    def _rebind_graph_to_local_worker(self, graph: TransferOpGraph) -> None:
+        """Rebind transfer graph ops to the local WorkerKey.
+
+        In cross-node PP setups, the master (PP0) creates transfer graphs with
+        its own (dp_rank=0, pp_rank=0). When these graphs are sent to a remote
+        node (e.g. PP1), the ops must be rebound to the local (dp_rank, pp_rank)
+        so the TransferEngine can find the correct workers.
+        """
+        model_pp_rank = self.model_config.pp_rank
+        model_dp_rank = self.model_config.dp_rank
+
+        if model_pp_rank == self._local_pp_rank and model_dp_rank == self._local_dp_rank:
+            return  # No rebinding needed
+
+        old_key = WorkerKey(dp_rank=model_dp_rank, pp_rank=model_pp_rank)
+        new_key = WorkerKey(dp_rank=self._local_dp_rank, pp_rank=self._local_pp_rank)
+        graph.bind_to_worker(self._local_dp_rank, self._local_pp_rank)
+        flexkv_logger.debug(
+            f"[TransferManagerOnRemote] Rebound graph {graph.graph_id} "
+            f"from {old_key} to {new_key}"
+        )
+
     def start(self) -> None:
         self.initialize_transfer_engine()
         super().start()
 
-        self._is_ready = true
+        self._is_ready = True
 
         self._worker_thread = threading.Thread(
             target=self._polling_worker, daemon=True
@@ -455,9 +557,6 @@ class TransferManagerOnRemote(TransferManager):
 
     @classmethod
     def create_process(cls, **kwargs: Any) -> Process:
-        import tempfile
-        import os
-
         # Serialize the class and kwargs
         cls_data = pickle.dumps(cls)
         kwargs_data = pickle.dumps(kwargs)
@@ -538,7 +637,6 @@ class TransferManagerOnRemote(TransferManager):
             except Exception:
                 pass
 
-        import threading
         cleanup_thread = threading.Thread(target=cleanup_files, daemon=True)
         cleanup_thread.start()
 
@@ -647,6 +745,11 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
         if self.process is not None and self.process.is_alive():
             return
 
+        flexkv_logger.debug(
+            f"Spawning TransferManager subprocess: "
+            f"pp_rank={self.model_config.pp_rank}, node_rank={self.model_config.node_rank}, "
+            f"tp_size={self.model_config.tp_size}, dp_size={self.model_config.dp_size}, "
+            f"gpu_register_port={self.gpu_register_port}")
         self.process = self.mp_ctx.Process(
             target=self._process_worker,
             args=(self.model_config,
@@ -659,6 +762,7 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
             daemon=False
         )
         self.process.start()
+        flexkv_logger.debug(f"TransferManager subprocess spawned, pid={self.process.pid}")
 
     def _process_worker(self,
                         model_config: ModelConfig,
@@ -682,11 +786,15 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
                     break
         signal.signal(signal.SIGCHLD, _reap_children)
         try:
+            flexkv_logger.debug(f"_process_worker started, pid={os.getpid()}, "
+                               f"gpu_register_port={gpu_register_port}, "
+                               f"pp_rank={model_config.pp_rank}, node_rank={model_config.node_rank}")
             start_event.set()
             os.environ['MPI4PY_RC_INITIALIZE'] = 'false'
             transfer_manager = TransferManager(model_config, cache_config, gpu_register_port)
             transfer_manager.initialize_transfer_engine()
             transfer_manager.start()
+            flexkv_logger.debug("TransferEngine started successfully, setting ready_event")
             ready_event.set()
 
             # Setup selector for event-driven processing (complete zero polling!)
@@ -825,7 +933,7 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
         self.shutdown()
 
 
-class TranserManagerMultiNodeHandle(TransferManagerHandleBase):
+class TransferManagerMultiNodeHandle(TransferManagerHandleBase):
     def __init__(self,
                  model_config: ModelConfig,
                  cache_config: CacheConfig,
@@ -1023,6 +1131,10 @@ class TransferManagerHandle:
                  gpu_register_port: Optional[str] = None,
                  mode: str = "process",
                  **kwargs): # process or thread or remote
+        flexkv_logger.debug(
+            f"Creating TransferManagerHandle: mode={mode}, "
+            f"pp_rank={model_config.pp_rank}, node_rank={model_config.node_rank}, "
+            f"gpu_register_port={gpu_register_port}")
         if gpu_register_port is None:
             gpu_register_port = f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}"
         if mode == "process":
@@ -1036,7 +1148,7 @@ class TransferManagerHandle:
         elif mode == "remote":
             master_host = kwargs["master_host"]
             master_ports = kwargs["master_ports"]
-            self._handle: TransferManagerHandleBase = TranserManagerMultiNodeHandle(
+            self._handle: TransferManagerHandleBase = TransferManagerMultiNodeHandle(
                 model_config, cache_config, gpu_register_port, master_host, master_ports
             )
         else:

--- a/tests/replay_from_tracer.py
+++ b/tests/replay_from_tracer.py
@@ -147,7 +147,6 @@ class FlexKVReplayEngine:
             num_remote_blocks=cache_config_data['num_remote_blocks'],
             ssd_cache_dir=cache_config_data['ssd_cache_dir'],
             gds_cache_dir=cache_config_data['gds_cache_dir'],
-            remote_cache_size_mode=cache_config_data['remote_cache_size_mode'],
             remote_file_size=cache_config_data['remote_file_size'],
             remote_file_num=cache_config_data['remote_file_num'],
             remote_file_prefix=cache_config_data['remote_file_prefix'],
@@ -234,7 +233,8 @@ class FlexKVReplayEngine:
 
             # Create registration request
             register_req = RegisterTPClientRequest(
-                dp_client_id=gpu_id // self.model_config.tp_size,  # DP client ID
+                dp_rank=gpu_id // self.model_config.tp_size,  # DP client ID
+                pp_rank=0,  # single PP stage for replay
                 device_id=gpu_id,
                 handles=handles,
                 gpu_layout=self.gpu_layout
@@ -305,7 +305,8 @@ class FlexKVReplayEngine:
         slot_mapping = np.array(data['slot_mapping'], dtype=np.int64)
         token_mask = np.array(data['token_mask'], dtype=bool) if data['token_mask'] else None
         layer_granularity = data.get('layer_granularity', -1)
-        dp_id = data.get('dp_id', 0)
+        dp_rank = data.get('dp_id', 0)
+        pp_rank = data.get('pp_rank', 0)
 
         self.log(f"Replaying {request_type} request with {len(token_ids)} tokens")
 
@@ -319,7 +320,8 @@ class FlexKVReplayEngine:
                 slot_mapping=slot_mapping,
                 token_mask=token_mask,
                 layer_granularity=layer_granularity,
-                dp_id=dp_id
+                dp_rank=dp_rank,
+                pp_rank=pp_rank
             )
         elif request_type == "PUT":
             print(f"✅✅✅PUT token_ids: {token_ids[:128]}")
@@ -330,7 +332,8 @@ class FlexKVReplayEngine:
                 token_ids=token_ids,
                 slot_mapping=slot_mapping,
                 token_mask=token_mask,
-                dp_id=dp_id
+                dp_rank=dp_rank,
+                pp_rank=pp_rank
             )
         elif request_type == "GET_MATCH":
             print(f"🔍📝GET_MATCH token_ids: {token_ids[:128]}")
@@ -341,7 +344,8 @@ class FlexKVReplayEngine:
                 token_ids=token_ids,
                 token_mask=token_mask,
                 layer_granularity=layer_granularity,
-                dp_id=dp_id
+                dp_rank=dp_rank,
+                pp_rank=pp_rank
             )
         elif request_type == "PUT_MATCH":
             print(f"✅📝PUT_MATCH token_ids: {token_ids[:128]}")
@@ -351,7 +355,8 @@ class FlexKVReplayEngine:
             task_id, return_mask = self.kvmanager.put_match(
                 token_ids=token_ids,
                 token_mask=token_mask,
-                dp_id=dp_id
+                dp_rank=dp_rank,
+                pp_rank=pp_rank
             )
         else:
             raise ValueError(f"Unknown request type: {request_type}")

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -40,7 +40,7 @@ def _fp8_cuda_ops_unavailable():
     except NotImplementedError:
         return True
 
-def run_tp_client(dp_client_id,
+def run_tp_client(dp_rank,
                   tp_rank,
                   server_recv_port,
                   model_config,
@@ -50,8 +50,8 @@ def run_tp_client(dp_client_id,
                   gpu_layout_type):
     """Run tp_client process"""
     try:
-        device_id = tp_rank + dp_client_id * model_config.tp_size
-        tp_client = KVTPClient(server_recv_port, dp_client_id, device_id)
+        device_id = tp_rank + dp_rank * model_config.tp_size
+        tp_client = KVTPClient(server_recv_port, dp_rank, device_id)
 
         gpu_kv_layout = create_gpu_kv_layout(model_config, cache_config, num_gpu_blocks, gpu_layout_type)
 
@@ -242,14 +242,14 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     initial_write_num = int(num_requests * initial_write_ratio)
     print("writing initial data...")
     put_ids = []
-    for token_ids, block_ids, dp_id in request_pairs[:initial_write_num]:
+    for token_ids, block_ids, dp_rank in request_pairs[:initial_write_num]:
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         write_request = kvmanager.put_async(
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
             namespace=namespace,
         )
         kvmanager.wait([write_request], completely=True)
@@ -261,7 +261,7 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
         token_ids=torch.randint(0, 100, size=(8,), dtype=torch.int64),
         slot_mapping=block_ids_2_slot_mapping(torch.arange(0,1, dtype=torch.int64), tokens_per_block, actual_length=8),
         token_mask=None,
-        dp_id=0,
+        dp_rank=0,
         namespace=namespace,
     )
     kvmanager.wait([write_request], completely=True)
@@ -272,7 +272,7 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     #    token_ids=torch.randint(0, 100, size=(16,), dtype=torch.int64),
     #    slot_mapping=block_ids_2_slot_mapping(torch.arange(0,1, dtype=torch.int64), tokens_per_block, actual_length=8),
     #    token_mask=my_mask,
-    #    dp_id=0,
+    #    dp_rank=0,
     #)
     #kvmanager.wait_for_graph_finished(write_request)
 
@@ -289,13 +289,13 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     for i in range(initial_write_num, num_requests):
         print(f"performing mixed read/write {i} / {num_requests} ...")
         read_idx = i - initial_write_num
-        token_ids, block_ids, dp_id = request_pairs[read_idx]
+        token_ids, block_ids, dp_rank = request_pairs[read_idx]
         slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
         request_id, _ = kvmanager.get_match(
             token_ids=token_ids,
             layer_granularity=-1,
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
             namespace=namespace,
         )
         kvmanager.launch(request_id, slot_mapping)
@@ -303,14 +303,14 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
         running_get_requests.append(request_id)
         req_id2block_ids[request_id] = block_ids
         req_id2token_ids[request_id] = token_ids
-        token_ids, block_ids, dp_id = request_pairs[i]
+        token_ids, block_ids, dp_rank = request_pairs[i]
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         request_id = kvmanager.put_async(
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
             namespace=namespace,
         )
         req_id2block_ids[request_id] = block_ids
@@ -378,14 +378,14 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
 
         # Create multiple get_match requests
         for i in range(batch_size):
-            token_ids, block_ids, dp_id = request_pairs[random.randint(0, num_requests - 1)]
+            token_ids, block_ids, dp_rank = request_pairs[random.randint(0, num_requests - 1)]
             slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
 
             request_id, return_mask = kvmanager.get_match(
                 token_ids=token_ids,
                 layer_granularity=-1,
                 token_mask=None,
-                dp_id=dp_id,
+                dp_rank=dp_rank,
                 namespace=namespace,
             )
             batched_get_task_ids.append(request_id)
@@ -580,7 +580,7 @@ class GPUIndexerCacheVerifier:
         return verification_passed
 
 
-def run_tp_client_with_indexer(dp_client_id,
+def run_tp_client_with_indexer(dp_rank,
                                tp_rank,
                                server_recv_port,
                                model_config,
@@ -593,7 +593,7 @@ def run_tp_client_with_indexer(dp_client_id,
     Indexer configuration is read from cache_config.indexer (IndexerCacheConfig).
     """
     try:
-        device_id = tp_rank + dp_client_id * model_config.tp_size
+        device_id = tp_rank + dp_rank * model_config.tp_size
 
         gpu_kv_layout = create_gpu_kv_layout(model_config, cache_config, num_gpu_blocks, gpu_layout_type)
 
@@ -647,7 +647,7 @@ def run_tp_client_with_indexer(dp_client_id,
         # Use KVTPClient directly with indexer buffers (shadow transfer mode)
         tp_client = KVTPClient(
             gpu_register_port=server_recv_port + "_gpu_register",
-            dp_client_id=dp_client_id,
+            dp_rank=dp_rank,
             device_id=device_id,
         )
         tp_client.register_to_server(
@@ -786,7 +786,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
     initial_write_num = int(num_requests * initial_write_ratio)
 
     print(f"[Test] Testing put flow ({test_label})...")
-    for token_ids, block_ids, dp_id in request_pairs[:initial_write_num]:
+    for token_ids, block_ids, dp_rank in request_pairs[:initial_write_num]:
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         if indexer_kv_verifier is not None:
@@ -795,7 +795,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
         )
         put_results = kvmanager.wait([write_request], completely=True)
         assert put_results[write_request].status == KVResponseStatus.SUCCESS
@@ -816,13 +816,13 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
     batch_slot_mappings = []
 
     for i in range(min(initial_write_num, num_requests)):
-        token_ids, block_ids, dp_id = request_pairs[i]
+        token_ids, block_ids, dp_rank = request_pairs[i]
         slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
         request_id, _ = kvmanager.get_match(
             token_ids=token_ids,
             layer_granularity=-1,
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
         )
         batch_task_ids.append(request_id)
         batch_slot_mappings.append(slot_mapping)
@@ -889,7 +889,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
 
     print(f"[Test] Testing try_wait flow ({test_label})...")
     if initial_write_num < num_requests:
-        token_ids, block_ids, dp_id = request_pairs[initial_write_num]
+        token_ids, block_ids, dp_rank = request_pairs[initial_write_num]
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         if indexer_kv_verifier is not None:
@@ -898,7 +898,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_id=dp_id,
+            dp_rank=dp_rank,
         )
         finished = {}
         for _ in range(200):
@@ -1018,11 +1018,8 @@ def _mock_sglang_eventfd_client(socket_path: str,
                   f"after {max_retries} attempts")
             return
 
-        # Send 24-byte metadata: tp_rank, tp_size, cp_rank, cp_size,
-        #                         num_layers, num_counters
-        metadata = struct.pack("iiiiii",
+        metadata = struct.pack("iiii",
                                tp_rank, tp_size,
-                               0, 1,  # cp_rank=0, cp_size=1
                                num_layers, num_counters)
         sock.sendall(metadata)
 

--- a/tests/test_transfer_engine_atomic_eviction.py
+++ b/tests/test_transfer_engine_atomic_eviction.py
@@ -300,7 +300,7 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine, main_worker, indexer_worker = self._make_engine_stub_with_indexer(enable_layerwise=True)
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_id = 0
+        op.dp_rank = 0
         engine.op_id_to_op[op.op_id] = op
 
         initial_pending_count = op.pending_count  # should be 1
@@ -324,7 +324,7 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine, main_worker, indexer_worker = self._make_engine_stub_with_indexer(enable_layerwise=True)
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_id = 0
+        op.dp_rank = 0
         engine.op_id_to_op[op.op_id] = op
 
         with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
@@ -358,7 +358,7 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine._worker_map[TransferType.LAYERWISE] = [main_layerwise_worker]
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_id = 0
+        op.dp_rank = 0
         engine.op_id_to_op[op.op_id] = op
 
         initial_pending_count = op.pending_count  # should be 1


### PR DESCRIPTION
## Summary

Add Pipeline Parallelism (PP) support with a **centralized control plane, decentralized data plane** architecture. Each PP stage independently handles its own scheduling (control plane), while a single TransferEngine instance serves all stages (data plane) keyed by `WorkerKey(dp_rank, pp_rank)`.

## Key Changes

### 1. ModelConfig — PP-aware fields & freeze
- Add `pp_start_layer`, `pp_end_layer`, `enable_dp_attention`, `attn_cp_size`, `attn_cp_rank`, `tp_rank`
- Add derived properties: `attn_tp_size`, `attn_tp_rank`, `num_layers_per_pp_stage`, `token_size_in_bytes_per_pp_stage`, `tp_rank_per_node`, `tp_size_per_node`
- Add `freeze()` to prevent post-init mutation of parallel config
- Cache block sizing now uses `token_size_in_bytes_per_pp_stage` (per-stage, not full model)

### 2. WorkerKey(dp_rank, pp_rank) — replaces flat dp_id
- New frozen dataclass `WorkerKey` in `common/transfer.py`
- `TransferOp`: `dp_id` → `(dp_rank, pp_rank)`
- `TransferOpGraph`: `bind_to_dp_group()` → `bind_to_worker(dp_rank, pp_rank)`
- All worker maps in `TransferEngine` keyed by `WorkerKey`

### 3. TransferOpGraph — deferred GPU block binding for PP
- `clear_gpu_blocks()`: strip GPU slot mappings from graph template
- `set_gpu_blocks(slot_mapping)`: rebind with PP-stage-specific slot mapping
- Enables: build one graph template per request, then each PP stage fills its own GPU blocks

### 4. TransferManager — PP-aware graph dispatch
- GPU registration: `device_id → WorkerKey(dp_rank, pp_rank)`
- New `set_slot_mapping` protocol: PP stage sends slot mapping separately from graph
- `_rebind_graph_to_local_worker()`: rebind graph ops to the correct worker on the receiving node
- Pending matching: slot_mapping may arrive before or after the graph — both orders handled