### PR TITLE
fix: update task.slot_mapping in _set_slot_mapping_impl

### DIFF
--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -405,6 +405,7 @@ class KVTaskManager:
         graph_ids = self.cache_engine.slot_mapping_to_block_ids(slot_mapping,
                                                                 self.cache_config.tokens_per_block)
         task.graph.set_gpu_blocks(graph_ids)
+        task.slot_mapping = slot_mapping
         task.status = TaskStatus.READY
 
     def _gen_task_id(self) -> int:


### PR DESCRIPTION
## Problem

In `_set_slot_mapping_impl`, `task.graph` GPU block ids and `task.status`
were updated, but `task.slot_mapping` was not.

This caused `merge_to_batch_kvtask` to read the fake zero slot_mapping
set during `create_get_task`, leading to incorrect batch KV task merging.

## Fix

Add `task.slot_mapping = slot_mapping` after updating the graph,
ensuring the task reflects the real slot mapping before status is
set to READY.
