### PR TITLE
[bug fix] Fix KV task resource release

### DIFF
--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -376,7 +376,6 @@ class KVTaskManager:
         task = self.tasks[task_id]
         if not task.is_completed():
             task.status = TaskStatus.CANCELLED
-            task.shed_heavy_resources()
         self._release_task(task_id)
 
     def check_completed(self, task_id: int, completely: bool = False) -> bool:

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -188,6 +188,10 @@ class KVTaskManager:
 
         self.running_tasks: int = 0
         self._pending_release_tasks: set = set()
+        # Cache of KVResponse for tasks already released from self.tasks but not yet observed by wait().
+        self._completed_results: ExpiringDict[int, KVResponse] = ExpiringDict(
+            max_age_seconds=1800, max_len=100000
+        )
 
     def start(self) -> None:
         for transfer_handle in self.transfer_handles:
@@ -419,11 +423,19 @@ class KVTaskManager:
         task.status = TaskStatus.RUNNING
         return task.graph
 
-    def _release_task(self, task_id: int) -> None:
+    def _release_task(self, task_id: int, cache_response: bool = True) -> None:
         """clean up task resources."""
         if task_id not in self.tasks:
             return
         task = self.tasks[task_id]
+        # Cache the result so a future wait() that arrives after this auto-release
+        # can still retrieve status + return_mask. 
+        if cache_response and task.is_completed():
+            self._completed_results[task_id] = KVResponse(
+                status=convert_to_response_status(task.status),
+                task_id=task_id,
+                return_mask=task.return_mask,
+            )
         batch_id = task.batch_task_id
         self.graph_to_task.pop(task.graph.graph_id, None)
         self.tasks.pop(task_id, None)
@@ -602,6 +614,11 @@ class KVTaskEngine(KVTaskManager):
             nvtx_range = nvtx.start_range(message=f"KVTask.wait[{task_id}]", color="red")
             while True:
                 if task_id not in self.tasks:
+                    # Task may have been auto-released after completion
+                    if task_id in self._completed_results:
+                        return_responses[task_id] = self._completed_results[task_id]
+                        del self._completed_results[task_id]
+                        break
                     flexkv_logger.error(f"task_id {task_id} not submitted into flexKV")
                     return_responses[task_id] = KVResponse(
                         status=KVResponseStatus.NOTFOUND,
@@ -625,7 +642,8 @@ class KVTaskEngine(KVTaskManager):
                         return_mask=self.tasks[task_id].return_mask
                     )
                     if self.tasks[effective_id].is_completed():
-                        self._release_task(task_id)
+                        # User has observed; do not duplicate into cache.
+                        self._release_task(task_id, cache_response=False)
                     break
                 elif only_return_finished:
                     break

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -78,6 +78,15 @@ class KVTask:
     def is_completed(self) -> bool:
         return self.status in [TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED]
 
