### PR TITLE
Validate block id range in Mempool.recycle_blocks

### DIFF
--- a/flexkv/cache/mempool.py
+++ b/flexkv/cache/mempool.py
@@ -1,4 +1,5 @@
 from collections import deque
+from operator import le
 from typing import List
 
 import numpy as np
@@ -42,7 +43,10 @@ class Mempool:
     def recycle_blocks(self, block_ids: np.ndarray) -> None:
         if block_ids.ndim != 1 or block_ids.dtype != np.int64:
             raise ValueError("block_ids must be a 1D tensor of int64")
-        
+        if len(block_ids) == 0:
+            return
+        if np.any(block_ids < 0) or np.any(block_ids >= self.num_total_blocks):
+            raise ValueError("block_ids must be within the range of [0, num_total_blocks)")
         # Remove duplicates first (same block ID appearing multiple times)
         block_ids = np.unique(block_ids)
         

--- a/flexkv/cache/mempool.py
+++ b/flexkv/cache/mempool.py
@@ -1,5 +1,4 @@
 from collections import deque
-from operator import le
 from typing import List
 
 import numpy as np


### PR DESCRIPTION
Mempool.recycle_blocks currently validates ndim and dtype, but out-of-range block ids are not rejected explicitly. In particular, negative ids are accepted by NumPy indexing and can refer to valid entries from the end of the free mask.