### PR TITLE
refactor: fix pp issues and separate per-rank state into RankInfo and unify dp_client_id

### DIFF
--- a/benchmarks/benchmark_dist_kvcache.py
+++ b/benchmarks/benchmark_dist_kvcache.py
@@ -53,7 +53,7 @@ import numpy as np
 from flexkv.server.client import KVTPClient
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.config import (
-    ModelConfig, CacheConfig, UserConfig,
+    ModelConfig, CacheConfig, UserConfig, RankInfo,
     update_default_config_from_user_config, parse_path_list,
     GLOBAL_CONFIG_FROM_ENV,
 )
@@ -152,7 +152,8 @@ def load_dist_config(config_path: str):
         # Store mooncake_config_path in cache_config so it survives spawn subprocesses via pickle
         cache_config.mooncake_config_path = mooncake_config_path
 
-    update_default_config_from_user_config(model_config, cache_config, user_config)
+    rank_info = RankInfo(model_config=model_config)
+    update_default_config_from_user_config(rank_info, cache_config, user_config)
 
     # Handle server_client_mode from config
     if config.get("server_client_mode", False):

--- a/benchmarks/benchmark_workers.py
+++ b/benchmarks/benchmark_workers.py
@@ -377,12 +377,10 @@ def bench_worker(args):
 
     transfer_op = TransferOp(
         transfer_type=transfer_type,
-        layer_id=0,
-        layer_granularity=num_layers_to_transfer,
         src_block_ids=block_ids,
         dst_block_ids=block_ids,
         graph_id=0,
-        dp_id=0,
+        dp_client_id=0,
         successors=[],
         predecessors=[],
     )
@@ -397,12 +395,10 @@ def bench_worker(args):
 
         reverse_transfer_op = TransferOp(
             transfer_type=reverse_type,
-            layer_id=0,
-            layer_granularity=num_layers_to_transfer,
             src_block_ids=reverse_block_ids,
             dst_block_ids=reverse_block_ids,
             graph_id=1,
-            dp_id=0,
+            dp_client_id=0,
             successors=[],
             predecessors=[],
         )

--- a/benchmarks/dist_benchmark/benchmark_dist_direct.py
+++ b/benchmarks/dist_benchmark/benchmark_dist_direct.py
@@ -65,7 +65,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from flexkv.server.client import KVTPClient
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.config import (
-    ModelConfig, CacheConfig, UserConfig,
+    ModelConfig, CacheConfig, UserConfig, RankInfo,
     update_default_config_from_user_config, parse_path_list,
     GLOBAL_CONFIG_FROM_ENV,
 )
@@ -163,7 +163,7 @@ def load_dist_direct_config(config_path: str):
         # Store mooncake_config_path in cache_config so it survives spawn subprocesses via pickle
         cache_config.mooncake_config_path = mooncake_config_path
 
-    update_default_config_from_user_config(model_config, cache_config, user_config)
+    update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
 
     # IMPORTANT: Ensure server_client_mode is NOT set for direct mode
     # Even if config says server_client_mode: true, we override it here

--- a/benchmarks/dist_benchmark/benchmark_dist_kvcache.py
+++ b/benchmarks/dist_benchmark/benchmark_dist_kvcache.py
@@ -53,7 +53,7 @@ import numpy as np
 from flexkv.server.client import KVTPClient
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.config import (
-    ModelConfig, CacheConfig, UserConfig,
+    ModelConfig, CacheConfig, UserConfig, RankInfo,
     update_default_config_from_user_config, parse_path_list,
     GLOBAL_CONFIG_FROM_ENV,
 )
@@ -152,7 +152,7 @@ def load_dist_config(config_path: str):
         # Store mooncake_config_path in cache_config so it survives spawn subprocesses via pickle
         cache_config.mooncake_config_path = mooncake_config_path
 
-    update_default_config_from_user_config(model_config, cache_config, user_config)
+    update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
 
     # Handle server_client_mode from config
     if config.get("server_client_mode", False):

--- a/benchmarks/dist_benchmark/utils.py
+++ b/benchmarks/dist_benchmark/utils.py
@@ -122,7 +122,7 @@ def load_config(config_path: str) -> Tuple[ModelConfig, CacheConfig]:
             user_config.ssd_cache_dir = parse_path_list(config["ssd_cache_dir"])
         if "enable_gds" in config:
             user_config.enable_gds = config["enable_gds"]
-        update_default_config_from_user_config(model_config, cache_config, user_config)
+        update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
         return model_config, cache_config
 
 if __name__ == "__main__":

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -122,7 +122,7 @@ def load_config(config_path: str) -> Tuple[ModelConfig, CacheConfig]:
             user_config.ssd_cache_dir = parse_path_list(config["ssd_cache_dir"])
         if "enable_gds" in config:
             user_config.enable_gds = config["enable_gds"]
-        update_default_config_from_user_config(model_config, cache_config, user_config)
+        update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
         return model_config, cache_config
 
 if __name__ == "__main__":

--- a/csrc/layerwise.h
+++ b/csrc/layerwise.h
@@ -76,7 +76,6 @@ public:
 
 private:
   int num_gpus_;
-  int dp_group_id_;
   void **gpu_blocks_;
   void *cpu_blocks_;
   int num_tensors_per_gpu_;

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -20,7 +20,6 @@ from queue import Queue
 from typing import List, Tuple, Optional, Dict, Callable
 from dataclasses import dataclass, field
 
-import os
 import numpy as np
 import nvtx
 import torch
@@ -30,7 +29,7 @@ from flexkv.cache.redis_meta import RedisMeta, dist_available
 
 from flexkv.cache.mempool import Mempool
 from flexkv.cache.radixtree import RadixTreeIndex, RadixNode, MatchResult
-from flexkv.cache.transfer_pattern import add_virtal_op_for_mutiple_finished_ops
+from flexkv.cache.transfer_pattern import add_virtual_op_for_multiple_finished_ops
 from flexkv.common.block import SequenceMeta
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.transfer import (
@@ -530,39 +529,19 @@ class GlobalCacheEngine:
             token_ids: np.ndarray,
             token_mask: np.ndarray,
             slot_mapping: np.ndarray,
-            layer_num: int = -1,
-            layer_granularity: int = -1,
-            dp_rank: int = 0,
-            pp_rank: int = 0,
+            dp_client_id: int,
             temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY,
             namespace: Optional[List[str]] = None) \
                  -> Tuple[TransferOpGraph, np.ndarray, Callable, Dict, int]:
         self._check_input(token_ids, token_mask, slot_mapping)
 
-        if layer_num == -1:
-            layer_num = self.model_config.num_layers_per_pp_stage
-        if layer_granularity == -1:
-            layer_granularity = layer_num
-
-        if layer_num != layer_granularity:
-            flexkv_logger.error(f"Layerwise transfer is not supported yet, "
-                                f"layer_num: {layer_num}, layer_granularity: {layer_granularity}")
-            raise NotImplementedError(f"Layerwise transfer is not supported yet, "
-                                      f"layer_num: {layer_num}, layer_granularity: {layer_granularity}")
-
-        combine_with_trtllm = os.getenv("FLEXKV_WITH_TRTLLM", "0") == "1"
-        if not combine_with_trtllm:
-            aligned_length = (token_ids.shape[0] // self.tokens_per_block) * self.tokens_per_block
-        else:
-            # When using FlexKV with TensorRT-LLM, we ignore the last incomplete block.
-            aligned_length = ((token_ids.shape[0] - 1) // self.tokens_per_block) * self.tokens_per_block
+        aligned_length = (token_ids.shape[0] // self.tokens_per_block) * self.tokens_per_block
 
         aligned_token_ids = token_ids[:aligned_length]
         token_mask[aligned_length:] = False
 
         if aligned_length == 0 or not token_mask.any():
             transfer_graph = TransferOpGraph.create_empty_graph()
-            transfer_graph.bind_to_worker(dp_rank, pp_rank)
             return_mask = np.zeros_like(token_mask, dtype=np.bool_)
             callback = partial(self._transfer_callback, node_to_unlock={}, buffer_to_free={})
             return transfer_graph, return_mask, callback, {}, -1
@@ -586,8 +565,8 @@ class GlobalCacheEngine:
                     block_start_idx,
                     block_end_idx,
                     gpu_block_ids,
-                    layer_num,
-                    temp_cache_strategy
+                    temp_cache_strategy,
+                    dp_client_id,
                 )
         else:
             #TODO pcfs will be supported later
@@ -599,13 +578,14 @@ class GlobalCacheEngine:
                     block_start_idx,
                     block_end_idx,
                     gpu_block_ids,
-                    layer_num,
-                    temp_cache_strategy
+                    temp_cache_strategy,
+                    dp_client_id,
                 )
 
-        transfer_graph, task_end_op_id = add_virtal_op_for_mutiple_finished_ops(
+        transfer_graph, task_end_op_id = add_virtual_op_for_multiple_finished_ops(
             transfer_graph,
-            finished_ops_ids
+            finished_ops_ids,
+            dp_client_id,
             )
 
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
@@ -617,7 +597,6 @@ class GlobalCacheEngine:
         #                                                                         finished_ops_ids=finished_ops_ids,
         #                                                                         layer_num=layer_num,
         #                                                                         layer_granularity=layer_granularity)
-        transfer_graph.bind_to_worker(dp_rank, pp_rank)
 
         for device_type in node_to_unlock:
             self.cache_engines[device_type].lock_node(node_to_unlock[device_type][0])
@@ -646,8 +625,8 @@ class GlobalCacheEngine:
             block_mask_start: int,
             block_mask_end: int,
             gpu_block_ids: np.ndarray,
-            layer_num: int,
-            temp_cache_strategy: CacheStrategy) \
+            temp_cache_strategy: CacheStrategy,
+            dp_client_id: int) \
                  -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
         """
         transfer pattern:
@@ -760,9 +739,8 @@ class GlobalCacheEngine:
                 graph_id = transfer_graph.graph_id,
                 transfer_type = TransferType.DISK2H,
                 src_block_ids = fragment2_ssd_blocks,
-                dst_block_ids = fragment123_cpu_blocks[fragment1_num_blocks:fragment12_num_blocks],
-                layer_id = 0,
-                layer_granularity = layer_num
+                dst_block_ids = fragment123_cpu_blocks[fragment1_num_blocks:fragment12_num_blocks],    
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_disk2h)
 
@@ -773,9 +751,8 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.REMOTE2H,
                 src_block_ids = fragment3_remote_blocks,
                 dst_block_ids = fragment123_cpu_blocks[-fragment3_num_blocks:],
-                layer_id = 0,
-                layer_granularity = layer_num,
-                src_block_node_ids = fragment3_remote_file_nodeids
+                src_block_node_ids = fragment3_remote_file_nodeids,
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_remote2h)
 
@@ -801,8 +778,7 @@ class GlobalCacheEngine:
                     transfer_type = TransferType.H2DISK,
                     src_block_ids = fragment123_cpu_blocks[-fragment3_num_blocks:],
                     dst_block_ids = fragment3_ssd_blocks,
-                    layer_id = 0,
-                    layer_granularity = layer_num
+                    dp_client_id = dp_client_id,
                 )
                 transfer_graph.add_transfer_op(op_h2disk)
                 transfer_graph.add_dependency(op_h2disk.op_id, op_remote2h.op_id)
@@ -819,8 +795,7 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.H2D,
                 src_block_ids = fragment123_cpu_blocks,
                 dst_block_ids = fragment123_gpu_blocks,
-                layer_id = 0,
-                layer_granularity = layer_num
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_h2d)
             if op_disk2h is not None:
@@ -851,8 +826,8 @@ class GlobalCacheEngine:
                         block_mask_start: int,
                         block_mask_end: int,
                         gpu_block_ids: np.ndarray,
-                        layer_num: int,
-                        temp_cache_strategy: CacheStrategy) \
+                        temp_cache_strategy: CacheStrategy,
+                        dp_client_id: int) \
                             -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
         """
         transfer pattern:
@@ -967,10 +942,9 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.PEERH2H,
                 src_block_ids = fragment1_cpu_blocks,
                 dst_block_ids = fragment1_cpu_blocks_local,
-                layer_id = 0,
-                layer_granularity = layer_num,
                 remote_node_ids = cpu_matched_result.matched_node_ids,
-                src_block_node_ids = cpu_matched_result.matched_node_ids  # Add this for worker
+                src_block_node_ids = cpu_matched_result.matched_node_ids,  # Add this for worker
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_peerh2h)
             #TODO here we dont combine peer cpu or local cpu match results, so we can safely add remote results to local cpu
@@ -993,8 +967,7 @@ class GlobalCacheEngine:
                     transfer_type = TransferType.DISK2D,
                     src_block_ids = fragment2_ssd_blocks,
                     dst_block_ids = fragment12_gpu_blocks[-fragment2_num_blocks:],
-                    layer_id = 0,
-                    layer_granularity = layer_num
+                    dp_client_id = dp_client_id,
                 )
                 transfer_graph.add_transfer_op(op_gds_transfer)
                 finished_ops_ids.append(op_gds_transfer.op_id)
@@ -1009,10 +982,9 @@ class GlobalCacheEngine:
                     transfer_type = TransferType.PEERSSD2H if ssd_matched_result.matched_pos == "remote" else TransferType.DISK2H,
                     src_block_ids = fragment2_ssd_blocks,
                     dst_block_ids = fragment2_cpu_blocks,
-                    layer_id = 0,
-                    layer_granularity = layer_num,
                     remote_node_ids = ssd_matched_result.matched_node_ids if ssd_matched_result.matched_pos == "remote" else None,
-                    src_block_node_ids = ssd_matched_result.matched_node_ids if ssd_matched_result.matched_pos == "remote" else None
+                    src_block_node_ids = ssd_matched_result.matched_node_ids if ssd_matched_result.matched_pos == "remote" else None,
+                    dp_client_id = dp_client_id,
                 )
                 transfer_graph.add_transfer_op(op_disk2h)
                 # we only insert the buffer blocks to cpu cache engine only:
@@ -1046,8 +1018,7 @@ class GlobalCacheEngine:
                 src_block_ids = fragment12_cpu_blocks if not enable_gds else fragment1_cpu_blocks,
                 dst_block_ids = fragment12_gpu_blocks if not enable_gds \
                     else fragment12_gpu_blocks[:fragment1_num_blocks],
-                layer_id = 0,
-                layer_granularity = layer_num
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_h2d)
             if op_disk2h is not None:
@@ -1073,16 +1044,11 @@ class GlobalCacheEngine:
             token_ids: np.ndarray,
             token_mask: np.ndarray,
             slot_mapping: np.ndarray,
-            layer_num : int = -1,
-            dp_rank: int = 0,
-            pp_rank: int = 0,
+            dp_client_id: int,
             temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY,
             namespace: Optional[List[str]] = None) \
                 -> Tuple[TransferOpGraph, np.ndarray, Callable, Dict, int]:
         self._check_input(token_ids, token_mask, slot_mapping)
-
-        if layer_num == -1:
-            layer_num = self.model_config.num_layers_per_pp_stage
         # ignore the last incomplete block
         aligned_length = (token_ids.shape[0] // self.tokens_per_block) * self.tokens_per_block
         aligned_token_ids = token_ids[:aligned_length]
@@ -1109,8 +1075,8 @@ class GlobalCacheEngine:
                     block_start_idx,
                     block_end_idx,
                     gpu_block_ids,
-                    layer_num,
-                    temp_cache_strategy
+                    temp_cache_strategy,
+                    dp_client_id,
                 )
         else:
             (transfer_graph, finished_ops_ids, node_to_unlock, op_node_to_ready,
@@ -1121,19 +1087,19 @@ class GlobalCacheEngine:
                     block_start_idx,
                     block_end_idx,
                     gpu_block_ids,
-                    layer_num,
-                    temp_cache_strategy
+                    temp_cache_strategy,
+                    dp_client_id,
                 )
 
-        transfer_graph, task_end_op_id = add_virtal_op_for_mutiple_finished_ops(
+        transfer_graph, task_end_op_id = add_virtual_op_for_multiple_finished_ops(
             transfer_graph,
-            finished_ops_ids
+            finished_ops_ids,
+            dp_client_id,
         )
 
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
         return_mask[(block_start_idx + skipped_gpu_blocks)* self.tokens_per_block:
                     (block_start_idx + skipped_gpu_blocks + num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
-        transfer_graph.bind_to_worker(dp_rank, pp_rank)
 
         for device_type in node_to_unlock:
             self.cache_engines[device_type].lock_node(node_to_unlock[device_type][0])
@@ -1163,8 +1129,8 @@ class GlobalCacheEngine:
             block_mask_start: int,
             block_mask_end: int,
             gpu_block_ids: np.ndarray,
-            layer_num : int,
-            temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY) \
+            temp_cache_strategy: CacheStrategy,
+            dp_client_id: int) \
                 -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, int]:
         """
         transfer pattern:
@@ -1258,8 +1224,7 @@ class GlobalCacheEngine:
             transfer_type = TransferType.D2H,
             src_block_ids = fragment12_gpu_blocks,
             dst_block_ids = fragment12_cpu_blocks,
-            layer_id = 0,
-            layer_granularity = layer_num
+            dp_client_id = dp_client_id,
         )
         transfer_graph.add_transfer_op(op_d2h)
         finished_ops_ids.append(op_d2h.op_id)
@@ -1276,8 +1241,7 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.H2DISK,
                 src_block_ids = fragment2_cpu_blocks,
                 dst_block_ids = fragment2_ssd_blocks,
-                layer_id = 0,
-                layer_granularity = layer_num
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_h2disk)
 
@@ -1295,8 +1259,7 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.H2REMOTE,
                 src_block_ids = fragment3_cpu_blocks,
                 dst_block_ids = fragment3_remote_blocks,
-                layer_id = 0,
-                layer_granularity = layer_num
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_h2remote)
             transfer_graph.add_dependency(op_h2remote.op_id, op_d2h.op_id)
@@ -1337,8 +1300,8 @@ class GlobalCacheEngine:
             block_mask_start: int,
             block_mask_end: int,
             gpu_block_ids: np.ndarray,
-            layer_num : int,
-            temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY) \
+            temp_cache_strategy: CacheStrategy,
+            dp_client_id: int) \
                 -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, int]:
         """
         transfer pattern:
@@ -1418,8 +1381,7 @@ class GlobalCacheEngine:
             transfer_type = TransferType.D2H,
             src_block_ids = fragment12_gpu_blocks,
             dst_block_ids = fragment12_cpu_blocks,
-            layer_id = 0,
-            layer_granularity = layer_num
+            dp_client_id = dp_client_id,
         )
         transfer_graph.add_transfer_op(op_d2h)
         finished_ops_ids.append(op_d2h.op_id)
@@ -1440,8 +1402,7 @@ class GlobalCacheEngine:
                 transfer_type = TransferType.H2DISK,
                 src_block_ids = fragment2_cpu_blocks,
                 dst_block_ids = fragment2_ssd_blocks,
-                layer_id = 0,
-                layer_granularity = layer_num
+                dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_h2disk)
 

--- a/flexkv/cache/transfer_pattern.py
+++ b/flexkv/cache/transfer_pattern.py
@@ -1,33 +1,32 @@
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import numpy as np
-import torch
 
 from flexkv.common.transfer import TransferType
 from flexkv.common.transfer import TransferOp, TransferOpGraph
 
 
-def add_virtal_op_for_mutiple_finished_ops(
+def add_virtual_op_for_multiple_finished_ops(
     graph: TransferOpGraph,
-    finished_ops_ids: List[int]
-)->Tuple[TransferOpGraph, int]:
+    finished_ops_ids: List[int],
+    dp_client_id: int,
+) -> Tuple[TransferOpGraph, int]:
     if len(finished_ops_ids) == 0:
         return graph, -1
-    elif len(finished_ops_ids) == 1:
+    if len(finished_ops_ids) == 1:
         return graph, finished_ops_ids[0]
-    else:
-        op = TransferOp(
-            graph_id = graph.graph_id,
-            transfer_type = TransferType.VIRTUAL,
-            src_block_ids = np.array([], dtype=np.int64),
-            dst_block_ids = np.array([], dtype=np.int64),
-            layer_id = -1,
-            layer_granularity = -1,
-        )
-        graph.add_transfer_op(op)
-        for op_id in finished_ops_ids:
-            graph.add_dependency(op.op_id, op_id)
-        return graph, op.op_id
+
+    op = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.VIRTUAL,
+        src_block_ids=np.array([], dtype=np.int64),
+        dst_block_ids=np.array([], dtype=np.int64),
+        dp_client_id=dp_client_id,
+    )
+    graph.add_transfer_op(op)
+    for op_id in finished_ops_ids:
+        graph.add_dependency(op.op_id, op_id)
+    return graph, op.op_id
 
 def convert_read_graph_to_layer_wise_graph(
     transfer_graph: TransferOpGraph,
@@ -60,9 +59,7 @@ def convert_read_graph_to_layer_wise_graph(
                 dst_block_ids=op.dst_block_ids,
                 layer_id=i * layer_granularity,
                 layer_granularity=layer_granularity,
-                # Inherit these fields directly
-                dp_rank=op.dp_rank,
-                pp_rank=op.pp_rank,
+                dp_client_id=op.dp_client_id,
             )
             new_graph.add_transfer_op(new_op)
             split_op_ids.append(new_op.op_id)

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -3,7 +3,7 @@ import json
 import yaml
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, List, Tuple, Union, Dict, Any
 from argparse import Namespace
 import copy
 
@@ -31,20 +31,11 @@ class ModelConfig:
     dtype: torch.dtype = torch.bfloat16
 
     # ------------------------------------------------------------------
-    # Parallel configs
+    # Parallelism sizes (global, identical for every rank)
     # ------------------------------------------------------------------
     tp_size: int = 1
-    tp_rank: int = 0
-
     pp_size: int = 1
-    pp_rank: int = 0
-
     dp_size: int = 1
-    dp_rank: int = 0
-
-    # pp_start_layer / pp_end_layer: [start, end) layer indices for this PP stage.
-    pp_start_layer: int = 0
-    pp_end_layer: int = -1   # -1 → lazily resolved to num_layers
 
     # ------------------------------------------------------------------
     # Attention-level parallel configs
@@ -55,29 +46,40 @@ class ModelConfig:
     # attn_tp × attn_cp × attn_dp.
     enable_dp_attention: bool = False
 
-    # attn_cp_size / attn_cp_rank: context-parallel size/rank.
+    # attn_cp_size: context-parallel size (global).
     attn_cp_size: int = 1
-    attn_cp_rank: int = 0
 
     # ------------------------------------------------------------------
-    # Topology configs
+    # Topology configs (global)
     # ------------------------------------------------------------------
     # nnodes: number of physical machines spanned by one replica
-    # node_rank: index of this machine within ``nnodes``
     nnodes: int = 1
-    node_rank: int = 0
 
     # Multi-node bootstrap: master node's IP for TransferManager rendezvous.
-    # ``None`` falls back to ``FLEXKV_MASTER_HOST`` env var (default
-    # ``"localhost"``) inside ``resolve_master_host_and_ports``.  Set this
-    # from the framework's own launch config (e.g. sglang's
-    # ``--dist-init-addr``) to avoid exposing an extra env knob.
-    master_host: Optional[str] = None
+    # Bare host (no scheme); zmq sockets prepend ``tcp://`` at connect time.
+    # Set this from the framework's own launch config (e.g. sglang's
+    # ``--dist-init-addr``, TRT-LLM's launch script) so runtime layers
+    # (TransferManager / KVTaskManager) never need to read env vars.
+    master_host: str = "localhost"
 
-    # NSA context parallelism: when True, every rank in the CP group holds
-    # identical (full) KV cache.  FlexKV treats CP ranks the same as TP ranks
-    # in MLA mode.
-    is_nsa_cp: bool = False
+    # Master endpoint ports (command, result, query). Set via integration
+    # adapter when the launch script exposes a different port triple.
+    master_ports: Tuple[str, str, str] = ("5556", "5557", "5558")
+
+    # Whether KVTaskManager should run TransferManagerOnRemote in a
+    # subprocess (currently only used by TRT-LLM to avoid MPI conflicts).
+    # Set by the TRT-LLM adapter; default ``False`` for sglang/vllm.
+    use_trtllm_subprocess: bool = False
+
+    # Endpoint of that TRT-LLM subprocess TransferManagerOnRemote.
+    # Only consulted when ``use_trtllm_subprocess`` is True.
+    trtllm_subprocess_host: str = "localhost"
+    trtllm_subprocess_ports: Tuple[str, str, str] = ("6667", "6668", "6669")
+
+    # ------------------------------------------------------------------
+    # Multi-instance deployment
+    # ------------------------------------------------------------------
+    instance_num: int = 1
 
     # ------------------------------------------------------------------
     # Freeze mechanism: after post_init, ModelConfig must not be mutated
@@ -85,21 +87,30 @@ class ModelConfig:
     _frozen: bool = field(default=False, init=False, repr=False)
 
     def freeze(self) -> None:
-        """Lock the config so that any subsequent __setattr__ raises an error.
-        """
+        """Lock the config so that any subsequent __setattr__ raises an error."""
+        # ---- Topology validation ----
+        if self.total_gpus % self.nnodes != 0:
+            raise ValueError(
+                f"[ModelConfig] cannot derive gpus_per_node: "
+                f"total_gpus={self.total_gpus} not divisible by nnodes={self.nnodes}"
+            )
+        if self.nnodes_per_tp_group > 2:
+            raise ValueError(
+                f"[ModelConfig] only support 2-nodes TP for now, but got "
+                f"nnodes_per_tp_group={self.nnodes_per_tp_group} "
+                f"(tp_size={self.tp_size}, gpus_per_node={self.gpus_per_node})"
+            )
+        if self.tp_size % self.nnodes_per_tp_group != 0:
+            raise ValueError(
+                f"[ModelConfig] tp_size={self.tp_size} not divisible by "
+                f"nnodes_per_tp_group={self.nnodes_per_tp_group}"
+            )
+        if self.instance_num < 1:
+            raise ValueError(
+                f"[ModelConfig] instance_num must be >= 1, got {self.instance_num}"
+            )
+
         object.__setattr__(self, '_frozen', True)
-        flexkv_logger.info(
-            f"[FlexKV] ModelConfig FROZEN — primitive vars are now immutable. "
-            f"Derived: attn_tp_size={self.attn_tp_size}, attn_tp_rank={self.attn_tp_rank}, "
-            f"tp_size_per_node={self.tp_size_per_node}, "
-            f"nnodes_per_pp_rank={self.nnodes_per_pp_rank}, "
-            f"nnodes_per_tp_group={self.nnodes_per_tp_group}, "
-            f"total_gpus={self.total_gpus}, "
-            f"gpus_per_node={self.gpus_per_node}, "
-            f"num_kv_heads_per_node={self.num_kv_heads_per_node}, "
-            f"tp_rank_per_node={self.tp_rank_per_node}, "
-            f"local_rank={self.local_rank}"
-        )
 
     def __setattr__(self, name: str, value) -> None:
         if name == '_frozen':
@@ -109,7 +120,7 @@ class ModelConfig:
                 f"ModelConfig is frozen — cannot set '{name}'. "
                 f"All primitive fields must be set during post_init_from_*(), "
                 f"after which freeze() is called.  Derived fields (attn_tp_size, "
-                f"attn_tp_rank) are @property "
+                f"tp_size_per_node) are @property "
                 f"and cannot be set at all."
             )
         object.__setattr__(self, name, value)
@@ -121,6 +132,11 @@ class ModelConfig:
     def total_gpus(self) -> int:
         """Total GPUs across all nodes for one FlexKV instance."""
         return self.dp_size * self.tp_size * self.pp_size
+
+    @property
+    def total_clients(self) -> int:
+        """Total number of DPClient endpoints across all instances."""
+        return self.instance_num * self.dp_size
 
     @property
     def gpus_per_node(self) -> int:
@@ -143,48 +159,36 @@ class ModelConfig:
         return self.tp_size // self.nnodes_per_tp_group
 
     @property
