### PR TITLE
fix: move critical section updates inside lock in SharedOpPool.allocate_slot

### DIFF
--- a/flexkv/common/ring_buffer.py
+++ b/flexkv/common/ring_buffer.py
@@ -61,10 +61,10 @@ class SharedOpPool:
 
                 slot_id = self.free_slots.popleft()
                 self.slot_map[slot_hash] = slot_id
-
-        # update status managers
-        self.slot_ref_count[slot_id] += 1
-        self.slot_hashes[slot_id] = slot_hash
+            # update status managers
+            self.slot_ref_count[slot_id] += 1
+            self.slot_hashes[slot_id] = slot_hash
+        
 
         # do copy
         if not reuse:


### PR DESCRIPTION
## Problem

In `SharedOpPool.allocate_slot`, `slot_ref_count` and `slot_hashes` 
updates were outside the lock, creating a race condition where two 
threads could obtain the same slot_id and corrupt the reference count.

## Fix

Move `slot_ref_count[slot_id] += 1` and `slot_hashes[slot_id] = slot_hash`
inside the lock to ensure atomic slot allocation.