+    def shed_heavy_resources(self) -> None:
+        # Drop heavy fields once the task terminates. Keeps status / return_mask / batch link 
+        # so wait() can still report the result; only when the user observes it (wait/try_wait) or cancels it.
+        self.graph = None
+        self.token_ids = None
+        self.slot_mapping = None
+        self.token_mask = None
+        self.callback = None
+
 TASK_STATUS_TO_RESPONSE_STATUS = {
     TaskStatus.COMPLETED: KVResponseStatus.SUCCESS,
     TaskStatus.CANCELLED: KVResponseStatus.CANCELLED,
@@ -187,11 +196,6 @@ class KVTaskManager:
         self.task_id_lock = threading.Lock()
 
         self.running_tasks: int = 0
-        self._pending_release_tasks: set = set()
-        # Cache of KVResponse for tasks already released from self.tasks but not yet observed by wait().
-        self._completed_results: ExpiringDict[int, KVResponse] = ExpiringDict(
-            max_age_seconds=1800, max_len=100000
-        )
 
     def start(self) -> None:
         for transfer_handle in self.transfer_handles:
@@ -336,11 +340,6 @@ class KVTaskManager:
                 transfer_handle.submit(transfer_graph)
 
     def _update_tasks(self, timeout: float = 0.001) -> None:
-        if self._pending_release_tasks:
-            for tid in list(self._pending_release_tasks):
-                self._release_task(tid)
-            self._pending_release_tasks.clear()
-
         completed_ops = self._get_completed_ops(timeout)
         metrics_collector = get_global_collector()
         for completed_op in completed_ops:
@@ -377,7 +376,8 @@ class KVTaskManager:
         task = self.tasks[task_id]
         if not task.is_completed():
             task.status = TaskStatus.CANCELLED
-        self._release_task(task_id, cache_response=False)
+            task.shed_heavy_resources()
+        self._release_task(task_id)
 
     def check_completed(self, task_id: int, completely: bool = False) -> bool:
         task = self.tasks[task_id]
@@ -423,26 +423,20 @@ class KVTaskManager:
         task.status = TaskStatus.RUNNING
         return task.graph
 
-    def _release_task(self, task_id: int, cache_response: bool = True) -> None:
-        """clean up task resources."""
+    def _release_task(self, task_id: int) -> None:
+        """Remove the task record entirely. Called when the user observes (wait/try_wait)
+        or cancels the task. """
         if task_id not in self.tasks:
             return
         task = self.tasks[task_id]
-        # Cache the result so a future wait() that arrives after this auto-release
-        # can still retrieve status + return_mask. 
-        if cache_response and task.is_completed():
-            self._completed_results[task_id] = KVResponse(
-                status=convert_to_response_status(task.status),
-                task_id=task_id,
-                return_mask=task.return_mask,
-            )
         batch_id = task.batch_task_id
-        self.graph_to_task.pop(task.graph.graph_id, None)
+        if task.graph is not None:
+            self.graph_to_task.pop(task.graph.graph_id, None)
         self.tasks.pop(task_id, None)
         if batch_id is not None and batch_id in self.tasks:
             self.tasks[batch_id].pending_sub_count -= 1
             if self.tasks[batch_id].pending_sub_count <= 0:
-                self._release_task(batch_id, cache_response=cache_response)
+                self._release_task(batch_id)
 
     def _mark_completed(self, task_id: int) -> None:
         task = self.tasks[task_id]
@@ -456,12 +450,13 @@ class KVTaskManager:
                 task.callback()
         task.status = TaskStatus.COMPLETED
         task.task_end_op_finished = True
-        self.graph_to_task.pop(task.graph.graph_id)
-        if task.batch_task_id is None and task.pending_sub_count == 0:
-            self._pending_release_tasks.add(task_id)
+        self.graph_to_task.pop(task.graph.graph_id, None)
+        task.shed_heavy_resources()
 
     def _process_empty_graph(self, task_id: int) -> None:
         task = self.tasks[task_id]
+        if task.graph is None:
+            return
         if task.graph.num_ops == 0:
             self._mark_completed(task_id)
 
@@ -614,11 +609,6 @@ class KVTaskEngine(KVTaskManager):
             nvtx_range = nvtx.start_range(message=f"KVTask.wait[{task_id}]", color="red")
             while True:
                 if task_id not in self.tasks:
-                    # Task may have been auto-released after completion
-                    if task_id in self._completed_results:
-                        return_responses[task_id] = self._completed_results[task_id]
-                        del self._completed_results[task_id]
-                        break
                     flexkv_logger.error(f"task_id {task_id} not submitted into flexKV")
                     return_responses[task_id] = KVResponse(
                         status=KVResponseStatus.NOTFOUND,
@@ -642,8 +632,7 @@ class KVTaskEngine(KVTaskManager):
                         return_mask=self.tasks[task_id].return_mask
                     )
                     if self.tasks[effective_id].is_completed():
-                        # User has observed; do not duplicate into cache.
-                        self._release_task(task_id, cache_response=False)
+                        self._release_task(task_id)
                     break
                 elif only_return_finished:
                     break

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -377,7 +377,7 @@ class KVTaskManager:
         task = self.tasks[task_id]
         if not task.is_completed():
             task.status = TaskStatus.CANCELLED
-        self._release_task(task_id)
+        self._release_task(task_id, cache_response=False)
 
     def check_completed(self, task_id: int, completely: bool = False) -> bool:
         task = self.tasks[task_id]
@@ -442,7 +442,7 @@ class KVTaskManager:
         if batch_id is not None and batch_id in self.tasks:
             self.tasks[batch_id].pending_sub_count -= 1
             if self.tasks[batch_id].pending_sub_count <= 0:
-                self._release_task(batch_id)
+                self._release_task(batch_id, cache_response=cache_response)
 
     def _mark_completed(self, task_id: int) -> None:
         task = self.tasks[task_id]


### PR DESCRIPTION
  This PR refactors KV task resource release into a two-stage lifecycle.

  Previously, completed tasks could be removed from self.tasks before the caller had a chance to observe the result through `wait() /
  try_wait()`. Because` _update_tasks()` consumes completion events globally, waiting on one group of tasks could complete and release
  another group first, causing later waits to return `NOTFOUND`.

  The new flow separates task completion from task record removal:

  - On task completion, FlexKV marks the task as completed and sheds heavy resources such as `transfer graph, token ids, slot mapping, token mask, and callbacks`.
  - The lightweight task record remains available so `wait() / try_wait()` can still return the final status and return_mask.
  - Once the caller observes the completed task, the task record is fully released from self.tasks.
  - Cancelled tasks are still removed immediately through the normal release path.

  This keeps the original goal of reducing Python GC pressure from completed tasks while preserving the public wait semantics for tasks whose completion was observed indirectly by another wait/update cycle.