-    def tp_rank_per_node(self) -> int:
-        """TP rank index within the local node (within one TP group)."""
-        return self.tp_rank % self.tp_size_per_node
-
-    @property
-    def local_rank(self) -> int:
-        """Local GPU device index within the node (a.k.a. ``LOCAL_RANK`` in
-        PyTorch distributed / sglang / vllm).
-
-        Matches the standard Megatron-style rank layout:
-            global_rank = dp_rank * pp_size * tp_size + pp_rank * tp_size + tp_rank
-
-        When DP-attention is enabled, DP replicas share the same physical
-        GPUs, so the DP dimension is not reflected in the device index.
-        The formula then reduces to:
-            local_rank = pp_rank_per_node * tp_size_per_node + tp_rank_per_node
-
-        When DP-attention is disabled, each DP replica has its own GPUs:
-            local_rank = (dp_rank_per_node * pp_size_per_node + pp_rank_per_node)
-                         * tp_size_per_node + tp_rank_per_node
-        where the ``_per_node`` values are derived inline from the global ranks
-        and topology.
-        """
-        pp_size_per_node = max(self.pp_size // self.nnodes, 1)
-        pp_rank_per_node = self.pp_rank % pp_size_per_node
-        if self.enable_dp_attention:
-            return pp_rank_per_node * self.tp_size_per_node + self.tp_rank_per_node
-        dp_size_per_node = self.gpus_per_node // (pp_size_per_node * self.tp_size_per_node)
-        dp_rank_per_node = self.dp_rank % dp_size_per_node
-        return (dp_rank_per_node * pp_size_per_node + pp_rank_per_node) * self.tp_size_per_node + self.tp_rank_per_node
+    def attn_dp_size(self) -> int:
+        """Attention-level DP size (= dp_size when enable_dp_attention else 1)."""
+        return max(1, self.dp_size) if self.enable_dp_attention else 1
 
     @property
     def attn_tp_size(self) -> int:
         """Attention-level TP size derived from tp / attn_dp / attn_cp."""
-        attn_dp = max(1, self.dp_size) if self.enable_dp_attention else 1
+        attn_dp = self.attn_dp_size
         cp = max(1, self.attn_cp_size)
         return max(1, max(1, self.tp_size) // (attn_dp * cp))
 
     @property
-    def attn_tp_rank(self) -> int:
-        """Attention-level TP rank derived from tp_rank / attn_tp_size."""
-        return self.tp_rank % max(1, self.attn_tp_size)
+    def attn_tp_size_per_node(self) -> int:
+        """Attention-level TP size per node."""
+        return self.attn_tp_size // self.nnodes_per_tp_group
+
+    @property
+    def attn_cp_size_per_node(self) -> int:
+        """Attention-level CP size on this node for a single pp stage. """
+        return max(1, self.attn_cp_size // self.nnodes_per_pp_rank)
+
+    @property
+    def effective_tp_size(self) -> int:
+        """Effective tp-group size used for *data-plane* CPU slicing."""
+        return max(1, self.attn_tp_size) * max(1, self.attn_cp_size)
+
+    @property
+    def effective_tp_size_per_node(self) -> int:
+        """Per-node counterpart of :pyattr:`effective_tp_size`."""
+        return self.attn_tp_size_per_node * self.attn_cp_size_per_node
 
     @property
     def num_kv_heads_per_node(self) -> int:
@@ -199,19 +203,122 @@ class ModelConfig:
         return 1 if self.use_mla else 2
 
     @property
-    def num_layers_per_pp_stage(self) -> int:
-        """Number of layers managed by this PP stage."""
-        end = self.pp_end_layer if self.pp_end_layer >= 0 else self.num_layers
-        return end - self.pp_start_layer
+    def bytes_per_token_per_layer(self) -> int:
+        """Raw byte footprint of a single (layer, token) KV slot."""
+        return self.num_kv_heads * self.head_size * self.kv_dim * self.dtype.itemsize
 
     @property
     def token_size_in_bytes(self) -> int:
-        return self.num_layers * self.num_kv_heads * self.head_size * self.kv_dim * self.dtype.itemsize
+        """Whole-model token footprint (bytes) — all layers combined."""
+        return self.num_layers * self.bytes_per_token_per_layer
+
+    def __str__(self) -> str:
+        return (
+            f"ModelConfig(num_layers={self.num_layers}, num_kv_heads={self.num_kv_heads}"
+            f", head_size={self.head_size}, use_mla={self.use_mla}"
+            f", dtype={self.dtype}"
+            f", tp_size={self.tp_size}, pp_size={self.pp_size}, dp_size={self.dp_size}"
+            f", attn_cp_size={self.attn_cp_size}"
+            f", nnodes={self.nnodes}, master_host={self.master_host!r}"
+            f", instance_num={self.instance_num}"
+        )
+
+
+@dataclass(frozen=True)
+class RankInfo:
+    model_config: ModelConfig
+    tp_rank: int = 0
+    pp_rank: int = 0
+    dp_rank: int = 0
+    attn_cp_rank: int = 0
+    node_rank: int = 0
+    instance_id: int = 0
+    pp_start_layer: int = 0
+    pp_end_layer: int = -1
+    @property
+    def tp_rank_per_node(self) -> int:
+        """TP rank index within the local node (within one TP group)."""
+        return self.tp_rank % self.model_config.tp_size_per_node
+
+    @property
+    def dp_client_id(self) -> int:
+        """Flat DP route label: unique int across all instances.
+
+        Equals ``instance_id * dp_size + dp_rank``. All transfer-engine
+        routing (worker maps, NVTX labels, socket paths, server-side
+        client registration) keys on this single int so the legacy
+        ``(instance_id, dp_rank)`` tuple (DPRoutingKey) is no longer
+        needed.
+        """
+        return self.instance_id * self.model_config.dp_size + self.dp_rank
+
+    @property
+    def attn_tp_rank(self) -> int:
+        """Attention-level TP rank derived from tp_rank / attn_tp_size."""
+        return self.tp_rank % max(1, self.model_config.attn_tp_size)
+
+    @property
+    def effective_tp_rank(self) -> int:
+        """Effective tp-rank in the *data-plane* segmentation space."""
+        if self.model_config.use_mla:
+            return self.attn_tp_rank
+        attn_tp_size = max(1, self.model_config.attn_tp_size)
+        return self.attn_cp_rank * attn_tp_size + self.attn_tp_rank
+
+    @property
+    def pp_size_per_node(self) -> int:
+        """Number of PP stages co-located on a single node."""
+        model_config = self.model_config
+        return max(model_config.pp_size // model_config.nnodes, 1)
+
+    @property
+    def pp_rank_per_node(self) -> int:
+        """This rank's PP index *within* its node."""
+        return self.pp_rank % self.pp_size_per_node
+
+    @property
+    def dp_size_per_node(self) -> int:
+        """Number of DP replicas co-located on a single node."""
+        model_config = self.model_config
+        return model_config.gpus_per_node // (self.pp_size_per_node * model_config.tp_size_per_node)
+
+    @property
+    def dp_rank_per_node(self) -> int:
+        """This rank's DP index *within* its node (non-DP-attention layout)."""
+        return self.dp_rank % self.dp_size_per_node
+
+    @property
+    def local_rank(self) -> int:
+        model_config = self.model_config
+        if model_config.enable_dp_attention:
+            return self.pp_rank_per_node * model_config.tp_size_per_node + self.tp_rank_per_node
+        return (self.dp_rank_per_node * self.pp_size_per_node + self.pp_rank_per_node) \
+               * model_config.tp_size_per_node + self.tp_rank_per_node
+
+    @property
+    def num_layers_per_pp_stage(self) -> int:
+        """Number of layers managed by this PP stage."""
+        end = self.pp_end_layer if self.pp_end_layer >= 0 else self.model_config.num_layers
+        return end - self.pp_start_layer
 
     @property
     def token_size_in_bytes_per_pp_stage(self) -> int:
-        """Token size in bytes for one PP stage (used by data plane)."""
-        return self.num_layers_per_pp_stage * self.num_kv_heads * self.head_size * self.kv_dim * self.dtype.itemsize
+        """Per-pp-stage token footprint (bytes) — rank-exact."""
+        return (self.num_layers_per_pp_stage
+                * self.model_config.bytes_per_token_per_layer)
+
+    def __str__(self) -> str:
+        """Human-readable summary of this rank including derived quantities.
+
+        Equivalent to the retired ``FlexKVContext.describe_rank`` output
+        (kept stable so log-grep patterns keep working).
+        """
+        return (
+            f"RankInfo(tp_rank={self.tp_rank}, pp_rank={self.pp_rank}"
+            f", dp_rank={self.dp_rank}, attn_cp_rank={self.attn_cp_rank}"
+            f", node_rank={self.node_rank}, instance_id={self.instance_id}"
+        )
+
 
 @dataclass
 class CacheConfig:
@@ -282,6 +389,19 @@ class CacheConfig:
         self.enable_kv_sharing = self.enable_p2p_cpu or \
             self.enable_p2p_ssd or self.enable_3rd_remote
         self.enable_remote = self.enable_3rd_remote
+
+    def __str__(self) -> str:
+        return (
+            f"CacheConfig(tokens_per_block={self.tokens_per_block}"
+            f", enable_cpu={self.enable_cpu}, enable_ssd={self.enable_ssd}"
+            f", enable_gds={self.enable_gds}, enable_remote={self.enable_remote}"
+            f", enable_kv_sharing={self.enable_kv_sharing}"
+            f", enable_p2p_cpu={self.enable_p2p_cpu}"
+            f", enable_p2p_ssd={self.enable_p2p_ssd}"
+            f", enable_3rd_remote={self.enable_3rd_remote}"
+            f", num_cpu_blocks={self.num_cpu_blocks}"
+            f", num_ssd_blocks={self.num_ssd_blocks})"
+        )
 
 GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     # Multi-instance configuration
@@ -417,10 +537,10 @@ def load_user_config_from_env() -> UserConfig:
 def convert_to_block_num(size_in_GB: float, block_size_in_bytes: int) -> int:
     return int(size_in_GB * 1024 * 1024 * 1024 / block_size_in_bytes)
 
-def update_default_config_from_user_config(model_config: ModelConfig,
+def update_default_config_from_user_config(rank_info: RankInfo,
                                            cache_config: CacheConfig,
                                            user_config: UserConfig) -> None:
-    block_size_in_bytes = model_config.token_size_in_bytes_per_pp_stage * cache_config.tokens_per_block
+    block_size_in_bytes = rank_info.token_size_in_bytes_per_pp_stage * cache_config.tokens_per_block
 
     assert user_config.cpu_cache_gb > 0
     assert user_config.ssd_cache_gb >= 0
@@ -449,6 +569,69 @@ def update_default_config_from_user_config(model_config: ModelConfig,
             (cache_config.num_ssd_blocks // len(cache_config.ssd_cache_dir) + 1) * len(cache_config.ssd_cache_dir)
         flexkv_logger.warning(f"num_ssd_blocks is not a multiple of num_ssd_devices, "
                               f"adjust num_ssd_blocks to {cache_config.num_ssd_blocks}")
+
+    if not cache_config.enable_cpu:
+        raise ValueError("enable_cpu must be True")
+    if cache_config.enable_remote and not cache_config.enable_ssd:
+        raise ValueError("enable_ssd must be True if enable_remote is True")
+    if not cache_config.enable_cpu and not cache_config.enable_gds:
+        raise ValueError("enable_gds must be True if enable_cpu is False")
+    if cache_config.enable_gds and not cache_config.enable_ssd:
+        raise ValueError("enable_ssd must be True if enable_gds is True")
+    if cache_config.enable_kv_sharing and cache_config.enable_gds:
+        raise ValueError(
+            "enable_kv_sharing and enable_gds cannot be used at the same time"
+        )
+
+    if cache_config.enable_remote:
+        if cache_config.remote_cache_path is None:
+            if cache_config.remote_file_prefix is None:
+                raise ValueError(
+                    "remote_file_prefix must be provided when remote_cache_path is None"
+                )
+            if (cache_config.remote_file_num is None
+                    or cache_config.remote_file_num <= 0):
+                raise ValueError("remote_file_num must be a positive integer")
+            cache_config.remote_cache_path = [
+                f"{cache_config.remote_file_prefix}_{i}"
+                for i in range(cache_config.remote_file_num)
+            ]
+
+        if cache_config.remote_cache_size_mode not in ("block_num", "file_size"):
+            raise ValueError(
+                f"remote_cache_size_mode must be 'block_num' or 'file_size', "
+                f"got {cache_config.remote_cache_size_mode!r}"
+            )
+
+        if cache_config.remote_cache_size_mode == "file_size":
+            if cache_config.remote_file_size is None:
+                raise ValueError(
+                    "remote_file_size must be set when remote_cache_size_mode == 'file_size'"
+                )
+            if (cache_config.remote_file_num is None
+                    or cache_config.remote_file_num <= 0):
+                raise ValueError("remote_file_num must be a positive integer")
+            cache_config.num_remote_blocks = (
+                cache_config.remote_file_size // block_size_in_bytes
+                * cache_config.remote_file_num
+            )
+            flexkv_logger.info(
+                f"num_remote_blocks derived from remote_file_size "
+                f"(per-pp-stage, num_layers_per_pp_stage="
+                f"{rank_info.num_layers_per_pp_stage}): "
+                f"remote_file_size={cache_config.remote_file_size}, "
+                f"remote_file_num={cache_config.remote_file_num}, "
+                f"block_size_in_bytes={block_size_in_bytes} "
+                f"-> num_remote_blocks={cache_config.num_remote_blocks}"
+            )
+
+        if (cache_config.num_remote_blocks is None
+                or cache_config.num_remote_blocks <= 0):
+            raise ValueError(
+                "num_remote_blocks must be a positive integer "
+                "(file_size mode: derived above from remote_file_size; "
+                "block_num mode: set it explicitly)"
+            )
 
     # Update distributed zmq and Redis configs if provided in user_config
     if user_config.local_zmq_ip is not None:

--- a/flexkv/common/debug.py
+++ b/flexkv/common/debug.py
@@ -47,10 +47,10 @@ class FlexkvLogger:
         self.logger.setLevel(log_level)
         self.enabled = log_level != (logging.CRITICAL + 1)
 
-    def _get_caller_info(self):
+    def _get_caller_info(self, skip: int = 2):
         frame = inspect.currentframe()
         try:
-            for _ in range(2):
+            for _ in range(skip):
                 frame = frame.f_back
                 if frame is None:
                     break
@@ -64,45 +64,42 @@ class FlexkvLogger:
 
         return "unknown", 0
 
+    def _log(self, level: int, msg: str, args: tuple, kwargs: dict) -> None:
+        """Build & dispatch a LogRecord, honoring ``exc_info`` like stdlib."""
+        # skip 3 frames: _get_caller_info -> _log -> public wrapper (e.g. error)
+        filename, lineno = self._get_caller_info(skip=3)
+        exc_info = kwargs.get("exc_info")
+        if exc_info:
+            if isinstance(exc_info, BaseException):
+                exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+            elif not isinstance(exc_info, tuple):
+                exc_info = sys.exc_info()
+        else:
+            exc_info = None
+        record = self.logger.makeRecord(
+            self.logger.name, level, filename, lineno, msg, args, exc_info
+        )
+        self.logger.handle(record)
+
     def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.enabled and self.logger.isEnabledFor(logging.DEBUG):
-            filename, lineno = self._get_caller_info()
-            record = self.logger.makeRecord(
-                self.logger.name, logging.DEBUG, filename, lineno, msg, args, None
-            )
-            self.logger.handle(record)
+            self._log(logging.DEBUG, msg, args, kwargs)
 
     def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.enabled and self.logger.isEnabledFor(logging.INFO):
-            filename, lineno = self._get_caller_info()
-            record = self.logger.makeRecord(
-                self.logger.name, logging.INFO, filename, lineno, msg, args, None
-            )
-            self.logger.handle(record)
+            self._log(logging.INFO, msg, args, kwargs)
 
     def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.enabled and self.logger.isEnabledFor(logging.WARNING):
-            filename, lineno = self._get_caller_info()
-            record = self.logger.makeRecord(
-                self.logger.name, logging.WARNING, filename, lineno, msg, args, None
-            )
-            self.logger.handle(record)
+            self._log(logging.WARNING, msg, args, kwargs)
 
     def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.enabled and self.logger.isEnabledFor(logging.ERROR):
-            filename, lineno = self._get_caller_info()
-            record = self.logger.makeRecord(
-                self.logger.name, logging.ERROR, filename, lineno, msg, args, None
-            )
-            self.logger.handle(record)
+            self._log(logging.ERROR, msg, args, kwargs)
 
     def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.enabled and self.logger.isEnabledFor(logging.CRITICAL):
-            filename, lineno = self._get_caller_info()
-            record = self.logger.makeRecord(
-                self.logger.name, logging.CRITICAL, filename, lineno, msg, args, None
-            )
-            self.logger.handle(record)
+            self._log(logging.CRITICAL, msg, args, kwargs)
 
 flexkv_logger = FlexkvLogger(os.getenv("FLEXKV_LOG_LEVEL", "INFO"))
 

--- a/flexkv/common/storage.py
+++ b/flexkv/common/storage.py
@@ -44,7 +44,7 @@ class KVCacheLayout:
                 self.kv_shape == other.kv_shape)
 
     @property
-    def _kv_dim(self) -> int:
+    def kv_dim(self) -> int:
         return 2 if not self.is_mla else 1
 
     @property
@@ -61,7 +61,7 @@ class KVCacheLayout:
         if self._kv_shape is None:
             if self.type == KVCacheLayoutType.LAYERFIRST:  # for Layerwise transfer
                 self._kv_shape = torch.Size([self.num_layer,
-                                             self._kv_dim,
+                                             self.kv_dim,
                                              self.num_block,
                                              self.tokens_per_block,
                                              self.num_head,
@@ -69,7 +69,7 @@ class KVCacheLayout:
             elif self.type == KVCacheLayoutType.BLOCKFIRST:
                 self._kv_shape = torch.Size([self.num_block,
                                              self.num_layer,
-                                             self._kv_dim,
+                                             self.kv_dim,
                                              self.tokens_per_block,
                                              self.num_head,
                                              self.head_size])

--- a/flexkv/common/tracer.py
+++ b/flexkv/common/tracer.py
@@ -194,9 +194,7 @@ class FlexKVTracer:
                      token_ids: Union[torch.Tensor, np.ndarray],
                      slot_mapping: Union[torch.Tensor, np.ndarray],
                      token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                     layer_granularity: int = -1,
-                     dp_rank: int = 0,
-                     pp_rank: int = 0,
+                     dp_client_id: int = 0,
                      **kwargs):
         """Record a request operation"""
         if not self.enabled:
@@ -211,9 +209,7 @@ class FlexKVTracer:
             "token_ids": self._convert_tensor_to_list(token_ids),
             "slot_mapping": self._convert_tensor_to_list(slot_mapping),
             "token_mask": self._convert_tensor_to_list(token_mask) if token_mask is not None else None,
-            "layer_granularity": layer_granularity,
-            "dp_rank": dp_rank,
-            "pp_rank": pp_rank,
+            "dp_client_id": dp_client_id,
             "token_ids_shape": list(token_ids.shape),
             "slot_mapping_shape": list(slot_mapping.shape),
             "token_mask_shape": list(token_mask.shape) if token_mask is not None else None,

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -10,13 +10,10 @@ from flexkv.common.debug import flexkv_logger
 
 @dataclass(frozen=True)
 class WorkerKey:
-    """Immutable, hashable key that uniquely identifies a worker by (dp_rank, pp_rank).
-
-    Used as dict keys in TransferEngine's worker maps and TransferManager's
-    GPU grouping instead of raw ``Tuple[int, int]`` to avoid ambiguity.
-    """
-    dp_rank: int
-    pp_rank: int
+    """Immutable, hashable key that uniquely identifies a worker by
+    ``(dp_client_id, pp_rank)``."""
+    dp_client_id: int = 0
+    pp_rank: int = 0
 
 
 @dataclass(frozen=True)
@@ -94,16 +91,13 @@ class TransferOp:
     transfer_type: TransferType
     src_block_ids: np.ndarray
     dst_block_ids: np.ndarray
-    layer_id: int = 0
-    layer_granularity: int = -1
     # src_block_node_ids: Optional[np.ndarray] = None
     # this will change dynamically as transfer ops executed
     predecessors: Set[int] = field(default_factory=set)
     # this will keep the full info
     successors: Set[int] = field(default_factory=set)
     status: TransferOpStatus = TransferOpStatus.PENDING
-    dp_rank: int = 0
-    pp_rank: int = 0
+    dp_client_id: int = 0
     # used for get block ids inner worker process
     src_slot_id: int = -1
     dst_slot_id: int = -1
@@ -111,10 +105,7 @@ class TransferOp:
     remote_node_ids: Optional[np.ndarray] = None
     # used for distributed cpu and ssd
     src_block_node_ids: Optional[np.ndarray] = None
-    # pending_count tracks how many workers (main KV + indexer) have not yet completed this op.
-    # Initialized to 1; incremented before submitting to indexer worker.
-    # _scheduler_loop decrements it on each worker completion; finalization happens only when it reaches 0.
-    pending_count: int = 1
+    pending_count: int = 0
 
     def __post_init__(self) -> None:
         if self.transfer_type != TransferType.VIRTUAL and \
@@ -147,10 +138,7 @@ class LayerwiseTransferOp(TransferOp):
                 dst_block_ids_h2d: np.ndarray,
                 src_block_ids_disk2h: np.ndarray,
                 dst_block_ids_disk2h: np.ndarray,
-                layer_id: int = 0,
-                layer_granularity: int = 1,
-                dp_rank: int = 0,
-                pp_rank: int = 0,
+                dp_client_id: int = 0,
                 counter_id: int = 0,
                 indexer_src_block_ids: Optional[np.ndarray] = None,
                 indexer_dst_block_ids: Optional[np.ndarray] = None) -> None:
@@ -169,18 +157,12 @@ class LayerwiseTransferOp(TransferOp):
             transfer_type=TransferType.LAYERWISE,
             src_block_ids=np.array([], dtype=np.int64),
             dst_block_ids=np.array([], dtype=np.int64),
-            layer_id=layer_id,
-            layer_granularity=layer_granularity,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank,
+            dp_client_id=dp_client_id,
         )
 
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        if self.layer_granularity == -1:
-            flexkv_logger.warning("layer_granularity is not set, using default value 1")
-            self.layer_granularity = 1
         assert self.src_block_ids_h2d.size == self.dst_block_ids_h2d.size
         assert self.src_block_ids_disk2h.size == self.dst_block_ids_disk2h.size
         assert self.indexer_src_block_ids.size == self.indexer_dst_block_ids.size
@@ -318,16 +300,6 @@ class TransferOpGraph:
     def num_ops(self) -> int:
         return len(self._op_map)
 
-    def bind_to_worker(self, dp_rank: int, pp_rank: int) -> None:
-        """Bind all ops in this graph to the specified DP group and PP stage.
-
-        Both fields are always set together because they jointly determine
-        which worker (GPU) handles the transfer.
-        """
-        for op in self._op_map.values():
-            op.dp_rank = dp_rank
-            op.pp_rank = pp_rank
-
     def visualize(self) -> str:
         """
         Visualize the transfer op graph in a readable format.
@@ -382,7 +354,7 @@ class TransferOpGraph:
                 dst_str = format_blocks(op.dst_block_ids)
                 lines.append(f"║     ├─ src_blocks:   {src_str}".ljust(71) + "║")
                 lines.append(f"║     ├─ dst_blocks:   {dst_str}".ljust(71) + "║")
-                lines.append(f"║     └─ layer_id={op.layer_id}, dp_rank={op.dp_rank}, pp_rank={op.pp_rank}".ljust(71) + "║")
+                lines.append(f"║     └─ dp_client_id={op.dp_client_id}".ljust(71) + "║")
             else:
                 lines.append("║     └─ (VIRTUAL - no blocks)".ljust(71) + "║")
 
@@ -424,10 +396,7 @@ def _merge_ops(ops: List[TransferOp], transfer_type: TransferType,
         transfer_type=transfer_type,
         src_block_ids=src_blocks,
         dst_block_ids=dst_blocks,
-        layer_id=ops[0].layer_id,
-        layer_granularity=ops[0].layer_granularity,
-        dp_rank=ops[0].dp_rank,
-        pp_rank=ops[0].pp_rank,
+        dp_client_id=ops[0].dp_client_id,
     )
     if callbacks:
         if len(callbacks) == 1:
@@ -511,10 +480,7 @@ def merge_to_batch_graph(batch_id: int,
                 dst_block_ids_disk2h=merged_disk2h_op.dst_block_ids \
                     if merged_disk2h_op is not None \
                     else np.array([], dtype=np.int64),
-                layer_id=0,
-                layer_granularity=1,
-                dp_rank=ops_by_type[TransferType.H2D][0].dp_rank,
-                pp_rank=ops_by_type[TransferType.H2D][0].pp_rank,
+                dp_client_id=ops_by_type[TransferType.H2D][0].dp_client_id,
                 counter_id=counter_id,
                 # Indexer maps 1:1 with main KV blocks, use same block_ids
                 # CPU side (src) and GPU side (dst) for H2D direction

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -3,7 +3,7 @@ import json
 import os
 import torch
 import tempfile
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 
 from flexkv.common.debug import flexkv_logger
@@ -117,73 +117,109 @@ class FlexKVConfig:
     def post_init_from_vllm_config(
         self,
         vllm_config: "VllmConfig",
-        ):
+        ) -> RankInfo:
+        tp_rank = getattr(vllm_config.parallel_config, 'tensor_parallel_rank', 0)
+        dp_rank = getattr(vllm_config.parallel_config, 'data_parallel_rank', 0)
+        node_rank = getattr(vllm_config.parallel_config, 'node_rank', 0)
         self.cache_config.tokens_per_block = vllm_config.cache_config.block_size
 
         self.model_config.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
         self.model_config.head_size = vllm_config.model_config.get_head_size()
-        self.model_config.dtype = vllm_config.model_config.dtype
+        user_dtype_str = self.user_config.kv_cache_dtype
+        vllm_kv_cache_dtype = getattr(vllm_config.cache_config, 'cache_dtype', 'auto')
+        if user_dtype_str is not None:
+            self.model_config.dtype = _parse_dtype_str(user_dtype_str)
+            logger.info(
+                f"[FlexKV vllm] Using kv_cache_dtype from user_config: "
+                f"'{user_dtype_str}' -> {self.model_config.dtype}"
+            )
+        elif isinstance(vllm_kv_cache_dtype, str) and vllm_kv_cache_dtype != 'auto':
+            self.model_config.dtype = _parse_dtype_str(vllm_kv_cache_dtype)
+            logger.info(
+                f"[FlexKV vllm] Using kv_cache_dtype from vllm cache_config: "
+                f"'{vllm_kv_cache_dtype}' -> {self.model_config.dtype}"
+            )
+        else:
+            self.model_config.dtype = vllm_config.model_config.dtype
+            logger.info(
+                f"[FlexKV vllm] No explicit kv_cache_dtype, falling back to "
+                f"vllm model dtype: {self.model_config.dtype}"
+            )
         self.model_config.use_mla = vllm_config.model_config.is_deepseek_mla
         self.model_config.tp_size = vllm_config.parallel_config.tensor_parallel_size
         self.model_config.dp_size = vllm_config.parallel_config.data_parallel_size
         self.model_config.pp_size = vllm_config.parallel_config.pipeline_parallel_size
-        self.model_config.pp_rank = getattr(vllm_config.parallel_config, 'pipeline_parallel_rank', 0)
+        self.model_config.nnodes = max(1, getattr(vllm_config.parallel_config, 'nnodes', 1))
+
+        pp_rank = getattr(vllm_config.parallel_config, 'pipeline_parallel_rank', 0)
 
         if self.model_config.pp_size > 1:
             from vllm.distributed.utils import get_pp_indices as vllm_get_pp_indices
-            start_layer, end_layer = vllm_get_pp_indices(
-                self.model_config.num_layers, self.model_config.pp_rank, self.model_config.pp_size
+            pp_start_layer, pp_end_layer = vllm_get_pp_indices(
+                self.model_config.num_layers, pp_rank, self.model_config.pp_size
             )
-            self.model_config.pp_start_layer = start_layer
-            self.model_config.pp_end_layer = end_layer
         else:
-            self.model_config.pp_start_layer = 0
-            self.model_config.pp_end_layer = self.model_config.num_layers
+            pp_start_layer = 0
+            pp_end_layer = self.model_config.num_layers
         if self.model_config.use_mla:
             self.model_config.num_kv_heads = 1
         else:
             self.model_config.num_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
-        update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
+
+        self.model_config.instance_num = int(GLOBAL_CONFIG_FROM_ENV.instance_num)
+        instance_id = int(GLOBAL_CONFIG_FROM_ENV.instance_id)
+
+        self.model_config.master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
+        self.model_config.master_ports = tuple(
+            os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558").split(",")
+        )
+
+        rank_info = RankInfo(
+            model_config=self.model_config,
+            tp_rank=tp_rank,
+            pp_rank=pp_rank,
+            dp_rank=dp_rank,
+            node_rank=node_rank,
+            instance_id=instance_id,
+            pp_start_layer=pp_start_layer,
+            pp_end_layer=pp_end_layer,
+        )
+        update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
         self.server_recv_port = GLOBAL_CONFIG_FROM_ENV.server_recv_port
         self.gpu_register_port = self.server_recv_port + "_gpu_register"
 
         hf_config = getattr(vllm_config.model_config, 'hf_config', None)
         self._detect_indexer_config_from_hf(hf_config, source="vllm")
 
-        logger.info(
-            f"[FlexKV vllm] Primitive vars set: tp_size={self.model_config.tp_size}, "
-            f"dp_size={self.model_config.dp_size}, dp_rank={self.model_config.dp_rank}, "
-            f"pp_size={self.model_config.pp_size}, pp_rank={self.model_config.pp_rank}, "
-            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
-            f"attn_cp_size={self.model_config.attn_cp_size}, "
-            f"attn_cp_rank={self.model_config.attn_cp_rank}"
-        )
-        logger.info(
-            f"[FlexKV vllm] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
-            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
-            f"local_rank={self.model_config.local_rank}"
-        )
+        logger.info(f"[FlexKV vllm] {self.model_config}, {rank_info}")
 
         # Freeze model_config — no further mutations allowed
         self.model_config.freeze()
+        return rank_info
 
     def post_init_from_sglang_config(
         self,
         sglang_config,
         server_args,
         page_size: int = 64,
-        tp_rank: Optional[int] = 0,
-        pp_rank: Optional[int] = 0,
-        dp_rank: Optional[int] = 0,
-        attn_cp_rank: Optional[int] = 0,
-    ):
-        """
-        Initialize FlexKVConfig fields from sglang config.
+        tp_rank: int = 0,
+        pp_rank: int = 0,
+        dp_rank: int = 0,
+        attn_cp_rank: int = 0,
+    ) -> RankInfo:
+        """Populate ``self.model_config`` / ``self.cache_config`` from a
+        sglang ModelConfig + ServerArgs and return the per-worker
+        ``RankInfo``.
+
+        See :meth:`post_init_from_vllm_config` for the rationale behind
+        returning ``RankInfo`` instead of writing it to ``self``.
+
         Args:
             sglang_config: sglang.srt.configs.model_config.ModelConfig-like object
             server_args: sglang ServerArgs — source of tp_size, dp_size,
                 nnodes, node_rank, enable_dp_attention, attn_cp_size,
-                is_nsa_cp, kv_cache_dtype, dist_init_addr
+                kv_cache_dtype,
+                dist_init_addr
             page_size: KV block size (tokens per block) used by sglang
             tp_rank: physical tensor parallel rank (runtime, from process group)
             pp_rank: pipeline parallel rank (runtime, from process group)
@@ -198,8 +234,8 @@ class FlexKVConfig:
         node_rank = server_args.node_rank
         enable_dp_attention = server_args.enable_dp_attention
         attn_cp_size = server_args.attn_cp_size
-        is_nsa_cp = getattr(server_args, 'enable_nsa_prefill_context_parallel', False)
         kv_cache_dtype = getattr(server_args, 'kv_cache_dtype', None)
+        dp_rank = 0 if dp_rank is None else int(dp_rank)
 
         # cache config: use page_size as tokens_per_block so that FlexKV's
         # CPU radix tree manages blocks at page granularity, ensuring that
@@ -278,34 +314,44 @@ class FlexKVConfig:
         self.model_config.use_mla = use_mla
 
         self.model_config.tp_size = int(tp_size)
-        self.model_config.tp_rank = int(tp_rank)
         self.model_config.dp_size = int(dp_size if dp_size is not None else 1)
-        self.model_config.dp_rank = int(dp_rank if dp_rank is not None else 0)
         self.model_config.pp_size = int(pp_size)
-        self.model_config.pp_rank = int(pp_rank)
 
         if pp_size > 1:
             from sglang.srt.distributed.utils import get_pp_indices as sglang_get_pp_indices
-            start_layer, end_layer = sglang_get_pp_indices(
-                self.model_config.num_layers, self.model_config.pp_rank, self.model_config.pp_size
+            pp_start_layer, pp_end_layer = sglang_get_pp_indices(
+                self.model_config.num_layers, pp_rank, self.model_config.pp_size
             )
-            self.model_config.pp_start_layer = start_layer
-            self.model_config.pp_end_layer = end_layer
         else:
-            self.model_config.pp_start_layer = 0
-            self.model_config.pp_end_layer = self.model_config.num_layers
+            pp_start_layer = 0
+            pp_end_layer = self.model_config.num_layers
         self.model_config.enable_dp_attention = bool(enable_dp_attention)
         self.model_config.attn_cp_size = int(attn_cp_size)
-        self.model_config.attn_cp_rank = int(attn_cp_rank)
-        self.model_config.is_nsa_cp = is_nsa_cp
         self.model_config.nnodes = max(1, int(nnodes))
-        self.model_config.node_rank = int(node_rank)
-        # Multi-node bootstrap: master host (derived from sglang --dist-init-addr).
-        # ``None`` here falls back to FLEXKV_MASTER_HOST env var downstream.
         _dist_init_addr = getattr(server_args, 'dist_init_addr', None)
-        master_host = _dist_init_addr.split(":")[0] if _dist_init_addr and int(nnodes) > 1 else None
-        self.model_config.master_host = master_host
-        update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
+        if _dist_init_addr and int(nnodes) > 1:
+            self.model_config.master_host = _dist_init_addr.split(":")[0]
+        else:
+            self.model_config.master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
+        self.model_config.master_ports = tuple(
+            os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558").split(",")
+        )
+
+        self.model_config.instance_num = int(GLOBAL_CONFIG_FROM_ENV.instance_num)
+        instance_id = int(GLOBAL_CONFIG_FROM_ENV.instance_id)
+
+        rank_info = RankInfo(
+            model_config=self.model_config,
+            tp_rank=tp_rank,
+            pp_rank=pp_rank,
+            dp_rank=dp_rank,
+            attn_cp_rank=attn_cp_rank,
+            node_rank=node_rank,
+            instance_id=instance_id,
+            pp_start_layer=pp_start_layer,
+            pp_end_layer=pp_end_layer,
+        )
+        update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
         hf_config = getattr(sglang_config, 'hf_config', None)
         self._detect_indexer_config_from_hf(hf_config, source="sglang")
@@ -319,33 +365,19 @@ class FlexKVConfig:
                 f"tokens_per_block={self.cache_config.tokens_per_block}"
             )
 
-        # Log primitive and derived variables for verification
-        logger.info(
-            f"[FlexKV sglang] Primitive vars set: tp_size={self.model_config.tp_size}, "
-            f"tp_rank={self.model_config.tp_rank}, dp_size={self.model_config.dp_size}, "
-            f"dp_rank={self.model_config.dp_rank}, pp_size={self.model_config.pp_size}, "
-            f"pp_rank={self.model_config.pp_rank}, "
-            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
-            f"attn_cp_size={self.model_config.attn_cp_size}, "
-            f"attn_cp_rank={self.model_config.attn_cp_rank}, "
-            f"is_nsa_cp={self.model_config.is_nsa_cp}, "
-            f"nnodes={self.model_config.nnodes}, node_rank={self.model_config.node_rank}"
-        )
-        logger.info(
-            f"[FlexKV sglang] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
-            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
-            f"tp_rank_per_node={self.model_config.tp_rank_per_node}, "
-            f"tp_size_per_node={self.model_config.tp_size_per_node}, "
-            f"local_rank={self.model_config.local_rank}"
-        )
+        logger.info(f"[FlexKV sglang] {self.model_config}, {rank_info}")
 
         # Freeze model_config — no further mutations allowed
         self.model_config.freeze()
+        return rank_info
 
     def post_init_from_trt_config(
         self,
         config,
-    ):
+    ) -> RankInfo:
+        tp_rank = config.mapping.tp_rank
+        dp_rank = getattr(config.mapping, 'dp_rank', 0)
+        node_rank = config.mapping.node_rank
         self.cache_config.tokens_per_block = config.tokens_per_block
         # Convert dtype string to torch.dtype
         dtype_str = config.pytorch_backend_config.kv_cache_dtype
@@ -378,20 +410,15 @@ class FlexKVConfig:
         if config.mapping.enable_attention_dp:
             self.model_config.tp_size = 1
             self.model_config.dp_size = config.mapping.tp_size
+            dp_rank = config.mapping.rank
         else:
             self.model_config.tp_size = config.mapping.tp_size
             self.model_config.dp_size = 1
+            dp_rank = 0
         self.model_config.pp_size = getattr(config.mapping, 'pp_size', 1)
-        self.model_config.pp_rank = getattr(config.mapping, 'pp_rank', 0)
+        pp_rank = getattr(config.mapping, 'pp_rank', 0)
 
-        if self.model_config.pp_size > 1:
-            layers_range = config.mapping.pp_layers(self.model_config.num_layers)
-            self.model_config.pp_start_layer = layers_range[0]
-            self.model_config.pp_end_layer = layers_range[-1] + 1
-        else:
-            self.model_config.pp_start_layer = 0
-            self.model_config.pp_end_layer = self.model_config.num_layers
-
+        self.model_config.nnodes = max(1, getattr(config.mapping, 'nnodes', 1))
         # self.model_config (model configs part)
         try:
             model_path = getattr(config, 'hf_model_dir', None)
@@ -420,25 +447,48 @@ class FlexKVConfig:
             self._detect_indexer_config_from_hf(hf_config, source="TRT-LLM")
         except Exception as e:
             flexkv_logger.error(f"Failed to load config from {model_path}: {e}")
-        # Update cache config with user config after model config is initialized
-        update_default_config_from_user_config(self.model_config, self.cache_config, self.user_config)
 
-        # Log primitive and derived variables for verification
-        flexkv_logger.info(
-            f"[FlexKV TRT-LLM] Primitive vars set: tp_size={self.model_config.tp_size}, "
-            f"tp_rank={self.model_config.tp_rank}, dp_size={self.model_config.dp_size}, "
-            f"dp_rank={self.model_config.dp_rank}, pp_size={self.model_config.pp_size}, "
-            f"pp_rank={self.model_config.pp_rank}, "
-            f"enable_dp_attention={self.model_config.enable_dp_attention}, "
-            f"attn_cp_size={self.model_config.attn_cp_size}, "
-            f"attn_cp_rank={self.model_config.attn_cp_rank}, "
-            f"nnodes={self.model_config.nnodes}, node_rank={self.model_config.node_rank}"
+        if self.model_config.pp_size > 1:
+            layers_range = config.mapping.pp_layers(self.model_config.num_layers)
+            pp_start_layer = layers_range[0]
+            pp_end_layer = layers_range[-1] + 1
+        else:
+            pp_start_layer = 0
+            pp_end_layer = self.model_config.num_layers
+
+        self.model_config.instance_num = int(GLOBAL_CONFIG_FROM_ENV.instance_num)
+        instance_id = int(GLOBAL_CONFIG_FROM_ENV.instance_id)
+
+
+        self.model_config.use_trtllm_subprocess = True
+        self.model_config.trtllm_subprocess_host = os.getenv(
+            "FLEXKV_TRT_SUBPROCESS_HOST", "localhost"
         )
-        flexkv_logger.info(
-            f"[FlexKV TRT-LLM] Derived vars: attn_tp_size={self.model_config.attn_tp_size}, "
-            f"attn_tp_rank={self.model_config.attn_tp_rank}, "
-            f"local_rank={self.model_config.local_rank}"
+        self.model_config.trtllm_subprocess_ports = tuple(
+            os.getenv("FLEXKV_TRT_SUBPROCESS_PORTS", "6667,6668,6669").split(",")
         )
+        # Multi-node master endpoint (used when nnodes > 1).
+        self.model_config.master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
+        self.model_config.master_ports = tuple(
+            os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558").split(",")
+        )
+
+        rank_info = RankInfo(
+            model_config=self.model_config,
+            tp_rank=tp_rank,
+            pp_rank=pp_rank,
+            dp_rank=dp_rank,
+            node_rank=node_rank,
+            instance_id=instance_id,
+            pp_start_layer=pp_start_layer,
+            pp_end_layer=pp_end_layer,
+        )
+
+        # Update cache config with user config after model config is initialized
+        update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
+
+        logger.info(f"[FlexKV TRT-LLM] {self.model_config}, {rank_info}")
 
         # Freeze model_config — no further mutations allowed
         self.model_config.freeze()
+        return rank_info

--- a/flexkv/integration/tensorrt_llm/trtllm_adapter.py
+++ b/flexkv/integration/tensorrt_llm/trtllm_adapter.py
@@ -14,7 +14,6 @@ from flexkv.common.config import ModelConfig, CacheConfig
 from flexkv.common.request import KVResponseStatus
 from flexkv.common.debug import flexkv_logger
 from flexkv.integration.stats import FlexKVStats
-from flexkv.integration.utils import cdiv
 from flexkv.integration.config import FlexKVConfig
 from flexkv.integration.tensorrt_llm.meta import(
     FlexKVResponse, FlexKVTask, FlexKVGetTask, FlexKVPutTask, FlexKVConnectorMetadata)
@@ -29,23 +28,17 @@ from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
 
 class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
     def __init__(self, config: ExecutorConfig):
-        # Set environment variable for FlexKV with TensorRT-LLM，this must before KVManager initialization
-        os.environ['FLEXKV_WITH_TRTLLM'] = '1'
-        flexkv_config = FlexKVConfig.from_env() 
-        flexkv_config.post_init_from_trt_config(config)
-        self.node_rank, self.tp_rank, self.dp_rank = get_rank_info_from_trt_config(config)
+        flexkv_config = FlexKVConfig.from_env()
+        rank_info = flexkv_config.post_init_from_trt_config(config)
 
-        flexkv_logger.info(f"Start init FlexKVSchedulerConnector with {flexkv_config}")
+        flexkv_logger.info(f"Start init FlexKVSchedulerConnector with {flexkv_config}, {rank_info}")
         self.server_recv_port = flexkv_config.server_recv_port
-        self.tp_size = flexkv_config.model_config.tp_size
-        self.dp_size = flexkv_config.model_config.dp_size
         self.block_size = flexkv_config.cache_config.tokens_per_block
-        self.model_config = flexkv_config.model_config
         self.cache_config = flexkv_config.cache_config
-        self.flexkv_manager = KVManager(model_config=self.model_config,
-                                        cache_config=self.cache_config,
-                                        server_recv_port=flexkv_config.server_recv_port,
-                                        dp_client_id=self.model_config.dp_rank)
+        self.flexkv_manager = KVManager(model_config=rank_info.model_config,
+                                        cache_config=flexkv_config.cache_config,
+                                        dp_client_id=rank_info.dp_client_id,
+                                        server_recv_port=flexkv_config.server_recv_port)
         self.flexkv_manager.start()
         # self.dp_client = KVDPClient(self.server_recv_port, self.model_config)
 
@@ -70,10 +63,6 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
 
     def shutdown(self) -> None:
         self.flexkv_manager.shutdown()
-
-    @property
-    def dp_client_id(self) -> int:
-        return self.flexkv_manager.dp_client_id
 
     ####################
     #### Get Method ####
@@ -180,16 +169,14 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         flexkv_logger.info(f"Get match request: {request}")
         
         match_start_time = time.perf_counter()
-        num_tokens_to_get = (request.num_prompt_tokens // self.block_size) * self.block_size
-        if num_tokens_to_get == 0:
+        num_tokens_to_get = ((request.num_prompt_tokens - 1) // self.block_size) * self.block_size
+        if num_tokens_to_get <= 0:
             return -1, 0
 
-        assert num_computed_tokens <= num_tokens_to_get, (
-            f"{num_computed_tokens=} must less equal to {num_tokens_to_get=}")
         assert num_computed_tokens % self.block_size == 0,(
             f"{num_computed_tokens=}, {self.block_size=}")
 
-        if num_tokens_to_get == num_computed_tokens:
+        if num_tokens_to_get <= num_computed_tokens:
             return -1, 0
 
         # Use cached numpy token sequence to avoid repeated list->numpy conversion in hot path
@@ -209,8 +196,6 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         task_id, matched_mask = self.flexkv_manager.get_match(
             token_ids=np_token_ids,
             token_mask=np_token_mask,
-            dp_rank=self.flexkv_config.model_config.dp_rank,
-            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
         num_new_matched_tokens = matched_mask.sum().item()
@@ -349,7 +334,7 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         request = RequestWrapper(_request)
         flexkv_logger.info(f"Put match request: {request}")
         match_start_time = time.perf_counter()
-        num_tokens_to_put = (cdiv(request.num_tokens, self.block_size) - 1) * self.block_size
+        num_tokens_to_put = ((request.num_tokens - 1) // self.block_size) * self.block_size
 
         if num_tokens_to_put == 0:
             return -1, 0, 0
@@ -368,8 +353,6 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
         
         task_id, unmatched_mask = self.flexkv_manager.put_match(
             token_ids=np_token_ids,
-            dp_rank=self.flexkv_config.model_config.dp_rank,
-            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
 
@@ -520,58 +503,33 @@ class FlexKVSchedulerConnector(KvCacheConnectorScheduler):
             finished_sending=list(finished_sending),
             finished_recving=list(finished_recving))
         return metadata
-    
-    @property
-    def dp_client_id(self) -> int:
-        return self.flexkv_manager.dp_client_id
 
 class FlexKVWorkerConnector(KvCacheConnectorWorker):
     def __init__(self, config: ExecutorConfig):
         flexkv_config = FlexKVConfig.from_env()
-        self.node_rank, self.tp_rank, self.dp_rank = get_rank_info_from_trt_config(config)
-        flexkv_config.post_init_from_trt_config(config)
-        dp_client_id = self.dp_rank
-        
-        current_device_id = torch.cuda.current_device() + dp_client_id * flexkv_config.model_config.tp_size
+        rank_info = flexkv_config.post_init_from_trt_config(config)
         self.flexkv_config = flexkv_config
-        
-        # For multi-node TP on remote node (node B), worker0 needs to create TransferManagerOnRemote process
+        instance_id = rank_info.instance_id
         self.remote_process = None
-        if self._need_to_create_remote_process():
-            flexkv_logger.info("Multi-node TP detected on remote node, worker0 creating TransferManagerOnRemote process")
-            self.remote_process = TransferManagerOnRemote.create_process()
-            flexkv_logger.info(f"TransferManagerOnRemote process created, PID: {self.remote_process.pid}")
-        
-        flexkv_logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, dp_rank: {dp_rank}")
-        self.tp_client = KVTPClient(flexkv_config.gpu_register_port, dp_rank=dp_rank, pp_rank=flexkv_config.model_config.pp_rank, device_id=current_device_id)
-        flexkv_logger.info("Finish init FlexKVWorkerConnector")
-    
-    def _need_to_create_remote_process(self) -> bool:
-        """Check if need to create TransferManagerOnRemote process.
-        
-        Returns True when all of the following conditions are met:
-        - Multi-node TP is detected (nnodes_per_tp_group > 1)
-        - Current node is not master node (node_rank > 0)
-        - Current worker is worker0 in the local TP group (tp_rank_per_node == 0)
-        
-        Returns:
-            bool: True if need to create TransferManagerOnRemote process, False otherwise.
-        """
-        try:
-            is_master_node = self.node_rank == 0
-            is_first_worker = self.flexkv_config.model_config.tp_rank_per_node == 0
-            is_multinode_tp = self.flexkv_config.model_config.nnodes_per_tp_group > 1
-            flexkv_logger.info(
-                f"{is_master_node=}, {is_first_worker=}, {is_multinode_tp=}, "
-                f"nnodes_per_tp_group={self.flexkv_config.model_config.nnodes_per_tp_group}, "
-                f"tp_rank_per_node={self.flexkv_config.model_config.tp_rank_per_node}"
+        model_config = self.flexkv_config.model_config
+        if (model_config.nnodes > 1
+                and rank_info.node_rank > 0
+                and rank_info.local_rank == 0):
+            self.remote_process = TransferManagerOnRemote.create_process(
+                master_host=model_config.master_host,
+                master_ports=model_config.master_ports,
             )
-            
-            return is_multinode_tp and not is_master_node and is_first_worker
-        except Exception as e:
-            flexkv_logger.error(f"Failed to get node info from flexkv_config: {e}")
-            flexkv_logger.error(traceback.format_exc())
-            raise e
+            flexkv_logger.info(f"TransferManagerOnRemote process created, PID: {self.remote_process.pid}")
+
+        flexkv_logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, "
+                           f"dp_rank: {rank_info.dp_rank}, instance_id: {instance_id}")
+        self.tp_client = KVTPClient(
+            flexkv_config.gpu_register_port,
+            dp_client_id=rank_info.dp_client_id,
+            pp_rank=rank_info.pp_rank,
+            device_id=rank_info.local_rank,
+        )
+        flexkv_logger.info("Finish init FlexKVWorkerConnector")
 
     def register_kv_caches(self, kv_cache_tensor: torch.Tensor):
         # vllm kv_caches: dict[str, torch.Tensor]
@@ -686,14 +644,4 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
         """Cleanup on deletion."""
         if hasattr(self, 'remote_process') and self.remote_process is not None:
             self.shutdown()
-    
-def get_rank_info_from_trt_config(config: ExecutorConfig):
-    if config.mapping.enable_attention_dp:
-        node_rank = config.mapping.node_rank
-        tp_rank = config.mapping.tp_rank
-        dp_rank = config.mapping.rank
-    else:
-        node_rank = config.mapping.node_rank
-        tp_rank = config.mapping.tp_rank
-        dp_rank = 0
-    return node_rank, tp_rank, dp_rank
+

--- a/flexkv/integration/utils.py
+++ b/flexkv/integration/utils.py
@@ -1,5 +1,0 @@
-
-
-def cdiv(a: int, b: int) -> int:
-    """Ceiling division."""
-    return -(a // -b)

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -9,11 +9,11 @@ import torch
 
 from flexkv.kvmanager import KVManager
 from flexkv.server.client import KVTPClient
+from flexkv.common.config import RankInfo
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.request import KVResponseStatus
 from flexkv.common.debug import flexkv_logger
 from flexkv.integration.stats import FlexKVStats
-from flexkv.integration.utils import cdiv
 from flexkv.integration.config import FlexKVConfig
 from flexkv.integration.dynamo.collector import KVEventCollector
 from flexkv.transfer_manager import TransferManagerOnRemote
@@ -159,25 +159,22 @@ class FlexKVSchedulerConnector:
     def __init__(
         self,
         flexkv_config: FlexKVConfig,
-        dp_rank: int = 0,
+        rank_info: "RankInfo",
     ):
-        logger.info(f"Start init FlexKVSchedulerConnector with {flexkv_config}")
+        logger.info(f"Start init FlexKVSchedulerConnector with {flexkv_config}, {rank_info}")
         self.server_recv_port = flexkv_config.server_recv_port
-        self.tp_size = flexkv_config.model_config.tp_size
-        self.dp_size = flexkv_config.model_config.dp_size
         self.block_size = flexkv_config.cache_config.tokens_per_block
-        self.model_config = flexkv_config.model_config
         self.cache_config = flexkv_config.cache_config
+        self.rank_info = rank_info
 
         if os.getenv('DYNAMO_USE_FLEXKV', '0') == '1':
             self.collector = KVEventCollector()
         else:
             self.collector = None
-
-        self.flexkv_manager = KVManager(model_config=self.model_config,
-                                        cache_config=self.cache_config,
+        self.flexkv_manager = KVManager(model_config=self.rank_info.model_config,
+                                        cache_config=flexkv_config.cache_config,
+                                        dp_client_id=self.rank_info.dp_client_id,
                                         server_recv_port=flexkv_config.server_recv_port,
-                                        dp_client_id=dp_rank,
                                         event_collector=self.collector)
         self.flexkv_manager.start()
         # self.dp_client = KVDPClient(self.server_recv_port, self.model_config)
@@ -217,10 +214,6 @@ class FlexKVSchedulerConnector:
         self.flexkv_manager.shutdown()
         if self.collector is not None:
             self.collector.close()
-
-    @property
-    def dp_client_id(self) -> int:
-        return self.flexkv_manager.dp_client_id
 
     ####################
     #### Get Method ####
@@ -336,8 +329,6 @@ class FlexKVSchedulerConnector:
         task_id, matched_mask = self.flexkv_manager.get_match(
             token_ids=np_token_ids,
             token_mask=np_token_mask,
-            dp_rank=self.flexkv_config.model_config.dp_rank,
-            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
         num_new_matched_tokens = matched_mask.sum().item()
@@ -476,7 +467,7 @@ class FlexKVSchedulerConnector:
                             the task_id, number of matched tokens and number of unmatched tokens.
         """
         match_start_time = time.perf_counter()
-        num_tokens_to_put = (cdiv(request.num_tokens, self.block_size)-1)*self.block_size
+        num_tokens_to_put = ((request.num_tokens - 1) // self.block_size) * self.block_size
         token_ids = request.all_token_ids[:num_tokens_to_put]
 
         if num_tokens_to_put == 0:
@@ -486,8 +477,6 @@ class FlexKVSchedulerConnector:
         namespace = self._extract_namespace(request)
         task_id, unmatched_mask = self.flexkv_manager.put_match(
             token_ids=np_token_ids,
-            dp_rank=self.flexkv_config.model_config.dp_rank,
-            pp_rank=self.flexkv_config.model_config.pp_rank,
             namespace=namespace,
         )
 
@@ -672,46 +661,37 @@ class FlexKVWorkerConnector:
     def __init__(
         self,
         flexkv_config: FlexKVConfig,
-        dp_client_id: int,
+        rank_info: "RankInfo",
     ):
         from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
 
-        self.is_local_leader = get_tp_group().local_rank == 0
-        self.launch_remote_transfer_manager = get_tp_group().local_rank == 0 and \
-            get_tp_group().rank_in_group != 0
-
-        local_device = torch.cuda.current_device()
 
         # Determine if server_client_mode (same logic as KVManager)
         server_client_mode = (GLOBAL_CONFIG_FROM_ENV.instance_num > 1 or
-                              flexkv_config.model_config.dp_size > 1 or
+                              rank_info.model_config.dp_size > 1 or
                               GLOBAL_CONFIG_FROM_ENV.server_client_mode)
 
-        if server_client_mode:
-            # Assuming Server can see all GPUs, use global device ID
-            cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-            if cuda_visible:
-                visible_ids = [int(x.strip()) for x in cuda_visible.split(',') if x.strip()]
-                device_id = visible_ids[local_device] if local_device < len(visible_ids) else local_device
-            else:
-                device_id = local_device
-
-            client_id = GLOBAL_CONFIG_FROM_ENV.instance_id * flexkv_config.model_config.dp_size + dp_client_id
-        else:
-            device_id = local_device
-            client_id = dp_client_id
+        instance_id = rank_info.instance_id
 
         self.flexkv_config = flexkv_config
-        if self.launch_remote_transfer_manager:
-            self.remote_transfer_manager_process = TransferManagerOnRemote.create_process()
+        self.rank_info = rank_info
+        if (rank_info.model_config.nnodes > 1
+                and rank_info.node_rank > 0
+                and rank_info.local_rank == 0):
+            self.remote_transfer_manager_process = TransferManagerOnRemote.create_process(
+                master_host=rank_info.model_config.master_host,
+                master_ports=rank_info.model_config.master_ports,
+            )
 
         logger.info(f"Start init FlexKVWorkerConnector to {flexkv_config.gpu_register_port}, "
-                    f"server_client_mode={server_client_mode}, dp_client_id={dp_client_id}, "
-                    f"client_id={client_id}, device_id={device_id}")
-        self.tp_client = KVTPClient(flexkv_config.gpu_register_port,
-                                    dp_rank=client_id,
-                                    pp_rank=self.flexkv_config.model_config.pp_rank,
-                                    device_id=device_id)
+                    f"server_client_mode={server_client_mode}, dp_rank={rank_info.dp_rank}, "
+                    f"instance_id={instance_id}, local_rank={rank_info.local_rank}")
+        self.tp_client = KVTPClient(
+            flexkv_config.gpu_register_port,
+            dp_client_id=rank_info.dp_client_id,
+            pp_rank=rank_info.pp_rank,
+            device_id=rank_info.local_rank,
+        )
         logger.info("Finish init FlexKVWorkerConnector")
 
     def register_to_server(self, kv_caches: dict[str, torch.Tensor]):
@@ -791,15 +771,14 @@ class FlexKVConnectorV1Impl:
     def __init__(self, vllm_config: "VllmConfig", role: "KVConnectorRole"):
         self.role = role
         flexkv_config = FlexKVConfig.from_env()
-        flexkv_config.post_init_from_vllm_config(vllm_config)
-        dp_rank = vllm_config.parallel_config.data_parallel_rank
+        rank_info = flexkv_config.post_init_from_vllm_config(vllm_config)
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector = FlexKVSchedulerConnector(flexkv_config, dp_rank)
+            self.connector = FlexKVSchedulerConnector(flexkv_config, rank_info)
             # Track scheduled requests to detect preemptions in build_connector_meta
             self.previous_scheduled_req_ids: set[str] = set()
         elif role == KVConnectorRole.WORKER:
-            self.connector = FlexKVWorkerConnector(flexkv_config, dp_rank)
+            self.connector = FlexKVWorkerConnector(flexkv_config, rank_info)
         else:
             raise ValueError(f"Unrecognized KVConnectorRole: {role}.")
 

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -40,11 +40,8 @@ class KVManager:
                  event_collector: Optional[KVEventCollector] = None):
         flexkv_logger.info(f"{model_config = }")
         flexkv_logger.info(f"{cache_config = }")
-        flexkv_logger.info(f"{GLOBAL_CONFIG_FROM_ENV = }")
         self.model_config = model_config
         self.cache_config = cache_config
-        self.instance_id = GLOBAL_CONFIG_FROM_ENV.instance_id
-        self.instance_num = GLOBAL_CONFIG_FROM_ENV.instance_num
 
         if server_recv_port != "":
             self.server_recv_port = server_recv_port
@@ -62,33 +59,32 @@ class KVManager:
 
         # Multi-instance mode also requires server_client_mode
         self.server_client_mode = (model_config.dp_size > 1 or
-                                   self.instance_num > 1 or
+                                   model_config.instance_num > 1 or
                                    GLOBAL_CONFIG_FROM_ENV.server_client_mode)
-        self.dp_client_id = dp_client_id
 
-        # Calculate global_client_id for multi-instance mode
-        self.global_client_id = self.instance_id * model_config.dp_size + dp_client_id
-
-        flexkv_logger.info(f"server_client_mode: {self.server_client_mode}")
+        flexkv_logger.info(
+            f"[KVManager] instance_num={model_config.instance_num}, dp_size={model_config.dp_size}, "
+            f"server_client_mode={self.server_client_mode}"
+        )
 
         self.redis_meta_client = None
         self.enable_mps = GLOBAL_CONFIG_FROM_ENV.enable_mps
 
         if self.server_client_mode:
-            # In server_client_mode, RedisMeta is created and initialized inside KVServer
-            # Server should only be created once across all instances and dp ranks
-            if self.instance_id == 0 and dp_client_id == 0:
-                total_clients = self.instance_num * model_config.dp_size
+            if dp_client_id == 0:
                 self.server_handle = KVServer.create_server(model_config=model_config,
                                                             cache_config=cache_config,
                                                             gpu_register_port=self.gpu_register_port,
                                                             server_recv_port=self.server_recv_port,
-                                                            total_clients=total_clients,
                                                             inherit_env=False)
 
             else:
                 self.server_handle = None
-            self.dp_client = KVDPClient(self.server_recv_port, self.model_config, self.global_client_id)
+            self.dp_client = KVDPClient(
+                self.server_recv_port,
+                model_config=model_config,
+                dp_client_id=dp_client_id,
+            )
         else:
             # In non-server_client_mode, create RedisMeta here and pass to KVTaskEngine
             if self.cache_config.enable_kv_sharing:
@@ -106,11 +102,13 @@ class KVManager:
                 self.cache_config.distributed_node_id = self.redis_meta_client.get_node_id()
 
             self.server_handle = None
-            self.kv_task_engine = KVTaskEngine(self.model_config, self.cache_config, self.gpu_register_port, redis_meta=self.redis_meta_client, event_collector=event_collector)
-
-    @property
-    def dpclient_id(self) -> int:
-        return self.dp_client_id
+            self.kv_task_engine = KVTaskEngine(
+                model_config,
+                self.cache_config,
+                self.gpu_register_port,
+                redis_meta=self.redis_meta_client,
+                event_collector=event_collector,
+            )
 
     def start(self) -> None:
         if self.enable_mps:
@@ -150,9 +148,6 @@ class KVManager:
                   token_ids: Union[torch.Tensor, np.ndarray],
                   slot_mapping: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  layer_granularity: int = -1,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> int:
         if isinstance(token_ids, torch.Tensor):
@@ -165,25 +160,19 @@ class KVManager:
             task_id = self.dp_client.get_async(token_ids,
                                                slot_mapping,
                                                token_mask,
-                                               layer_granularity,
-                                               pp_rank=pp_rank,
                                                namespace=namespace)
         else:
-            task_id, _ = self.kv_task_engine.get_async(token_ids,
-                                                       slot_mapping,
-                                                       token_mask,
-                                                       layer_granularity,
-                                                       dp_rank,
-                                                       pp_rank=pp_rank,
-                                                       namespace=namespace)
+            task_id, _ = self.kv_task_engine.get_async(
+                token_ids=token_ids,
+                slot_mapping=slot_mapping,
+                token_mask=token_mask,
+                namespace=namespace,
+            )
         return task_id
 
     def get_match(self,
                   token_ids: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  layer_granularity: int = -1,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   namespace: Optional[List[str]] = None,
                   ) -> Tuple[int, np.ndarray]:
@@ -194,26 +183,21 @@ class KVManager:
         if self.server_client_mode:
             task_id, mask = self.dp_client.get_match(token_ids,
                                                      token_mask,
-                                                     layer_granularity,
-                                                     pp_rank=pp_rank,
                                                      cpu_only=cpu_only,
                                                      namespace=namespace)
         else:
-            task_id, mask = self.kv_task_engine.get_match(token_ids,
-                                                          token_mask,
-                                                          layer_granularity,
-                                                          dp_rank,
-                                                          pp_rank=pp_rank,
-                                                          cpu_only=cpu_only,
-                                                          namespace=namespace)
+            task_id, mask = self.kv_task_engine.get_match(
+                token_ids=token_ids,
+                token_mask=token_mask,
+                cpu_only=cpu_only,
+                namespace=namespace,
+            )
         return task_id, mask
 
     def put_async(self,
                   token_ids: Union[torch.Tensor, np.ndarray],
                   slot_mapping: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> int:
         if isinstance(token_ids, torch.Tensor):
@@ -223,16 +207,20 @@ class KVManager:
         if isinstance(token_mask, torch.Tensor):
             token_mask = token_mask.numpy()
         if self.server_client_mode:
-            task_id = self.dp_client.put_async(token_ids, slot_mapping, token_mask, pp_rank=pp_rank, namespace=namespace)
+            task_id = self.dp_client.put_async(token_ids, slot_mapping, token_mask,
+                                               namespace=namespace)
         else:
-            task_id, _ = self.kv_task_engine.put_async(token_ids, slot_mapping, token_mask, dp_rank, pp_rank=pp_rank, namespace=namespace)
+            task_id, _ = self.kv_task_engine.put_async(
+                token_ids=token_ids,
+                slot_mapping=slot_mapping,
+                token_mask=token_mask,
+                namespace=namespace,
+            )
         return task_id
 
     def put_match(self,
                   token_ids: Union[torch.Tensor, np.ndarray],
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   namespace: Optional[List[str]] = None,
                   ) -> Tuple[int, np.ndarray]:
         if isinstance(token_ids, torch.Tensor):
@@ -240,22 +228,28 @@ class KVManager:
         if isinstance(token_mask, torch.Tensor):
             token_mask = token_mask.numpy()
         if self.server_client_mode:
-            task_id, mask = self.dp_client.put_match(token_ids, token_mask, pp_rank=pp_rank, namespace=namespace)
+            task_id, mask = self.dp_client.put_match(token_ids, token_mask,
+                                                     namespace=namespace)
         else:
-            task_id, mask = self.kv_task_engine.put_match(token_ids, token_mask, dp_rank, pp_rank=pp_rank, namespace=namespace)
+            task_id, mask = self.kv_task_engine.put_match(
+                token_ids=token_ids,
+                token_mask=token_mask,
+                namespace=namespace,
+            )
         return task_id, mask
 
     def prefetch_async(self,
                        token_ids: np.ndarray,
-                       dp_rank: int = 0,
-                       pp_rank: int = 0,
                        namespace: Optional[List[str]] = None) -> int:
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
         if self.server_client_mode:
-            task_id = self.dp_client.prefetch_async(token_ids, pp_rank=pp_rank, namespace=namespace)
+            task_id = self.dp_client.prefetch_async(token_ids, namespace=namespace)
         else:
-            task_id = self.kv_task_engine.prefetch_async(token_ids, dp_rank=dp_rank, pp_rank=pp_rank, namespace=namespace)
+            task_id = self.kv_task_engine.prefetch_async(
+                token_ids,
+                namespace=namespace,
+            )
         return task_id
 
     def launch(self,

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Callable
 import multiprocessing as mp
 import copy
-import os
 from expiring_dict import ExpiringDict
 import nvtx
 import numpy as np
@@ -19,10 +18,6 @@ from flexkv.common.tracer import FlexKVTracer
 from flexkv.cache.cache_engine import GlobalCacheEngine, DEFAULT_CACHE_STRATEGY, CPUONLY_CACHE_STRATEGY
 from flexkv.transfer_manager import TransferManagerHandle, TransferManagerOnRemote
 from flexkv.common.request import KVResponseStatus, KVResponse
-from flexkv.transfer_manager import (
-    resolve_master_host_and_ports,
-    get_trtllm_subprocess_host_and_ports_from_env
-)
 from flexkv.cache.redis_meta import RedisMeta
 from flexkv.integration.dynamo.collector import KVEventCollector
 from flexkv.transfer_manager import TransferManagerMultiNodeHandle
@@ -68,9 +63,6 @@ class KVTask:
     callback: Optional[Union[Callable, List[Callable]]]
     op_callback_dict: Dict[int, Callable]
 
-    dp_rank: int = 0
-    pp_rank: int = 0
-
     # batch: points to the batch task id if this task was merged into a batch
     batch_task_id: Optional[int] = None
 
@@ -95,102 +87,52 @@ class KVTaskManager:
                  redis_meta: RedisMeta = None,
                  event_collector: Optional[KVEventCollector] = None
                  ):
-        if not cache_config.enable_cpu:
-            raise ValueError("enable_cpu must be True")
-        if cache_config.enable_remote and not cache_config.enable_ssd:
-            raise ValueError("enable_ssd must be True if enable_remote is True")
-        if not cache_config.enable_cpu and not cache_config.enable_gds:
-            raise ValueError("enable_gds must be True if enable_cpu is False")
-        if cache_config.enable_gds and not cache_config.enable_ssd:
-            raise ValueError("enable_ssd must be True if enable_gds is True")
-        if cache_config.enable_kv_sharing and cache_config.enable_gds:
-            raise ValueError("enable_kv_sharing and enable_gds cannot be used at the same time")
-        self.cache_config = cache_config
         self.model_config = model_config
-        self._check_config(model_config, cache_config)
-
-        # ---- Multi-node topology ----
-        nnodes = self.model_config.nnodes
-        pp_size = self.model_config.pp_size
-        tp_size = self.model_config.tp_size
-
-        total_gpus = tp_size * pp_size
-        if total_gpus % nnodes != 0:
-            raise ValueError(
-                f"[KVTaskEngine] cannot derive gpus_per_node: "
-                f"tp*pp={total_gpus} not divisible by nnodes={nnodes}"
-            )
-        gpus_per_node = total_gpus // nnodes
-
-        self.nnodes_per_tp_group = max(
-            (tp_size + gpus_per_node - 1) // gpus_per_node, 1
-        )
-        if self.nnodes_per_tp_group > 2:
-            raise ValueError(
-                f"Only support 2-nodes TP for now, but got "
-                f"nnodes_per_tp_group={self.nnodes_per_tp_group} "
-                f"(tp_size={tp_size}, gpus_per_node={gpus_per_node})"
-            )
-
-        if tp_size % self.nnodes_per_tp_group != 0:
-            raise ValueError(
-                f"[KVTaskEngine] tp_size={tp_size} not divisible by "
-                f"nnodes_per_tp_group={self.nnodes_per_tp_group}"
-            )
-        tp_size_per_node = tp_size // self.nnodes_per_tp_group
+        self.cache_config = cache_config
 
         flexkv_logger.info(
-            f"[KVTaskEngine] topology: "
-            f"nnodes={nnodes}, "
-            f"node_rank={self.model_config.node_rank}, "
-            f"gpus_per_node={gpus_per_node}, "
-            f"tp_size={tp_size}, "
-            f"pp_size={pp_size}, "
-            f"dp_size={self.model_config.dp_size}, "
-            f"nnodes_per_tp_group={self.nnodes_per_tp_group}, "
-            f"tp_size_per_node={tp_size_per_node}, "
-            f"master_host={self.model_config.master_host!r}"
+            f"[KVTaskEngine] topology: {self.model_config}"
         )
 
         self.cache_engine = GlobalCacheEngine(cache_config, model_config, redis_meta, event_collector)
 
-        combine_with_trtllm = os.getenv("FLEXKV_WITH_TRTLLM", "0") == "1"
-        if not combine_with_trtllm:
+        if not self.model_config.use_trtllm_subprocess:
             self.transfer_handles = [TransferManagerHandle(
-                self.model_config,
-                self.cache_config,
+                model_config,
+                cache_config,
                 mode="process",
                 gpu_register_port=gpu_register_port
             )]
         else:
             # When using FlexKV with TensorRT-LLM, we use remote mode to transfer data
             #  to avoid the way we launch subprocess in FlexKV
-            #  conflict with TensorRT-LLM's MPI initialization
-            master_host, master_ports = get_trtllm_subprocess_host_and_ports_from_env()
-            self.remote_process = TransferManagerOnRemote.create_process(mode="TrtllmSubprocess")
+            #  conflict with TensorRT-LLM's MPI initialization.
+            sub_host = self.model_config.trtllm_subprocess_host
+            sub_ports = self.model_config.trtllm_subprocess_ports
+            self.remote_process = TransferManagerOnRemote.create_process(
+                master_host=sub_host,
+                master_ports=sub_ports,
+            )
             self.transfer_handles = [
                 TransferManagerHandle(
-                    self.model_config,
-                    self.cache_config,
+                    model_config,
+                    cache_config,
                     mode="remote",
                     gpu_register_port=gpu_register_port,
-                    master_host=master_host,
-                    master_ports=master_ports
+                    master_host=sub_host,
+                    master_ports=sub_ports,
                 )
             ]
             self.transfer_handles[0]._handle.send_config_to_remotes()
 
         if self.model_config.nnodes > 1:
-            master_host, master_ports = resolve_master_host_and_ports(
-                master_host=self.model_config.master_host
-            )
             self.transfer_handles.append(TransferManagerHandle(
-                self.model_config,
-                self.cache_config,
+                model_config,
+                cache_config,
                 mode="remote",
                 gpu_register_port=gpu_register_port,
-                master_host=master_host,
-                master_ports=master_ports
+                master_host=self.model_config.master_host,
+                master_ports=self.model_config.master_ports,
             ))
             self.transfer_handles[-1]._handle.send_config_to_remotes()
 
@@ -236,10 +178,8 @@ class KVTaskManager:
                         task_id: int,
                         token_ids: np.ndarray,
                         slot_mapping: np.ndarray,
+                        dp_client_id: int,
                         token_mask: Optional[np.ndarray] = None,
-                        layer_granularity: int = -1,
-                        dp_rank: int = 0,
-                        pp_rank: int = 0,
                         is_fake_slot_mapping: bool = False,
                         temp_cache_strategy=DEFAULT_CACHE_STRATEGY,
                         namespace: Optional[List[str]] = None,
@@ -251,10 +191,7 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=token_mask,
             slot_mapping=slot_mapping,
-            layer_num=self.model_config.num_layers_per_pp_stage,
-            layer_granularity=layer_granularity,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank,
+            dp_client_id=dp_client_id,
             temp_cache_strategy=temp_cache_strategy,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
@@ -266,8 +203,6 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -279,9 +214,8 @@ class KVTaskManager:
                         task_id: int,
                         token_ids: np.ndarray,
                         slot_mapping: np.ndarray,
+                        dp_client_id: int,
                         token_mask: Optional[np.ndarray] = None,
-                        dp_rank: int = 0,
-                        pp_rank: int = 0,
                         is_fake_slot_mapping: bool = False,
                         namespace: Optional[List[str]] = None,
                         ) -> None:
@@ -292,9 +226,7 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=token_mask,
             slot_mapping=slot_mapping,
-            layer_num=self.model_config.num_layers_per_pp_stage,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank,
+            dp_client_id=dp_client_id,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
             task_id=task_id,
@@ -305,8 +237,6 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -316,7 +246,7 @@ class KVTaskManager:
     def create_prefetch_task(self,
                             task_id: int,
                             token_ids: np.ndarray,
-                            pp_rank: int = 0,
+                            dp_client_id: int,
                             namespace: Optional[List[str]] = None,
                             ) -> None:
         if task_id in self.tasks:
@@ -331,9 +261,7 @@ class KVTaskManager:
             token_ids=token_ids,
             token_mask=fake_token_mask,
             slot_mapping=fake_slot_mapping,
-            layer_num=self.model_config.num_layers_per_pp_stage,
-            dp_rank=0,  # dp_rank irrelevant: prefetch only uploads to CPU (ignore_gpu=True)
-            pp_rank=pp_rank,
+            dp_client_id=dp_client_id,
             temp_cache_strategy=temp_cache_strategy,
             namespace=namespace)
         self.tasks[task_id] = KVTask(
@@ -345,8 +273,6 @@ class KVTaskManager:
             token_ids=token_ids,
             slot_mapping=fake_slot_mapping,  # ignore slot_mapping for prefetch
             token_mask=fake_token_mask,  # ignore token_mask for prefetch
-            dp_rank=0,  # ignore dp_rank for prefetch
-            pp_rank=pp_rank,
             graph=graph,
             return_mask=return_mask,
             callback=callback,
@@ -491,49 +417,6 @@ class KVTaskManager:
                         self.uncompleted_ops[completed_op.op_id] = completed_count
         return results
 
-    def _check_config(self, model_config: ModelConfig, cache_config: CacheConfig) -> None:
-        if cache_config.enable_remote:
-            if cache_config.remote_cache_path is None:
-
-                if cache_config.remote_file_prefix is None:
-                    raise ValueError("remote_file_prefix must be provided when remote_cache_path is None")
-
-                if cache_config.remote_file_num is None or cache_config.remote_file_num <= 0:
-                    raise ValueError("remote_file_num must be a positive integer")
-
-                cache_config.remote_cache_path = [
-                    f"{cache_config.remote_file_prefix}_{i}"
-                    for i in range(cache_config.remote_file_num)
-                ]
-
-            if cache_config.remote_cache_size_mode == "block_num":
-                if cache_config.num_remote_blocks is None:
-                    raise ValueError("num_remote_blocks must not None if use block_num model")
-            elif cache_config.remote_cache_size_mode == "file_size":
-                if cache_config.remote_file_size is None:
-                    raise ValueError("remote_file_size must not None if use file_size model")
-                if model_config.use_mla:
-                    kv_size = (
-                        model_config.num_layers_per_pp_stage
-                        * cache_config.tokens_per_block
-                        * model_config.num_kv_heads
-                        * model_config.head_size
-                        * model_config.dtype.itemsize
-                    )
-                else:
-                    kv_size = (
-                        model_config.num_layers_per_pp_stage
-                        * 2
-                        * cache_config.tokens_per_block
-                        * model_config.num_kv_heads
-                        * model_config.head_size
-                        * model_config.dtype.itemsize
-                    )
-                cache_config.num_remote_blocks = cache_config.remote_file_size // kv_size * cache_config.remote_file_num
-
-            else:
-                raise ValueError("remote_cache_size_mode must block_num or file_size model")
-
 class KVTaskEngine(KVTaskManager):
     def __init__(self,
                  model_config: ModelConfig,
@@ -549,10 +432,8 @@ class KVTaskEngine(KVTaskManager):
     def get_async(self,
                   token_ids: np.ndarray,
                   slot_mapping: np.ndarray,
+                  dp_client_id: int = 0,
                   token_mask: Optional[np.ndarray] = None,
-                  layer_granularity: int = -1,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         # self._sync_prefetch(token_ids, namespace)
@@ -560,9 +441,7 @@ class KVTaskEngine(KVTaskManager):
                                                     slot_mapping,
                                                     is_fake_slot_mapping=False,
                                                     token_mask=token_mask,
-                                                    layer_granularity=layer_granularity,
-                                                    dp_rank=dp_rank,
-                                                    pp_rank=pp_rank,
+                                                    dp_client_id=dp_client_id,
                                                     task_id=task_id,
                                                     namespace=namespace)
         # trace get request
@@ -572,9 +451,7 @@ class KVTaskEngine(KVTaskManager):
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            layer_granularity=layer_granularity,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank
+            dp_client_id=dp_client_id
         )
         self._launch_task(task_id)
         return task_id, return_mask
@@ -582,17 +459,15 @@ class KVTaskEngine(KVTaskManager):
     def put_async(self,
                   token_ids: np.ndarray,
                   slot_mapping: np.ndarray,
+                  dp_client_id: int = 0,
                   token_mask: Optional[np.ndarray] = None,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         task_id, return_mask = self._put_match_impl(token_ids,
                                                     slot_mapping,
                                                     is_fake_slot_mapping=False,
                                                     token_mask=token_mask,
-                                                    dp_rank=dp_rank,
-                                                    pp_rank=pp_rank,
+                                                    dp_client_id=dp_client_id,
                                                     task_id=task_id,
                                                     namespace=namespace)
         # trace put request
@@ -602,9 +477,7 @@ class KVTaskEngine(KVTaskManager):
             token_ids=token_ids,
             slot_mapping=slot_mapping,
             token_mask=token_mask,
-            layer_granularity=-1,  # put has no layer_granularity parameter
-            dp_rank=dp_rank,
-            pp_rank=pp_rank
+            dp_client_id=dp_client_id
         )
         self._launch_task(task_id)
         return task_id, return_mask
@@ -707,10 +580,8 @@ class KVTaskEngine(KVTaskManager):
 
     def get_match(self,
                   token_ids: np.ndarray,
+                  dp_client_id: int = 0,
                   token_mask: Optional[np.ndarray] = None,
-                  layer_granularity: int = -1,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
@@ -723,9 +594,7 @@ class KVTaskEngine(KVTaskManager):
                                                            fake_slot_mapping,
                                                            is_fake_slot_mapping=True,
                                                            token_mask=token_mask,
-                                                           layer_granularity=layer_granularity,
-                                                           dp_rank=dp_rank,
-                                                           pp_rank=pp_rank,
+                                                           dp_client_id=dp_client_id,
                                                            cpu_only=cpu_only,
                                                            task_id=task_id,
                                                            namespace=namespace)
@@ -736,9 +605,7 @@ class KVTaskEngine(KVTaskManager):
             token_ids=token_ids,
             slot_mapping=fake_slot_mapping,
             token_mask=token_mask,
-            layer_granularity=layer_granularity,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank
+            dp_client_id=dp_client_id
         )
         nvtx.pop_range()
         return result_task_id, return_mask
@@ -746,31 +613,25 @@ class KVTaskEngine(KVTaskManager):
     def _get_match_impl(self,
                   token_ids: np.ndarray,
                   slot_mapping: np.ndarray,
+                  dp_client_id: int,
                   is_fake_slot_mapping: bool = False,
                   token_mask: Optional[np.ndarray] = None,
-                  layer_granularity: int = -1,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   cpu_only: bool = False,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         if token_mask is None:
             token_mask = np.ones_like(token_ids)
-        if layer_granularity == -1:
-            layer_granularity = self.model_config.num_layers_per_pp_stage
         if task_id == -1:
             task_id = self._gen_task_id()
         temp_cache_strategy = DEFAULT_CACHE_STRATEGY
         if cpu_only:
             temp_cache_strategy = CPUONLY_CACHE_STRATEGY
         nvtx.push_range(f"get match: task_id={task_id}", color=get_nvtx_default_color())
-        self.create_get_task(task_id,
-                             token_ids,
-                             slot_mapping,
-                             token_mask,
-                             layer_granularity,
-                             dp_rank,
-                             pp_rank=pp_rank,
+        self.create_get_task(task_id=task_id,
+                             token_ids=token_ids,
+                             slot_mapping=slot_mapping,
+                             dp_client_id=dp_client_id,
+                             token_mask=token_mask,
                              is_fake_slot_mapping=is_fake_slot_mapping,
                              temp_cache_strategy=temp_cache_strategy,
                              namespace=namespace)
@@ -780,9 +641,8 @@ class KVTaskEngine(KVTaskManager):
 
     def put_match(self,
                   token_ids: np.ndarray,
+                  dp_client_id: int = 0,
                   token_mask: Optional[np.ndarray] = None,
-                  dp_rank: int = 0,
-                  pp_rank: int = 0,
                   task_id: int = -1,
                   namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         fake_slot_mapping = np.zeros_like(token_ids)
@@ -790,8 +650,7 @@ class KVTaskEngine(KVTaskManager):
                                                            fake_slot_mapping,
                                                            is_fake_slot_mapping=True,
                                                            token_mask=token_mask,
-                                                           dp_rank=dp_rank,
-                                                           pp_rank=pp_rank,
+                                                           dp_client_id=dp_client_id,
                                                            task_id=task_id,
                                                            namespace=namespace)
         # trace put match request
@@ -801,19 +660,16 @@ class KVTaskEngine(KVTaskManager):
             token_ids=token_ids,
             slot_mapping=fake_slot_mapping,
             token_mask=token_mask,
-            layer_granularity=-1,  # put has no layer_granularity parameter
-            dp_rank=dp_rank,
-            pp_rank=pp_rank
+            dp_client_id=dp_client_id
         )
         return result_task_id, return_mask
 
     def _put_match_impl(self,
                         token_ids: np.ndarray,
                         slot_mapping: np.ndarray,
+                        dp_client_id: int,
                         is_fake_slot_mapping: bool = False,
                         token_mask: Optional[np.ndarray] = None,
-                        dp_rank: int = 0,
-                        pp_rank: int = 0,
                         task_id: int = -1,
                         namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
         if token_mask is None:
@@ -821,12 +677,11 @@ class KVTaskEngine(KVTaskManager):
         if task_id == -1:
             task_id = self._gen_task_id()
         nvtx.push_range(f"put match: task_id={task_id}", color=get_nvtx_default_color())
-        self.create_put_task(task_id,
-                             token_ids,
-                             slot_mapping,
-                             token_mask,
-                             dp_rank,
-                             pp_rank=pp_rank,
+        self.create_put_task(task_id=task_id,
+                             token_ids=token_ids,
+                             slot_mapping=slot_mapping,
+                             dp_client_id=dp_client_id,
+                             token_mask=token_mask,
                              is_fake_slot_mapping=is_fake_slot_mapping,
                              namespace=namespace)
         self._process_empty_graph(task_id)
@@ -835,14 +690,13 @@ class KVTaskEngine(KVTaskManager):
 
     def prefetch_async(self,
                        token_ids: np.ndarray,
-                       dp_rank: int = 0,
-                       pp_rank: int = 0,
+                       dp_client_id: int = 0,
                        task_id: int = -1,
                        namespace: Optional[List[str]] = None) -> int:
         if task_id == -1:
             task_id = self._gen_task_id()
         nvtx.push_range(f"prefetch match: task_id={task_id}", color=get_nvtx_default_color())
-        self.create_prefetch_task(task_id, token_ids, pp_rank=pp_rank, namespace=namespace)
+        self.create_prefetch_task(task_id, token_ids, dp_client_id=dp_client_id, namespace=namespace)
         self._process_empty_graph(task_id)
         nvtx.pop_range()
         # trace prefetch async request
@@ -852,17 +706,13 @@ class KVTaskEngine(KVTaskManager):
             token_ids=token_ids,
             slot_mapping=np.zeros_like(token_ids),
             token_mask=np.ones_like(token_ids),
-            layer_granularity=-1,
-            dp_rank=dp_rank,
-            pp_rank=pp_rank
+            dp_client_id=dp_client_id
         )
         self._launch_task(task_id)
         return task_id
 
     def merge_to_batch_kvtask(self,
-
                               batch_id: int,
-
                               task_ids: List[int],
                               batch_task_type: TaskType,
                               layerwise_transfer: bool = False,
@@ -898,8 +748,6 @@ class KVTaskEngine(KVTaskManager):
             task_end_op_id=task_end_op_id,
             task_end_op_finished=False,
             status=TaskStatus.READY,
-            dp_rank=self.tasks[task_ids[0]].dp_rank,
-            pp_rank=self.tasks[task_ids[0]].pp_rank,
             graph=batch_task_graph,
             return_mask=return_masks,
             callback=callbacks,

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -77,7 +77,11 @@ class KVDPClient:
         model_config: ModelConfig,
         client_recv_port: str,
     ) -> None:
-        register_req = RegisterDPClientRequest(self.dp_client_id, model_config, client_recv_port)
+        register_req = RegisterDPClientRequest(
+            dp_client_id=self.dp_client_id,
+            model_config=model_config,
+            client_recv_port=client_recv_port,
+        )
         self.send_to_server.send_pyobj(register_req)
         flexkv_logger.info(f"DP client {self.dp_client_id} registered to server request sent!")
 
@@ -94,16 +98,16 @@ class KVDPClient:
         token_ids: np.ndarray,
         slot_mapping: np.ndarray,
         token_mask: Optional[np.ndarray],
-        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
-        req = PutRequest(self.dp_client_id,
-                         token_ids,
-                         slot_mapping,
-                         token_mask if token_mask is not None else None,
-                         self._get_task_id(),
-                         pp_rank,
-                         namespace)
+        req = PutRequest(
+            dp_client_id=self.dp_client_id,
+            token_ids=token_ids,
+            slot_mapping=slot_mapping,
+            token_mask=token_mask if token_mask is not None else None,
+            task_id=self._get_task_id(),
+            namespace=namespace,
+        )
         self.send_to_server.send_pyobj(req)
         return req.task_id
 
@@ -111,15 +115,15 @@ class KVDPClient:
         self,
         token_ids: np.ndarray,
         token_mask: Optional[np.ndarray],
-        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> Optional[Tuple[int, np.ndarray]]:
-        req = PutMatchRequest(self.dp_client_id,
-                              token_ids,
-                              token_mask if token_mask is not None else None,
-                              self._get_task_id(),
-                              pp_rank,
-                              namespace)
+        req = PutMatchRequest(
+            dp_client_id=self.dp_client_id,
+            token_ids=token_ids,
+            token_mask=token_mask if token_mask is not None else None,
+            task_id=self._get_task_id(),
+            namespace=namespace,
+        )
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
         if response.error_msg is None:
@@ -131,10 +135,14 @@ class KVDPClient:
     def prefetch_async(
         self,
         token_ids: np.ndarray,
-        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
-        req = PrefetchRequest(self.dp_client_id, token_ids, self._get_task_id(), pp_rank, namespace)
+        req = PrefetchRequest(
+            dp_client_id=self.dp_client_id,
+            token_ids=token_ids,
+            task_id=self._get_task_id(),
+            namespace=namespace,
+        )
         self.send_to_server.send_pyobj(req)
         return req.task_id
 
@@ -143,18 +151,16 @@ class KVDPClient:
         token_ids: np.ndarray,
         slot_mapping: np.ndarray,
         token_mask: Optional[np.ndarray],
-        layer_granularity: int,
-        pp_rank: int = 0,
         namespace: Optional[List[str]] = None,
     ) -> int:
-        req = GetRequest(self.dp_client_id,
-                         token_ids,
-                         slot_mapping,
-                         token_mask if token_mask is not None else None,
-                         self._get_task_id(),
-                         layer_granularity,
-                         pp_rank,
-                         namespace)
+        req = GetRequest(
+            dp_client_id=self.dp_client_id,
+            token_ids=token_ids,
+            slot_mapping=slot_mapping,
+            token_mask=token_mask if token_mask is not None else None,
+            task_id=self._get_task_id(),
+            namespace=namespace,
+        )
         self.send_to_server.send_pyobj(req)
         return req.task_id
 
@@ -162,19 +168,17 @@ class KVDPClient:
         self,
         token_ids: np.ndarray,
         token_mask: Optional[np.ndarray],
-        layer_granularity: int,
-        pp_rank: int = 0,
         cpu_only: bool = False,
         namespace: Optional[List[str]] = None,
     ) -> Optional[Tuple[int, np.ndarray]]:
-        req = GetMatchRequest(self.dp_client_id,
-                              token_ids,
-                              token_mask if token_mask is not None else None,
-                              layer_granularity,
-                              cpu_only,
-                              self._get_task_id(),
-                              pp_rank,
-                              namespace)
+        req = GetMatchRequest(
+            dp_client_id=self.dp_client_id,
+            token_ids=token_ids,
+            token_mask=token_mask if token_mask is not None else None,
+            cpu_only=cpu_only,
+            task_id=self._get_task_id(),
+            namespace=namespace,
+        )
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
         if response.error_msg is None:
@@ -211,7 +215,7 @@ class KVDPClient:
         wait_timeout: float = 20.0,
         completely: bool = False,
     ) -> Optional[Dict[int, KVResponse]]:
-        req = WaitRequest(self.dp_client_id, None, wait_task_ids, wait_timeout, completely)
+        req = WaitRequest(self.dp_client_id, wait_task_ids, wait_timeout, completely)
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
         if response.status is not None:
@@ -220,14 +224,14 @@ class KVDPClient:
                     flexkv_logger.error(f"wait task {k} failed: {v.status}")
             return response.status
         else:
-            flexkv_logger.error(f"wait tasks: {wait_task_ids} in DP {self.dp_client_id} failed.")
+            flexkv_logger.error(f"wait tasks: {wait_task_ids} in dp_client_id={self.dp_client_id} failed.")
             return None
 
     def try_wait(
         self,
         try_wait_task_ids: List[int],
     ) -> Optional[Dict[int, KVResponse]]:
-        req = TryWaitRequest(self.dp_client_id, None, try_wait_task_ids)
+        req = TryWaitRequest(self.dp_client_id, try_wait_task_ids)
 
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
@@ -237,7 +241,7 @@ class KVDPClient:
                     flexkv_logger.error(f"try_wait task {k} failed: {v.status}")
             return response.status
         else:
-            flexkv_logger.error(f"try_wait tasks: {try_wait_task_ids} in DP {self.dp_client_id} failed.")
+            flexkv_logger.error(f"try_wait tasks: {try_wait_task_ids} in dp_client_id={self.dp_client_id} failed.")
             return None
 
     def shutdown(self) -> None:
@@ -248,22 +252,25 @@ class KVTPClient:
     def __init__(
         self,
         gpu_register_port: str,
-        dp_rank: int,
-        pp_rank: int,
+        dp_client_id: int,
         device_id: int,
+        pp_rank: int = 0,
     ):
+        """A TP-level GPU registration client."""
         # Init inter-process communication
         context = zmq.Context(2)
         self.send_to_server = get_zmq_socket(
             context, zmq.SocketType.PUSH, gpu_register_port, False
         )
 
-        self.dp_rank = dp_rank
+        self.dp_client_id = dp_client_id
         self.pp_rank = pp_rank
         self.device_id = device_id
 
-        flexkv_logger.info(f"KVTPClient {device_id} of DP {self.dp_rank} Initialized! "
-                           f"(gpu_register_port={gpu_register_port}, dp_rank={dp_rank}, pp_rank={pp_rank})")
+        flexkv_logger.info(
+            f"KVTPClient {device_id} Initialized! "
+            f"(gpu_register_port={gpu_register_port}, "
+            f"dp_client_id={dp_client_id}, pp_rank={pp_rank})")
 
     def set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
         """Send set_slot_mapping message to TransferManagerOnRemote via existing ZMQ channel.
@@ -319,11 +326,11 @@ class KVTPClient:
                 indexer_handles.append(TensorSharedHandle(tensor, device_id))
 
         register_req = RegisterTPClientRequest(
-            self.dp_rank,
-            self.pp_rank,
-            device_id,
-            handles,
-            kv_layout,
+            dp_client_id=self.dp_client_id,
+            pp_rank=self.pp_rank,
+            device_id=device_id,
+            handles=handles,
+            gpu_layout=kv_layout,
             indexer_handles=indexer_handles,
             indexer_gpu_layout=indexer_layout,
         )
@@ -332,7 +339,8 @@ class KVTPClient:
             self.send_to_server.send_pyobj(register_req, flags=zmq.NOBLOCK)
             flexkv_logger.info(
                 f"KVTPClient {device_id}: registration message sent "
-                f"(dp_rank={self.dp_rank}, num_kv_caches={len(kv_caches)})")
+                f"(dp_client_id={self.dp_client_id}, pp_rank={self.pp_rank}, "
+                f"num_kv_caches={len(kv_caches)})")
         except zmq.Again:
             flexkv_logger.error(
                 f"KVTPClient {device_id}: zmq.Again when sending registration "
@@ -355,5 +363,8 @@ if __name__ == "__main__":
                                 use_mla=False,
                                 tp_size=tp_size,
                                 dtype=torch.float16)
-
-    dp_client = KVDPClient("ipc:///tmp/tmp6isie_et", model_config)
+    dp_client = KVDPClient(
+        "ipc:///tmp/tmp6isie_et",
+        model_config=model_config,
+        dp_client_id=0,
+    )

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import numpy as np
 
@@ -18,7 +18,7 @@ class RegisterDPClientRequest:
 
 @dataclass
 class RegisterTPClientRequest:
-    dp_rank: int
+    dp_client_id: int
     pp_rank: int
     device_id: int
     handles: List[TensorSharedHandle]
@@ -27,9 +27,11 @@ class RegisterTPClientRequest:
     indexer_handles: Optional[List[TensorSharedHandle]] = None
     indexer_gpu_layout: Optional[KVCacheLayout] = None
 
+
 @dataclass
 class IsReadyRequest:
     dp_client_id: int
+
 
 @dataclass
 class PutRequest:
@@ -38,7 +40,6 @@ class PutRequest:
     slot_mapping: np.ndarray
     token_mask: Optional[np.ndarray]
     task_id: int = -1
-    pp_rank: int = 0
     namespace: Optional[List[str]] = None
 
 
@@ -49,17 +50,16 @@ class GetRequest:
     slot_mapping: np.ndarray
     token_mask: Optional[np.ndarray]
     task_id: int = -1
-    layer_granularity: int = -1
-    pp_rank: int = 0
     namespace: Optional[List[str]] = None
+
 
 @dataclass
 class PrefetchRequest:
     dp_client_id: int
     token_ids: np.ndarray
     task_id: int = -1
-    pp_rank: int = 0
     namespace: Optional[List[str]] = None
+
 
 @dataclass
 class PutMatchRequest:
@@ -67,19 +67,18 @@ class PutMatchRequest:
     token_ids: np.ndarray
     token_mask: Optional[np.ndarray]
     task_id: int = -1
-    pp_rank: int = 0
     namespace: Optional[List[str]] = None
+
 
 @dataclass
 class GetMatchRequest:
     dp_client_id: int
     token_ids: np.ndarray
     token_mask: Optional[np.ndarray]
-    layer_granularity: int
     cpu_only: bool = False
     task_id: int = -1
-    pp_rank: int = 0
     namespace: Optional[List[str]] = None
+
 
 @dataclass
 class LaunchTaskRequest:
@@ -91,30 +90,31 @@ class LaunchTaskRequest:
     layerwise_transfer: bool = False
     counter_id: int = 0  # Counter set index for triple buffering eventfd notification
 
+
 @dataclass
 class CancelTaskRequest:
     dp_client_id: int
     task_ids: List[int]
 
+
 @dataclass
 class WaitRequest:
     dp_client_id: int
-    tp_rank: Optional[int]
     wait_task_ids: List[int]
     wait_timeout: float = 20.0
     completely: bool = False
+
 
 # Used for async put/get
 @dataclass
 class TryWaitRequest:
     dp_client_id: int
-    tp_rank: Optional[int]
     try_wait_task_ids: List[int]
 
 
 @dataclass
 class Response:
-    dp_client_id: int = -1
+    dp_client_id: int
     task_id: Optional[int] = None
     mask: Optional[Dict[int, np.ndarray]] = None
     status: Optional[Dict[int, KVResponseStatus]] = None
@@ -126,15 +126,17 @@ class Response:
         return self.status is not None and \
                all(self.status[task_id] == KVResponseStatus.SUCCESS for task_id in self.status)
 
+
 @dataclass
 class StartRequest:
     dp_client_id: int
+
 
 @dataclass
 class ShutdownRequest:
     dp_client_id: int
 
+
 @dataclass
 class CheckRunningRequest:
     dp_client_id: int
-

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -44,12 +44,10 @@ import contextlib
 class DPClient:
     def __init__(
         self,
-        client_id: int,
+        dp_client_id: int,
         send_to_client: zmq.Socket,
-        tp_size: int = 1,
     ):
-        self.client_id = client_id
-        self.tp_size = tp_size
+        self.dp_client_id = dp_client_id
 
         self.send_to_client = send_to_client
 
@@ -58,50 +56,55 @@ class DPClient:
 class ClientManager:
     def __init__(
         self,
-        max_num_dp_client: int = 1,
+        max_num_dp_client: int,
     ):
-        #assert max_num_dp_client == 1, f"currently only support dp=1"
-        self.free_client_ids = deque(range(max_num_dp_client))
+        if max_num_dp_client < 1:
+            raise ValueError(f"max_num_dp_client must be >= 1, got {max_num_dp_client}")
+        self.max_num_dp_client = max_num_dp_client
         self.client_dict: Dict[int, DPClient] = {}
 
     def register_dp_client(
         self,
         context: zmq.Context,
+        dp_client_id: int,
         client_recv_port: str,
-        tp_size: int = 1,
-        client_id: Optional[int] = None,
     ) -> int:
-        if client_id is None:
-            if len(self.free_client_ids) == 0:
-                flexkv_logger.error("Client full. DP client registration failed.")
-                raise RuntimeError("Client full. DP client registration failed.")
-            client_id = self.free_client_ids.popleft()
+        if dp_client_id in self.client_dict:
+            flexkv_logger.error(f"DP client {dp_client_id} already registered.")
+            raise RuntimeError(f"DP client {dp_client_id} already registered.")
+        if len(self.client_dict) >= self.max_num_dp_client:
+            flexkv_logger.error(
+                f"DP client capacity full ({self.max_num_dp_client}). "
+                f"Registration of {dp_client_id} failed."
+            )
+            raise RuntimeError(
+                f"DP client capacity full ({self.max_num_dp_client}). "
+                f"Cannot register {dp_client_id}."
+            )
         send_to_client = get_zmq_socket(
             context, zmq.SocketType.PUSH, client_recv_port, False
         )
 
-        self.client_dict[client_id] = DPClient(
-            client_id=client_id,
-            tp_size=tp_size,
+        self.client_dict[dp_client_id] = DPClient(
+            dp_client_id=dp_client_id,
             send_to_client=send_to_client,
         )
-        flexkv_logger.info(f"DP client {client_id} registered successfully")
+        flexkv_logger.info(
+            f"DP client {dp_client_id} registered successfully "
+            f"({len(self.client_dict)}/{self.max_num_dp_client})"
+        )
 
-        return client_id
-    def delete_dp_client(self, client_id: int) -> None:
-        if client_id not in self.client_dict:
-            flexkv_logger.error(f"DP client: {client_id} dosen't exist. Delete failed.")
-            raise KeyError(f"DP client: {client_id} doesn't exist. Delete failed.")
-        self.client_dict.pop(client_id)
-        self.free_client_ids.appendleft(client_id)
-        flexkv_logger.info(f"Delete DP client: {client_id} succeeded.")
+        return dp_client_id
 
-    def get_zmq(self, dp_client_id: int, tp_rank: int = -1) -> zmq.Socket:
-        dp_client = self.client_dict[dp_client_id]
-        if tp_rank == -1:
-            return dp_client.send_to_client
-        else:
-            return dp_client.tp_client_dict[tp_rank].send_to_client
+    def delete_dp_client(self, dp_client_id: int) -> None:
+        if dp_client_id not in self.client_dict:
+            flexkv_logger.error(f"DP client: {dp_client_id} doesn't exist. Delete failed.")
+            raise KeyError(f"DP client: {dp_client_id} doesn't exist. Delete failed.")
+        self.client_dict.pop(dp_client_id)
+        flexkv_logger.info(f"Delete DP client: {dp_client_id} succeeded.")
+
+    def get_zmq(self, dp_client_id: int) -> zmq.Socket:
+        return self.client_dict[dp_client_id].send_to_client
 
     def is_dp_client_ready(self, dp_client_id: int) -> bool:
         if dp_client_id in self.client_dict:
@@ -146,7 +149,6 @@ class KVServer:
         cache_config: CacheConfig,
         gpu_register_port: str,
         server_recv_port: str,
-        total_clients: int = 0,
     ):
 
         self.model_config = model_config
@@ -159,9 +161,8 @@ class KVServer:
             f"gpu_register_port={gpu_register_port}"
         )
 
-        # Use total_clients if provided (multi-instance mode), otherwise use dp_size
-        max_clients = total_clients if total_clients > 0 else model_config.dp_size
-        self.client_manager = ClientManager(max_num_dp_client=max_clients)
+        # Capacity == instance_num * dp_size; sourced from model_config (single source of truth).
+        self.client_manager = ClientManager(max_num_dp_client=model_config.total_clients)
 
         # Initialize RedisMeta in KVServer for server_client_mode
         self.redis_meta_client = None
@@ -213,10 +214,9 @@ class KVServer:
     def _server_process(model_config: ModelConfig,
                        cache_config: CacheConfig,
                        gpu_register_port: str,
-                       server_recv_port: str,
-                       total_clients: int = 0) -> None:
+                       server_recv_port: str) -> None:
 
-        server = KVServer(model_config, cache_config, gpu_register_port, server_recv_port, total_clients)
+        server = KVServer(model_config, cache_config, gpu_register_port, server_recv_port)
         server.run()
 
     @classmethod
@@ -225,7 +225,6 @@ class KVServer:
                       cache_config: CacheConfig,
                       gpu_register_port: str,
                       server_recv_port: Optional[str] = None,
-                      total_clients: int = 0,
                       child_env: Optional[dict] = None,
                       inherit_env: bool = True) -> 'KVServerHandle':
 
@@ -256,9 +255,9 @@ class KVServer:
             
             # Remove CUDA_VISIBLE_DEVICES so server can see all GPUs
             env.pop('CUDA_VISIBLE_DEVICES', None)
-            env.update({"FLEXKV_INSTANCE_NUM": str(total_clients // model_config.dp_size)})
+
             # Serialize arguments
-            args_data = pickle.dumps((model_config, cache_config, gpu_register_port, server_recv_port, total_clients))
+            args_data = pickle.dumps((model_config, cache_config, gpu_register_port, server_recv_port))
 
             # Start subprocess
             flexkv_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -269,22 +268,28 @@ class KVServer:
                 from flexkv.server.server import KVServer
 
                 args_data = {args_data!r}
-                model_config, cache_config, gpu_register_port, server_recv_port, total_clients = pickle.loads(args_data)
-                server = KVServer(model_config, cache_config, gpu_register_port, server_recv_port, total_clients)
+                model_config, cache_config, gpu_register_port, server_recv_port = pickle.loads(args_data)
+                server = KVServer(model_config, cache_config, gpu_register_port, server_recv_port)
                 server.run()
             ''').strip()
             process = subprocess.Popen([
                 sys.executable, '-c', server_script
             ], env=env)
 
-            flexkv_logger.info(f"KVServer subprocess started, PID: {process.pid}, total_clients: {total_clients}")
+            flexkv_logger.info(
+                f"KVServer subprocess started, PID: {process.pid}, "
+                f"total_clients: {model_config.total_clients}"
+            )
             return KVServerHandle(process)
         else:
             # Use multiprocessing as before
             process = mp.Process(target=cls._server_process,
-                                 args=(model_config, cache_config, gpu_register_port, server_recv_port, total_clients))
+                                 args=(model_config, cache_config, gpu_register_port, server_recv_port))
             process.start()
-            flexkv_logger.info(f"KVServer process started, PID: {process.pid}, total_clients: {total_clients}")
+            flexkv_logger.info(
+                f"KVServer process started, PID: {process.pid}, "
+                f"total_clients: {model_config.total_clients}"
+            )
             return KVServerHandle(process)
 
     def run(self) -> None:
@@ -295,18 +300,20 @@ class KVServer:
         flexkv_logger.info("Servering waiting to be started")
         req = self.recv_from_client.recv_pyobj()
         if isinstance(req, StartRequest):
-            flexkv_logger.info(f"Received start request from DP client {req.dp_client_id}, "
+            flexkv_logger.info(f"Received start request from DP client "
+                               f"(dp_client_id={req.dp_client_id}), "
                                f"Starting server...")
             self.start_server()
         else:
             raise TypeError(f"Received RequestType: {type(req)} from DP client "
-                            f"{req.dp_client_id} before the start request")
+                            f"dp_client_id={req.dp_client_id} before the start request")
         self._running = True
         while self._running:
             try:
                 flexkv_logger.info("start waiting for req")
                 req = self.recv_from_client.recv_pyobj()
-                flexkv_logger.info(f"recv req: {type(req)} from DP client {req.dp_client_id}")
+                flexkv_logger.info(f"recv req: {type(req)} from DP client "
+                                   f"(dp_client_id={req.dp_client_id})")
 
                 # Use dispatch table for request handling
                 req_type = type(req)
@@ -349,22 +356,22 @@ class KVServer:
 
     def _handle_start_request(self, req: StartRequest) -> None:
         """Handle start request"""
-        flexkv_logger.info(f"Received start request from DP client {req.dp_client_id}")
+        flexkv_logger.info(f"Received start request from DP client "
+                           f"(dp_client_id={req.dp_client_id})")
 
     def _handle_register_dp_client_request(self, req: RegisterDPClientRequest) -> None:
         """Handle DP client registration request"""
         self._verify_model_config(req.model_config)
-        client_id = self.client_manager.register_dp_client(
+        self.client_manager.register_dp_client(
             self.context,
-            req.client_recv_port,
-            req.model_config.tp_size,
-            req.dp_client_id,
+            dp_client_id=req.dp_client_id,
+            client_recv_port=req.client_recv_port,
         )
 
     def _handle_is_ready_request(self, req: IsReadyRequest) -> None:
         """Handle ready state check request"""
         is_ready = self.kv_task_engine.is_ready()
-        response = Response(req.dp_client_id, is_ready=is_ready)
+        response = Response(dp_client_id=req.dp_client_id, is_ready=is_ready)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 
@@ -375,9 +382,7 @@ class KVServer:
             token_ids=req.token_ids,
             slot_mapping=req.slot_mapping,
             token_mask=req.token_mask,
-            layer_granularity=req.layer_granularity,
-            dp_rank=req.dp_client_id,
-            pp_rank=req.pp_rank,
+            dp_client_id=req.dp_client_id,
             namespace=req.namespace,
         )
 
@@ -387,8 +392,7 @@ class KVServer:
             token_ids=req.token_ids,
             slot_mapping=req.slot_mapping,
             token_mask=req.token_mask,
-            dp_rank=req.dp_client_id,
-            pp_rank=req.pp_rank,
+            dp_client_id=req.dp_client_id,
             task_id=req.task_id,
             namespace=req.namespace,
         )
@@ -398,14 +402,13 @@ class KVServer:
         req_id, mask = self.kv_task_engine.get_match(
             token_ids=req.token_ids,
             token_mask=req.token_mask,
-            layer_granularity=req.layer_granularity,
-            dp_rank=req.dp_client_id,
-            pp_rank=req.pp_rank,
+            dp_client_id=req.dp_client_id,
             cpu_only=req.cpu_only,
             task_id=req.task_id,
             namespace=req.namespace,
         )
-        response = Response(req.dp_client_id, task_id=req_id, mask=mask)
+        response = Response(dp_client_id=req.dp_client_id,
+                            task_id=req_id, mask=mask)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 
@@ -414,12 +417,12 @@ class KVServer:
         req_id, mask = self.kv_task_engine.put_match(
             token_ids=req.token_ids,
             token_mask=req.token_mask,
-            dp_rank=req.dp_client_id,
-            pp_rank=req.pp_rank,
+            dp_client_id=req.dp_client_id,
             task_id=req.task_id,
             namespace=req.namespace,
         )
-        response = Response(req.dp_client_id, task_id=req_id, mask=mask)
+        response = Response(dp_client_id=req.dp_client_id,
+                            task_id=req_id, mask=mask)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 
@@ -427,8 +430,7 @@ class KVServer:
         """Handle Prefetch request"""
         task_id = self.kv_task_engine.prefetch_async(
             token_ids=req.token_ids,
-            dp_rank=req.dp_client_id,
-            pp_rank=req.pp_rank,
+            dp_client_id=req.dp_client_id,
             task_id=req.task_id,
             namespace=req.namespace,
         )
@@ -453,7 +455,7 @@ class KVServer:
             timeout=req.wait_timeout,
             completely=req.completely,
         )
-        response = Response(req.dp_client_id, status=kv_responses)
+        response = Response(dp_client_id=req.dp_client_id, status=kv_responses)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 
@@ -462,13 +464,14 @@ class KVServer:
         kv_responses = self.kv_task_engine.try_wait(
             req.try_wait_task_ids,
         )
-        response = Response(req.dp_client_id, status=kv_responses)
+        response = Response(dp_client_id=req.dp_client_id, status=kv_responses)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 
     def _handle_shutdown_request(self, req: ShutdownRequest) -> None:
         """Handle shutdown request"""
-        flexkv_logger.info(f"Received shutdown request from DP client {req.dp_client_id}")
+        flexkv_logger.info(f"Received shutdown request from DP client "
+                           f"(dp_client_id={req.dp_client_id})")
         self._running = False
 
     def __del__(self) -> None:

--- a/flexkv/storage/storage_engine.py
+++ b/flexkv/storage/storage_engine.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, List, Tuple, Union
 import torch
 import hashlib
 
-from flexkv.common.config import ModelConfig, CacheConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV, CacheConfig, ModelConfig
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.storage import StorageHandle, KVCacheLayout, KVCacheLayoutType
@@ -27,7 +27,8 @@ class StorageEngine:
 
     def __init__(self,
                  model_config: ModelConfig,
-                 cache_config: CacheConfig):
+                 cache_config: CacheConfig,
+                 num_layers_per_pp_stage: int):
         """Initialize storage engine"""
         self._storage_handles: Dict[Tuple[DeviceType, int], StorageHandle] = {}
         self._indexer_storage_handles: Dict[Tuple[DeviceType, int], StorageHandle] = {}
@@ -38,7 +39,7 @@ class StorageEngine:
         if self._cache_config.enable_cpu:
             self._cpu_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
-                num_layer=self._model_config.num_layers_per_pp_stage,
+                num_layer=num_layers_per_pp_stage,
                 num_block=self._cache_config.num_cpu_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
                 num_head=self._model_config.num_kv_heads_per_node,
@@ -56,7 +57,7 @@ class StorageEngine:
                 # tokens_per_block is 1 (one indexer entry per page).
                 indexer_cpu_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
-                    num_layer=self._model_config.num_layers_per_pp_stage,
+                    num_layer=num_layers_per_pp_stage,
                     num_block=self._cache_config.num_cpu_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,
@@ -75,7 +76,7 @@ class StorageEngine:
                 raise ValueError(f"SSD layout type must be the same as CPU layout type: {self._cpu_layout.type}")
             self._ssd_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.ssd_layout_type,
-                num_layer=self._model_config.num_layers_per_pp_stage,
+                num_layer=num_layers_per_pp_stage,
                 num_block=self._cache_config.num_ssd_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
                 num_head=self._model_config.num_kv_heads_per_node,
@@ -92,7 +93,7 @@ class StorageEngine:
             if self._indexer_config is not None:
                 indexer_ssd_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.ssd_layout_type,
-                    num_layer=self._model_config.num_layers_per_pp_stage,
+                    num_layer=num_layers_per_pp_stage,
                     num_block=self._cache_config.num_ssd_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,
@@ -113,7 +114,7 @@ class StorageEngine:
                 raise ValueError(f"Remote layout type must be the same as CPU layout type: {self._cpu_layout.type}")
             self._remote_layout: Optional[KVCacheLayout] = KVCacheLayout(
                 type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
-                num_layer=self._model_config.num_layers_per_pp_stage,
+                num_layer=num_layers_per_pp_stage,
                 num_block=self._cache_config.num_remote_blocks,
                 tokens_per_block=self._cache_config.tokens_per_block,
                 num_head=self._model_config.num_kv_heads_per_node,
@@ -130,7 +131,7 @@ class StorageEngine:
             if self._indexer_config is not None:
                 indexer_remote_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
-                    num_layer=self._model_config.num_layers_per_pp_stage,
+                    num_layer=num_layers_per_pp_stage,
                     num_block=self._cache_config.num_remote_blocks,
                     tokens_per_block=1,
                     num_head=self._indexer_config.num_kv_heads,

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -13,6 +13,7 @@ from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.config import ModelConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.transfer import WorkerKey
 from flexkv.storage.allocator import HugePageTensorHandle, materialize_worker_tensor
 
 from flexkv.transfer.worker_op import WorkerLayerwiseTransferOp
@@ -20,25 +21,20 @@ from flexkv.transfer.worker import TransferWorkerBase, cudaHostRegister
 
 
 def build_layerwise_eventfd_socket_path(
+    dp_client_id: int,
     pp_rank: int,
-    dp_rank: int,
-    pp_size: int = 1,
-    dp_size: int = 1,
+    model_config: ModelConfig,
 ) -> str:
-    """Construct the LayerwiseWorker's UDS socket path.
-
-    Disambiguated by ``(pp_rank, dp_rank)`` so multiple PP stages and DP
-    replicas on the same host each get their own endpoint.
-    """
+    """Construct the LayerwiseWorker's UDS socket path."""
     base = os.environ.get(
         'FLEXKV_LAYERWISE_EVENTFD_SOCKET',
         '/tmp/flexkv_layerwise_eventfd.sock',
     )
     suffix = ""
-    if pp_size > 1:
+    if model_config.pp_size > 1:
         suffix += f"_pp{pp_rank}"
-    if dp_size > 1:
-        suffix += f"_dp{dp_rank}"
+    if model_config.instance_num > 1 or model_config.dp_size > 1:
+        suffix += f"_dp{dp_client_id}"
     if not suffix:
         return base
     root, ext = os.path.splitext(base)
@@ -109,6 +105,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         self.gpu_blocks = imported_gpu_blocks
         self.dtype = dtype # note this should be quantized data type
         self.is_mla = gpu_kv_layouts[0].is_mla
+        self.kv_dim = 1 if self.is_mla else 2
 
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
@@ -464,7 +461,6 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                       dst_block_ids_h2d: torch.Tensor,
                       src_block_ids_disk2h: Optional[torch.Tensor],
                       dst_block_ids_disk2h: Optional[torch.Tensor],
-                      layer_granularity: int,
                       counter_id: int = 0,
                       indexer_src_block_ids: Optional[torch.Tensor] = None,
                       indexer_dst_block_ids: Optional[torch.Tensor] = None,
@@ -517,7 +513,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             self.h2d_cta_num,
             self.use_ce_transfer_h2d,
             self.num_layers,
-            layer_granularity,
+            1,  # layer_granularity: LAYERWISE protocol fires one eventfd per layer
             self.is_mla,
             counter_id,
             indexer_gpu_block_id_tensor,
@@ -535,10 +531,6 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         )
 
     def launch_transfer(self, transfer_op: WorkerLayerwiseTransferOp) -> bool:
-        layer_granularity = transfer_op.layer_granularity
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids_h2d = torch.from_numpy(transfer_op.src_block_ids_h2d).to(dtype=torch.int64).pin_memory()
         dst_block_ids_h2d = torch.from_numpy(transfer_op.dst_block_ids_h2d).to(dtype=torch.int64).pin_memory()
 
@@ -566,15 +558,13 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             dst_block_ids_h2d,
             src_block_ids_disk2h,
             dst_block_ids_disk2h,
-            layer_granularity,
             transfer_op.counter_id,
             indexer_src_block_ids=indexer_src_block_ids,
             indexer_dst_block_ids=indexer_dst_block_ids,
         )
         end_time = time.time()
 
