### PR TITLE
avoid per-IO iovec allocation in SSD io_uring path

### DIFF
--- a/csrc/transfer_ssd.h
+++ b/csrc/transfer_ssd.h
@@ -96,8 +96,6 @@ public:
         if (cqes[i]->res < 0) {
           cqe_err++;
         }
-        iov2 = reinterpret_cast<iovec *>(io_uring_cqe_get_data(cqes[i]));
-        delete iov2;
       }
       total_completed += count;
       inflight -= count;
@@ -123,14 +121,12 @@ public:
       return -1;
     }
 
-    iov = new iovec;
-    iov->iov_base = ptr;
-    iov->iov_len = size;
-    io_uring_prep_readv(sqe, fd, iov, 1, offset);
+    // Single-segment I/O: io_uring_prep_read takes (buf, len) directly, so we
+    // avoid a per-I/O heap iovec (and the matching delete on completion).
+    io_uring_prep_read(sqe, fd, ptr, size, offset);
 
     sqe->ioprio = read_ioprio;
 
-    io_uring_sqe_set_data(sqe, iov);
     prepared++;
     return 0;
   }
@@ -146,14 +142,12 @@ public:
       return -1;
     }
 
-    iov = new iovec;
-    iov->iov_base = ptr;
-    iov->iov_len = size;
-    io_uring_prep_writev(sqe, fd, iov, 1, offset);
+    // Single-segment I/O: io_uring_prep_write takes (buf, len) directly, so we
+    // avoid a per-I/O heap iovec (and the matching delete on completion).
+    io_uring_prep_write(sqe, fd, ptr, size, offset);
 
     sqe->ioprio = write_ioprio;
 
-    io_uring_sqe_set_data(sqe, iov);
     prepared++;
     return 0;
   }
@@ -184,16 +178,13 @@ private:
         cqe_err++;
       }
 
-      iov2 = reinterpret_cast<iovec *>(io_uring_cqe_get_data(cqe));
       io_uring_cqe_seen(&ring, cqe);
       total_completed++;
       inflight--;
-      delete iov2;
     }
     return 0;
   }
 
-  iovec *iov, *iov2;
   io_uring ring;
   io_uring_sqe *sqe;
   io_uring_cqe *cqe;


### PR DESCRIPTION
## Summary

This PR replaces the single-entry `readv`/`writev` io_uring preparation path with `io_uring_prep_read` / `io_uring_prep_write` in the SSD io_uring backend.

Previously, each I/O request allocated a heap `iovec` and attached it to the SQE only so it could be deleted after CQE completion. Since the current SSD transfer path only submits single-buffer I/O, the vectored API is unnecessary. Passing the buffer pointer and length directly is equivalent and removes the per-I/O allocation/free bookkeeping.

## Changes

- Use `io_uring_prep_read` instead of `io_uring_prep_readv` for single-segment reads.
- Use `io_uring_prep_write` instead of `io_uring_prep_writev` for single-segment writes.
- Remove per-I/O heap `iovec` allocation and deletion.
- Remove unused `iov` / `iov2` members and SQE user-data bookkeeping that existed only for freeing the `iovec`.

## Performance

Benchmarked locally and did not observe a significant performance difference.

This change is mainly intended to reduce unnecessary allocation overhead and simplify the io_uring SSD I/O path rather than improve end-to-end throughput.