### PR TITLE
fix: handle shutdown signal in inner batch loop of TransferWorker.run()

### DIFF
--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -246,6 +246,7 @@ class TransferWorkerBase(ABC):
 
     def run(self) -> None:
         """main loop for worker process"""
+        should_shutdown = False
         while True:
             try:
                 if self.transfer_conn.poll(timeout=0.0001):  # check if data available
@@ -262,6 +263,7 @@ class TransferWorkerBase(ABC):
                     while self.transfer_conn.poll(timeout=0):
                         op = self.transfer_conn.recv()
                         if op is None:
+                            should_shutdown = True
                             break
                         batch_ops.append(op)
                     for op in batch_ops:
@@ -279,6 +281,13 @@ class TransferWorkerBase(ABC):
                         if transfer_status:
                             ## only put the op when transfer success
                             self.finished_ops_queue.put(op.transfer_op_id)
+                    if should_shutdown:
+                        if hasattr(self, "shutdown") and callable(self.shutdown):
+                            try:
+                                self.shutdown()
+                            except Exception as e:
+                                flexkv_logger.error(f"Error when shut down worker: {e}")
+                        break
                 else:
                     continue
             except EOFError:


### PR DESCRIPTION
## Problem

In `TransferWorkerBase.run()`, when the outer loop receives a normal 
op and enters the inner batch-collection loop, a concurrent `shutdown()` 
call may send `None` which gets consumed by the inner loop.

The inner loop only does `break` on `None`, missing the shutdown logic 
that the outer loop handles correctly. The worker then exits only via 
`EOFError`, skipping cleanup.

## Trigger Condition

1. Outer loop polls and receives a normal op
2. `shutdown()` is called concurrently, sending `None`
3. Inner loop receives `None`, only breaks out of inner loop
4. Outer loop continues, shutdown logic never executes
5. Worker exits only via `EOFError`, skipping cleanup

## Fix

Add a `should_shutdown` flag. When the inner loop receives `None`, 
set the flag and break. After the current batch finishes processing, 
check the flag and execute shutdown logic before exiting.

This ensures in-flight ops are completed before shutdown, and cleanup 
is always called.