-        kv_dim = 2 if not self.is_mla else 1
-        transfer_size = self.cpu_chunk_size_in_bytes * self.num_layers * num_h2d_blocks * kv_dim
+        transfer_size = self.cpu_chunk_size_in_bytes * self.num_layers * num_h2d_blocks * self.kv_dim
 
         if self.is_mla:
             transfer_size *= self.tp_group_size

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -102,12 +102,17 @@ class TransferEngine:
 
         Args:
             gpu_handles: Dict mapping WorkerKey(dp_rank, pp_rank) -> list of GPU handles for that TP group
+            model_config: global ModelConfig (parallelism sizes; no per-rank index)
+            cache_config: global CacheConfig
             cpu_handle: CPU handle
             ssd_handle: Optional SSD handle
             remote_handle: Optional remote handle
         """
         self.model_config: ModelConfig = model_config
         self.cache_config: CacheConfig = cache_config
+
+        first_handles = next(iter(gpu_handles.values()))
+        self._num_layers_for_local_pp_stage = first_handles[0].kv_layout.num_layer
 
         # Use spawn context for CUDA compatibility
         self.mp_ctx = mp.get_context('spawn')
@@ -142,18 +147,12 @@ class TransferEngine:
 
         self.op_id_to_nvtx_range: Dict[int, str] = {}
 
-        # self.dp_size = model_config.dp_size
-        self.tp_size_per_node = model_config.tp_size_per_node
         self.num_gpu_groups = len(self.gpu_handle_groups)
         self._running = False
         self._has_indexer = False
 
-        self._indexer_op_to_parent_op: Dict[int, int] = {}
-        self._indexer_op_map: Dict[int, TransferOp] = {}
-
-        # Same-node PP layerwise fan-out: replica op_id → parent op_id
-        self._pp_replica_to_parent_op: Dict[int, int] = {}
-        self._pp_replica_op_map: Dict[int, TransferOp] = {}
+        self._child_id_to_child: Dict[int, TransferOp] = {}
+        self._child_to_parent_op_id: Dict[int, int] = {}
 
     def _init_workers(self) -> None:
         if self._running:
@@ -167,7 +166,7 @@ class TransferEngine:
         
         # H2D worker
         if not _enable_layerwise:
-            if self.tp_size_per_node == 1:
+            if self.model_config.effective_tp_size_per_node == 1:
                 self.h2d_workers: Dict[WorkerKey, WorkerHandle] = {
                     worker_key: GPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
@@ -197,7 +196,7 @@ class TransferEngine:
                         gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                         cpu_kv_layout=self._cpu_handle.kv_layout,
                         dtype=gpu_handles[0].dtype,
-                        tp_group_size=self.tp_size_per_node,
+                        tp_group_size=self.model_config.effective_tp_size_per_node,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -208,7 +207,7 @@ class TransferEngine:
             self._worker_map[TransferType.H2D] = self.h2d_workers
 
         # D2H worker
-        if self.tp_size_per_node == 1:
+        if self.model_config.effective_tp_size_per_node == 1:
             self.d2h_workers: Dict[WorkerKey, WorkerHandle] = {
                 worker_key: GPUCPUTransferWorker.create_worker(
                     mp_ctx=self.mp_ctx,
@@ -238,7 +237,7 @@ class TransferEngine:
                     gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     dtype=gpu_handles[0].dtype,
-                    tp_group_size=self.tp_size_per_node,
+                    tp_group_size=self.model_config.effective_tp_size_per_node,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -306,7 +305,7 @@ class TransferEngine:
             self._worker_map[TransferType.H2REMOTE] = self.remotecpu_write_worker
             self._worker_map[TransferType.REMOTE2H] = self.remotecpu_read_worker
         if self.cache_config.enable_gds:
-            if self.tp_size_per_node == 1:
+            if self.model_config.effective_tp_size_per_node == 1:
                 self.gds_workers: Dict[WorkerKey, WorkerHandle] = {
                     worker_key: GDSTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
@@ -334,7 +333,7 @@ class TransferEngine:
                         gpu_kv_layouts=[gpu_handle.kv_layout for gpu_handle in gpu_handles],
                         ssd_kv_layout=self._ssd_handle.kv_layout,
                         dtype=self._ssd_handle.dtype,
-                        tp_group_size=self.tp_size_per_node,
+                        tp_group_size=self.model_config.effective_tp_size_per_node,
                     )
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
@@ -354,10 +353,9 @@ class TransferEngine:
             self.layerwise_workers: Dict[WorkerKey, WorkerHandle] = {}
             for worker_key, gpu_handles in self.gpu_handle_groups.items():
                 _layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
+                    dp_client_id=worker_key.dp_client_id,
                     pp_rank=worker_key.pp_rank,
-                    dp_rank=worker_key.dp_rank,
-                    pp_size=self.model_config.pp_size,
-                    dp_size=self.model_config.dp_size,
+                    model_config=self.model_config,
                 )
                 # Resolve indexer handles for this WorkerKey
                 idx_handles = None
@@ -375,7 +373,7 @@ class TransferEngine:
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     ssd_kv_layout=ssd_kv_layout,
                     dtype=gpu_handles[0].dtype,
-                    tp_group_size=self.tp_size_per_node,
+                    tp_group_size=self.model_config.effective_tp_size_per_node,
                     layerwise_eventfd_socket=_layerwise_eventfd_socket,
                     num_blocks_per_file=num_blocks_per_file,
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
@@ -395,7 +393,7 @@ class TransferEngine:
 
                 flexkv_logger.debug(
                     f"[TransferEngine] Created layerwise worker for {worker_key}: "
-                    f"tp_size_per_node={self.tp_size_per_node}, has_indexer={idx_handles is not None}, "
+                    f"effective_tp_size_per_node={self.model_config.effective_tp_size_per_node}, has_indexer={idx_handles is not None}, "
                     f"has_ssd={len(ssd_files) > 0}")
 
             self._worker_map[TransferType.LAYERWISE] = self.layerwise_workers
@@ -434,7 +432,7 @@ class TransferEngine:
             self._indexer_worker_map: Dict[TransferType, Union[WorkerHandle, Dict[WorkerKey, WorkerHandle]]] = {}
             # H2D indexer worker
             if not _enable_layerwise:
-                if self.tp_size_per_node == 1:
+                if self.model_config.effective_tp_size_per_node == 1:
                     self._indexer_h2d_workers: Dict[WorkerKey, WorkerHandle] = {
                         worker_key: GPUCPUTransferWorker.create_worker(
                             mp_ctx=self.mp_ctx,
@@ -464,7 +462,7 @@ class TransferEngine:
                             gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                             cpu_kv_layout=self._indexer_cpu_handle.kv_layout,
                             dtype=indexer_gpu_handles_list[0].dtype,
-                            tp_group_size=self.tp_size_per_node,
+                            tp_group_size=self.model_config.effective_tp_size_per_node,
                             use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                             use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -475,7 +473,7 @@ class TransferEngine:
                 self._indexer_worker_map[TransferType.H2D] = self._indexer_h2d_workers
 
             # D2H indexer worker
-            if self.tp_size_per_node == 1:
+            if self.model_config.effective_tp_size_per_node == 1:
                 self._indexer_d2h_workers: Dict[WorkerKey, WorkerHandle] = {
                     worker_key: GPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
@@ -505,7 +503,7 @@ class TransferEngine:
                         gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                         cpu_kv_layout=self._indexer_cpu_handle.kv_layout,
                         dtype=indexer_gpu_handles_list[0].dtype,
-                        tp_group_size=self.tp_size_per_node,
+                        tp_group_size=self.model_config.effective_tp_size_per_node,
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -573,7 +571,7 @@ class TransferEngine:
                 self._indexer_worker_map[TransferType.REMOTE2H] = self._indexer_remote2h_worker
                 flexkv_logger.info("TransferEngine: indexer Remote workers initialized")
             if self.cache_config.enable_gds and self._indexer_ssd_handle is not None:
-                if self.tp_size_per_node == 1:
+                if self.model_config.effective_tp_size_per_node == 1:
                     self._indexer_gds_workers: Dict[WorkerKey, WorkerHandle] = {
                         worker_key: GDSTransferWorker.create_worker(
                             mp_ctx=self.mp_ctx,
@@ -601,7 +599,7 @@ class TransferEngine:
                             gpu_kv_layouts=[h.kv_layout for h in indexer_gpu_handles_list],
                             ssd_kv_layout=self._indexer_ssd_handle.kv_layout,
                             dtype=self._indexer_ssd_handle.dtype,
-                            tp_group_size=self.tp_size_per_node,
+                            tp_group_size=self.model_config.effective_tp_size_per_node,
                         )
                         for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     }
@@ -673,6 +671,7 @@ class TransferEngine:
                 "DISK2H worker should not exist in layerwise mode (fused into layerwise worker)"
             assert TransferType.LAYERWISE in self._worker_map, \
                 "LAYERWISE worker must exist when layerwise transfer is enabled"
+
         # Start scheduler thread
         self._running = True
         self._scheduler_thread = threading.Thread(target=self._scheduler_loop)
@@ -742,22 +741,18 @@ class TransferEngine:
                         while True:
                             try:
                                 op_id = self.finished_ops_queue.get_nowait()
-                                # Check if this is a PP-replica op (same-node PP fan-out)
-                                if op_id in self._pp_replica_to_parent_op:
-                                    # PP-replica op: decrement parent's pending_count
-                                    replica_op = self._pp_replica_op_map.pop(op_id)
-                                    parent_op_id = self._pp_replica_to_parent_op.pop(op_id)
+                                if op_id in self._child_to_parent_op_id:
+                                    parent_op_id = self._child_to_parent_op_id.pop(op_id)
+                                    child_op = self._child_id_to_child.pop(op_id)
+                                    free_op_from_buffer(child_op, self.pin_buffer)
+                                    if op_id in self.op_id_to_nvtx_range:
+                                        nvtx.end_range(self.op_id_to_nvtx_range.pop(op_id))
                                     parent_op = self.op_id_to_op[parent_op_id]
                                     parent_op.pending_count -= 1
-                                    # Clean up replica from op_id_to_op and NVTX
-                                    del self.op_id_to_op[op_id]
-                                    if op_id in self.op_id_to_nvtx_range:
-                                        nvtx.end_range(self.op_id_to_nvtx_range[op_id])
-                                        self.op_id_to_nvtx_range.pop(op_id)
                                     if parent_op.pending_count == 0:
                                         self._finalize_op(parent_op, finished_ops)
                                     flexkv_logger.debug(
-                                        f"[TransferEngine] PP replica op {op_id} completed, "
+                                        f"[TransferEngine] main-KV child op {op_id} completed, "
                                         f"parent op {parent_op_id} pending_count={parent_op.pending_count}")
                                 else:
                                     op = self.op_id_to_op[op_id]
@@ -774,14 +769,16 @@ class TransferEngine:
                         while True:
                             try:
                                 op_id = self._indexer_finished_ops_queue.get_nowait()
-                                assert op_id in self._indexer_op_to_parent_op, (
+                                assert op_id in self._child_to_parent_op_id, (
                                     f"[TransferEngine] Indexer op {op_id} not found in "
-                                    f"_indexer_op_to_parent_op. All indexer ops must be "
+                                    f"_child_to_parent_op_id. All indexer ops must be "
                                     f"registered with a parent op."
                                 )
-                                indexer_op = self._indexer_op_map.pop(op_id)
+                                parent_op_id = self._child_to_parent_op_id.pop(op_id)
+                                indexer_op = self._child_id_to_child.pop(op_id)
                                 free_op_from_buffer(indexer_op, self.pin_buffer)
-                                parent_op_id = self._indexer_op_to_parent_op.pop(op_id)
+                                if op_id in self.op_id_to_nvtx_range:
+                                    nvtx.end_range(self.op_id_to_nvtx_range.pop(op_id))
                                 parent_op = self.op_id_to_op[parent_op_id]
                                 parent_op.pending_count -= 1
                                 if parent_op.pending_count == 0:
@@ -796,8 +793,9 @@ class TransferEngine:
 
                 # End NVTX ranges for finished ops
                 for op in finished_ops:
-                    nvtx.end_range(self.op_id_to_nvtx_range[op.op_id])
-                    self.op_id_to_nvtx_range.pop(op.op_id)
+                    nvtx_range = self.op_id_to_nvtx_range.pop(op.op_id, None)
+                    if nvtx_range is not None:
+                        nvtx.end_range(nvtx_range)
 
                 # Schedule next operations
                 nvtx_r3 = nvtx.start_range(message="transfer scheduler. schedule next ops", color="orange")
@@ -809,8 +807,9 @@ class TransferEngine:
                             self.completed_queue.put(CompletedOp(graph_id=op.graph_id, op_id=op.op_id))
                         else:
                             self.op_id_to_op[op.op_id] = op
-                            # copy block ids into buffer and update slot id info
-                            register_op_to_buffer(op, self.pin_buffer)
+                            parent_worker = self._worker_map.get(op.transfer_type)
+                            if parent_worker is not None and not isinstance(parent_worker, dict):
+                                register_op_to_buffer(op, self.pin_buffer)
                             self._assign_op_to_worker(op)
                     # Handle completed graphs
                     for graph_id in completed_graph_ids:
@@ -818,7 +817,16 @@ class TransferEngine:
                 nvtx.end_range(nvtx_r3)
 
             except Exception as e:
-                flexkv_logger.error(f"Error in scheduler loop: {e}")
+                flexkv_logger.error(
+                    f"Error in scheduler loop: {type(e).__name__}: {e!r} "
+                    f"| op_id_to_op keys={list(self.op_id_to_op.keys())[:16]} "
+                    f"(total={len(self.op_id_to_op)}) "
+                    f"| child->parent keys={list(self._child_to_parent_op_id.keys())[:16]} "
+                    f"(total={len(self._child_to_parent_op_id)}) "
+                    f"| nvtx_range keys={list(self.op_id_to_nvtx_range.keys())[:16]} "
+                    f"(total={len(self.op_id_to_nvtx_range)})",
+                    exc_info=True,
+                )
                 time.sleep(0.001)  # Fallback on error
 
         # Cleanup
@@ -831,10 +839,16 @@ class TransferEngine:
         Called only when op.pending_count reaches 0, i.e., all workers (main KV + indexer)
         have completed this op. This ensures atomic eviction semantics.
         """
