### PR TITLE
fix: cancel KVTask immediately when match/put condition not met to prevent memory leak

### DIFF
--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -251,7 +251,6 @@ class FlexKVSchedulerConnector:
         if not self._need_to_get(num_prompt_tokens=request.num_tokens,
                                    num_computed_tokens=num_computed_tokens,
                                    num_new_matched_tokens=num_new_matched_tokens):
-            self.flexkv_manager.cancel(task_ids=[task_id])
             return 0, False
 
         return num_new_matched_tokens, True
@@ -449,7 +448,6 @@ class FlexKVSchedulerConnector:
         if not self._need_to_put(num_all_tokens=request.num_tokens,
                                 num_matched_tokens=num_matched_tokens,
                                 num_unmatched_tokens=num_unmatched_tokens):
-            self.flexkv_manager.cancel(task_ids=[task_id])
             return False
 
         # prepare to launch task
@@ -507,7 +505,8 @@ class FlexKVSchedulerConnector:
                                                         match_start_time=match_start_time,
                                                         match_end_time=match_end_time)
             # logger.debug(f"FlexKV create put task: {self.tasks_to_cancel[task_id]}")
-
+        else:
+            self.flexkv_manager.cancel(task_ids=[task_id])
         return task_id, num_matched_tokens, num_unmatched_tokens
 
     def _need_to_put(

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -251,6 +251,7 @@ class FlexKVSchedulerConnector:
         if not self._need_to_get(num_prompt_tokens=request.num_tokens,
                                    num_computed_tokens=num_computed_tokens,
                                    num_new_matched_tokens=num_new_matched_tokens):
+            self.flexkv_manager.cancel(task_ids=[task_id])
             return 0, False
 
         return num_new_matched_tokens, True
@@ -448,6 +449,7 @@ class FlexKVSchedulerConnector:
         if not self._need_to_put(num_all_tokens=request.num_tokens,
                                 num_matched_tokens=num_matched_tokens,
                                 num_unmatched_tokens=num_unmatched_tokens):
+            self.flexkv_manager.cancel(task_ids=[task_id])
             return False
 
         # prepare to launch task


### PR DESCRIPTION
## Problem

In `_get_match()` and the put path, `flexkv_manager.get_match()` / 
`get_put()` unconditionally creates a KVTask stored in 
`KVTaskManager.tasks`. When the match/put condition is not met 
(num_new_matched_tokens == 0 or num_unmatched_tokens == 0), the 
task is neither added to `req_id_to_task_dict` nor cancelled, 
causing it to leak in `self.tasks` until ExpiringDict auto-expires 
it after 30 minutes.

Under high concurrency with frequent cache misses, each request 
produces a leaked KVTask holding `token_ids`, `slot_mapping`, and 
`token_mask` arrays, leading to significant memory pressure.

## Fix

Call `self.flexkv_manager.cancel(task_ids=[task_id])` immediately 
in the early-return branches where the task would otherwise be 
abandoned, ensuring prompt cleanup of task resources.