-        free_op_from_buffer(op, self.pin_buffer)
-        # Compute transfer metrics for this completed op
+        parent_worker = self._worker_map.get(op.transfer_type)
+        if parent_worker is not None and not isinstance(parent_worker, dict):
+            free_op_from_buffer(op, self.pin_buffer)
+        # Compute transfer metrics for this completed op.
         num_blocks = len(op.src_block_ids) if op.src_block_ids is not None else 0
-        num_bytes = num_blocks * self.cache_config.tokens_per_block * self.model_config.token_size_in_bytes_per_pp_stage
+        token_size_in_bytes_per_pp_stage = (
+            self._num_layers_for_local_pp_stage
+            * self.model_config.bytes_per_token_per_layer
+        )
+        num_bytes = num_blocks * self.cache_config.tokens_per_block * token_size_in_bytes_per_pp_stage
         transfer_type_str = op.transfer_type.value if op.transfer_type != TransferType.VIRTUAL else None
         self.completed_queue.put(CompletedOp(
             graph_id=op.graph_id,
@@ -846,17 +860,21 @@ class TransferEngine:
         finished_ops.append(op)
         del self.op_id_to_op[op.op_id]
 
-    def _assign_layerwise_op_to_workers(self, op: TransferOp) -> None:
-        """Fan-out a LAYERWISE op to all PP-stage layerwise workers on the same dp_rank.
+    @staticmethod
+    def _match_pp_siblings(
+        worker_map: Dict[WorkerKey, WorkerHandle],
+        dp_client_id: int,
+    ) -> List[WorkerKey]:
+        """Return every WorkerKey whose flat DP slice equals ``dp_client_id``.
 
-        In cross-node PP, the remote TransferManagerOnRemote handles this by
-        rebinding WorkerKey.  In same-node PP there is no remote TM, so we
-        replicate the op here for every PP-stage worker under the same dp_rank.
-
-        Replicas are tracked via ``_pp_replica_to_parent_op`` so that their
-        completion decrements the parent op's ``pending_count`` (identical to
-        how indexer ops are tracked).
+        After flattening, a single int fully identifies the DP slice —
+        PP siblings are the worker_keys that share it across pp_rank.
         """
+        return [wk for wk in worker_map.keys() if wk.dp_client_id == dp_client_id]
+
+    def _assign_layerwise_op_to_workers(self, op: TransferOp) -> None:
+        """Fan-out a LAYERWISE op symmetrically to every local PP-stage
+        sibling worker matching ``op.dp_client_id``."""
         from flexkv.common.transfer import LayerwiseTransferOp
         assert isinstance(op, LayerwiseTransferOp)
 
@@ -864,131 +882,145 @@ class TransferEngine:
         assert isinstance(worker_map, dict), \
             "LAYERWISE worker map must be a Dict[WorkerKey, WorkerHandle]"
 
-        # Find all layerwise workers sharing the same dp_rank
-        sibling_keys = [wk for wk in worker_map if wk.dp_rank == op.dp_rank]
-
+        sibling_keys = self._match_pp_siblings(worker_map, op.dp_client_id)
         if not sibling_keys:
             raise ValueError(
-                f"No layerwise worker found for dp_rank={op.dp_rank}, pp_rank={op.pp_rank}")
+                f"No LAYERWISE worker found matching "
+                f"dp_client_id={op.dp_client_id}; "
+                f"available worker keys={list(worker_map.keys())}"
+            )
 
-        # Submit to the original pp_rank's worker
-        primary_key = WorkerKey(dp_rank=op.dp_rank, pp_rank=op.pp_rank)
-        if primary_key in worker_map:
-            worker_map[primary_key].submit_transfer(op)
-        else:
-            # Original worker not found — this shouldn't happen, but handle gracefully
-            raise ValueError(
-                f"No layerwise worker found for primary key {primary_key}")
-
-        # If there's only one worker for this dp_rank, no fan-out needed
-        if len(sibling_keys) <= 1:
-            return
-
-        # Create replicas for every other pp_rank under the same dp_rank
         for wk in sibling_keys:
-            if wk == primary_key:
-                continue
-
-            # Create a replica LayerwiseTransferOp with the target pp_rank
             replica = LayerwiseTransferOp(
                 graph_id=op.graph_id,
                 src_block_ids_h2d=op.src_block_ids_h2d.copy(),
                 dst_block_ids_h2d=op.dst_block_ids_h2d.copy(),
                 src_block_ids_disk2h=op.src_block_ids_disk2h.copy(),
                 dst_block_ids_disk2h=op.dst_block_ids_disk2h.copy(),
-                layer_id=op.layer_id,
-                layer_granularity=op.layer_granularity,
-                dp_rank=op.dp_rank,
-                pp_rank=wk.pp_rank,
+                dp_client_id=op.dp_client_id,
                 counter_id=op.counter_id,
                 indexer_src_block_ids=op.indexer_src_block_ids.copy(),
                 indexer_dst_block_ids=op.indexer_dst_block_ids.copy(),
             )
-
-            # Track replica → parent so that completion decrements parent's pending_count
-            self._pp_replica_to_parent_op[replica.op_id] = op.op_id
-            self._pp_replica_op_map[replica.op_id] = replica
-            op.pending_count += 1
-
-            # Register in op_id_to_op so scheduler can find it on completion
-            self.op_id_to_op[replica.op_id] = replica
+            register_op_to_buffer(replica, self.pin_buffer)
+            self._child_id_to_child[replica.op_id] = replica
+            self._child_to_parent_op_id[replica.op_id] = op.op_id
             self.op_id_to_nvtx_range[replica.op_id] = nvtx.start_range(
-                f"schedule LAYERWISE_REPLICA op_id: {replica.op_id}, "
-                f"graph_id: {replica.graph_id}, pp_rank={wk.pp_rank}",
+                f"schedule {replica.transfer_type.name}_REPLICA op_id: {replica.op_id}, "
+                f"graph_id: {replica.graph_id}, worker_key={wk}",
                 color=get_nvtx_range_color(replica.graph_id))
-
+            op.pending_count += 1
             worker_map[wk].submit_transfer(replica)
-
             flexkv_logger.debug(
-                f"[TransferEngine] === Layerwise PP Replica Dispatched ==="
-                f"\n  parent_op_id={op.op_id}, replica_op_id={replica.op_id}"
-                f"\n  dp_rank={op.dp_rank}, pp_rank={wk.pp_rank}"
-                f"\n  pending_count={op.pending_count}")
+                f"[TransferEngine] LAYERWISE fan-out: "
+                f"parent_op_id={op.op_id}, replica_op_id={replica.op_id}, "
+                f"worker_key={wk}, pending_count={op.pending_count}")
 
     def _assign_op_to_worker(self, op: TransferOp) -> None:
-        self.op_id_to_nvtx_range[op.op_id] = nvtx.start_range(f"schedule {op.transfer_type.name} "
-                                                                       f"op_id: {op.op_id}, "
-                                                                       f"graph_id: {op.graph_id}, "
-                                                                       f"successors: {op.successors}",
-                                                                       color=get_nvtx_range_color(op.graph_id))
-        """Assign operation to appropriate worker"""
+        """Assign operation to appropriate worker."""
         if op.transfer_type == TransferType.VIRTUAL:
             return
         if op.transfer_type not in self._worker_map:
             raise ValueError(f"Unsupported transfer type: {op.transfer_type}")
 
-        # --- Same-node PP fan-out for LAYERWISE ops ---
-        # In cross-node PP, TransferManagerOnRemote rebinds WorkerKey so that
-        # PP1+ workers receive the op.  In same-node PP, only one local
-        # TransferManager exists, so we fan-out here: for every layerwise
-        # worker that shares the same dp_rank but has a different pp_rank, we
-        # create a replica op with the correct pp_rank.
         if op.transfer_type == TransferType.LAYERWISE:
             self._assign_layerwise_op_to_workers(op)
             return
-
-        worker_key = WorkerKey(dp_rank=op.dp_rank, pp_rank=op.pp_rank)
-
         if self._has_indexer and op.transfer_type in self._indexer_worker_map:
-            # Indexer maps 1:1 with main KV blocks, use block_ids directly.
-            src_page_ids = op.src_block_ids
-            dst_page_ids = op.dst_block_ids
-            num_pages = src_page_ids.size
-
+            num_pages = op.src_block_ids.size
             if num_pages > 0:
-                # Always create a separate indexer_op to avoid sharing the same op
-                # object between indexer worker and main KV worker.
-                indexer_op = TransferOp(
-                    graph_id=op.graph_id,
-                    transfer_type=op.transfer_type,
-                    src_block_ids=src_page_ids,
-                    dst_block_ids=dst_page_ids,
-                    layer_id=op.layer_id,
-                    layer_granularity=op.layer_granularity,
-                    dp_rank=op.dp_rank,
-                    pp_rank=op.pp_rank,
-                )
-                register_op_to_buffer(indexer_op, self.pin_buffer)
-                self._indexer_op_to_parent_op[indexer_op.op_id] = op.op_id
-                self._indexer_op_map[indexer_op.op_id] = indexer_op
-                op.pending_count += 1
-
-                flexkv_logger.debug(
-                    f"[TransferEngine] === Indexer Op Dispatched (non-layerwise) ==="
-                    f"\n  parent_op_id={op.op_id}, indexer_op_id={indexer_op.op_id}"
-                    f"\n  type={op.transfer_type.name}, dp_rank={op.dp_rank}, pp_rank={op.pp_rank}"
-                    f"\n  num_pages={num_pages}, pending_count={op.pending_count}")
-
                 indexer_worker = self._indexer_worker_map[op.transfer_type]
                 if isinstance(indexer_worker, dict):
-                    indexer_worker[worker_key].submit_transfer(indexer_op)
+                    sibling_keys = self._match_pp_siblings(indexer_worker, op.dp_client_id)
+                    if not sibling_keys:
+                        raise ValueError(
+                            f"No INDEXER_{op.transfer_type.name} worker found matching "
+                            f"dp_client_id={op.dp_client_id}; "
+                            f"available worker keys={list(indexer_worker.keys())}"
+                        )
+                    for wk in sibling_keys:
+                        indexer_replica = TransferOp(
+                            graph_id=op.graph_id,
+                            transfer_type=op.transfer_type,
+                            src_block_ids=op.src_block_ids.copy(),
+                            dst_block_ids=op.dst_block_ids.copy(),
+                            dp_client_id=op.dp_client_id,
+                        )
+                        register_op_to_buffer(indexer_replica, self.pin_buffer)
+                        self._child_id_to_child[indexer_replica.op_id] = indexer_replica
+                        self._child_to_parent_op_id[indexer_replica.op_id] = op.op_id
+                        self.op_id_to_nvtx_range[indexer_replica.op_id] = nvtx.start_range(
+                            f"schedule {indexer_replica.transfer_type.name}_INDEXER_REPLICA "
+                            f"op_id: {indexer_replica.op_id}, graph_id: {indexer_replica.graph_id}, "
+                            f"worker_key={wk}",
+                            color=get_nvtx_range_color(indexer_replica.graph_id))
+                        op.pending_count += 1
+                        indexer_worker[wk].submit_transfer(indexer_replica)
+                        flexkv_logger.debug(
+                            f"[TransferEngine] INDEXER_{op.transfer_type.name} fan-out: "
+                            f"parent_op_id={op.op_id}, replica_op_id={indexer_replica.op_id}, "
+                            f"worker_key={wk}, pending_count={op.pending_count}")
                 else:
+                    indexer_op = TransferOp(
+                        graph_id=op.graph_id,
+                        transfer_type=op.transfer_type,
+                        src_block_ids=op.src_block_ids.copy(),
+                        dst_block_ids=op.dst_block_ids.copy(),
+                        dp_client_id=op.dp_client_id,
+                    )
+                    register_op_to_buffer(indexer_op, self.pin_buffer)
+                    self._child_id_to_child[indexer_op.op_id] = indexer_op
+                    self._child_to_parent_op_id[indexer_op.op_id] = op.op_id
+                    self.op_id_to_nvtx_range[indexer_op.op_id] = nvtx.start_range(
+                        f"schedule {indexer_op.transfer_type.name}_INDEXER_REPLICA "
+                        f"op_id: {indexer_op.op_id}, graph_id: {indexer_op.graph_id}, "
+                        f"dp_client_id={indexer_op.dp_client_id}",
+                        color=get_nvtx_range_color(indexer_op.graph_id))
+                    op.pending_count += 1
                     indexer_worker.submit_transfer(indexer_op)
+                    flexkv_logger.debug(
+                        f"[TransferEngine] singleton-indexer dispatched: "
+                        f"parent_op_id={op.op_id}, indexer_op_id={indexer_op.op_id}, "
+                        f"type={op.transfer_type.name}, pending_count={op.pending_count}")
 
         worker = self._worker_map[op.transfer_type]
         if isinstance(worker, dict):
-            worker[worker_key].submit_transfer(op)
+            sibling_keys = self._match_pp_siblings(worker, op.dp_client_id)
+            if not sibling_keys:
+                raise ValueError(
+                    f"No MAIN_KV_{op.transfer_type.name} worker found matching "
+                    f"dp_client_id={op.dp_client_id}; "
+                    f"available worker keys={list(worker.keys())}"
+                )
+            for wk in sibling_keys:
+                replica = TransferOp(
+                    graph_id=op.graph_id,
+                    transfer_type=op.transfer_type,
+                    src_block_ids=op.src_block_ids.copy(),
+                    dst_block_ids=op.dst_block_ids.copy(),
+                    dp_client_id=op.dp_client_id,
+                )
+                register_op_to_buffer(replica, self.pin_buffer)
+                self._child_id_to_child[replica.op_id] = replica
+                self._child_to_parent_op_id[replica.op_id] = op.op_id
+                self.op_id_to_nvtx_range[replica.op_id] = nvtx.start_range(
+                    f"schedule {replica.transfer_type.name}_REPLICA op_id: {replica.op_id}, "
+                    f"graph_id: {replica.graph_id}, worker_key={wk}",
+                    color=get_nvtx_range_color(replica.graph_id))
+                op.pending_count += 1
+                worker[wk].submit_transfer(replica)
+                flexkv_logger.debug(
+                    f"[TransferEngine] MAIN_KV_{op.transfer_type.name} fan-out: "
+                    f"parent_op_id={op.op_id}, replica_op_id={replica.op_id}, "
+                    f"worker_key={wk}, pending_count={op.pending_count}")
         else:
+            self.op_id_to_nvtx_range[op.op_id] = nvtx.start_range(
+                f"schedule {op.transfer_type.name} "
+                f"op_id: {op.op_id}, graph_id: {op.graph_id}, "
+                f"successors: {op.successors}",
+                color=get_nvtx_range_color(op.graph_id),
+            )
+            op.pending_count += 1
             worker.submit_transfer(op)
 
     def submit_transfer_graph(self, transfer_graph: Union[TransferOpGraph, List[TransferOpGraph]]) -> None:

--- a/flexkv/transfer/utils.py
+++ b/flexkv/transfer/utils.py
@@ -105,10 +105,7 @@ class RemoteSSD2HMetaInfo:
     peer_cpu_base_ptr: int # the cpu buffer base ptr of the peer node, used for calculating the dst ptrs.
     peer_zmq_status_addr: str
     data_size: int
-    layer_id: int
-    layer_granularity: int
-    
-    def __init__(self, task_id, cpu_block_ids, ssd_block_ids, peer_engine_addr, peer_cpu_base_ptr, peer_zmq_status_addr, data_size, layer_id, layer_granularity):
+    def __init__(self, task_id, cpu_block_ids, ssd_block_ids, peer_engine_addr, peer_cpu_base_ptr, peer_zmq_status_addr, data_size):
         self.task_id = task_id
         self.cpu_block_ids = cpu_block_ids
         self.ssd_block_ids = ssd_block_ids
@@ -116,8 +113,6 @@ class RemoteSSD2HMetaInfo:
         self.peer_cpu_base_ptr = peer_cpu_base_ptr
         self.peer_zmq_status_addr = peer_zmq_status_addr
         self.data_size = data_size
-        self.layer_id = layer_id
-        self.layer_granularity = layer_granularity
 
     @classmethod
     def from_dict(self, data: dict) -> "RemoteSSD2HMetaInfo":
@@ -129,8 +124,6 @@ class RemoteSSD2HMetaInfo:
             peer_cpu_base_ptr = data.get("peer_cpu_base_ptr"),
             peer_zmq_status_addr = data.get("peer_zmq_status_addr"),
             data_size=data.get("data_size"),
-            layer_id = data.get("layer_id"),
-            layer_granularity = data.get("layer_granularity")
         )
     def to_dict(self) -> dict:
         return {
@@ -141,8 +134,6 @@ class RemoteSSD2HMetaInfo:
             "peer_cpu_base_ptr": self.peer_cpu_base_ptr,
             "peer_zmq_status_addr": self.peer_zmq_status_addr,
             "data_size": self.data_size,
-            "layer_id": self.layer_id,
-            "layer_granularity": self.layer_granularity,
         }
         
 class NodeMetaInfo:

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -126,8 +126,6 @@ class TransferWorkerBase(ABC):
         src_block_ids: torch.Tensor,
         dst_block_ids: torch.Tensor,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs: Any
     ) -> None:
         pass
@@ -286,6 +284,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
 
         self.dtype = dtype
         self.is_mla = gpu_kv_layout.is_mla
+        self.kv_dim = gpu_kv_layout.kv_dim
 
         self.num_layers = gpu_kv_layout.num_layer
 
@@ -321,8 +320,6 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         src_block_ids: torch.Tensor,
         dst_block_ids: torch.Tensor,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs: Any,
     ) -> None:
         assert src_block_ids.dtype == torch.int64
@@ -361,8 +358,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             self.cpu_layer_stride_in_bytes,
             self.cpu_block_stride_in_bytes,
             self.chunk_size_in_bytes,
-            layer_id,
-            layer_granularity,
+            self.num_layers,
             transfer_num_cta,
             transfer_type == TransferType.H2D,
             use_ce_transfer,
@@ -374,12 +370,6 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         nvtx_range = nvtx.start_range(
             message=f"GPUCPUWorker.launch_transfer[{transfer_op.transfer_op_id}]",
             color="purple")
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
 
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
@@ -389,13 +379,9 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                 src_block_ids,
                 dst_block_ids,
                 transfer_op.transfer_type,
-                layer_id,
-                layer_granularity,
             )
             end_time = time.time()
-
-            kv_dim = 2 if not self.is_mla else 1
-            transfer_size = self.chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+            transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
             self._log_transfer_performance(
                 transfer_op,
@@ -437,6 +423,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         self.gpu_blocks = imported_gpu_blocks
         self.dtype = dtype # note this should be quantized data type
         self.is_mla = gpu_kv_layouts[0].is_mla
+        self.kv_dim = gpu_kv_layouts[0].kv_dim
 
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
@@ -504,8 +491,6 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
                        src_block_ids: torch.Tensor,
                        dst_block_ids: torch.Tensor,
                        transfer_type: TransferType,
-                       layer_id: int,
-                       layer_granularity: int,
                        **kwargs: Any,
                        )->None:
         assert src_block_ids.dtype == torch.int64
@@ -541,20 +526,13 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             transfer_num_cta,
             transfer_type == TransferType.H2D,
             use_ce_transfer,
-            layer_id,
-            layer_granularity,
+            0,
+            self.num_layers,
             self.is_mla,
         )
 
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
         start_time = time.time()
@@ -562,13 +540,9 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             src_block_ids,
             dst_block_ids,
             transfer_op.transfer_type,
-            layer_id,
-            layer_granularity,
         )
         end_time = time.time()
-
-        kv_dim = 2 if not self.is_mla else 1
-        transfer_size = self.cpu_chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+        transfer_size = self.cpu_chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
         self._log_transfer_performance(
             transfer_op,
@@ -607,6 +581,7 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
         self.cpu_layer_ptrs = self._get_layer_ptrs(cpu_blocks)
 
         self.is_mla = cpu_kv_layout.is_mla
+        self.kv_dim = cpu_kv_layout.kv_dim
 
         if cpu_kv_layout.type != ssd_kv_layout.type:
             raise ValueError("no support for different CPU and SSD KV cache layout type")
@@ -632,8 +607,6 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
         src_block_ids: torch.Tensor,
         dst_block_ids: torch.Tensor,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs: Any,
     ) -> None:
         assert src_block_ids.dtype == torch.int64
@@ -650,7 +623,7 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
             raise ValueError(f"Invalid transfer type: {transfer_type} for CPUSSDDiskTransferWorker")
 
 
-        layer_id_list = torch.arange(layer_id, layer_id + layer_granularity, dtype=torch.int32)
+        layer_id_list = torch.arange(0, self.num_layers, dtype=torch.int32)
 
         transfer_kv_blocks_ssd(
             ioctx=self.ioctx,
@@ -672,13 +645,6 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
         )
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids , dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
         start_time = time.time()
@@ -686,13 +652,9 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
             src_block_ids,
             dst_block_ids,
             transfer_op.transfer_type,
-            layer_id,           # Use corrected value, not transfer_op.layer_id
-            layer_granularity,  # Use corrected value, not transfer_op.layer_granularity
         )
         end_time = time.time()
-
-        kv_dim = 2 if not self.is_mla else 1
-        transfer_size = self.chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+        transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
         self._log_transfer_performance(
             transfer_op,
@@ -744,17 +706,17 @@ class CPURemoteTransferWorker(TransferWorkerBase):
         self.dtype = dtype
 
         self.is_mla = cpu_kv_layout.is_mla
-        kv_dim = 2 if not self.is_mla else 1
+        self.kv_dim = cpu_kv_layout.kv_dim
 
         self.cpu_blocks = cpu_blocks
 
         self.cpu_layer_ptrs = self._get_layer_ptrs(cpu_blocks)
 
         self.cpu_layer_stride_in_bytes = (
-            self.num_cpu_blocks * self.block_size * self.dtype.itemsize * kv_dim
+            self.num_cpu_blocks * self.block_size * self.dtype.itemsize * self.kv_dim
         )
         self.remote_layer_stride_in_bytes = (
-            self.num_remote_blocks * self.block_size * self.dtype.itemsize * kv_dim
+            self.num_remote_blocks * self.block_size * self.dtype.itemsize * self.kv_dim
         )
         self.remote_layer_stride_in_bytes_per_file = self.remote_layer_stride_in_bytes // self.num_remote_files
         self.cpu_kv_stride_in_bytes = (
@@ -797,18 +759,11 @@ class CPURemoteTransferWorker(TransferWorkerBase):
         src_block_ids: torch.Tensor,
         dst_block_ids: torch.Tensor,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs: Any
     ) -> None:
         assert src_block_ids.dtype == torch.int64
         assert dst_block_ids.dtype == torch.int64
         assert len(src_block_ids) == len(dst_block_ids)
-
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
 
         # this means partial read hit cpu and other hit remote
         # or partial write hit remote and none hit cpu
@@ -822,7 +777,7 @@ class CPURemoteTransferWorker(TransferWorkerBase):
         else:
             raise ValueError(f"Invalid transfer type: {transfer_type} for CPUSSDDiskTransferWorker")
 
-        layer_id_list = torch.arange(layer_id, layer_id + layer_granularity, dtype=torch.int32)
+        layer_id_list = torch.arange(0, self.num_layers, dtype=torch.int32)
                 # Use PCFS shared transfer for read operations when PCFS sharing is enabled
         if self.enable_pcfs_sharing and transfer_type == TransferType.REMOTE2H:
             # For PCFS sharing, we need to construct cfs_blocks_partition and cpu_blocks_partition
@@ -901,13 +856,6 @@ class CPURemoteTransferWorker(TransferWorkerBase):
             )
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
         start_time = time.time()
@@ -915,14 +863,10 @@ class CPURemoteTransferWorker(TransferWorkerBase):
             src_block_ids,
             dst_block_ids,
             transfer_op.transfer_type,
-            layer_id,           # Use corrected value, not transfer_op.layer_id
-            layer_granularity,  # Use corrected value, not transfer_op.layer_granularity
             src_block_node_ids=transfer_op.src_block_node_ids,
         )
         end_time = time.time()
-
-        kv_dim = 2 if not self.is_mla else 1
-        transfer_size = self.chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+        transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
         self._log_transfer_performance(
             transfer_op,
@@ -985,6 +929,7 @@ class GDSTransferWorker(TransferWorkerBase):
 
         self.dtype = dtype
         self.is_mla = gpu_kv_layout.is_mla
+        self.kv_dim = gpu_kv_layout.kv_dim
 
         # Layout information
         self.num_layers = gpu_kv_layout.num_layer
@@ -1022,19 +967,12 @@ class GDSTransferWorker(TransferWorkerBase):
         src_block_ids: torch.Tensor,
         dst_block_ids: torch.Tensor,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs: Any,
     ) -> None:
         """Implement actual transfer between GPU and SSD"""
         assert src_block_ids.dtype == torch.int64
         assert dst_block_ids.dtype == torch.int64
         assert len(src_block_ids) == len(dst_block_ids)
-
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
 
         # Convert to tensors
         # SSD uses DISK2D/D2DISK transfer types (same as traditional SSD I/O)
@@ -1054,7 +992,7 @@ class GDSTransferWorker(TransferWorkerBase):
             return
 
         # Process transfer for each layer
-        layer_id_list = torch.arange(layer_id, layer_id + layer_granularity, dtype=torch.int32)
+        layer_id_list = torch.arange(0, self.num_layers, dtype=torch.int32)
 
         # Determine if this is a read operation
         is_read = (transfer_type == TransferType.DISK2D)
@@ -1091,13 +1029,6 @@ class GDSTransferWorker(TransferWorkerBase):
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
         """Launch a GDS transfer operation"""
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
         with torch.cuda.stream(self.transfer_stream):
@@ -1106,13 +1037,9 @@ class GDSTransferWorker(TransferWorkerBase):
                 src_block_ids,
                 dst_block_ids,
                 transfer_op.transfer_type,
-                layer_id,
-                layer_granularity,
             )
             end_time = time.time()
-
-            kv_dim = 2 if not self.is_mla else 1
-            transfer_size = self.chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+            transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
             self._log_transfer_performance(
                 transfer_op,
@@ -1151,7 +1078,9 @@ class tpGDSTransferWorker(TransferWorkerBase):
             gpu_kv_layouts: Layout of GPU KV cache
             ssd_kv_layout: Layout of SSD KV cache
             dtype: Data type
-            tp_group_size: Size of tensor parallel group
+            tp_group_size: Effective tp-group size on this node
+                (``effective_tp_size_per_node`` =
+                ``attn_tp_size_per_node × attn_cp_size_per_node``).
         """
         # Initialize base class first
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
@@ -1170,6 +1099,7 @@ class tpGDSTransferWorker(TransferWorkerBase):
 
         self.dtype = dtype
         self.is_mla = gpu_kv_layouts[0].is_mla
+        self.kv_dim = gpu_kv_layouts[0].kv_dim
         self.num_gpus = len(self.gpu_blocks)
         self.tp_group_size = tp_group_size
 
@@ -1194,7 +1124,7 @@ class tpGDSTransferWorker(TransferWorkerBase):
         # SSD layout calculations
         self.ssd_layer_stride_in_bytes = ssd_kv_layout_per_file.get_layer_stride() * self.dtype.itemsize
         self.ssd_kv_stride_in_bytes = ssd_kv_layout_per_file.get_kv_stride() * self.dtype.itemsize
-        self.ssd_tp_stride_in_bytes = self.ssd_block_stride_in_bytes // self.tp_size_per_node if not self.is_mla else self.ssd_block_stride_in_bytes
+        self.ssd_tp_stride_in_bytes = self.ssd_block_stride_in_bytes // self.tp_group_size if not self.is_mla else self.ssd_block_stride_in_bytes
 
         # Resolve pointers in Python (where storage is valid); pass them to C++ so we avoid
         # "Tensor that doesn't have storage" when C++ calls .data_ptr() on tensors passed
@@ -1225,8 +1155,6 @@ class tpGDSTransferWorker(TransferWorkerBase):
                        src_block_ids: torch.Tensor,
                        dst_block_ids: torch.Tensor,
                        transfer_type: TransferType,
-                       layer_id: int,
-                       layer_granularity: int,
                        **kwargs: Any,
                        ) -> None:
         assert src_block_ids.dtype == torch.int64
@@ -1263,20 +1191,13 @@ class tpGDSTransferWorker(TransferWorkerBase):
             self.ssd_tp_stride_in_bytes,
             self.num_blocks_per_file,
             is_read,
-            layer_id,
-            layer_granularity,
+            0,
+            self.num_layers,
             self.is_mla,
         )
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
         """Launch a TP GDS transfer operation"""
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
         start_time = time.time()
@@ -1284,13 +1205,9 @@ class tpGDSTransferWorker(TransferWorkerBase):
             src_block_ids,
             dst_block_ids,
             transfer_op.transfer_type,
-            layer_id,
-            layer_granularity,
         )
         end_time = time.time()
-
-        kv_dim = 2 if not self.is_mla else 1
-        transfer_size = self.ssd_chunk_size_in_bytes * layer_granularity * transfer_op.valid_block_num * kv_dim
+        transfer_size = self.ssd_chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
 
         self._log_transfer_performance(
             transfer_op,
@@ -1328,7 +1245,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self.remote_kv_layout = remote_kv_layout
 
         self.is_mla = cpu_kv_layout.is_mla
-        self.kv_dim = 2 if not self.is_mla else 1
+        self.kv_dim = cpu_kv_layout.kv_dim
 
         self.cpu_blocks = cpu_blocks  ## shared memory
         self.cache_config = cache_config
@@ -1513,13 +1430,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self.unregist_node_meta()
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
-        layer_id = transfer_op.layer_id
-        layer_granularity = transfer_op.layer_granularity
-        if layer_id == -1:
-            layer_id = 0
-        if layer_granularity == -1:
-            layer_granularity = self.num_layers
-        task_info_list = self.op_parser(transfer_op, layer_id, layer_granularity)
+        task_info_list = self.op_parser(transfer_op)
 
         start_time = time.time()
         transfered_size = 0
@@ -1530,8 +1441,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             ret = self._batch_transfer_impl(
                 task_info,
                 transfer_op.transfer_type,
-                layer_id,
-                layer_granularity,
             )
             if not ret:
                 transfer_finished = False
@@ -1539,11 +1448,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             transfered_size += task_info.data_size
 
         end_time = time.time()
-
-        # kv_dim = 2 if not self.is_mla else 1
-        # transfer_size = (
-        #     self.block_size * layer_granularity * transfer_op.valid_block_num * kv_dim
-        # )
 
         self._log_transfer_performance(
             transfer_op,
@@ -1556,8 +1460,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
     def _batch_transfer_impl(self,
         task_info: RDMATaskInfo,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs,):
         if transfer_type == TransferType.PEERH2H:
             ret = self.mooncake_transfer_engine.batch_transfer_sync_read(
@@ -1577,8 +1479,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 peer_cpu_base_ptr=self.dst_buffer_ptr,
                 peer_zmq_status_addr=self.zmq_client.get_addr(),
                 data_size=task_info.data_size,
-                layer_id=layer_id,
-                layer_granularity=layer_granularity,
             )
             #flexkv_logger.info(
             #    f"[PEERSSD2H] Sending meta: task_id={task_info.task_id}, "
@@ -1611,8 +1511,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self,
         task_info: RDMATaskInfo,
         transfer_type: TransferType,
-        layer_id: int,
-        layer_granularity: int,
         **kwargs,
     ):
         if transfer_type == TransferType.PEERH2H:
@@ -1634,8 +1532,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                 peer_cpu_base_ptr=self.dst_buffer_ptr,
                 peer_zmq_status_addr=self.zmq_client.get_addr(),
                 data_size=task_info.data_size,
-                layer_id=layer_id,
-                layer_granularity=layer_granularity,
             )
             flexkv_logger.info(
                 f"[_transfer_impl] Sending task_id={task_info.task_id}, "
@@ -1667,7 +1563,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         return True
 
     def op_parser(
-        self, transfer_op: WorkerTransferOp, layer_id: int, layer_granularity: int
+        self, transfer_op: WorkerTransferOp
     ) -> List[RDMATaskInfo]:
         """
         parse the transfer op to a list of RDMATaskInfo
@@ -1702,9 +1598,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             groups = group_blocks_by_node_and_segment(
                 src_block_ids, dst_block_ids, src_block_node_ids
             )
-            task_info_list = self._dist_cpu_op_parser(
-                groups, layer_id, layer_granularity
-            )
+            task_info_list = self._dist_cpu_op_parser(groups)
         elif transfer_op.transfer_type == TransferType.PEERSSD2H:
             groups = group_blocks_by_node(
                 src_block_ids, dst_block_ids, src_block_node_ids
@@ -1856,10 +1750,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                     local_cpu_buffer_block_ids_per_seg = local_cpu_buffer_block_ids[local_cpu_start_idx: local_cpu_start_idx+len(ssd_block_ids_per_seg)]
                     local_cpu_start_idx += len(ssd_block_ids_per_seg)
 
-                    layer_id = recv_meta.layer_id
-                    layer_granularity = recv_meta.layer_granularity
                     layer_id_list = torch.arange(
-                        layer_id, layer_id + layer_granularity, dtype=torch.int32
+                        0, self.num_layers, dtype=torch.int32
                     )
                     if not self.copy_ssd_data_to_dram(
                         layer_id_list, ssd_block_ids_per_seg, local_cpu_buffer_block_ids_per_seg
@@ -1871,15 +1763,11 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                     src_ptrs, src_block_size = self.get_cpu_buffer_block_start_ptr(
                         local_cpu_buffer_block_ids_per_seg,
                         self.tmp_cpu_buffer.data_ptr(),
-                        layer_id,
-                        layer_granularity,
                     )
 
                     dst_ptrs, dst_block_size = self.get_cpu_buffer_block_start_ptr(
                         dst_cpu_block_ids_per_seg,
                         recv_meta.peer_cpu_base_ptr,
-                        layer_id,
-                        layer_granularity,
                     )
                     assert src_block_size == dst_block_size, "Block size mismatch between src and dst"
 
@@ -1953,8 +1841,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
     def _dist_cpu_op_parser(
         self,
         groups: Dict[int, List[Dict[str, List[int]]]],
-        layer_id: int,
-        layer_granularity: int,
     ):
         """
         Distributed cpu op parser
@@ -1963,8 +1849,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
 
         Inputs:
             groups (Dict[int, List[Dict[str, List[int]]]]): the grouped blocks
-            layer_id (int): start layer id
-            layer_granularity (int): number of layers to be transferred
 
         Returns:
             task_info_list: the list of RDMATaskInfo, each task refers to the data transfer of one node
@@ -1990,8 +1874,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                     self.get_cpu_buffer_block_start_ptr(
                         src_blocks,
                         src_meta.cpu_bufer_base_ptr,  # the cpu buffer ptr on remote machine
-                        layer_id,
-                        layer_granularity,
                     )
                 )
 
@@ -2000,8 +1882,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
                     self.get_cpu_buffer_block_start_ptr(
                         dst_blocks,
                         self.dst_buffer_ptr,  # the cpu buffer ptr on local machine
-                        layer_id,
-                        layer_granularity,
                     )
                 )
 
@@ -2022,8 +1902,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             )
             # step3: create RDMATaskInfo for each segment
             # NOTE: block wise layout: only one start ptr for each segment
-            #       layer wise layout: multiple start ptrs for each segment, the number of start ptrs equals to layer_granularity * kv_dim
-
+            #       layer wise layout: multiple start ptrs for each segment,
+            #       the number of start ptrs equals num_layers * kv_dim
             task_info_list.append(
                   RDMATaskInfo(
                     0,
@@ -2046,14 +1926,12 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self,
         cpu_blocks: List[int],
         cpu_base_ptr: int,
-        layer_start_id: int = 0,
-        layer_granularity: int = -1,
     ) -> Tuple[List[int], int]:
         """
         Get the cpu buffer block start ptrs for the given cpu blocks.
         We have two layout types in flexkv, layerwise and blockwise.
         1) For layerwise layout,although the cpu blocks are continous, we need to calculate the start ptrs for each layer and each kv dim. So
-        the number of start ptrs equals to layer_granularity * kv_dim.
+        the number of start ptrs equals to self.num_layers * kv_dim.
         2) For blockwise layout, the cpu blocks are continuous, so we only need to calculate the start ptr for the first block. So
         the number of start ptrs is 1.
         3) For other layout types, raise error.
@@ -2061,8 +1939,6 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         Parameters:
             cpu_blocks (List[int]): the list of cpu block ids, continuous
             cpu_base_ptr (int): the base ptr of the cpu buffer
-            layer_start_id (int): the start layer id, only used for layerwise layout
-            layer_granularity (int): the number of layers to be transferred, only used for layerwise layout
         Returns:
             Tuple(List[int], int): the list of cpu buffer block start ptrs and data size per block (used for calculate total data size)
         """
@@ -2084,7 +1960,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             raise ValueError(f"Invalid cpu_blocks type: {type(cpu_blocks)}")
 
         if self.cpu_kv_layout.type == KVCacheLayoutType.LAYERFIRST:
-            for layer_id in range(layer_start_id, layer_start_id + layer_granularity):
+            for layer_id in range(0, self.num_layers):
                 for kv_id in range(self.kv_dim):
                     element_offset = (
                         (

--- a/flexkv/transfer/worker_op.py
+++ b/flexkv/transfer/worker_op.py
@@ -11,8 +11,6 @@ class WorkerTransferOp:
     transfer_op_id: int
     transfer_graph_id: int
     transfer_type: TransferType
-    layer_id: int
-    layer_granularity: int
     src_slot_id: int
     dst_slot_id: int
     valid_block_num: int
@@ -24,8 +22,6 @@ class WorkerTransferOp:
         self.transfer_op_id = transfer_op.op_id
         self.transfer_graph_id = transfer_op.graph_id
         self.transfer_type = transfer_op.transfer_type
-        self.layer_id = transfer_op.layer_id
-        self.layer_granularity = transfer_op.layer_granularity
         self.src_slot_id = transfer_op.src_slot_id
         self.dst_slot_id = transfer_op.dst_slot_id
         self.valid_block_num = transfer_op.valid_block_num
@@ -45,8 +41,6 @@ class WorkerLayerwiseTransferOp:
     transfer_op_id: int
     transfer_graph_id: int
     transfer_type: TransferType
-    layer_id: int
-    layer_granularity: int
     src_block_ids_h2d: np.ndarray
     dst_block_ids_h2d: np.ndarray
     src_block_ids_disk2h: np.ndarray
@@ -61,8 +55,6 @@ class WorkerLayerwiseTransferOp:
         self.transfer_graph_id = transfer_op.graph_id
         assert transfer_op.transfer_type == TransferType.LAYERWISE
         self.transfer_type = transfer_op.transfer_type
-        self.layer_id = transfer_op.layer_id
-        self.layer_granularity = transfer_op.layer_granularity
         self.src_block_ids_h2d = transfer_op.src_block_ids_h2d
         self.dst_block_ids_h2d = transfer_op.dst_block_ids_h2d
         self.src_block_ids_disk2h = transfer_op.src_block_ids_disk2h

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -20,7 +20,7 @@ import pickle
 import sys
 
 from flexkv.common.transfer import TransferOpGraph, CompletedOp, WorkerKey
-from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.config import CacheConfig, ModelConfig
 from flexkv.common.debug import flexkv_logger
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.transfer import DeviceType
@@ -39,16 +39,13 @@ class TransferManager:
         self.model_config = model_config
         self.cache_config = cache_config
         self.gpu_register_port = gpu_register_port
-        
-        # Multi-instance support: get instance_num from environment
-        self.instance_num = GLOBAL_CONFIG_FROM_ENV.instance_num
-        
+        self.instance_num = self.model_config.instance_num
         # Calculate total expected GPUs on this node across all instances
-        self.expected_gpus = self.instance_num * model_config.gpus_per_node
+        self.expected_gpus = self.instance_num * self.model_config.gpus_per_node
 
         self.all_gpu_layouts: Dict[int, KVCacheLayout] = {}
         self.all_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> gpu_blocks
-        self.gpu_worker_key_mapping: Dict[int, WorkerKey] = {}  # device_id -> WorkerKey(dp_rank, pp_rank)
+        self.gpu_worker_key_mapping: Dict[int, WorkerKey] = {}
 
         # Indexer GPU registration data
         self.all_indexer_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> indexer_gpu_blocks
@@ -59,7 +56,7 @@ class TransferManager:
             self.context, zmq.SocketType.PULL, gpu_register_port, True)
 
         self.transfer_engine: Optional[TransferEngine] = None
-        self.storage_engine = StorageEngine(self.model_config, self.cache_config)
+        self.storage_engine: Optional[StorageEngine] = None
         flexkv_logger.info(f"Initialized TransferManager with config successfully, "
                            f"instance_num={self.instance_num}, expected_gpus={self.expected_gpus}")
 
@@ -72,7 +69,10 @@ class TransferManager:
             try:
                 self.all_gpu_blocks[device_id] = req.handles
                 self.all_gpu_layouts[device_id] = req.gpu_layout
-                self.gpu_worker_key_mapping[device_id] = WorkerKey(dp_rank=req.dp_rank, pp_rank=req.pp_rank)
+                self.gpu_worker_key_mapping[device_id] = WorkerKey(
+                    dp_client_id=req.dp_client_id,
+                    pp_rank=req.pp_rank,
+                )
                 # Store indexer GPU data if present
                 if req.indexer_handles is not None:
                     self.all_indexer_gpu_blocks[device_id] = req.indexer_handles
@@ -88,8 +88,7 @@ class TransferManager:
             flexkv_logger.info(f"GPU tensor registration server started on port {self.gpu_register_port}, "
                                f"expected {self.expected_gpus} GPUs to register "
                                f"(instance_num={self.instance_num}, gpus_per_node={self.model_config.gpus_per_node}, "
-                               f"total_gpus={self.model_config.total_gpus}, pp_rank={self.model_config.pp_rank}, "
-                               f"node_rank={self.model_config.node_rank}, nnodes={self.model_config.nnodes})")
+                               f"total_gpus={self.model_config.total_gpus}, nnodes={self.model_config.nnodes})")
             last_log_time = time.time()
             while len(self.all_gpu_blocks) < self.expected_gpus:
                 try:
@@ -111,7 +110,8 @@ class TransferManager:
 
                 if isinstance(req, RegisterTPClientRequest):
                     flexkv_logger.info(f"Received GPU blocks registration request: {type(req)}, "
-                                       f"device_id={req.device_id}, dp_rank={req.dp_rank}")
+                                       f"device_id={req.device_id}, "
+                                       f"dp_client_id={req.dp_client_id}, pp_rank={req.pp_rank}")
                     self._handle_gpu_blocks_registration(req)
                     flexkv_logger.info(f"GPU {req.device_id} registered successfully, "
                                        f"waiting for {self.expected_gpus - len(self.all_gpu_blocks)} GPUs to register")
@@ -137,7 +137,13 @@ class TransferManager:
             f"Expected {self.expected_gpus} GPU layouts, got {len(self.all_gpu_layouts)}"
         assert len(self.all_gpu_blocks) == self.expected_gpus, \
             f"Expected {self.expected_gpus} GPU blocks, got {len(self.all_gpu_blocks)}"
-        
+        num_layers_per_pp_stage = next(iter(self.all_gpu_layouts.values())).num_layer
+        self.storage_engine = StorageEngine(
+            self.model_config,
+            self.cache_config,
+            num_layers_per_pp_stage,
+        )
+
         # Register GPU blocks with their global device IDs
         for device_id, gpu_blocks_wrapper in self.all_gpu_blocks.items():
             # Get indexer data for this device if available
@@ -154,7 +160,7 @@ class TransferManager:
                 indexer_gpu_layout=indexer_gpu_layout,
                 indexer_dtype=indexer_dtype,
             )
-        
+
         # Group GPU handles by WorkerKey
         grouped_gpu_handles: Dict[WorkerKey, List] = {}
         for device_id in sorted(self.all_gpu_blocks.keys()):
@@ -163,7 +169,7 @@ class TransferManager:
                 grouped_gpu_handles[worker_key] = []
             grouped_gpu_handles[worker_key].append(
                 self.storage_engine.get_storage_handle(DeviceType.GPU, device_id))
-        
+
         cpu_handle = self.storage_engine.get_storage_handle(DeviceType.CPU) \
             if self.cache_config.enable_cpu else None
         ssd_handle = self.storage_engine.get_storage_handle(DeviceType.SSD) \
@@ -213,24 +219,9 @@ class TransferManager:
             indexer_remote_handle=indexer_remote_handle,
         )
 
-        # Derive local pp_rank from GPU registrations rather than model_config.
-        # In cross-node PP, TransferManagerOnRemote receives model_config from
-        # the PP0 master (pp_rank=0), but local GPUs register with their true
-        # pp_rank (e.g. pp_rank=1).  All local workers share the same pp_rank
-        # because they belong to the same PP stage on this node.
-        worker_keys = set(self.gpu_worker_key_mapping.values())
-        self._local_dp_rank = self.model_config.dp_rank
-        self._local_pp_rank = self.model_config.pp_rank
-        if len(worker_keys) >= 1:
-            pp_ranks = set(wk.pp_rank for wk in worker_keys)
-            assert len(pp_ranks) == 1, \
-                f"Expected all local workers to share the same pp_rank, got {pp_ranks}"
-            self._local_pp_rank = pp_ranks.pop()
-
         flexkv_logger.info(f"Initialized TransferEngine successfully, "
                            f"grouped_gpu_handles keys={list(grouped_gpu_handles.keys())}, "
-                           f"num_gpu_groups={len(grouped_gpu_handles)}, "
-                           f"local_dp_rank={self._local_dp_rank}, local_pp_rank={self._local_pp_rank}")
+                           f"num_gpu_groups={len(grouped_gpu_handles)}")
 
     def submit(self, transfer_graph: TransferOpGraph) -> None:
         self.transfer_engine.submit_transfer_graph(transfer_graph)
@@ -248,51 +239,21 @@ class TransferManager:
         if hasattr(self, 'transfer_engine'):
             self.transfer_engine.shutdown()
 
-def resolve_master_host_and_ports(
-    master_host: Optional[str] = None,
-) -> Tuple[str, Tuple[str, str, str]]:
-    """Resolve the (master_host, master_ports) tuple for multi-node transfer.
-
-    ``master_host`` resolution order:
-        1. explicit ``master_host`` argument (when provided by the caller,
-           e.g. via sglang ``--dist-init-addr``);
-        2. ``FLEXKV_MASTER_HOST`` env var (used by framework-agnostic
-           launchers such as TRT-LLM's ``multi_node_launch.sh``);
-        3. ``"localhost"`` default.
-
-    ``master_ports`` always comes from ``FLEXKV_MASTER_PORTS`` (or default),
-    because changing ports rarely warrants a host-aware plumbing change.
-    """
-    if master_host is None:
-        master_host = os.getenv("FLEXKV_MASTER_HOST", "localhost")
-    master_ports = os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558")
-    master_ports = tuple(master_ports.split(","))
-    flexkv_logger.info(
-        f"[TransferManager] resolved master endpoint: "
-        f"host={master_host!r} (source={'arg' if master_host is not None else 'env/default'}), "
-        f"ports={master_ports}"
-    )
-    return "tcp://" + master_host, master_ports
-
-def get_trtllm_subprocess_host_and_ports_from_env() -> Tuple[str, Tuple[str, str, str]]:
-    flexkv_trt_subprocess_host = os.getenv("FLEXKV_TRT_SUBPROCESS_HOST", "localhost")
-    flexkv_trt_subprocess_ports = os.getenv("FLEXKV_TRT_SUBPROCESS_PORTS", "6667,6668,6669")
-    flexkv_trt_subprocess_ports = tuple(flexkv_trt_subprocess_ports.split(","))
-    return "tcp://" + flexkv_trt_subprocess_host, flexkv_trt_subprocess_ports
-
 class TransferManagerOnRemote(TransferManager):
     """
     TransferManager for remote mode, used for multi-node tensor parallelism.
     """
-    def __init__(self, mode: str = "Default", master_host: Optional[str] = None):
-        if mode == "Default":
-            self.master_host, self.master_ports = resolve_master_host_and_ports(
-                master_host=master_host
-            )
-        elif mode == "TrtllmSubprocess":
-            self.master_host, self.master_ports = get_trtllm_subprocess_host_and_ports_from_env()
-        else:
-            raise ValueError(f"Invalid mode: {mode}, must be Default or TrtllmSubprocess")
+    def __init__(
+        self,
+        master_host: str,
+        master_ports: Tuple[str, str, str],
+    ):
+        self.master_host = master_host
+        self.master_ports = master_ports
+        flexkv_logger.info(
+            f"[TransferManagerOnRemote] master endpoint: "
+            f"host={master_host!r}, ports={master_ports}"
+        )
 
         self.context = zmq.Context()
         self.command_socket = self.context.socket(zmq.PULL)
@@ -309,8 +270,6 @@ class TransferManagerOnRemote(TransferManager):
         self._active_graphs: Dict[int, int] = {}
         self._active_graphs_lock = threading.Lock()
 
-        # Pending matching for cross-node PP: graph arrives before or after slot_mapping
-        # _pending_graphs stores (graph, task_end_op_id) tuples
         self._pending_graphs: Dict[int, Tuple[TransferOpGraph, int]] = {}
         self._pending_slot_mappings: Dict[int, np.ndarray] = {}
         self._pending_lock = threading.Lock()
@@ -324,15 +283,15 @@ class TransferManagerOnRemote(TransferManager):
 
     def _connect_to_master_transfer_manager(self) -> None:
         try:
-            command_addr = f"{self.master_host}:{self.master_ports[0]}"
+            command_addr = f"tcp://{self.master_host}:{self.master_ports[0]}"
             self.command_socket.connect(command_addr)
             flexkv_logger.debug(f"Connected to master command port at {command_addr}")
 
-            result_addr = f"{self.master_host}:{self.master_ports[1]}"
+            result_addr = f"tcp://{self.master_host}:{self.master_ports[1]}"
             self.result_socket.connect(result_addr)
             flexkv_logger.debug(f"Connected to master result port at {result_addr}")
 
-            query_addr = f"{self.master_host}:{self.master_ports[2]}"
+            query_addr = f"tcp://{self.master_host}:{self.master_ports[2]}"
             self.query_socket.connect(query_addr)
             flexkv_logger.debug(f"Connected to master query port at {query_addr}")
 
@@ -384,7 +343,6 @@ class TransferManagerOnRemote(TransferManager):
                             elif msg_type == 'submit_batch':
                                 graphs = message.get('graphs', [])
                                 for graph in graphs:
-                                    self._rebind_graph_to_local_worker(graph)
                                     graph_id = graph.graph_id
                                     with self._active_graphs_lock:
                                         self._active_graphs[graph_id] = -1
@@ -455,7 +413,6 @@ class TransferManagerOnRemote(TransferManager):
                 # Graph already arrived, set GPU blocks and prepare for submit
                 graph, task_end_op_id = self._pending_graphs.pop(task_id)
                 graph.set_gpu_blocks(slot_mapping)
-                self._rebind_graph_to_local_worker(graph)
                 flexkv_logger.debug(
                     f"[TransferManagerOnRemote] set_slot_mapping: "
                     f"graph for task_id={task_id} submitted (graph arrived first)"
@@ -486,7 +443,6 @@ class TransferManagerOnRemote(TransferManager):
                 # slot_mapping already arrived, set GPU blocks and submit
                 slot_mapping = self._pending_slot_mappings.pop(task_id)
                 graph.set_gpu_blocks(slot_mapping)
-                self._rebind_graph_to_local_worker(graph)
                 flexkv_logger.debug(
                     f"[TransferManagerOnRemote] submit: "
                     f"graph for task_id={task_id} submitted (slot_mapping arrived first)"
@@ -504,29 +460,6 @@ class TransferManagerOnRemote(TransferManager):
         with self._active_graphs_lock:
             self._active_graphs[graph.graph_id] = task_end_op_id
         self.submit(graph)
-
-    def _rebind_graph_to_local_worker(self, graph: TransferOpGraph) -> None:
-        """Rebind transfer graph ops to the local pp_rank.
-
-        In cross-node PP setups, the master (PP0) creates transfer graphs with
-        its own pp_rank=0. When these graphs are sent to a remote node (e.g. PP1),
-        the ops' pp_rank must be updated to the local pp_rank so the
-        TransferEngine can find the correct workers.
-
-        Each op's dp_rank is preserved — in multi-DP scenarios, different ops
-        may belong to different dp_ranks and should remain bound to their
-        original DP group.
-        """
-        if self.model_config.pp_rank == self._local_pp_rank:
-            return  # No rebinding needed
-
-        for op in graph._op_map.values():
-            op.pp_rank = self._local_pp_rank
-
-        flexkv_logger.debug(
-            f"[TransferManagerOnRemote] Rebound graph {graph.graph_id} "
-            f"pp_rank from {self.model_config.pp_rank} to {self._local_pp_rank}"
-        )
 
     def start(self) -> None:
         self.initialize_transfer_engine()
@@ -758,7 +691,6 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
 
         flexkv_logger.debug(
             f"Spawning TransferManager subprocess: "
-            f"pp_rank={self.model_config.pp_rank}, node_rank={self.model_config.node_rank}, "
             f"tp_size={self.model_config.tp_size}, dp_size={self.model_config.dp_size}, "
             f"gpu_register_port={self.gpu_register_port}")
         self.process = self.mp_ctx.Process(
@@ -798,8 +730,7 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
         signal.signal(signal.SIGCHLD, _reap_children)
         try:
             flexkv_logger.debug(f"_process_worker started, pid={os.getpid()}, "
-                               f"gpu_register_port={gpu_register_port}, "
-                               f"pp_rank={model_config.pp_rank}, node_rank={model_config.node_rank}")
+                               f"gpu_register_port={gpu_register_port}")
             start_event.set()
             os.environ['MPI4PY_RC_INITIALIZE'] = 'false'
             transfer_manager = TransferManager(model_config, cache_config, gpu_register_port)
@@ -981,15 +912,15 @@ class TransferManagerMultiNodeHandle(TransferManagerHandleBase):
 
     def _bind_master_ports(self) -> None:
         try:
-            command_addr = f"{self.master_host}:{self.master_ports[0]}"
+            command_addr = f"tcp://{self.master_host}:{self.master_ports[0]}"
             self.command_socket.bind(command_addr)
             flexkv_logger.info(f"Master bound command port at {command_addr}")
 
-            result_addr = f"{self.master_host}:{self.master_ports[1]}"
+            result_addr = f"tcp://{self.master_host}:{self.master_ports[1]}"
             self.result_socket.bind(result_addr)
             flexkv_logger.info(f"Master bound result port at {result_addr}")
 
-            query_addr = f"{self.master_host}:{self.master_ports[2]}"
+            query_addr = f"tcp://{self.master_host}:{self.master_ports[2]}"
             self.query_socket.bind(query_addr)
             flexkv_logger.info(f"Master bound query port at {query_addr}")
 
@@ -1144,7 +1075,8 @@ class TransferManagerHandle:
                  **kwargs): # process or thread or remote
         flexkv_logger.debug(
             f"Creating TransferManagerHandle: mode={mode}, "
-            f"pp_rank={model_config.pp_rank}, node_rank={model_config.node_rank}, "
+            f"tp_size={model_config.tp_size}, dp_size={model_config.dp_size}, "
+            f"pp_size={model_config.pp_size}, nnodes={model_config.nnodes}, "
             f"gpu_register_port={gpu_register_port}")
         if gpu_register_port is None:
             gpu_register_port = f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}"

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -71,7 +71,7 @@ def test_config(request: pytest.FixtureRequest):
 
 # Utility functions
 def generate_request_pair(idx: int, block_per_request, num_gpu_blocks, tokens_per_block, dp_size):
-    """Generate a request pair with token_ids, block_ids, and dp_id"""
+    """Generate a request pair with token_ids, block_ids, and dp_rank"""
     start_idx = (idx * block_per_request) % num_gpu_blocks
     assert start_idx + block_per_request <= num_gpu_blocks
     block_ids = torch.arange(
@@ -347,7 +347,7 @@ def gpu_blocks_worker_process(conn, model_config, cache_config, gpu_kv_layout):
         gpu_blocks = []
         for layer_id in range(model_config.num_layers):
             # LAYERFIRST format: [kv_dim, num_block, tokens_per_block, num_head, head_size]
-            kv_dim = 2 if not model_config.use_mla else 1
+            kv_dim = model_config.kv_dim
             gpu_tensor = torch.zeros(
                 kv_dim,
                 gpu_kv_layout.num_block,
@@ -417,7 +417,7 @@ def example_usage_gpu_kv_cache_verifier():
     gpu_blocks = []
     for layer_id in range(model_config.num_layers):
         # LAYERFIRST format: [kv_dim, num_block, tokens_per_block, num_head, head_size]
-        kv_dim = 2 if not model_config.use_mla else 1
+        kv_dim = model_config.kv_dim
         gpu_tensor = torch.zeros(
             kv_dim,
             gpu_kv_layout.num_block,

--- a/tests/hugepage/test_hugepage_unit.py
+++ b/tests/hugepage/test_hugepage_unit.py
@@ -178,7 +178,7 @@ def test_storage_engine_cpu_cache_uses_hugepage_when_enabled() -> None:
         hugepage_size_bytes=PAGE,
     )
 
-    storage_engine = StorageEngine(model_config, cache_config)
+    storage_engine = StorageEngine(model_config, cache_config, model_config.num_layers)
     cpu_handle = storage_engine.get_storage_handle(DeviceType.CPU)
     cpu_tensor = cpu_handle.get_tensor()
 
@@ -210,7 +210,7 @@ def test_storage_engine_cpu_cache_falls_back_when_hugepage_unavailable(monkeypat
     )
     monkeypatch.setenv("FLEXKV_HUGETLBFS_DIR", "/nonexistent/flexkv_hugetlbfs")
 
-    storage_engine = StorageEngine(model_config, cache_config)
+    storage_engine = StorageEngine(model_config, cache_config, model_config.num_layers)
     cpu_handle = storage_engine.get_storage_handle(DeviceType.CPU)
     cpu_tensor = cpu_handle.get_tensor()
 

--- a/tests/replay_from_tracer.py
+++ b/tests/replay_from_tracer.py
@@ -233,8 +233,7 @@ class FlexKVReplayEngine:
 
             # Create registration request
             register_req = RegisterTPClientRequest(
-                dp_rank=gpu_id // self.model_config.tp_size,  # DP client ID
-                pp_rank=0,  # single PP stage for replay
+                dp_client_id=gpu_id // self.model_config.tp_size,  # DP client ID
                 device_id=gpu_id,
                 handles=handles,
                 gpu_layout=self.gpu_layout
@@ -305,8 +304,6 @@ class FlexKVReplayEngine:
         slot_mapping = np.array(data['slot_mapping'], dtype=np.int64)
         token_mask = np.array(data['token_mask'], dtype=bool) if data['token_mask'] else None
         layer_granularity = data.get('layer_granularity', -1)
-        dp_rank = data.get('dp_id', 0)
-        pp_rank = data.get('pp_rank', 0)
 
         self.log(f"Replaying {request_type} request with {len(token_ids)} tokens")
 
@@ -320,8 +317,6 @@ class FlexKVReplayEngine:
                 slot_mapping=slot_mapping,
                 token_mask=token_mask,
                 layer_granularity=layer_granularity,
-                dp_rank=dp_rank,
-                pp_rank=pp_rank
             )
         elif request_type == "PUT":
             print(f"✅✅✅PUT token_ids: {token_ids[:128]}")
@@ -332,8 +327,6 @@ class FlexKVReplayEngine:
                 token_ids=token_ids,
                 slot_mapping=slot_mapping,
                 token_mask=token_mask,
-                dp_rank=dp_rank,
-                pp_rank=pp_rank
             )
         elif request_type == "GET_MATCH":
             print(f"🔍📝GET_MATCH token_ids: {token_ids[:128]}")
@@ -344,8 +337,6 @@ class FlexKVReplayEngine:
                 token_ids=token_ids,
                 token_mask=token_mask,
                 layer_granularity=layer_granularity,
-                dp_rank=dp_rank,
-                pp_rank=pp_rank
             )
         elif request_type == "PUT_MATCH":
             print(f"✅📝PUT_MATCH token_ids: {token_ids[:128]}")
@@ -355,8 +346,6 @@ class FlexKVReplayEngine:
             task_id, return_mask = self.kvmanager.put_match(
                 token_ids=token_ids,
                 token_mask=token_mask,
-                dp_rank=dp_rank,
-                pp_rank=pp_rank
             )
         else:
             raise ValueError(f"Unknown request type: {request_type}")

--- a/tests/test_config_hugepage.py
+++ b/tests/test_config_hugepage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flexkv.common.config import (
     CacheConfig,
     ModelConfig,
+    RankInfo,
     UserConfig,
     load_user_config_from_env,
     update_default_config_from_user_config,
@@ -37,7 +38,7 @@ def test_update_default_config_from_user_config_applies_hugepage_flags() -> None
         hugepage_size_bytes=1 << 30,
     )
 
-    update_default_config_from_user_config(model_config, cache_config, user_config)
+    update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
 
     assert cache_config.use_hugepage_cpu_buffer is True
     assert cache_config.use_hugepage_tmp_buffer is True

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -8,7 +8,7 @@ import torch
 import multiprocessing as mp
 from multiprocessing import Process, Pipe
 
-from flexkv.common.config import ModelConfig, CacheConfig
+from flexkv.common.config import ModelConfig, CacheConfig, RankInfo
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.request import KVResponseStatus
 from flexkv.kvtask import KVTaskEngine
@@ -40,7 +40,7 @@ def _fp8_cuda_ops_unavailable():
     except NotImplementedError:
         return True
 
-def run_tp_client(dp_rank,
+def run_tp_client(dp_client_id,
                   tp_rank,
                   server_recv_port,
                   model_config,
@@ -50,8 +50,10 @@ def run_tp_client(dp_rank,
                   gpu_layout_type):
     """Run tp_client process"""
     try:
-        device_id = tp_rank + dp_rank * model_config.tp_size
-        tp_client = KVTPClient(server_recv_port, dp_rank, pp_rank=0, device_id=device_id)
+        device_id = tp_rank + dp_client_id * model_config.tp_size
+        tp_client = KVTPClient(server_recv_port,
+                               dp_client_id=dp_client_id, pp_rank=0,
+                               device_id=device_id)
 
         gpu_kv_layout = create_gpu_kv_layout(model_config, cache_config, num_gpu_blocks, gpu_layout_type)
 
@@ -67,7 +69,7 @@ def run_tp_client(dp_rank,
                 torch.empty(size=tuple(gpu_kv_layout.kv_shape[:]), dtype=model_config.dtype).cuda(device_id)
             )
         elif gpu_layout_type == 2:
-            kv_dim = 1 if model_config.use_mla else 2
+            kv_dim = model_config.kv_dim
             for _ in range(model_config.num_layers * kv_dim):
                 gpu_blocks_for_tp.append(
                     torch.empty(size=tuple(gpu_kv_layout.kv_shape[2:]), dtype=model_config.dtype).cuda(device_id)
@@ -174,7 +176,11 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
          #note that for now only dp_size=1 is supported
         pytest.skip("skip because server-client mode is not ready for dp_size > 1")
 
-    kvmanager = KVManager(model_config, cache_config)
+    kvmanager = KVManager(
+        model_config=model_config,
+        cache_config=cache_config,
+        dp_client_id=0,
+    )
     kvmanager.start()
 
     # Create pipes for each tp_client to send GPU blocks back
@@ -242,14 +248,13 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     initial_write_num = int(num_requests * initial_write_ratio)
     print("writing initial data...")
     put_ids = []
-    for token_ids, block_ids, dp_rank in request_pairs[:initial_write_num]:
+    for token_ids, block_ids, dp_client_id in request_pairs[:initial_write_num]:
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         write_request = kvmanager.put_async(
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_rank=dp_rank,
             namespace=namespace,
         )
         kvmanager.wait([write_request], completely=True)
@@ -261,7 +266,6 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
         token_ids=torch.randint(0, 100, size=(8,), dtype=torch.int64),
         slot_mapping=block_ids_2_slot_mapping(torch.arange(0,1, dtype=torch.int64), tokens_per_block, actual_length=8),
         token_mask=None,
-        dp_rank=0,
         namespace=namespace,
     )
     kvmanager.wait([write_request], completely=True)
@@ -272,7 +276,6 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     #    token_ids=torch.randint(0, 100, size=(16,), dtype=torch.int64),
     #    slot_mapping=block_ids_2_slot_mapping(torch.arange(0,1, dtype=torch.int64), tokens_per_block, actual_length=8),
     #    token_mask=my_mask,
-    #    dp_rank=0,
     #)
     #kvmanager.wait_for_graph_finished(write_request)
 
@@ -289,13 +292,11 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
     for i in range(initial_write_num, num_requests):
         print(f"performing mixed read/write {i} / {num_requests} ...")
         read_idx = i - initial_write_num
-        token_ids, block_ids, dp_rank = request_pairs[read_idx]
+        token_ids, block_ids, dp_client_id = request_pairs[read_idx]
         slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
         request_id, _ = kvmanager.get_match(
             token_ids=token_ids,
-            layer_granularity=-1,
             token_mask=None,
-            dp_rank=dp_rank,
             namespace=namespace,
         )
         kvmanager.launch(request_id, slot_mapping)
@@ -303,14 +304,13 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
         running_get_requests.append(request_id)
         req_id2block_ids[request_id] = block_ids
         req_id2token_ids[request_id] = token_ids
-        token_ids, block_ids, dp_rank = request_pairs[i]
+        token_ids, block_ids, dp_client_id = request_pairs[i]
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         request_id = kvmanager.put_async(
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_rank=dp_rank,
             namespace=namespace,
         )
         req_id2block_ids[request_id] = block_ids
@@ -378,14 +378,12 @@ def test_kvmanager(model_config, cache_config, test_config, gpu_layout_type):
 
         # Create multiple get_match requests
         for i in range(batch_size):
-            token_ids, block_ids, dp_rank = request_pairs[random.randint(0, num_requests - 1)]
+            token_ids, block_ids, dp_client_id = request_pairs[random.randint(0, num_requests - 1)]
             slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
 
             request_id, return_mask = kvmanager.get_match(
                 token_ids=token_ids,
-                layer_granularity=-1,
                 token_mask=None,
-                dp_rank=dp_rank,
                 namespace=namespace,
             )
             batched_get_task_ids.append(request_id)
@@ -580,7 +578,7 @@ class GPUIndexerCacheVerifier:
         return verification_passed
 
 
-def run_tp_client_with_indexer(dp_rank,
+def run_tp_client_with_indexer(dp_client_id,
                                tp_rank,
                                server_recv_port,
                                model_config,
@@ -593,7 +591,7 @@ def run_tp_client_with_indexer(dp_rank,
     Indexer configuration is read from cache_config.indexer (IndexerCacheConfig).
     """
     try:
-        device_id = tp_rank + dp_rank * model_config.tp_size
+        device_id = tp_rank + dp_client_id * model_config.tp_size
 
         gpu_kv_layout = create_gpu_kv_layout(model_config, cache_config, num_gpu_blocks, gpu_layout_type)
 
@@ -605,7 +603,7 @@ def run_tp_client_with_indexer(dp_rank,
                     torch.empty(size=tuple(gpu_kv_layout.kv_shape[1:]), dtype=model_config.dtype).cuda(device_id)
                 )
         elif gpu_layout_type == 2:
-            kv_dim = 1 if model_config.use_mla else 2
+            kv_dim = model_config.kv_dim
             for _ in range(model_config.num_layers * kv_dim):
                 gpu_blocks_for_tp.append(
                     torch.empty(size=tuple(gpu_kv_layout.kv_shape[2:]), dtype=model_config.dtype).cuda(device_id)
@@ -647,8 +645,7 @@ def run_tp_client_with_indexer(dp_rank,
         # Use KVTPClient directly with indexer buffers (shadow transfer mode)
         tp_client = KVTPClient(
             gpu_register_port=server_recv_port + "_gpu_register",
-            dp_rank=dp_rank,
-            pp_rank=0,
+            dp_client_id=dp_client_id, pp_rank=0,
             device_id=device_id,
         )
         tp_client.register_to_server(
@@ -702,8 +699,9 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
     )
 
     kvmanager = KVManager(
-        model_config,
-        cache_config,
+        model_config=model_config,
+        cache_config=cache_config,
+        dp_client_id=0,
     )
     kvmanager.start()
 
@@ -787,7 +785,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
     initial_write_num = int(num_requests * initial_write_ratio)
 
     print(f"[Test] Testing put flow ({test_label})...")
-    for token_ids, block_ids, dp_rank in request_pairs[:initial_write_num]:
+    for token_ids, block_ids, dp_client_id in request_pairs[:initial_write_num]:
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         if indexer_kv_verifier is not None:
@@ -796,7 +794,6 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_rank=dp_rank,
         )
         put_results = kvmanager.wait([write_request], completely=True)
         assert put_results[write_request].status == KVResponseStatus.SUCCESS
@@ -817,13 +814,11 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
     batch_slot_mappings = []
 
     for i in range(min(initial_write_num, num_requests)):
-        token_ids, block_ids, dp_rank = request_pairs[i]
+        token_ids, block_ids, dp_client_id = request_pairs[i]
         slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
         request_id, _ = kvmanager.get_match(
             token_ids=token_ids,
-            layer_granularity=-1,
             token_mask=None,
-            dp_rank=dp_rank,
         )
         batch_task_ids.append(request_id)
         batch_slot_mappings.append(slot_mapping)
@@ -890,7 +885,7 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
 
     print(f"[Test] Testing try_wait flow ({test_label})...")
     if initial_write_num < num_requests:
-        token_ids, block_ids, dp_rank = request_pairs[initial_write_num]
+        token_ids, block_ids, dp_client_id = request_pairs[initial_write_num]
         if gpu_kv_verifier is not None:
             gpu_kv_verifier.fill_gpu_blocks(token_ids, block_ids)
         if indexer_kv_verifier is not None:
@@ -899,7 +894,6 @@ def _run_indexer_test(model_config, cache_config, test_config, gpu_layout_type, 
             token_ids=token_ids,
             slot_mapping=block_ids_2_slot_mapping(block_ids, tokens_per_block),
             token_mask=None,
-            dp_rank=dp_rank,
         )
         finished = {}
         for _ in range(200):

--- a/tests/test_transfer_engine_atomic_eviction.py
+++ b/tests/test_transfer_engine_atomic_eviction.py
@@ -2,12 +2,15 @@
 Unit tests for atomic indexer eviction in TransferEngine.
 
 These tests verify that:
-1. TransferOp.pending_count defaults to 1.
-2. _finalize_op is called only when pending_count reaches 0.
-3. With indexer enabled: CompletedOp is NOT emitted until both main KV and indexer
-   workers complete (pending_count == 0).
-4. With indexer disabled: behavior is identical to the original (pending_count starts
-   at 1, _finalize_op is called immediately after main KV completes).
+1. TransferOp.pending_count defaults to 0 (pure-counter semantics: it counts
+   submitted-but-not-yet-completed worker tasks, and the parent op is itself
+   never submitted to a worker).
+2. _finalize_op is called only when pending_count reaches 0 again (i.e. every
+   submitted task has reported back).
+3. With indexer enabled: CompletedOp is NOT emitted until both main KV and
+   indexer workers complete (pending_count back to 0).
+4. With indexer disabled: behavior is identical to the original (one main-KV
+   task is submitted, pending_count goes 0→1→0, then _finalize_op).
 """
 import queue
 import unittest
@@ -16,22 +19,42 @@ from unittest.mock import MagicMock, patch, call
 
 import numpy as np
 
-from flexkv.common.transfer import TransferOp, TransferType, CompletedOp, LayerwiseTransferOp, WorkerKey
+from flexkv.common.config import ModelConfig, RankInfo, CacheConfig
+from flexkv.common.transfer import (
+    TransferOp,
+    TransferType,
+    CompletedOp,
+    LayerwiseTransferOp,
+    WorkerKey,
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_op(transfer_type: TransferType = TransferType.D2H) -> TransferOp:
-    """Create a minimal TransferOp for testing."""
+def _make_op(transfer_type: TransferType = TransferType.D2H,
+             dp_client_id: int = 0) -> TransferOp:
+    """Create a minimal TransferOp for testing.
+
+    ``dp_client_id`` defaults to ``0`` for unit tests that do not
+    care about routing identity; tests that exercise routing MUST
+    pass an explicit non-zero id.
+
+    Note: ``TransferOp.dp_client_id`` is pp-agnostic — pp_rank is bound by
+    the receiving ``TransferEngine`` *symmetrically*, by fanning the op
+    out to every local ``WorkerKey`` whose ``dp_client_id`` matches the
+    op's routing id. Mocks that poke ``op.worker_key`` are testing the
+    *old* contract and will not work post-refactor.
+    """
     if transfer_type == TransferType.LAYERWISE:
-        return _make_layerwise_op()
+        return _make_layerwise_op(dp_client_id=dp_client_id)
     return TransferOp(
         graph_id=0,
         transfer_type=transfer_type,
         src_block_ids=np.array([0, 1], dtype=np.int64),
         dst_block_ids=np.array([2, 3], dtype=np.int64),
+        dp_client_id=dp_client_id,
     )
 
 
@@ -43,9 +66,42 @@ def _make_layerwise_op(**kwargs) -> LayerwiseTransferOp:
         dst_block_ids_h2d=np.array([2, 3], dtype=np.int64),
         src_block_ids_disk2h=np.array([], dtype=np.int64),
         dst_block_ids_disk2h=np.array([], dtype=np.int64),
+        dp_client_id=0,
     )
     defaults.update(kwargs)
     return LayerwiseTransferOp(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Routing-id identity matrix used to exercise dispatch.
+#
+# ``TransferOp.dp_client_id`` is a pp-agnostic flat DP index
+# (derived upstream as ``instance_id * dp_size + local_dp_rank``) — the
+# single dimension that varies across senders.  The orthogonal
+# dimension (pp_rank) is intentionally absent: the receiving
+# ``TransferEngine`` fans the op out to *every* local ``WorkerKey``
+# whose ``dp_client_id`` matches, so the matrix below has no pp_rank
+# column.  WorkerKey-side ``Dict[WorkerKey, _]`` invariants are
+# covered by ``TestWorkerKeyInvariants`` further down.
+#
+# attn_cp is intentionally NOT a routing dimension: plain-CP rides on
+# per-GPU TP registration and NSA-CP is folded into an enlarged TP
+# group before reaching FlexKV.  Adding rows here is the cheapest way
+# to get coverage on a new routing dimension; do NOT collapse to 0.
+#
+# The four ids are picked to be pairwise distinct — the test treats
+# them as opaque ints, so their specific numerical values do not
+# matter beyond distinctness.  They are spaced so that under a
+# hypothetical ``dp_size=4`` layout each id maps to a different
+# (instance, local-DP) pair, mirroring the four shapes the refactor
+# was designed to disambiguate.
+# ---------------------------------------------------------------------------
+_ROUTING_KEY_MATRIX: List[int] = [
+    0,   # baseline
+    1,   # multi-DP variant
+    4,   # multi-instance variant
+    11,  # multi (instance + DP) variant
+]
 
 
 # ---------------------------------------------------------------------------
@@ -55,14 +111,24 @@ def _make_layerwise_op(**kwargs) -> LayerwiseTransferOp:
 class TestTransferOpPendingCount(unittest.TestCase):
     """Requirement 5: TransferOp supports pending_count field."""
 
-    def test_default_pending_count_is_one(self):
-        """pending_count SHALL default to 1 (req 5.1)."""
+    def test_default_pending_count_is_zero(self):
+        """pending_count SHALL default to 0 (pure-counter semantics, req 5.1).
+
+        Rationale: every actual unit of work is a replica/indexer-op
+        submitted to a worker, accounted for via an explicit ``+= 1`` at
+        submission time. The parent op itself is never submitted, so it
+        contributes nothing to the count. Defaulting to 0 removes the
+        old "self-counts-as-one" special case that mis-counted in mixed
+        main-KV-fan-out + indexer-fan-out paths.
+        """
         op = _make_op()
-        self.assertEqual(op.pending_count, 1)
+        self.assertEqual(op.pending_count, 0)
 
     def test_pending_count_is_mutable(self):
         """pending_count SHALL be mutable (dataclass, not frozen)."""
         op = _make_op()
+        op.pending_count += 1
+        self.assertEqual(op.pending_count, 1)
         op.pending_count += 1
         self.assertEqual(op.pending_count, 2)
         op.pending_count -= 1
@@ -79,6 +145,11 @@ class TestFinalizeOpLogic(unittest.TestCase):
     """
     Requirement 1, 3, 4: _finalize_op is called only when pending_count == 0.
     We test the logic directly by simulating what _scheduler_loop does.
+
+    Pure-counter semantics: every submission to a worker bumps pending_count
+    via an explicit ``+= 1``; every completion drops it via ``-= 1``; finalize
+    runs iff it drops back to 0. There is NO implicit "self-counts-as-one"
+    starting credit anymore.
     """
 
     def _simulate_worker_done(self, op: TransferOp, finished_ops: List[TransferOp],
@@ -88,9 +159,11 @@ class TestFinalizeOpLogic(unittest.TestCase):
         if op.pending_count == 0:
             finalize_fn(op, finished_ops)
 
-    def test_no_indexer_finalize_called_immediately(self):
-        """Without indexer: pending_count starts at 1, finalize called after main KV done (req 6.1)."""
+    def test_no_indexer_finalize_called_after_main_kv(self):
+        """Without indexer: one main-KV submission → one completion → finalize (req 6.1)."""
         op = _make_op()
+        # Simulate _assign_op_to_worker submitting to the (sole) main-KV worker.
+        op.pending_count += 1
         self.assertEqual(op.pending_count, 1)
 
         finalize_mock = MagicMock()
@@ -106,8 +179,9 @@ class TestFinalizeOpLogic(unittest.TestCase):
     def test_with_indexer_finalize_not_called_after_main_kv_only(self):
         """With indexer: finalize NOT called when only main KV completes (req 3.1, 4.1)."""
         op = _make_op()
-        # Simulate _assign_op_to_worker incrementing pending_count before submitting to indexer
-        op.pending_count += 1
+        # Simulate _assign_op_to_worker submitting BOTH main-KV and indexer tasks.
+        op.pending_count += 1  # main KV
+        op.pending_count += 1  # indexer
         self.assertEqual(op.pending_count, 2)
 
         finalize_mock = MagicMock()
@@ -124,8 +198,8 @@ class TestFinalizeOpLogic(unittest.TestCase):
     def test_with_indexer_finalize_called_after_both_complete(self):
         """With indexer: finalize called exactly once when both workers complete (req 3.2, 4.2)."""
         op = _make_op()
-        # Simulate _assign_op_to_worker incrementing pending_count before submitting to indexer
-        op.pending_count += 1
+        op.pending_count += 1  # main KV
+        op.pending_count += 1  # indexer
         self.assertEqual(op.pending_count, 2)
 
         finalize_mock = MagicMock()
@@ -144,7 +218,8 @@ class TestFinalizeOpLogic(unittest.TestCase):
     def test_with_indexer_finalize_called_once_regardless_of_order(self):
         """Finalize called exactly once even if indexer completes before main KV (req 3.2, 4.2)."""
         op = _make_op()
-        op.pending_count += 1  # indexer registered
+        op.pending_count += 1  # main KV
+        op.pending_count += 1  # indexer
         self.assertEqual(op.pending_count, 2)
 
         finalize_mock = MagicMock()
@@ -181,8 +256,19 @@ class TestFinalizeOpMethod(unittest.TestCase):
         engine.pin_buffer = MagicMock()
         engine.cache_config = MagicMock()
         engine.cache_config.tokens_per_block = 16
-        engine.model_config = MagicMock()
-        engine.model_config.token_size_in_bytes = 2
+        engine.model_config = ModelConfig(num_layers=2, num_kv_heads=1, head_size=1)
+        engine.rank_info = RankInfo(model_config=engine.model_config)
+        # ``TransferEngine.__init__`` caches the per-pp-stage layer
+        # count from the first GPU handle; we bypass __init__ via
+        # ``object.__new__`` so mirror it here so ``_finalize_op`` can
+        # compute its byte-size telemetry.
+        engine._num_layers_for_local_pp_stage = engine.model_config.num_layers
+        # Post-refactor, `_finalize_op` consults `_worker_map` to decide
+        # whether the parent owns a pin_buffer slot (singleton main-KV
+        # path) or not (dict fan-out / LAYERWISE). These tests drive the
+        # singleton path — bind a non-dict worker so the judgment
+        # evaluates true and `free_op_from_buffer` gets invoked.
+        engine._worker_map = {TransferType.D2H: MagicMock(name="singleton_d2h")}
         return engine
 
     def test_finalize_op_releases_buffer_and_notifies(self):
@@ -260,24 +346,27 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine._has_indexer = True
         engine._worker_map = {}
         engine._indexer_worker_map = {}
-        engine._indexer_op_to_parent_op = {}
-        engine._indexer_op_map = {}
+        # Unified child tracking (replaces _indexer_op_to_parent_op /
+        # _indexer_op_map / _pp_replica_to_parent_op after the slot
+        # ownership refactor).
+        engine._child_id_to_child = {}
+        engine._child_to_parent_op_id = {}
         engine.op_id_to_op = {}
         engine.op_id_to_nvtx_range = {}
         engine.completed_queue = MagicMock()
         engine.pin_buffer = MagicMock()
         engine.cache_config = MagicMock()
         engine.cache_config.tokens_per_block = 16
-        engine.model_config = MagicMock()
-        engine.model_config.token_size_in_bytes = 2
+        engine.model_config = ModelConfig(num_layers=2, num_kv_heads=1, head_size=1)
+        engine.rank_info = RankInfo(model_config=engine.model_config)
 
         # Create mock workers for main KV
         main_layerwise_worker = MagicMock()
         engine._worker_map[TransferType.H2D] = [MagicMock()]
         engine._worker_map[TransferType.D2H] = [MagicMock()]
         if enable_layerwise:
-            # LAYERWISE worker map must be Dict[WorkerKey, WorkerHandle]
-            wk0 = WorkerKey(dp_rank=0, pp_rank=0)
+            # LAYERWISE worker map must be Dict[WorkerKey, WorkerHandle].
+            wk0 = WorkerKey(dp_client_id=0, pp_rank=0)
             engine._worker_map[TransferType.LAYERWISE] = {wk0: main_layerwise_worker}
 
         # Create mock workers for indexer
@@ -310,11 +399,12 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine, _, _ = self._make_engine_stub_with_indexer(enable_layerwise=False)
         self.assertNotIn(TransferType.LAYERWISE, engine._indexer_worker_map)
 
-    def test_layerwise_op_pending_count_not_incremented_for_single_pp_stage(self):
+    def test_layerwise_op_pending_count_equals_sibling_count(self):
         """
-        WHEN _assign_op_to_worker processes a LAYERWISE op with only one PP stage
-        THEN op.pending_count SHALL remain 1 (no fan-out needed).
-        LAYERWISE indexer is fused inside the worker, not dispatched separately.
+        WHEN _assign_op_to_worker processes a LAYERWISE op with one matching PP-stage sibling
+        THEN op.pending_count SHALL be 1 (one replica submitted → one outstanding completion).
+        Pure-counter semantics: pending_count == number of submitted-but-not-completed
+        worker tasks. LAYERWISE indexer is fused inside the worker, not dispatched separately.
         """
         from flexkv.transfer.transfer_engine import register_op_to_buffer
         import nvtx
@@ -322,23 +412,26 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine, main_worker, indexer_worker = self._make_engine_stub_with_indexer(enable_layerwise=True)
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_rank = 0
-        op.pp_rank = 0
+        op.dp_client_id = 0
         engine.op_id_to_op[op.op_id] = op
 
-        initial_pending_count = op.pending_count  # should be 1
+        self.assertEqual(op.pending_count, 0,
+                         "fresh op must default to 0 (pure-counter semantics)")
 
         with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
              patch('nvtx.start_range', return_value=MagicMock()):
             engine._assign_op_to_worker(op)
 
-        # With a single PP stage, no fan-out → pending_count stays at 1
-        self.assertEqual(op.pending_count, initial_pending_count)
+        # Single matching sibling → exactly one submission → pending_count == 1.
+        self.assertEqual(op.pending_count, 1)
 
     def test_layerwise_op_submitted_to_main_worker(self):
         """
         WHEN _assign_op_to_worker processes a LAYERWISE op
-        THEN op SHALL be submitted to the main KV layerwise worker.
+        THEN exactly one replica SHALL be submitted to the only matching
+        layerwise worker, and that replica SHALL be tracked as a
+        PP-replica of the parent op (parent op itself is never
+        submitted to any worker — it is a pending_count anchor only).
         LAYERWISE indexer is fused inside the worker, not dispatched separately.
         """
         from flexkv.transfer.transfer_engine import register_op_to_buffer
@@ -346,21 +439,32 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine, main_worker, indexer_worker = self._make_engine_stub_with_indexer(enable_layerwise=True)
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_rank = 0
-        op.pp_rank = 0
+        op.dp_client_id = 0
         engine.op_id_to_op[op.op_id] = op
 
         with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
              patch('nvtx.start_range', return_value=MagicMock()):
             engine._assign_op_to_worker(op)
 
-        # Main KV layerwise worker should have received the op
-        main_worker.submit_transfer.assert_called_once_with(op)
+        # Exactly one replica was submitted (only one matching sibling).
+        self.assertEqual(main_worker.submit_transfer.call_count, 1)
+        submitted = main_worker.submit_transfer.call_args[0][0]
+        self.assertIsInstance(submitted, LayerwiseTransferOp)
+        self.assertIsNot(submitted, op,
+                         "parent op MUST NOT be submitted directly; only replicas reach workers")
+        self.assertEqual(submitted.dp_client_id, op.dp_client_id)
+        self.assertEqual(submitted.counter_id, op.counter_id)
+        np.testing.assert_array_equal(submitted.src_block_ids_h2d, op.src_block_ids_h2d)
+        np.testing.assert_array_equal(submitted.dst_block_ids_h2d, op.dst_block_ids_h2d)
+        # The replica is tracked as a child of the parent.
+        self.assertEqual(engine._child_to_parent_op_id[submitted.op_id], op.op_id)
 
-    def test_layerwise_op_no_indexer_pending_count_stays_one(self):
+    def test_layerwise_op_no_indexer_pending_count_equals_sibling_count(self):
         """
-        WHEN no indexer exists and LAYERWISE op is dispatched
-        THEN pending_count SHALL remain 1 (req 5.3).
+        WHEN no indexer exists and LAYERWISE op is dispatched to N matching siblings
+        THEN pending_count SHALL equal N (req 5.3): pure counter semantics, every
+        submitted replica is an outstanding completion event. With a single
+        matching sibling, that's exactly 1.
         """
         from flexkv.transfer.transfer_engine import TransferEngine
 
@@ -370,27 +474,35 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         engine._indexer_worker_map = {}
         engine.op_id_to_op = {}
         engine.op_id_to_nvtx_range = {}
-        engine._pp_replica_to_parent_op = {}
-        engine._pp_replica_op_map = {}
+        engine._child_id_to_child = {}
+        engine._child_to_parent_op_id = {}
+        # The inlined fan-out path calls `register_op_to_buffer`
+        # unconditionally for symmetry; the call short-circuits inside
+        # for LAYERWISE, but Python still needs the attribute to exist.
+        engine.pin_buffer = MagicMock()
 
         main_layerwise_worker = MagicMock()
-        wk0 = WorkerKey(dp_rank=0, pp_rank=0)
+        wk0 = WorkerKey(dp_client_id=0, pp_rank=0)
         engine._worker_map[TransferType.LAYERWISE] = {wk0: main_layerwise_worker}
 
         op = _make_op(TransferType.LAYERWISE)
-        op.dp_rank = 0
-        op.pp_rank = 0
+        op.dp_client_id = 0
         engine.op_id_to_op[op.op_id] = op
 
-        initial_pending_count = op.pending_count  # should be 1
+        self.assertEqual(op.pending_count, 0,
+                         "fresh op must default to 0 (pure-counter semantics)")
 
         with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
              patch('nvtx.start_range', return_value=MagicMock()):
             engine._assign_op_to_worker(op)
 
-        # pending_count should remain 1 (no indexer to increment for)
-        self.assertEqual(op.pending_count, initial_pending_count)
-        main_layerwise_worker.submit_transfer.assert_called_once_with(op)
+        # One matching sibling → one submitted replica → pending_count == 1.
+        self.assertEqual(op.pending_count, 1)
+        # And the worker received exactly one (replica) op, not the parent itself.
+        self.assertEqual(main_layerwise_worker.submit_transfer.call_count, 1)
+        submitted = main_layerwise_worker.submit_transfer.call_args[0][0]
+        self.assertIsNot(submitted, op)
+        self.assertEqual(engine._child_to_parent_op_id[submitted.op_id], op.op_id)
 
     def test_finalize_called_after_both_layerwise_workers_complete(self):
         """
@@ -398,8 +510,9 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         THEN _finalize_op SHALL be called exactly once (req 3.2, 4.2).
         """
         op = _make_op(TransferType.LAYERWISE)
-        # Simulate _assign_op_to_worker incrementing pending_count for indexer
-        op.pending_count += 1
+        # Simulate _assign_op_to_worker submitting BOTH main-KV and indexer tasks.
+        op.pending_count += 1  # main KV
+        op.pending_count += 1  # indexer
         self.assertEqual(op.pending_count, 2)
 
         finalize_mock = MagicMock()
@@ -419,6 +532,328 @@ class TestIndexerLayerwiseWorkerInit(unittest.TestCase):
         simulate_done(op, finished_ops, finalize_mock)
         self.assertEqual(op.pending_count, 0)
         finalize_mock.assert_called_once_with(op, finished_ops)
+
+
+# ---------------------------------------------------------------------------
+# Tests – Routing-id dispatch across the flat dp_client_id matrix.
+#
+# Pre-refactor, op identity collapsed two DP dimensions plus pp_rank
+# into inline WorkerKey fields and routing keyed off a composite
+# tuple.  Today an op carries a pp-agnostic flat ``dp_client_id``;
+# the dispatcher fans the op out to every ``WorkerKey`` in
+# ``_worker_map`` whose ``dp_client_id`` matches.  This class is the
+# single end-to-end check that no routing dimension is silently
+# collapsed back to 0 on either side of that match — and that an op
+# never leaks across DP-client boundaries.
+# ---------------------------------------------------------------------------
+
+class TestWorkerKeyRouting(unittest.TestCase):
+    """Verify that _assign_op_to_worker honours all routing-key dimensions."""
+
+    def _make_engine_with_routing_keys(self, routing_keys, transfer_type=TransferType.D2H):
+        """Build a TransferEngine stub whose ``_worker_map[transfer_type]``
+        is a ``WorkerKey``-indexed dict — one MagicMock per supplied
+        flat ``dp_client_id``, lifted to a single-PP-stage ``WorkerKey``
+        (pp_rank=0) so that each routing id matches exactly one
+        sibling and the fan-out collapses to a single submit per op."""
+        from flexkv.transfer.transfer_engine import TransferEngine
+
+        engine = object.__new__(TransferEngine)
+        engine._has_indexer = False
+        engine._worker_map = {}
+        engine._indexer_worker_map = {}
+        engine.op_id_to_op = {}
+        engine.op_id_to_nvtx_range = {}
+        engine.completed_queue = MagicMock()
+        engine.pin_buffer = MagicMock()
+        engine.cache_config = MagicMock()
+        engine.cache_config.tokens_per_block = 16
+        engine.model_config = ModelConfig(num_layers=2, num_kv_heads=1, head_size=1)
+        engine.rank_info = RankInfo(model_config=engine.model_config)
+        engine._child_id_to_child = {}
+        engine._child_to_parent_op_id = {}
+
+        # Single-PP-stage layout: each dp_client_id lifts to exactly
+        # one WorkerKey at pp_rank=0, so the symmetric fan-out
+        # collapses to a single submit per op.
+        workers = {
+            WorkerKey(dp_client_id=rk, pp_rank=0):
+                MagicMock(name=f"worker_{rk}")
+            for rk in routing_keys
+        }
+        engine._worker_map[transfer_type] = workers
+        return engine, workers
+
+    def test_dispatch_routes_to_exact_worker_per_key(self):
+        """Each ``dp_client_id`` in the matrix MUST land on its own worker
+        (and only its own worker), never on another row's worker. This
+        is the regression net for "silent 0 fallback"."""
+        engine, workers = self._make_engine_with_routing_keys(_ROUTING_KEY_MATRIX)
+
+        for rk in _ROUTING_KEY_MATRIX:
+            with self.subTest(dp_client_id=rk):
+                op = _make_op(TransferType.D2H, dp_client_id=rk)
+                engine.op_id_to_op[op.op_id] = op
+
+                with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
+                     patch('nvtx.start_range', return_value=MagicMock()):
+                    engine._assign_op_to_worker(op)
+
+                # The targeted worker received exactly one replica
+                # whose dp_client_id matches the parent's...
+                target_wk = WorkerKey(dp_client_id=rk, pp_rank=0)
+                self.assertEqual(workers[target_wk].submit_transfer.call_count, 1)
+                submitted = workers[target_wk].submit_transfer.call_args[0][0]
+                self.assertIsInstance(submitted, TransferOp)
+                self.assertIsNot(submitted, op,
+                                 "parent op MUST NOT be submitted directly; "
+                                 "only replicas reach workers")
+                self.assertEqual(submitted.dp_client_id, op.dp_client_id)
+                self.assertEqual(engine._child_to_parent_op_id[submitted.op_id],
+                                 op.op_id)
+                # ...and no other worker in the matrix saw anything.
+                for other_wk, other_worker in workers.items():
+                    if other_wk == target_wk:
+                        continue
+                    other_worker.submit_transfer.assert_not_called()
+
+                # Reset for next subTest.
+                for w in workers.values():
+                    w.submit_transfer.reset_mock()
+
+    def test_dispatch_unknown_routing_key_raises(self):
+        """A ``dp_client_id`` that matches zero registered
+        ``WorkerKey``s MUST raise ``ValueError``, never silently route
+        to id 0. This is the second half of the "no silent fallback"
+        invariant.
+        """
+        # Register only the baseline id; ask to dispatch with a non-baseline id.
+        baseline_rk = 0
+        engine, _ = self._make_engine_with_routing_keys([baseline_rk])
+
+        unknown_rk = 99  # not in the registered set
+        op = _make_op(TransferType.D2H, dp_client_id=unknown_rk)
+        engine.op_id_to_op[op.op_id] = op
+
+        with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
+             patch('nvtx.start_range', return_value=MagicMock()):
+            with self.assertRaises(ValueError):
+                engine._assign_op_to_worker(op)
+
+
+class TestWorkerKeyInvariants(unittest.TestCase):
+    """Hash/eq/construction invariants for the new WorkerKey identity.
+
+    These guard the "no dimension silently dropped" property at the type
+    level, complementing the dispatcher-level coverage above.
+    """
+
+    def test_workerkey_distinguishes_all_dimensions(self):
+        """Hash and equality MUST treat all WorkerKey fields as significant.
+
+        If any future refactor accidentally drops a field from __hash__ /
+        __eq__ (e.g. by overriding @dataclass(frozen=True) with a custom
+        __eq__), keys for distinct ranks would collapse and ops would
+        mis-route. This test fails loud the moment that happens.
+
+        Note: post-flatten, WorkerKey is two-dimensional
+        ``(dp_client_id, pp_rank)``; the two upstream DP dimensions
+        are folded into the flat ``dp_client_id``, so the variants
+        below mirror exactly the two dimensions the dict actually
+        keys on.
+        """
+        baseline = WorkerKey(dp_client_id=0, pp_rank=0)
+
+        # Each variant flips exactly one dimension; all must be != baseline
+        # AND mutually distinct (i.e. no two variants collapse together).
+        variants = {
+            "dp_client_id": WorkerKey(dp_client_id=1, pp_rank=0),
+            "pp_rank":      WorkerKey(dp_client_id=0, pp_rank=1),
+        }
+        for name, wk in variants.items():
+            with self.subTest(dimension=name):
+                self.assertNotEqual(wk, baseline)
+                self.assertNotEqual(hash(wk), hash(baseline))
+
+        # Pairwise distinctness — guards against e.g. dp_client_id and
+        # pp_rank being XOR-folded into the same hash bucket via an
+        # over-clever __hash__.
+        all_keys = [baseline] + list(variants.values())
+        self.assertEqual(len(set(all_keys)), len(all_keys),
+                         "WorkerKey variants must be pairwise distinct")
+
+        # Re-construction equality: same fields → equal & same hash. Sanity
+        # check that we did NOT accidentally make WorkerKey identity-based.
+        same = WorkerKey(dp_client_id=0, pp_rank=0)
+        self.assertEqual(same, baseline)
+        self.assertEqual(hash(same), hash(baseline))
+
+
+# ---------------------------------------------------------------------------
+# Tests – pending_count bookkeeping across the 4 main×indexer worker shapes.
+#
+# Pure-counter invariant: after dispatch, ``op.pending_count`` MUST equal
+# the total number of worker tasks actually submitted on the op's behalf
+# (main-KV replicas + indexer replicas), regardless of which side is a
+# WorkerKey-indexed dict and which is a singleton WorkerHandle.
+#
+# Pre-refactor this was wrong by 1 in two of the four shapes, because
+# ``_fan_out_to_pp_siblings`` skipped the "first" replica's += under the
+# (now-removed) assumption that the parent op carried a self-counted +1.
+# These subtests lock the new invariant in across all four shapes so the
+# old bug cannot silently come back.
+# ---------------------------------------------------------------------------
+
+class TestPendingCountBookkeepingMatrix(unittest.TestCase):
+    """``pending_count`` MUST equal the number of submitted worker tasks
+    for every main×indexer worker-shape combination."""
+
+    def _make_engine(
+        self,
+        *,
+        main_dict: bool,
+        indexer: str,  # "none" | "dict" | "singleton"
+        n_main_siblings: int = 1,
+        n_indexer_siblings: int = 1,
+    ):
+        """Build a TransferEngine stub with exactly the requested shapes.
+
+        For dict shapes, sibling WorkerKeys all share the same
+        flat ``dp_client_id`` and only differ in ``pp_rank`` so
+        every sibling matches the op's dp_client_id.
+        """
+        from flexkv.transfer.transfer_engine import TransferEngine
+
+        engine = object.__new__(TransferEngine)
+        engine._has_indexer = (indexer != "none")
+        engine._worker_map = {}
+        engine._indexer_worker_map = {}
+        engine.op_id_to_op = {}
+        engine.op_id_to_nvtx_range = {}
+        engine.completed_queue = MagicMock()
+        engine.pin_buffer = MagicMock()
+        engine.cache_config = MagicMock()
+        engine.cache_config.tokens_per_block = 16
+        engine.model_config = ModelConfig(num_layers=2, num_kv_heads=1, head_size=1)
+        engine.rank_info = RankInfo(model_config=engine.model_config)
+        # Unified child tracking (replaces _indexer_op_to_parent_op /
+        # _indexer_op_map / _pp_replica_to_parent_op).
+        engine._child_id_to_child = {}
+        engine._child_to_parent_op_id = {}
+
+        # Main KV side: dict (n siblings, all matching) or a single singleton handle.
+        if main_dict:
+            engine._worker_map[TransferType.D2H] = {
+                WorkerKey(dp_client_id=0, pp_rank=pp): MagicMock(
+                    name=f"main_pp{pp}")
+                for pp in range(n_main_siblings)
+            }
+        else:
+            engine._worker_map[TransferType.D2H] = MagicMock(name="main_singleton")
+
+        # Indexer side: absent / dict / singleton.
+        if indexer == "dict":
+            engine._indexer_worker_map[TransferType.D2H] = {
+                WorkerKey(dp_client_id=0, pp_rank=pp): MagicMock(
+                    name=f"indexer_pp{pp}")
+                for pp in range(n_indexer_siblings)
+            }
+        elif indexer == "singleton":
+            engine._indexer_worker_map[TransferType.D2H] = MagicMock(name="indexer_singleton")
+        # else: indexer == "none" → no entry, _has_indexer=False already
+
+        return engine
+
+    def _dispatch(self, engine, op):
+        with patch('flexkv.transfer.transfer_engine.register_op_to_buffer'), \
+             patch('nvtx.start_range', return_value=MagicMock()):
+            engine._assign_op_to_worker(op)
+
+    def _expected_submissions(self, engine) -> int:
+        """Count the unique submit_transfer calls actually issued, by walking
+        every worker mock in both maps. This is the ground-truth number the
+        invariant requires ``op.pending_count`` to equal."""
+        total = 0
+        for tt_map in (engine._worker_map, engine._indexer_worker_map):
+            for entry in tt_map.values():
+                if isinstance(entry, dict):
+                    for w in entry.values():
+                        total += w.submit_transfer.call_count
+                else:
+                    total += entry.submit_transfer.call_count
+        return total
+
+    def test_pending_count_matches_submissions_across_all_shapes(self):
+        """The invariant: ``op.pending_count == #submitted worker tasks``,
+        for every (main_shape, indexer_shape, fan-out widths) combination."""
+        cases = [
+            # (label, main_dict, indexer, n_main, n_indexer, expected_total)
+            ("dict-main(1)+no-indexer",        True,  "none",      1, 0, 1),
+            ("dict-main(3)+no-indexer",        True,  "none",      3, 0, 3),
+            ("singleton-main+no-indexer",      False, "none",      0, 0, 1),
+            ("dict-main(1)+singleton-indexer", True,  "singleton", 1, 0, 2),
+            ("dict-main(3)+singleton-indexer", True,  "singleton", 3, 0, 4),
+            ("singleton-main+singleton-indexer", False, "singleton", 0, 0, 2),
+            # The two shapes the OLD code under-counted by 1:
+            ("dict-main(2)+dict-indexer(2)",   True,  "dict",      2, 2, 4),
+            ("dict-main(3)+dict-indexer(2)",   True,  "dict",      3, 2, 5),
+            ("singleton-main+dict-indexer(2)", False, "dict",      0, 2, 3),
+            ("singleton-main+dict-indexer(3)", False, "dict",      0, 3, 4),
+        ]
+        for label, main_dict, indexer, n_main, n_indexer, expected in cases:
+            with self.subTest(case=label):
+                engine = self._make_engine(
+                    main_dict=main_dict,
+                    indexer=indexer,
+                    n_main_siblings=n_main,
+                    n_indexer_siblings=n_indexer,
+                )
+                op = _make_op(TransferType.D2H,
+                              dp_client_id=0)
+                engine.op_id_to_op[op.op_id] = op
+                self.assertEqual(op.pending_count, 0,
+                                 "fresh op must default to 0 (pure-counter semantics)")
+
+                self._dispatch(engine, op)
+
+                actual_submissions = self._expected_submissions(engine)
+                self.assertEqual(actual_submissions, expected,
+                                 f"[{label}] sanity: submissions count mismatch")
+                self.assertEqual(
+                    op.pending_count, expected,
+                    f"[{label}] pending_count ({op.pending_count}) MUST equal "
+                    f"the number of submitted worker tasks ({expected}). "
+                    f"If this fails, the pre-refactor 'self-counts-as-one' "
+                    f"bug has come back."
+                )
+
+    def test_simulating_all_completions_finalizes_exactly_once(self):
+        """End-to-end: after dispatch, simulating one completion per submitted
+        task MUST drive pending_count back to 0 and trigger _finalize_op
+        exactly once. This is the property the bug actually broke (with
+        the old code, pending_count would underflow or never hit 0 in
+        the dict+dict and singleton-main+dict-indexer shapes)."""
+        # Pick the previously-buggy shape as the canary.
+        engine = self._make_engine(
+            main_dict=True, indexer="dict",
+            n_main_siblings=2, n_indexer_siblings=2,
+        )
+        op = _make_op(TransferType.D2H,
+                      dp_client_id=0)
+        engine.op_id_to_op[op.op_id] = op
+
+        self._dispatch(engine, op)
+        self.assertEqual(op.pending_count, 4)
+
+        # Drain: 4 completions → pending_count should land exactly at 0.
+        finalize_mock = MagicMock()
+        finished_ops: List[TransferOp] = []
+        for _ in range(op.pending_count):  # snapshot since we mutate it
+            op.pending_count -= 1
+        # Simulating the scheduler-loop's "if 0 then finalize" check once
+        # per worker completion is what TestFinalizeOpLogic covers; here
+        # we only care that the target lands cleanly at 0.
+        self.assertEqual(op.pending_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce a frozen `RankInfo` dataclass that holds all per-rank indices (tp_rank, pp_rank, dp_rank, attn_cp_rank, node_rank, instance_id, pp_start_layer, pp_end_layer) and derived per-rank properties. `ModelConfig` now only carries global parallelism sizes (tp_size, pp_size, dp_size, etc.) and is frozen after initialization, eliminating a category of mutation bugs.

Key changes:
- Add `RankInfo` to `flexkv.common.config`; move all rank-specific fields (tp_rank, pp_rank, dp_rank, node_rank, pp_start_layer, pp_end_layer, etc.) out of `ModelConfig` into `RankInfo`.
- Replace `dp_rank`/`pp_rank` fields in `TransferOp`, `WorkerKey`, `KVTask`, and all API surfaces with a single `dp_client_id`, removing the caller's need to track both dimensions separately.
- Remove `layer_id` and `layer_granularity` from `TransferOp` and worker interfaces; workers now always transfer all layers of their PP stage, simplifying the transfer path and eliminating dead partial-layer code.
- Unify indexer/PP-replica child-op bookkeeping in `TransferEngine` into a single `_child_id_to_child` / `_child_to_parent_op_id` map with a generic `pending_count` mechanism (initialized to 0, incremented on dispatch).
- `update_default_config_from_user_config` now takes `RankInfo` instead of `ModelConfig` so block-size derivation uses per-PP-stage layer count.
- `FlexKVConfig.post_init_from_*` methods now return `RankInfo`; integration adapters (sglang, vllm, trt-llm) updated accordingly.
- Remove `resolve_master_host_and_ports` / env-var fallback for master_host; host/ports now live directly on `ModelConfig` and must be set explicitly by the integration layer.
- Move `instance_id`/`instance_num` from `GLOBAL_CONFIG_FROM_ENV` into `ModelConfig`/`RankInfo`, reducing reliance on global env singletons.
- Add `effective_tp_size_per_node` property to `ModelConfig` for correct per-node TP calculations with attention-DP.