### PR TITLE
 Feature: SWA pool attached to Radix node

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -660,7 +660,9 @@ PYBIND11_MODULE(c_ext, m) {
       .def("match_prefix", &flexkv::CRadixTreeIndex::match_prefix,
            py::arg("block_hashes"), py::arg("num_blocks"),
            py::arg("update_cache_info"),
-           py::call_guard<py::gil_scoped_release>());
+           py::call_guard<py::gil_scoped_release>())
+      .def("drain_freed_swa_slots",
+           &flexkv::CRadixTreeIndex::drain_freed_swa_slots);
 
   py::class_<flexkv::CRadixNode>(m, "CRadixNode")
       .def(py::init<flexkv::CRadixTreeIndex *, bool, int>())
@@ -668,7 +670,16 @@ PYBIND11_MODULE(c_ext, m) {
       .def("size", &flexkv::CRadixNode::size)
       .def("has_block_node_ids", &flexkv::CRadixNode::has_block_node_ids)
       .def_property_readonly("parent", &flexkv::CRadixNode::get_parent,
-                             py::return_value_policy::reference);
+                             py::return_value_policy::reference)
+      // ===== SWA accessors (node-attached SWA state) =====
+      .def_property("swa_host_slot", &flexkv::CRadixNode::get_swa_host_slot,
+                    &flexkv::CRadixNode::set_swa_host_slot)
+      .def_property("swa_tombstone", &flexkv::CRadixNode::get_swa_tombstone,
+                    &flexkv::CRadixNode::set_swa_tombstone)
+      .def_property_readonly("swa_lock_ref",
+                             &flexkv::CRadixNode::get_swa_lock_ref)
+      .def("inc_swa_lock_ref", &flexkv::CRadixNode::inc_swa_lock_ref)
+      .def("dec_swa_lock_ref", &flexkv::CRadixNode::dec_swa_lock_ref);
 
   py::class_<flexkv::CMatchResult, std::shared_ptr<flexkv::CMatchResult>>(
       m, "CMatchResult")

--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -571,6 +571,9 @@ int LocalRadixTree::evict(torch::Tensor &evicted_blocks, int num_evicted) {
         done++;
       }
       delete blocks;
+      // SWA: node survives but its trailing range shrank, so any snapshot on it
+      // no longer covers the full range. Release the slot.
+      record_freed_swa_slot(node);
     } else {
       auto parent = node->get_parent();
       auto &blocks = node->get_physical_blocks();
@@ -593,6 +596,8 @@ int LocalRadixTree::evict(torch::Tensor &evicted_blocks, int num_evicted) {
         evicted_blocks_ptr[has_evicted + done] = *it;
         done++;
       }
+      // SWA: node is being deleted; release its slot if any so it is not leaked.
+      record_freed_swa_slot(node);
       remove_leaf(node);
       remove_node(node);
     }

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -696,11 +696,41 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
   }
 
   // Uncached layers (e.g. DSv4 layers 0/1/MTP with compress_ratio==0 at the
-  // model level) carry empty member lists and are skipped entirely — no
-  // kernels launched, no eventfd callback registered, no NVTX range opened.
-  // Sglang does not wait on their eventfds, so omitting the callback is safe.
+  // model level) carry empty member lists: no data to transfer, so no kernels
+  // are launched, no eventfd callback is registered, and no NVTX range opened.
+  //
+  // HOWEVER, the model's forward still waits per-layer on these eventfds for
+  // any path that reads a per-layer buffer regardless of compress_ratio. In
+  // particular DSv4-Flash's SWA reload path calls
+  // ``get_swa_key_buffer_radix(layer_id) -> wait_layer_transfer(layer_id) ->
+  // eventfd_read`` for EVERY layer (the SWA pool spans all layers, including
+  // the ratio==0 dense layers). If we never post the skipped layers' eventfds,
+  // the consumer blocks forever -> scheduler watchdog timeout. So we post a
+  // "no-op satisfied" signal (the same value 2 the real callback writes) for
+  // every skipped layer immediately: they have no in-flight transfer, so the
+  // data they cover (none) is trivially "ready". Done before the active-layer
+  // loop launches kernels so the consumer can never observe an unposted gap.
   std::vector<int> active_origs;
   active_origs.reserve(num_original_layers_);
+  if (enable_eventfd_ && num_counters_ > 0 && !layer_eventfds_.empty()) {
+    int offset = current_counter_id_ * tp_size_ * num_layers_;
+    int *eventfds_ptr = layer_eventfds_.data() + offset;
+    for (int orig = 0; orig < num_original_layers_; ++orig) {
+      if (!layer_members_[orig].empty()) {
+        continue;
+      }
+      for (int tp_rank = 0; tp_rank < tp_size_; ++tp_rank) {
+        int fd = eventfds_ptr[tp_rank * num_layers_ + orig];
+        if (fd >= 0) {
+          // Match layer_done_host_callback: write 2 to satisfy both
+          // get_key_buffer and get_value_buffer waits for this layer.
+          uint64_t val = 2;
+          ssize_t ret = write(fd, &val, sizeof(val));
+          (void)ret;
+        }
+      }
+    }
+  }
   for (int orig = 0; orig < num_original_layers_; ++orig) {
     if (!layer_members_[orig].empty()) {
       active_origs.push_back(orig);

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -163,6 +163,11 @@ CRadixNode *CRadixNode::split(int prefix_length) {
   new_node->set_child(get_head_hash(), this);
 
   set_parent(new_node);
+
+  // SWA: the snapshot stored on the original node covered the full pre-split
+  // range, which no longer exists. Free it (if any) and leave both halves as
+  // tombstones. new_node defaults to tombstone=true / slot=-1.
+  index->record_freed_swa_slot(this);
   return new_node;
 }
 
@@ -194,6 +199,12 @@ void CRadixNode::merge_child() {
     }
   }
   children.clear();
+
+  // SWA: the merged child disappears; release its slot if any. The parent (this)
+  // keeps its own SWA state, but since its block range grew, any snapshot on it
+  // no longer covers the full range either — free it too to stay conservative.
+  index->record_freed_swa_slot(child);
+  index->record_freed_swa_slot(this);
 
   child->clear_parent();
   index->remove_leaf(child);
@@ -354,6 +365,9 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted
       }
       delete blocks;
       delete block_hashes;
+      // SWA: node survives but its trailing range was removed, so any snapshot
+      // on it no longer covers the full range. Release the slot.
+      record_freed_swa_slot(node);
     } else {
       auto parent = node->get_parent();
       auto &blocks = node->get_physical_blocks();
@@ -376,6 +390,9 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted
           candidate.push(parent);
         }
       }
+
+      // SWA: node is being deleted; release its slot if any so it is not leaked.
+      record_freed_swa_slot(node);
 
       node->clear_parent();
       remove_leaf(node);

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -46,6 +46,16 @@ private:
   int hit_count;
   int leaf_vector_index = -1;
 
+  // ===== SWA (Sliding Window Attention) fields =====
+  // SWA snapshot state attached to this node. Mirrors the Python RadixNode
+  // fields (see flexkv/cache/radixtree.py). swa_host_slot uses -1 as the
+  // "no slot" sentinel (Python uses None). Invariant: SWA is a subset of full,
+  // i.e. a node may have full KV without SWA (tombstone), but never the reverse.
+  int swa_host_slot = -1;          // CPU SWA host pool slot id (-1 = no backup)
+  bool swa_tombstone = true;       // true = no SWA data available (default)
+  int swa_lock_ref = 0;            // SWA lock reference count
+  uint64_t swa_last_access_time = 0; // SWA LRU timestamp
+
   std::deque<int64_t> block_hashes;
   std::deque<int64_t> physical_blocks;
   std::unordered_map<HashType, CRadixNode *> children;
@@ -112,6 +122,28 @@ public:
   void set_leaf_vector_index(int index) { leaf_vector_index = index; }
 
   int get_leaf_vector_index() { return leaf_vector_index; }
+
+  // ===== SWA accessors =====
+  int get_swa_host_slot() { return swa_host_slot; }
+
+  void set_swa_host_slot(int slot) { swa_host_slot = slot; }
+
+  bool get_swa_tombstone() { return swa_tombstone; }
+
+  void set_swa_tombstone(bool tombstone) { swa_tombstone = tombstone; }
+
+  int get_swa_lock_ref() { return swa_lock_ref; }
+
+  void inc_swa_lock_ref() { swa_lock_ref++; }
+
+  void dec_swa_lock_ref() {
+    assert(swa_lock_ref > 0);
+    swa_lock_ref--;
+  }
+
+  void set_swa_last_access_time(uint64_t time) { swa_last_access_time = time; }
+
+  uint64_t get_swa_last_access_time() { return swa_last_access_time; }
 
   void update_time(int hit_reward_seconds) {
     struct timeval now;
@@ -254,6 +286,12 @@ protected:
   int hit_reward_seconds;
   EvictionPolicy eviction_policy;
 
+  // SWA slots that were freed because their node was deleted/invalidated by a
+  // structural change (split / merge / evict). The Python side drains this and
+  // returns the slots to the SWA host pool, enforcing the SWA-subset-of-full
+  // invariant (full evicted => SWA slot must be released).
+  std::vector<int> freed_swa_slots;
+
 public:
   CRadixTreeIndex(int tokens_per_block, int max_num_blocks = 1000000,
                   int hit_reward_seconds = 0,
@@ -363,6 +401,25 @@ public:
   void inc_node_count() { node_count++; }
 
   void dec_node_count() { node_count--; }
+
+  // If the node holds a SWA host-pool slot, record it for release and clear the
+  // node's SWA state. Called from any path that deletes or invalidates a node
+  // (split / merge / evict) so the slot is never leaked.
+  void record_freed_swa_slot(CRadixNode *node) {
+    int slot = node->get_swa_host_slot();
+    if (slot != -1) {
+      freed_swa_slots.push_back(slot);
+      node->set_swa_host_slot(-1);
+      node->set_swa_tombstone(true);
+    }
+  }
+
+  // Drain and return all SWA slots freed since the last call.
+  std::vector<int> drain_freed_swa_slots() {
+    std::vector<int> out;
+    out.swap(freed_swa_slots);
+    return out;
+  }
 
   virtual void set_ready(CRadixNode *node, bool ready = true,
                          int ready_length = -1) {

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -79,6 +79,29 @@ class CacheEngineAccel:
         self.event_collector = event_collector
         self._metrics_collector = metrics_collector
 
+        # SWA (Sliding Window Attention) production manager — node-attached.
+        # Created lazily via init_swa() when SWA is enabled. SWA state lives on
+        # each CRadixNode (swa_host_slot / swa_tombstone); this manager owns only
+        # the host pool and the LRU ordering for SWA-only eviction. Cascade
+        # eviction is driven by self.index.drain_freed_swa_slots() in insert()/take().
+        self.swa_manager = None
+
+    def init_swa(self, swa_config: "SWAPoolConfig") -> None:
+        """Initialize the node-attached SWA manager for this cache engine."""
+        from flexkv.swa.swa_production_manager import SWAProductionManager
+        self.swa_manager = SWAProductionManager(
+            config=swa_config,
+            tokens_per_block=self.tokens_per_block,
+        )
+
+    def _drain_swa_slots(self) -> None:
+        """Return SWA slots freed by structural tree changes (split/evict) to the pool."""
+        if self.swa_manager is None:
+            return
+        freed_slots = self.index.drain_freed_swa_slots()
+        if freed_slots:
+            self.swa_manager.free_slots(freed_slots)
+
     def reset(self) -> None:
         self.index.reset()
         self.mempool.reset()
@@ -138,6 +161,11 @@ class CacheEngineAccel:
                 block_size=self.tokens_per_block,
                 medium=DEVICE_TYPE[self.device_type]
             )
+
+        # Cascade (SWA subset of full): insert may split an existing node, which
+        # invalidates its SWA snapshot. Drain freed slots back to the pool now.
+        self._drain_swa_slots()
+
         return node
 
     def lock_node(self, node: CRadixNode) -> None:
@@ -183,6 +211,10 @@ class CacheEngineAccel:
                     evicted_block_hashes.resize_(num_evicted)
                 target_blocks = target_blocks.numpy()
                 self.mempool.recycle_blocks(target_blocks)
+
+                # Cascade (SWA subset of full): evicted/split nodes recorded their
+                # SWA slots; return them to the pool so they are not leaked.
+                self._drain_swa_slots()
 
                 # Record eviction metrics
                 if self._metrics_collector is not None and num_evicted > 0:

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -105,9 +105,11 @@ class HierarchyLRCacheEngine:
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the production SWA manager for this cache engine.
 
-        Should be called after construction when SWA is enabled.
-        The SWA manager uses endpoint hashing to track SWA data independently
-        of the C++ radix tree node objects.
+        Should be called after construction when SWA is enabled. The SWA manager
+        is node-attached: SWA state lives on each CRadixNode (swa_host_slot /
+        swa_tombstone), and this manager owns only the host pool and the LRU
+        ordering used for SWA-only eviction. Cascade eviction is driven by the
+        tree's drain_freed_swa_slots() (see insert() and take()).
 
         Args:
             swa_config: SWA pool configuration.
@@ -348,6 +350,15 @@ class HierarchyLRCacheEngine:
             )
         # NOTE: Do NOT lock the node here, because the caller (put() method) will lock it
         # The node will be unlocked in _transfer_callback after data transfer completes
+
+        # Cascade (SWA subset of full): insert may split an existing node, which
+        # invalidates its SWA snapshot. Drain any slots freed by that split so
+        # they are returned to the pool promptly rather than at the next evict.
+        if self.swa_manager is not None:
+            freed_slots = self.local_index.drain_freed_swa_slots()
+            if freed_slots:
+                self.swa_manager.free_slots(freed_slots)
+
         return node
 
     def lock_node(self, node: CRadixNode) -> None:
@@ -445,9 +456,13 @@ class HierarchyLRCacheEngine:
                 evicted_np = target_blocks.numpy()
                 self.mempool.recycle_blocks(evicted_np)
 
-                # Notify SWA manager about evicted blocks (cascade eviction)
-                if self.swa_manager is not None and num_evicted > 0:
-                    self.swa_manager.on_blocks_evicted(evicted_np)
+                # Cascade eviction (SWA subset of full): the C++ tree recorded
+                # the SWA slots of any node deleted/invalidated by this evict (and
+                # by any split during insert). Drain them and return to the pool.
+                if self.swa_manager is not None:
+                    freed_slots = self.local_index.drain_freed_swa_slots()
+                    if freed_slots:
+                        self.swa_manager.free_slots(freed_slots)
             
             if protected_node is not None:
                 self.local_index.unlock(protected_node)

--- a/flexkv/cache/radix_remote.py
+++ b/flexkv/cache/radix_remote.py
@@ -261,6 +261,15 @@ class LocalRadixTree:
             raise RuntimeError("LocalRadixTree must be started before calling insert_and_publish")
         return bool(self._c.insert_and_publish(node))
 
+    def drain_freed_swa_slots(self) -> List[int]:
+        """Drain SWA host-pool slots freed by structural changes (split/merge/evict).
+
+        Returns the list of slot ids whose owning node was deleted or invalidated
+        since the last call. The caller (SWA manager) returns them to the host
+        pool, enforcing the "SWA subset of full" invariant.
+        """
+        return list(self._c.drain_freed_swa_slots())
+
     def drain_pending_queues(self) -> int:
         return int(self._c.drain_pending_queues())
 

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -411,6 +411,34 @@ class FlexKVConfig:
         )
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
+        # ---- SWA host pool config (DeepSeek V4 all-SWA models) ----
+        # DSv4 stores its sliding-window KV in a dedicated paged pool whose
+        # physical page/window is swa_page_size (hard-asserted == 256 in
+        # sglang model_runner_kv_cache_mixin), NOT the HF attention
+        # sliding_window (128). The per-token byte size is hard-asserted to
+        # 584 (qk_nope_head_dim fp8 448 + qk_rope_head_dim bf16 128 + scale 8)
+        # in DeepSeekV4SingleKVPool. Without this config, cache_config.swa
+        # stays None -> kvmanager.swa_available() always returns False -> the
+        # connector never stores/reloads SWA KV, so host->device reload (H2D)
+        # is never triggered for this all-SWA model.
+        is_dsv4 = bool(getattr(sglang_config, "is_deepseek_v4_arch", False))
+        if is_dsv4 and self.cache_config.swa is None:
+            swa_window = 256  # physical swa_page_size, asserted == 256 by sglang
+            self.cache_config.swa = SWAPoolConfig(
+                enabled=True,
+                window_size=swa_window,
+                num_swa_layers=self.model_config.num_layers,
+                bytes_per_token_per_layer=584,
+            )
+            logger.info(
+                f"[FlexKV sglang] Constructed SWAPoolConfig for DSv4: "
+                f"window_size={swa_window}, "
+                f"num_swa_layers={self.model_config.num_layers}, "
+                f"bytes_per_token_per_layer=584, "
+                f"num_slots={self.cache_config.swa.num_slots}, "
+                f"slot_size_bytes={self.cache_config.swa.slot_size_bytes}"
+            )
+
         logger.info(f"[FlexKV sglang] {self.model_config}, {rank_info}")
 
         # Freeze model_config — no further mutations allowed

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -28,6 +28,7 @@ from flexkv.common.config import ModelConfig, CacheConfig, GLOBAL_CONFIG_FROM_EN
 from flexkv.integration.dynamo.collector import KVEventCollector
 from flexkv.common.debug import flexkv_logger
 from flexkv.cache.redis_meta import RedisMeta
+from flexkv.common.block import SequenceMeta
 
 
 class KVManager:
@@ -324,58 +325,100 @@ class KVManager:
 
     # ===== SWA (Sliding Window Attention) Integration =====
 
+    def _get_cpu_cache_engine(self):
+        """Return the CPU cache engine that owns the local radix tree.
+
+        Only available in non-server_client_mode (the engine runs in-process).
+        DSv4 SWA runs in this mode. Works for CacheEngineAccel (default,
+        index_accel=1), CacheEngine, and HierarchyLRCacheEngine. Returns None if
+        unavailable.
+        """
+        if self.server_client_mode:
+            return None
+        try:
+            return self.kv_task_engine.cache_engine.cpu_cache_engine
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def _engine_tree(engine):
+        """Return the radix tree index of a cache engine, field-name agnostic.
+
+        CacheEngineAccel / CacheEngine expose it as `index`; HierarchyLRCacheEngine
+        (p2p path) as `local_index`. Returns None if neither is present.
+        """
+        tree = getattr(engine, "index", None)
+        if tree is None:
+            tree = getattr(engine, "local_index", None)
+        return tree
+
     def _get_swa_production_manager(self):
-        """Lazily create SWAProductionManager if SWA is configured (production C++ path)."""
+        """Return the node-attached SWAProductionManager owned by the cache engine.
+
+        The manager is created once (lazily) on the cache engine via init_swa(),
+        so that SWA put/get (here) and cascade eviction (in the engine's take())
+        share a single pool and a single source of truth (the SWA state stored on
+        each CRadixNode).
+        """
         if hasattr(self, '_swa_prod_manager'):
             return self._swa_prod_manager
 
+        self._swa_prod_manager = None
         if self.cache_config.swa is None or not self.cache_config.swa.enabled:
-            self._swa_prod_manager = None
             return None
 
-        from flexkv.swa.swa_production_manager import SWAProductionManager
+        engine = self._get_cpu_cache_engine()
+        if engine is None:
+            return None
 
-        self._swa_prod_manager = SWAProductionManager(
-            config=self.cache_config.swa,
-            tokens_per_block=self.cache_config.tokens_per_block,
-        )
+        # Node-attached SWA requires the C++ tree (drain_freed_swa_slots) and an
+        # init_swa hook. CacheEngineAccel (default) and HierarchyLRCacheEngine
+        # qualify; the pure-Python CacheEngine fallback does not.
+        tree = self._engine_tree(engine)
+        if tree is None or not hasattr(tree, "drain_freed_swa_slots") \
+                or not hasattr(engine, "init_swa"):
+            flexkv_logger.warning(
+                "[KVManager] SWA enabled but cache engine does not support "
+                "node-attached SWA; SWA disabled for this engine."
+            )
+            return None
+
+        # Ensure the engine has a SWA manager and reuse it (single shared pool).
+        if getattr(engine, "swa_manager", None) is None:
+            engine.init_swa(self.cache_config.swa)
+        self._swa_prod_manager = engine.swa_manager
         flexkv_logger.info(
-            f"[KVManager] SWA production manager initialized: "
+            f"[KVManager] SWA production manager bound: "
             f"num_slots={self.cache_config.swa.num_slots}, "
             f"window_size={self.cache_config.swa.window_size}"
         )
         return self._swa_prod_manager
 
-    def _get_swa_connector(self):
-        """Lazily create SWAConnector if SWA is configured (Python radix tree path)."""
-        if hasattr(self, '_swa_connector'):
-            return self._swa_connector
+    def _match_node(self, token_ids: np.ndarray):
+        """Resolve token_ids to the deepest matching CRadixNode in the local tree.
 
-        if self.cache_config.swa is None or not self.cache_config.swa.enabled:
-            self._swa_connector = None
+        Returns the last matched node, or None if there is no match (empty tree
+        or no shared prefix). This is the single query path: SWA never does its
+        own prefix matching — it only reads SWA state off the resolved node.
+        """
+        engine = self._get_cpu_cache_engine()
+        if engine is None:
             return None
-
-        from flexkv.swa.swa_connector import SWAConnector
-        from flexkv.swa.swa_radix_manager import SWARadixManager
-
-        swa_manager = SWARadixManager(
-            config=self.cache_config.swa,
+        tree = self._engine_tree(engine)
+        if tree is None:
+            return None
+        seq = SequenceMeta(
+            token_ids=np.asarray(token_ids, dtype=np.int64),
             tokens_per_block=self.cache_config.tokens_per_block,
         )
-
-        # Get the radix tree index from the cache engine
-        radix_tree = self.kv_task_engine.cache_engine.cpu_cache_engine.tree_index
-
-        self._swa_connector = SWAConnector(
-            swa_manager=swa_manager,
-            radix_tree=radix_tree,
-        )
-        flexkv_logger.info(
-            f"[KVManager] SWA connector initialized: "
-            f"num_slots={self.cache_config.swa.num_slots}, "
-            f"window_size={self.cache_config.swa.window_size}"
-        )
-        return self._swa_connector
+        seq.gen_hashes()
+        if seq.num_blocks == 0:
+            return None
+        block_hashes_t = torch.from_numpy(seq.block_hashes).to(torch.int64)
+        mr = tree.match_prefix(block_hashes_t, int(seq.num_blocks), False)
+        if mr is None or int(mr.num_matched_blocks) == 0:
+            return None
+        return mr.last_node
 
     def swa_put(self,
                 token_ids: Union[torch.Tensor, np.ndarray],
@@ -396,23 +439,22 @@ class KVManager:
         Returns:
             True if stored successfully, False otherwise.
         """
-        # SWA pool is process-local (lives on every rank's leader connector).
-        # It does NOT need to go through dp_client/server. We can run the
-        # production SWAManager locally even in server_client_mode.
+        # SWA pool is process-local. Query the radix tree to resolve the node,
+        # then store the snapshot on it. swa_put does NOT depend on the full-KV
+        # put task having completed: the node only needs to exist in the tree
+        # (the ready blocks are inserted synchronously). If it isn't there yet,
+        # we skip storing — SWA can always be recomputed.
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
 
-        # Try production manager first
         prod_mgr = self._get_swa_production_manager()
-        if prod_mgr is not None:
-            return prod_mgr.put(token_ids, swa_data, physical_block_ids=physical_block_ids)
-
-        # Fallback to Python connector path
-        connector = self._get_swa_connector()
-        if connector is None:
+        if prod_mgr is None:
             return False
 
-        return connector.store_swa(token_ids, swa_data)
+        node = self._match_node(token_ids)
+        if node is None:
+            return False
+        return prod_mgr.put(node, swa_data)
 
     def swa_get(self,
                 token_ids: Union[torch.Tensor, np.ndarray]) -> Optional[Union[torch.Tensor, np.ndarray]]:
@@ -428,21 +470,17 @@ class KVManager:
         Returns:
             SWA data buffer or None if not available.
         """
-        # SWA pool is process-local (lives on every rank's leader connector).
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
 
-        # Try production manager first
         prod_mgr = self._get_swa_production_manager()
-        if prod_mgr is not None:
-            return prod_mgr.get(token_ids)
-
-        # Fallback to Python connector path
-        connector = self._get_swa_connector()
-        if connector is None:
+        if prod_mgr is None:
             return None
 
-        return connector.load_swa(token_ids)
+        node = self._match_node(token_ids)
+        if node is None:
+            return None
+        return prod_mgr.get(node)
 
     def swa_available(self,
                       token_ids: Union[torch.Tensor, np.ndarray]) -> bool:
@@ -458,18 +496,14 @@ class KVManager:
         Returns:
             True if SWA data is available for the trailing window.
         """
-        # SWA pool is process-local (lives on every rank's leader connector).
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
 
-        # Try production manager first
         prod_mgr = self._get_swa_production_manager()
-        if prod_mgr is not None:
-            return prod_mgr.has(token_ids)
-
-        # Fallback to Python connector path
-        connector = self._get_swa_connector()
-        if connector is None:
+        if prod_mgr is None:
             return False
 
-        return connector.check_swa(token_ids)
+        node = self._match_node(token_ids)
+        if node is None:
+            return False
+        return prod_mgr.has(node)

--- a/flexkv/swa/swa_host_pool.py
+++ b/flexkv/swa/swa_host_pool.py
@@ -59,7 +59,9 @@ class SWAHostPool:
     def write(self, slot_id: int, data: Union['torch.Tensor', np.ndarray, bytes]) -> None:
         """Write SWA data into a slot."""
         if isinstance(data, bytes):
-            arr = np.frombuffer(data, dtype=np.uint8)
+            # np.frombuffer on bytes yields a read-only array; copy so the
+            # resulting tensor is writable and torch.from_numpy stays quiet.
+            arr = np.frombuffer(data, dtype=np.uint8).copy()
         elif _TORCH_AVAILABLE and isinstance(data, torch.Tensor):
             arr = data.detach().cpu().view(-1).to(torch.uint8)
         else:

--- a/flexkv/swa/swa_production_manager.py
+++ b/flexkv/swa/swa_production_manager.py
@@ -1,20 +1,32 @@
-"""SWA Production Manager — Production-ready SWA manager for C++ radix trees.
+"""SWA Production Manager — node-attached SWA pool manager for C++ radix trees.
 
-Works with the C++ LocalRadixTree (via flexkv.c_ext) where nodes are opaque
-CRadixNode pointers that cannot have Python fields attached. Instead, SWA
-metadata is tracked in Python-side dictionaries keyed by an endpoint hash
-derived from the token sequence.
+Works with the C++ LocalRadixTree (via flexkv.c_ext) whose CRadixNode now
+carries SWA state directly (swa_host_slot / swa_tombstone / swa_lock_ref).
+This manager is therefore a thin layer over the SWA host pool plus an LRU
+ordering used only for *SWA-only* eviction (tombstoning). It does NOT do any
+prefix matching of its own — the caller resolves the node via the radix tree
+and passes it in.
 
-Design:
-    - Uses hash(token_ids[-tokens_per_block:].tobytes()) as the endpoint key
-    - Maintains a Dict[int, int] mapping: endpoint_hash -> swa_pool_slot_id
-    - Has its own LRU tracking (simple ordered list, no intrusive pointers)
-    - Integrates with HierarchyLRCacheEngine via on_blocks_evicted() callback
-    - No dependency on Python RadixNode objects at all
+Design (mirrors the Python SWARadixManager and sglang's swa_radix_cache):
+    - SWA state lives on the node: node.swa_host_slot (-1 = none),
+      node.swa_tombstone (True = no SWA data), node.swa_lock_ref.
+    - put/get/has take a node, not token_ids.
+    - SWA-only eviction: when the pool is full, pick the LRU unlocked node,
+      free its slot, tombstone it (the node and its full KV stay alive).
+    - Cascade eviction (full KV evicted -> SWA slot released) is handled by the
+      C++ tree recording freed slots; the cache engine drains them and calls
+      free_slots(). This manager only owns the pool and the LRU ordering.
+
+Invariant: SWA is a subset of full. A node may have full KV without SWA
+(tombstone); it must never have SWA without full. The single source of truth is
+node.swa_host_slot — the LRU dict may lag (stale entries) but is never trusted
+for correctness, only for eviction ordering.
+
+Thread-safety: all public methods are protected by a lock for safe use from
+the FlexKV task engine's callback threads.
 """
-import time
 import threading
-from typing import Optional, Dict, List, Union
+from typing import Optional, Iterable, Union
 from collections import OrderedDict
 
 import numpy as np
@@ -26,17 +38,16 @@ except ImportError:
     _TORCH_AVAILABLE = False
 
 from flexkv.common.config import SWAPoolConfig
+from flexkv.common.debug import flexkv_logger
 from flexkv.swa.swa_host_pool import SWAHostPool
 
 
 class SWAProductionManager:
-    """Production SWA manager that works with C++ radix trees.
+    """Node-attached SWA pool manager for the C++ radix tree path.
 
-    Uses endpoint hashing (hash of last block's token_ids) to key SWA metadata,
-    avoiding any dependency on Python RadixNode objects.
-
-    Thread-safety: All public methods are protected by a lock for safe use
-    from the FlexKV task engine's callback threads.
+    SWA state is stored on the CRadixNode (swa_host_slot / swa_tombstone /
+    swa_lock_ref). This class owns only the host pool and an LRU ordering for
+    SWA-only eviction.
     """
 
     def __init__(self, config: SWAPoolConfig, tokens_per_block: int):
@@ -44,30 +55,19 @@ class SWAProductionManager:
 
         Args:
             config: SWA pool configuration.
-            tokens_per_block: Number of tokens per radix tree block.
+            tokens_per_block: Number of tokens per radix tree block (kept for
+                API parity; not used for keying anymore).
         """
         self._config = config
         self._tokens_per_block = tokens_per_block
         self._pool = SWAHostPool(config)
         self._lock = threading.Lock()
 
-        # SWA slot tracking: endpoint_hash -> slot_id
-        self._hash_to_slot: Dict[int, int] = {}
-
-        # LRU ordering: OrderedDict for efficient move-to-end (MRU) and pop-first (LRU)
-        # Key = endpoint_hash, Value = insertion/access timestamp
-        self._lru_order: 'OrderedDict[int, float]' = OrderedDict()
-
-        # Lock tracking: endpoint_hash -> lock_count
-        self._locks: Dict[int, int] = {}
-
-        # Reverse mapping for eviction cascade: block_id -> endpoint_hash
-        # Tracks the LAST block ID of each stored sequence so that when the
-        # radix tree evicts blocks, we can identify which SWA entries to invalidate.
-        self._block_to_hash: Dict[int, int] = {}
-
-        # Forward mapping: endpoint_hash -> last_block_id (for cleanup)
-        self._hash_to_block: Dict[int, int] = {}
+        # LRU ordering for SWA-only eviction. Key = id(node), Value = node.
+        # Only nodes that currently hold a slot are kept here. id(node) is used
+        # as the key to avoid relying on CRadixNode being hashable; the node
+        # object is stored as the value so we can read/write its SWA fields.
+        self._lru: "OrderedDict[int, object]" = OrderedDict()
 
         # Statistics
         self._stats_puts = 0
@@ -76,264 +76,163 @@ class SWAProductionManager:
         self._stats_evictions = 0
         self._stats_cascade_evictions = 0
 
-    # --- Endpoint Hash Computation -------------------------------------------
-
-    def _compute_endpoint_hash(self, token_ids: np.ndarray) -> int:
-        """Compute the endpoint hash for a token sequence.
-
-        Uses the last tokens_per_block tokens as the key.
-        This is stable: same token sequence always produces same hash.
-
-        Args:
-            token_ids: Token sequence (at least tokens_per_block long).
-
-        Returns:
-            Integer hash value.
-        """
-        if len(token_ids) < self._tokens_per_block:
-            # For short sequences, use all tokens
-            return hash(token_ids.tobytes())
-        # Use the last block's worth of tokens
-        last_block = token_ids[-self._tokens_per_block:]
-        return hash(last_block.tobytes())
-
-    def _compute_last_block_id(self, token_ids: np.ndarray,
-                                physical_block_ids: Optional[np.ndarray] = None) -> Optional[int]:
-        """Compute the last physical block ID for eviction tracking.
-
-        If physical_block_ids is provided, uses the last one.
-        Otherwise returns None (eviction tracking disabled for this entry).
-        """
-        if physical_block_ids is not None and len(physical_block_ids) > 0:
-            return int(physical_block_ids[-1])
-        return None
-
     # --- Core Operations -----------------------------------------------------
 
-    def put(self, token_ids: np.ndarray,
-            swa_data: Union['torch.Tensor', np.ndarray, bytes],
-            physical_block_ids: Optional[np.ndarray] = None) -> bool:
-        """Store SWA data keyed by endpoint hash of token_ids.
+    def put(self, node, swa_data: Union['torch.Tensor', np.ndarray, bytes]) -> bool:
+        """Store SWA data on a radix-tree node (write-through on request finish).
+
+        The node must already exist in the tree (full KV inserted), which the
+        caller guarantees by resolving it via match_prefix / insert. If the pool
+        is full, a SWA-only eviction is triggered to make space.
 
         Args:
-            token_ids: Token sequence for this SWA entry.
+            node: The radix tree node (CRadixNode) to annotate.
             swa_data: Raw SWA snapshot data.
-            physical_block_ids: Optional physical block IDs from the radix tree
-                insert. Used for eviction cascade tracking.
 
         Returns:
-            True if successfully stored, False if pool is full and all locked.
+            True if stored, False if the pool is full and every entry is locked.
         """
-        if _TORCH_AVAILABLE and isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        token_ids = np.asarray(token_ids, dtype=np.int64)
-
-        endpoint_hash = self._compute_endpoint_hash(token_ids)
-        last_block_id = self._compute_last_block_id(token_ids, physical_block_ids)
+        if node is None:
+            return False
 
         with self._lock:
-            # If already stored, update in place
-            if endpoint_hash in self._hash_to_slot:
-                slot_id = self._hash_to_slot[endpoint_hash]
-                self._pool.write(slot_id, swa_data)
-                # Promote to MRU
-                self._lru_order.move_to_end(endpoint_hash)
-                self._lru_order[endpoint_hash] = time.time()
-                # Update block tracking if changed
-                if last_block_id is not None:
-                    old_block = self._hash_to_block.get(endpoint_hash)
-                    if old_block is not None and old_block != last_block_id:
-                        self._block_to_hash.pop(old_block, None)
-                    self._hash_to_block[endpoint_hash] = last_block_id
-                    self._block_to_hash[last_block_id] = endpoint_hash
+            # Case A: node already holds a slot -> overwrite in place (no new
+            # allocation, so the old slot is never leaked).
+            if node.swa_host_slot != -1:
+                self._pool.write(node.swa_host_slot, swa_data)
+                node.swa_tombstone = False
+                self._lru[id(node)] = node
+                self._lru.move_to_end(id(node))
                 self._stats_puts += 1
                 return True
 
-            # Allocate new slot
+            # Case B: allocate a new slot, evicting (tombstoning) if needed.
             slot_id = self._pool.allocate()
             if slot_id is None:
-                # Pool full — evict to make space
-                num_to_evict = max(1, int(self._config.num_slots * self._config.evict_ratio))
-                evicted = self._evict_lru(num_to_evict)
-                if evicted == 0:
-                    return False  # All locked, can't evict
-                slot_id = self._pool.allocate()
+                slot_id = self._evict_lru_and_alloc()
                 if slot_id is None:
-                    return False
+                    return False  # everything locked, cannot make space
 
-            # Write data
+            # Write data first, then bind to the node (write-before-bind: a node
+            # never points at a slot whose data is not yet valid).
             self._pool.write(slot_id, swa_data)
-            self._hash_to_slot[endpoint_hash] = slot_id
-            self._lru_order[endpoint_hash] = time.time()
-
-            # Set up block tracking
-            if last_block_id is not None:
-                self._hash_to_block[endpoint_hash] = last_block_id
-                self._block_to_hash[last_block_id] = endpoint_hash
-
+            node.swa_host_slot = slot_id
+            node.swa_tombstone = False
+            self._lru[id(node)] = node
+            self._lru.move_to_end(id(node))
             self._stats_puts += 1
             return True
 
-    def get(self, token_ids: np.ndarray) -> Optional[Union['torch.Tensor', np.ndarray]]:
-        """Retrieve SWA data by token_ids.
+    def get(self, node) -> Optional[Union['torch.Tensor', np.ndarray]]:
+        """Retrieve SWA data for a node, or None if not available.
 
         Args:
-            token_ids: Token sequence to look up.
+            node: The radix tree node to read.
 
         Returns:
-            SWA data buffer (CPU tensor/array copy) or None if not available.
+            SWA data buffer (CPU tensor/array copy) or None.
         """
-        if _TORCH_AVAILABLE and isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        token_ids = np.asarray(token_ids, dtype=np.int64)
-
-        endpoint_hash = self._compute_endpoint_hash(token_ids)
+        if node is None:
+            return None
 
         with self._lock:
-            slot_id = self._hash_to_slot.get(endpoint_hash)
-            if slot_id is None:
+            if node.swa_tombstone or node.swa_host_slot == -1:
                 self._stats_misses += 1
                 return None
-
-            # Read data and promote to MRU
-            data = self._pool.read_copy(slot_id)
-            self._lru_order.move_to_end(endpoint_hash)
-            self._lru_order[endpoint_hash] = time.time()
+            data = self._pool.read_copy(node.swa_host_slot)
+            # promote to MRU
+            self._lru[id(node)] = node
+            self._lru.move_to_end(id(node))
             self._stats_hits += 1
             return data
 
-    def has(self, token_ids: np.ndarray) -> bool:
-        """Check if SWA is available for given token_ids.
+    def has(self, node) -> bool:
+        """Check whether SWA data is available for a node.
 
         Args:
-            token_ids: Token sequence to check.
+            node: The radix tree node to check.
 
         Returns:
-            True if SWA data is stored for this sequence.
+            True if the node has a live SWA slot (not a tombstone).
         """
-        if _TORCH_AVAILABLE and isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        token_ids = np.asarray(token_ids, dtype=np.int64)
+        if node is None:
+            return False
+        return (not node.swa_tombstone) and node.swa_host_slot != -1
 
-        endpoint_hash = self._compute_endpoint_hash(token_ids)
-
+    def lock(self, node) -> None:
+        """Lock a node's SWA entry from eviction."""
+        if node is None:
+            return
         with self._lock:
-            return endpoint_hash in self._hash_to_slot
+            if node.swa_host_slot != -1:
+                node.inc_swa_lock_ref()
 
-    def on_blocks_evicted(self, evicted_block_ids: np.ndarray) -> int:
-        """Called when blocks are evicted from the radix tree.
+    def unlock(self, node) -> None:
+        """Unlock a node's SWA entry."""
+        if node is None:
+            return
+        with self._lock:
+            if node.swa_lock_ref > 0:
+                node.dec_swa_lock_ref()
 
-        Checks if any of the evicted blocks is an "endpoint block" for one of
-        our tracked SWA entries. If so, invalidates that SWA entry (cascading eviction).
+    def free_slots(self, slot_ids: Iterable[int]) -> int:
+        """Return slots to the pool (cascade eviction from the radix tree).
+
+        Called by the cache engine after draining freed_swa_slots from the C++
+        tree, i.e. when full-KV eviction / split deleted or invalidated nodes
+        that held SWA slots. Enforces the SWA-subset-of-full invariant.
+
+        Note: the node's swa_host_slot was already cleared to -1 by the C++ side
+        (record_freed_swa_slot), so the stale LRU entry will be skipped lazily
+        on the next eviction scan.
 
         Args:
-            evicted_block_ids: Array of physical block IDs that were evicted.
+            slot_ids: Slot ids to release.
 
         Returns:
-            Number of SWA entries invalidated.
+            Number of slots freed.
         """
-        if len(evicted_block_ids) == 0:
-            return 0
-
-        invalidated = 0
+        freed = 0
         with self._lock:
-            for block_id in evicted_block_ids:
-                block_id_int = int(block_id)
-                endpoint_hash = self._block_to_hash.get(block_id_int)
-                if endpoint_hash is not None:
-                    # Check if locked
-                    if self._locks.get(endpoint_hash, 0) > 0:
-                        # Cannot evict locked entry - skip
-                        continue
-                    self._release_entry(endpoint_hash)
-                    invalidated += 1
+            for s in slot_ids:
+                if s is not None and int(s) >= 0:
+                    self._pool.free(int(s))
+                    freed += 1
                     self._stats_cascade_evictions += 1
-
-        return invalidated
-
-    def lock(self, token_ids: np.ndarray) -> None:
-        """Lock SWA entry from eviction.
-
-        Args:
-            token_ids: Token sequence identifying the SWA entry to lock.
-        """
-        if _TORCH_AVAILABLE and isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        token_ids = np.asarray(token_ids, dtype=np.int64)
-
-        endpoint_hash = self._compute_endpoint_hash(token_ids)
-
-        with self._lock:
-            if endpoint_hash in self._hash_to_slot:
-                self._locks[endpoint_hash] = self._locks.get(endpoint_hash, 0) + 1
-
-    def unlock(self, token_ids: np.ndarray) -> None:
-        """Unlock SWA entry.
-
-        Args:
-            token_ids: Token sequence identifying the SWA entry to unlock.
-        """
-        if _TORCH_AVAILABLE and isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        token_ids = np.asarray(token_ids, dtype=np.int64)
-
-        endpoint_hash = self._compute_endpoint_hash(token_ids)
-
-        with self._lock:
-            if endpoint_hash in self._locks:
-                self._locks[endpoint_hash] -= 1
-                if self._locks[endpoint_hash] <= 0:
-                    del self._locks[endpoint_hash]
+        return freed
 
     # --- Internal Helpers ----------------------------------------------------
 
-    def _evict_lru(self, num_to_evict: int) -> int:
-        """Evict LRU (oldest) SWA entries to free pool slots.
+    def _evict_lru_and_alloc(self) -> Optional[int]:
+        """SWA-only eviction: free the LRU unlocked node's slot, then allocate.
 
-        Skips locked entries.
-
-        Args:
-            num_to_evict: Target number of entries to evict.
-
-        Returns:
-            Actual number of entries evicted.
-        """
-        evicted = 0
-        # Iterate from LRU (front of OrderedDict) toward MRU (end)
-        # Collect hashes to evict first to avoid modifying dict during iteration
-        to_evict: List[int] = []
-        for endpoint_hash in self._lru_order:
-            if evicted + len(to_evict) >= num_to_evict:
-                break
-            if self._locks.get(endpoint_hash, 0) == 0:
-                to_evict.append(endpoint_hash)
-
-        for endpoint_hash in to_evict:
-            self._release_entry(endpoint_hash)
-            evicted += 1
-            self._stats_evictions += 1
-
-        return evicted
-
-    def _release_entry(self, endpoint_hash: int) -> None:
-        """Release an SWA entry: free slot, remove from all tracking dicts.
+        Walks the LRU from oldest to newest. Stale entries (whose node was
+        already released to -1 by a cascade) are dropped. Locked entries
+        (swa_lock_ref > 0) are skipped. The victim is tombstoned — its node and
+        full KV remain; only the SWA snapshot is dropped.
 
         MUST be called while holding self._lock.
+
+        Returns:
+            A freshly allocated slot id, or None if nothing was evictable.
         """
-        slot_id = self._hash_to_slot.pop(endpoint_hash, None)
-        if slot_id is not None:
-            self._pool.free(slot_id)
-
-        # Remove from LRU
-        self._lru_order.pop(endpoint_hash, None)
-
-        # Remove block tracking
-        block_id = self._hash_to_block.pop(endpoint_hash, None)
-        if block_id is not None:
-            self._block_to_hash.pop(block_id, None)
-
-        # Remove locks (if any)
-        self._locks.pop(endpoint_hash, None)
+        for nid in list(self._lru):
+            node = self._lru[nid]
+            # Stale: the tree already released this node's slot (cascade). Drop.
+            if node.swa_host_slot == -1:
+                del self._lru[nid]
+                continue
+            # Locked: actively in use, cannot evict.
+            if node.swa_lock_ref > 0:
+                continue
+            # Evict (tombstone) this victim.
+            self._pool.free(node.swa_host_slot)
+            node.swa_host_slot = -1
+            node.swa_tombstone = True
+            del self._lru[nid]
+            self._stats_evictions += 1
+            return self._pool.allocate()
+        return None
 
     # --- Properties & Stats --------------------------------------------------
 
@@ -349,9 +248,9 @@ class SWAProductionManager:
 
     @property
     def num_entries(self) -> int:
-        """Number of active SWA entries."""
+        """Number of nodes currently tracked as holding a slot (approximate)."""
         with self._lock:
-            return len(self._hash_to_slot)
+            return len(self._lru)
 
     @property
     def stats(self) -> dict:
@@ -365,6 +264,5 @@ class SWAProductionManager:
                 "cascade_evictions": self._stats_cascade_evictions,
                 "pool_used": self._pool.num_used,
                 "pool_free": self._pool.num_free,
-                "num_entries": len(self._hash_to_slot),
-                "num_locked": len(self._locks),
+                "lru_size": len(self._lru),
             }

--- a/tests/test_swa_accel_engine.py
+++ b/tests/test_swa_accel_engine.py
@@ -1,0 +1,121 @@
+"""SWA wiring on CacheEngineAccel (the default, index_accel=1 path).
+
+Verifies the node-attached SWA support that was moved onto CacheEngineAccel:
+  - init_swa() creates a node-attached SWAProductionManager;
+  - put a snapshot on a real CRadixNode returned by insert(), read it back;
+  - take()/evict() drains the evicted node's SWA slot back to the pool (no leak).
+
+Requires a real flexkv.c_ext (CRadixTreeIndex). Skips otherwise.
+"""
+import numpy as np
+import pytest
+
+c_ext = pytest.importorskip("flexkv.c_ext")
+if "swa_host_slot" not in dir(c_ext.CRadixNode):
+    pytest.skip("CRadixNode SWA bindings not present (rebuild c_ext)",
+                allow_module_level=True)
+
+from flexkv.cache.cache_engine import CacheEngineAccel
+from flexkv.common.transfer import DeviceType
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import SWAPoolConfig
+
+TPB = 4
+
+
+def _engine(num_blocks=64):
+    return CacheEngineAccel(
+        DeviceType.CPU, num_total_blocks=num_blocks, tokens_per_block=TPB,
+        evict_ratio=0.0, hit_reward_seconds=0, evict_start_threshold=1.0,
+        eviction_policy="lru",
+    )
+
+
+def _swa_config(num_slots):
+    return SWAPoolConfig(
+        enabled=True, num_slots=num_slots, window_size=4, num_swa_layers=2,
+        bytes_per_token_per_layer=8, evict_ratio=0.25, pin_memory=False,
+    )
+
+
+def _seq(token_ids):
+    s = SequenceMeta(token_ids=np.asarray(token_ids, dtype=np.int64), tokens_per_block=TPB)
+    s.gen_hashes()
+    return s
+
+
+def _insert(engine, token_ids):
+    """Allocate blocks and insert; return the leaf CRadixNode."""
+    seq = _seq(token_ids)
+    mr = engine.match(seq)
+    num_new = seq.num_blocks - mr.num_matched_blocks
+    if num_new <= 0:
+        return mr.last_node
+    phys = engine.take(num_new, strict=True)
+    # take() returns an np.ndarray and insert() expects one (it calls
+    # torch.from_numpy() internally), so pass it through unchanged.
+    return engine.insert(seq, phys,
+                         num_insert_blocks=seq.num_blocks, is_ready=True, match_result=mr)
+
+
+def _data(cfg, value):
+    return np.full(cfg.slot_size_bytes, value, dtype=np.uint8)
+
+
+def test_init_swa_and_roundtrip():
+    eng = _engine()
+    eng.init_swa(_swa_config(8))
+    assert eng.swa_manager is not None
+
+    node = _insert(eng, np.arange(0, TPB * 3, dtype=np.int64))
+    assert node is not None
+
+    assert eng.swa_manager.put(node, _data(eng.swa_manager.config, 77)) is True
+    assert eng.swa_manager.has(node) is True
+    out = eng.swa_manager.get(node)
+    assert out is not None and int(out[0]) == 77
+
+
+def test_take_drains_swa_slot_no_leak():
+    # Small block pool so take() must evict; SWA pool large enough to hold all.
+    eng = _engine(num_blocks=6)
+    eng.init_swa(_swa_config(16))
+
+    nodes = []
+    for i in range(3):
+        toks = np.arange(1000 * (i + 1), 1000 * (i + 1) + TPB * 2, dtype=np.int64)
+        n = _insert(eng, toks)
+        assert eng.swa_manager.put(n, _data(eng.swa_manager.config, i)) is True
+        nodes.append(n)
+
+    used_before = eng.swa_manager.pool.num_used
+    assert used_before == 3
+
+    # Force eviction by requesting more blocks than free -> some nodes deleted,
+    # their SWA slots recorded and drained by take().
+    eng.take(6, strict=False)
+    # At least one node's slot must have been reclaimed via the cascade.
+    assert eng.swa_manager.pool.num_used < used_before
+
+
+def test_swa_only_eviction_keeps_full_kv():
+    # SWA pool smaller than node count -> SWA-only eviction (tombstone) kicks in,
+    # but full KV (the tree nodes) stays intact.
+    eng = _engine(num_blocks=64)
+    eng.init_swa(_swa_config(2))
+
+    nodes, seqs = [], []
+    for i in range(3):
+        toks = np.arange(2000 * (i + 1), 2000 * (i + 1) + TPB * 2, dtype=np.int64)
+        n = _insert(eng, toks)
+        assert eng.swa_manager.put(n, _data(eng.swa_manager.config, i)) is True
+        nodes.append(n); seqs.append(toks)
+
+    # First node should have been tombstoned (pool held only 2 slots).
+    assert nodes[0].swa_tombstone is True
+    assert nodes[0].swa_host_slot == -1
+    # But its full KV is still matchable in the tree.
+    mr = eng.match(_seq(seqs[0]))
+    assert mr.num_matched_blocks == 2
+    assert eng.swa_manager.has(nodes[0]) is False
+    assert eng.swa_manager.has(nodes[2]) is True

--- a/tests/test_swa_cnode_cascade.py
+++ b/tests/test_swa_cnode_cascade.py
@@ -1,0 +1,139 @@
+"""Step 1 + Step 2 verification: node-attached SWA state on the C++ radix tree.
+
+Covers:
+  - CRadixNode SWA fields are exposed and read/write round-trips (Step 1).
+  - split / evict release the node's SWA slot into freed_swa_slots so the Python
+    side can drain it, enforcing the "SWA subset of full" invariant (Step 2).
+
+Requires a real flexkv.c_ext built with FLEXKV_ENABLE_P2P=1 (LocalRadixTree).
+Skips cleanly if the C extension or LocalRadixTree is unavailable.
+"""
+import numpy as np
+import pytest
+import torch
+
+c_ext = pytest.importorskip("flexkv.c_ext")
+
+if not hasattr(c_ext, "LocalRadixTree"):
+    pytest.skip("LocalRadixTree not built (needs FLEXKV_ENABLE_P2P=1)",
+                allow_module_level=True)
+
+if "swa_host_slot" not in dir(c_ext.CRadixNode):
+    pytest.skip("CRadixNode SWA bindings not present (rebuild c_ext)",
+                allow_module_level=True)
+
+from flexkv.cache.radix_remote import LocalRadixTree
+from flexkv.common.block import SequenceMeta
+
+
+TPB = 4
+
+
+def _block_hashes(token_ids: np.ndarray) -> torch.Tensor:
+    """Compute per-block hashes via the canonical SequenceMeta path."""
+    seq = SequenceMeta(token_ids=token_ids.astype(np.int64), tokens_per_block=TPB)
+    return torch.from_numpy(seq.block_hashes.astype(np.int64))
+
+
+def _make_tree() -> LocalRadixTree:
+    return LocalRadixTree(tokens_per_block=TPB, max_num_blocks=1024)
+
+
+def _insert(tree: LocalRadixTree, token_ids: np.ndarray, base_block: int):
+    """Insert a fresh sequence; return the new leaf CRadixNode."""
+    num_blocks = len(token_ids) // TPB
+    block_hashes = _block_hashes(token_ids)
+    phys = torch.arange(base_block, base_block + num_blocks, dtype=torch.int64)
+    node = tree.insert(phys, block_hashes, num_blocks, -1, True)
+    return node, block_hashes
+
+
+# --------------------------------------------------------------------------- #
+# Step 1: field round-trip                                                     #
+# --------------------------------------------------------------------------- #
+
+class TestStep1Fields:
+    def test_defaults(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 3, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 0)
+        assert node is not None
+        assert node.swa_host_slot == -1
+        assert node.swa_tombstone is True
+        assert node.swa_lock_ref == 0
+
+    def test_setters_roundtrip(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 3, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 0)
+        node.swa_host_slot = 7
+        node.swa_tombstone = False
+        assert node.swa_host_slot == 7
+        assert node.swa_tombstone is False
+
+    def test_lock_ref_inc_dec(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 3, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 0)
+        node.inc_swa_lock_ref()
+        node.inc_swa_lock_ref()
+        assert node.swa_lock_ref == 2
+        node.dec_swa_lock_ref()
+        assert node.swa_lock_ref == 1
+
+
+# --------------------------------------------------------------------------- #
+# Step 2: cascade release on evict / split                                     #
+# --------------------------------------------------------------------------- #
+
+class TestStep2Cascade:
+    def test_evict_drains_slot(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 2, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 100)
+        node.swa_host_slot = 7
+        node.swa_tombstone = False
+
+        # Evict everything; the node should be deleted and its slot drained.
+        buf = torch.zeros(64, dtype=torch.int64)
+        tree.evict(buf, 64)
+        freed = tree.drain_freed_swa_slots()
+        assert 7 in freed
+
+    def test_no_slot_no_drain(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 2, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 100)
+        # node keeps default slot=-1
+        buf = torch.zeros(64, dtype=torch.int64)
+        tree.evict(buf, 64)
+        assert tree.drain_freed_swa_slots() == []
+
+    def test_split_drains_slot(self):
+        tree = _make_tree()
+        # Long sequence, then a sequence sharing a prefix to force a split.
+        long_tokens = np.arange(0, TPB * 4, dtype=np.int64)
+        node, _ = _insert(tree, long_tokens, 200)
+        node.swa_host_slot = 9
+        node.swa_tombstone = False
+
+        # Shared first 2 blocks, divergent tail -> split of the existing node.
+        shared = np.arange(0, TPB * 2, dtype=np.int64)
+        divergent = np.arange(900, 900 + TPB * 2, dtype=np.int64)
+        seq2 = np.concatenate([shared, divergent])
+        _insert(tree, seq2, 300)
+
+        freed = tree.drain_freed_swa_slots()
+        assert 9 in freed
+
+    def test_drain_is_idempotent(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 2, dtype=np.int64)
+        node, _ = _insert(tree, tokens, 100)
+        node.swa_host_slot = 5
+        node.swa_tombstone = False
+        buf = torch.zeros(64, dtype=torch.int64)
+        tree.evict(buf, 64)
+        assert 5 in tree.drain_freed_swa_slots()
+        # second drain returns nothing
+        assert tree.drain_freed_swa_slots() == []

--- a/tests/test_swa_e2e.py
+++ b/tests/test_swa_e2e.py
@@ -80,19 +80,10 @@ def _compute_block_hashes(token_ids: np.ndarray, tokens_per_block: int) -> np.nd
     return hashes
 
 
-def _insert_sequence(radix_tree, token_ids, tokens_per_block):
-    """Insert a token sequence into the radix tree and return the leaf node.
-
-    Uses direct hash computation (no c_ext/SequenceMeta dependency).
-    """
-    if isinstance(token_ids, torch.Tensor):
-        token_ids = token_ids.numpy()
-    token_ids = np.asarray(token_ids, dtype=np.int64)
-
+def _fake_seq(token_ids, tokens_per_block):
+    """A minimal SequenceMeta-like object hashed with the local sha256 scheme."""
     block_hashes = _compute_block_hashes(token_ids, tokens_per_block)
-    num_blocks = len(block_hashes)
 
-    # Create a minimal SequenceMeta-like object for match_prefix
     class _FakeSeq:
         def __init__(self, hashes, tpb):
             self.block_hashes = hashes
@@ -106,7 +97,45 @@ def _insert_sequence(radix_tree, token_ids, tokens_per_block):
                 return HashType(int(self.block_hashes[idx]))
             return HashType(0)
 
-    seq = _FakeSeq(block_hashes, tokens_per_block)
+    return _FakeSeq(block_hashes, tokens_per_block)
+
+
+def _make_seq(token_ids, tokens_per_block):
+    """Build a sequence object hashed the SAME way as SWAConnector._find_leaf_node.
+
+    When c_ext is real, the connector hashes via SequenceMeta (xxhash), so the
+    tree must be populated with SequenceMeta too — otherwise lookup-by-token-ids
+    inserts under one hash and searches under another and never matches. When
+    c_ext is mocked (this file run in isolation), SequenceMeta yields degenerate
+    hashes, so we use the local sha256 scheme on both sides instead.
+
+    We branch on _c_ext_is_real rather than try/except: a half-active MagicMock
+    makes SequenceMeta.gen_hashes() succeed silently with garbage hashes (all
+    zero → colliding nodes), which try/except cannot detect.
+
+    Running the whole suite imports the real c_ext (this file's mock then
+    no-ops), which is why insert and lookup must agree on hashing dynamically.
+    """
+    if _c_ext_is_real:
+        from flexkv.common.block import SequenceMeta
+        seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+        seq.gen_hashes()
+        return seq
+    return _fake_seq(token_ids, tokens_per_block)
+
+
+def _insert_sequence(radix_tree, token_ids, tokens_per_block):
+    """Insert a token sequence into the radix tree and return the leaf node.
+
+    Hashing matches SWAConnector._find_leaf_node (see _make_seq) so store-then-
+    lookup-by-token-ids resolves the same node.
+    """
+    if isinstance(token_ids, torch.Tensor):
+        token_ids = token_ids.numpy()
+    token_ids = np.asarray(token_ids, dtype=np.int64)
+
+    seq = _make_seq(token_ids, tokens_per_block)
+    num_blocks = seq.num_blocks
 
     # Match existing prefix
     match_result = radix_tree.match_prefix(seq, update_cache_info=False)
@@ -265,21 +294,7 @@ class TestSWAConnectorPrefixMatch:
         # New request: first 8 tokens match (shares prefix)
         # The match should find the stored node
         new_tokens = np.array([1, 2, 3, 4, 5, 6, 7, 8, 99, 99, 99, 99], dtype=np.int64)
-        block_hashes = _compute_block_hashes(new_tokens, tokens_per_block)
-
-        class _FakeSeq:
-            def __init__(self, hashes, tpb):
-                self.block_hashes = hashes
-                self.num_blocks = len(hashes)
-                self.tokens_per_block = tpb
-            def gen_hashes(self):
-                pass
-            def get_hash(self, idx):
-                if idx < len(self.block_hashes):
-                    return HashType(int(self.block_hashes[idx]))
-                return HashType(0)
-
-        seq = _FakeSeq(block_hashes, tokens_per_block)
+        seq = _make_seq(new_tokens, tokens_per_block)
         match_result = radix_tree.match_prefix(seq)
 
         # Should match at least 2 blocks (8 tokens)
@@ -429,21 +444,7 @@ class TestSWAEndToEndFlow:
         req2_tokens = np.array([1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23], dtype=np.int64)
 
         # 2a. Prefix match (simulates get_match)
-        block_hashes_2 = _compute_block_hashes(req2_tokens, tokens_per_block)
-
-        class _FakeSeq2:
-            def __init__(self, hashes, tpb):
-                self.block_hashes = hashes
-                self.num_blocks = len(hashes)
-                self.tokens_per_block = tpb
-            def gen_hashes(self):
-                pass
-            def get_hash(self, idx):
-                if idx < len(self.block_hashes):
-                    return HashType(int(self.block_hashes[idx]))
-                return HashType(0)
-
-        seq2 = _FakeSeq2(block_hashes_2, tokens_per_block)
+        seq2 = _make_seq(req2_tokens, tokens_per_block)
         match = radix_tree.match_prefix(seq2)
 
         # Should match first 2 blocks (8 tokens)

--- a/tests/test_swa_node_cascade_e2e.py
+++ b/tests/test_swa_node_cascade_e2e.py
@@ -1,0 +1,126 @@
+"""End-to-end cascade test (Step 4 + Step 5): real C++ LocalRadixTree + real
+node-attached SWAProductionManager, wired the way the cache engine wires them.
+
+Proves the SWA-subset-of-full invariant end to end:
+  - put a snapshot on a tree node, get it back (node-attached round trip);
+  - SWA-only eviction tombstones an LRU node but leaves its full KV in the tree;
+  - full-KV eviction of a node drains its SWA slot back to the pool (no leak).
+
+Requires flexkv.c_ext built with FLEXKV_ENABLE_P2P=1.
+"""
+import numpy as np
+import pytest
+import torch
+
+c_ext = pytest.importorskip("flexkv.c_ext")
+if not hasattr(c_ext, "LocalRadixTree"):
+    pytest.skip("LocalRadixTree not built (needs FLEXKV_ENABLE_P2P=1)",
+                allow_module_level=True)
+if "swa_host_slot" not in dir(c_ext.CRadixNode):
+    pytest.skip("CRadixNode SWA bindings not present (rebuild c_ext)",
+                allow_module_level=True)
+
+from flexkv.cache.radix_remote import LocalRadixTree
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import SWAPoolConfig
+from flexkv.swa.swa_production_manager import SWAProductionManager
+
+
+TPB = 4
+
+
+def _swa_config(num_slots):
+    return SWAPoolConfig(
+        enabled=True, num_slots=num_slots, window_size=4, num_swa_layers=2,
+        bytes_per_token_per_layer=8, evict_ratio=0.25, pin_memory=False,
+    )
+
+
+def _hashes(token_ids):
+    seq = SequenceMeta(token_ids=token_ids.astype(np.int64), tokens_per_block=TPB)
+    return torch.from_numpy(seq.block_hashes.astype(np.int64))
+
+
+def _insert(tree, token_ids, base_block):
+    nb = len(token_ids) // TPB
+    phys = torch.arange(base_block, base_block + nb, dtype=torch.int64)
+    return tree.insert(phys, _hashes(token_ids), nb, -1, True)
+
+
+def _data(cfg, value):
+    return np.full(cfg.slot_size_bytes, value, dtype=np.uint8)
+
+
+def _match_last_node(tree, token_ids):
+    seq = SequenceMeta(token_ids=token_ids.astype(np.int64), tokens_per_block=TPB)
+    bh = torch.from_numpy(seq.block_hashes.astype(np.int64))
+    mr = tree.match_prefix(bh, int(seq.num_blocks), False)
+    if mr is None or int(mr.num_matched_blocks) == 0:
+        return None
+    return mr.last_node
+
+
+def test_put_get_roundtrip_via_node():
+    tree = LocalRadixTree(tokens_per_block=TPB, max_num_blocks=1024)
+    mgr = SWAProductionManager(_swa_config(8), TPB)
+
+    tokens = np.arange(0, TPB * 3, dtype=np.int64)
+    _insert(tree, tokens, 0)
+    node = _match_last_node(tree, tokens)
+    assert node is not None
+
+    assert mgr.put(node, _data(mgr.config, 99)) is True
+    assert mgr.has(node) is True
+    out = mgr.get(node)
+    assert out is not None and int(out[0]) == 99
+
+
+def test_full_evict_frees_swa_slot_no_leak():
+    tree = LocalRadixTree(tokens_per_block=TPB, max_num_blocks=1024)
+    mgr = SWAProductionManager(_swa_config(8), TPB)
+
+    # Insert a few distinct sequences and attach SWA to each leaf.
+    nodes = []
+    for i in range(3):
+        tokens = np.arange(1000 * (i + 1), 1000 * (i + 1) + TPB * 2, dtype=np.int64)
+        _insert(tree, tokens, 100 * (i + 1))
+        n = _match_last_node(tree, tokens)
+        assert mgr.put(n, _data(mgr.config, i)) is True
+        nodes.append(n)
+
+    used_before = mgr.pool.num_used
+    assert used_before == 3
+
+    # Evict everything from the tree; nodes get deleted and their slots recorded.
+    buf = torch.zeros(256, dtype=torch.int64)
+    tree.evict(buf, 256)
+    freed = tree.drain_freed_swa_slots()
+    assert len(freed) == 3  # all three SWA slots recorded by the cascade
+
+    mgr.free_slots(freed)
+    assert mgr.pool.num_used == 0  # no leak: pool fully reclaimed
+
+
+def test_swa_only_evict_keeps_full_kv():
+    # Pool smaller than the number of nodes -> SWA-only eviction must kick in.
+    tree = LocalRadixTree(tokens_per_block=TPB, max_num_blocks=1024)
+    mgr = SWAProductionManager(_swa_config(2), TPB)
+
+    seqs = []
+    nodes = []
+    for i in range(3):
+        tokens = np.arange(2000 * (i + 1), 2000 * (i + 1) + TPB * 2, dtype=np.int64)
+        _insert(tree, tokens, 100 * (i + 1))
+        n = _match_last_node(tree, tokens)
+        assert mgr.put(n, _data(mgr.config, i)) is True
+        seqs.append(tokens)
+        nodes.append(n)
+
+    # Pool had 2 slots, 3 puts -> the first (LRU) node was tombstoned.
+    assert nodes[0].swa_tombstone is True
+    assert nodes[0].swa_host_slot == -1
+    # But its full KV is still in the tree: it still matches.
+    assert _match_last_node(tree, seqs[0]) is not None
+    # SWA is reported unavailable for it (tombstone), available for the newest.
+    assert mgr.has(nodes[0]) is False
+    assert mgr.has(nodes[2]) is True

--- a/tests/test_swa_production_manager.py
+++ b/tests/test_swa_production_manager.py
@@ -1,11 +1,17 @@
-"""Tests for SWA Production Manager — production-ready SWA with endpoint hashing.
+"""Tests for the node-attached SWAProductionManager (Step 3).
 
-Tests the full lifecycle: put → get → evict → cascade, all without dependency
-on Python RadixNode objects. Uses only token_ids and physical_block_ids.
+Uses a lightweight FakeNode that mimics the CRadixNode SWA interface
+(swa_host_slot / swa_tombstone / swa_lock_ref + inc/dec). No C extension or
+radix tree is needed, so these run fast and isolate the manager's logic:
+put (overwrite vs allocate), SWA-only eviction (tombstoning), lock skipping,
+stale-entry handling, and cascade free_slots.
 """
-import threading
-import time
-from collections import OrderedDict
+import sys
+from unittest.mock import MagicMock
+
+# Mock the C extension before importing flexkv.swa
+if 'flexkv.c_ext' not in sys.modules:
+    sys.modules['flexkv.c_ext'] = MagicMock()
 
 import numpy as np
 import pytest
@@ -14,730 +20,205 @@ from flexkv.common.config import SWAPoolConfig
 from flexkv.swa.swa_production_manager import SWAProductionManager
 
 
+class FakeNode:
+    """Mimics the CRadixNode SWA interface used by SWAProductionManager."""
+
+    def __init__(self):
+        self.swa_host_slot = -1
+        self.swa_tombstone = True
+        self.swa_lock_ref = 0
+
+    def inc_swa_lock_ref(self):
+        self.swa_lock_ref += 1
+
+    def dec_swa_lock_ref(self):
+        assert self.swa_lock_ref > 0
+        self.swa_lock_ref -= 1
+
+
 @pytest.fixture
 def swa_config():
     return SWAPoolConfig(
         enabled=True,
-        num_slots=8,
+        num_slots=4,
         window_size=4,
         num_swa_layers=2,
         bytes_per_token_per_layer=8,
-        evict_ratio=0.25,  # evict 25% (= 2 slots) when full
+        evict_ratio=0.25,
         pin_memory=False,
     )
 
 
 @pytest.fixture
-def tokens_per_block():
-    return 4
+def manager(swa_config):
+    return SWAProductionManager(config=swa_config, tokens_per_block=4)
 
 
-@pytest.fixture
-def manager(swa_config, tokens_per_block):
-    return SWAProductionManager(config=swa_config, tokens_per_block=tokens_per_block)
-
-
-def _make_swa_data(config: SWAPoolConfig, value: int = 42) -> np.ndarray:
-    """Create test SWA data of the correct size."""
+def _data(config, value=42):
     return np.full(config.slot_size_bytes, value, dtype=np.uint8)
 
 
-def _make_token_ids(base: int, num_tokens: int = 8) -> np.ndarray:
-    """Create a deterministic token_ids array."""
-    return np.arange(base, base + num_tokens, dtype=np.int64)
+# --------------------------------------------------------------------------- #
+# put / get / has                                                             #
+# --------------------------------------------------------------------------- #
 
-
-def _make_block_ids(base: int, num_blocks: int = 2) -> np.ndarray:
-    """Create physical block IDs."""
-    return np.arange(base, base + num_blocks, dtype=np.int64)
-
-
-class TestSWAProductionManagerBasicPut:
-    """Test basic put operations."""
-
-    def test_put_single(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        data = _make_swa_data(swa_config, value=7)
-        assert manager.put(token_ids, data) is True
-        assert manager.num_entries == 1
-        assert manager.pool.num_used == 1
-
-    def test_put_with_block_ids(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)
-        data = _make_swa_data(swa_config, value=7)
-        assert manager.put(token_ids, data, physical_block_ids=block_ids) is True
-        assert manager.num_entries == 1
-
-    def test_put_updates_existing(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        data1 = _make_swa_data(swa_config, value=7)
-        data2 = _make_swa_data(swa_config, value=99)
-
-        manager.put(token_ids, data1)
-        manager.put(token_ids, data2)
-
-        # Should still be 1 entry
-        assert manager.num_entries == 1
-        assert manager.pool.num_used == 1
-
-        # Data should be updated
-        loaded = manager.get(token_ids)
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 99
-
-    def test_put_multiple_distinct(self, manager, swa_config):
-        for i in range(5):
-            token_ids = _make_token_ids(i * 100)
-            data = _make_swa_data(swa_config, value=i + 1)
-            assert manager.put(token_ids, data) is True
-
-        assert manager.num_entries == 5
-        assert manager.pool.num_used == 5
-
-
-class TestSWAProductionManagerGet:
-    """Test get (retrieve) operations."""
+class TestPutGetHas:
+    def test_put_sets_node_state(self, manager, swa_config):
+        n = FakeNode()
+        assert manager.put(n, _data(swa_config)) is True
+        assert n.swa_host_slot != -1
+        assert n.swa_tombstone is False
+        assert manager.has(n) is True
 
     def test_get_after_put(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        data = _make_swa_data(swa_config, value=42)
-        manager.put(token_ids, data)
+        n = FakeNode()
+        manager.put(n, _data(swa_config, value=123))
+        out = manager.get(n)
+        assert out is not None
+        assert int(out[0]) == 123
 
-        result = manager.get(token_ids)
-        assert result is not None
-        assert np.asarray(result)[0] == 42
+    def test_get_miss_returns_none(self, manager):
+        assert manager.get(FakeNode()) is None
+        assert manager.get(None) is None
 
-    def test_get_nonexistent_returns_none(self, manager):
-        token_ids = _make_token_ids(999)
-        result = manager.get(token_ids)
-        assert result is None
+    def test_has_false_for_tombstone(self, manager, swa_config):
+        n = FakeNode()
+        manager.put(n, _data(swa_config))
+        # simulate tombstone
+        n.swa_tombstone = True
+        assert manager.has(n) is False
 
-    def test_get_returns_copy(self, manager, swa_config):
-        """Verify get returns a copy (modifications don't affect stored data)."""
-        token_ids = _make_token_ids(100)
-        data = _make_swa_data(swa_config, value=42)
-        manager.put(token_ids, data)
-
-        result1 = manager.get(token_ids)
-        np.asarray(result1)[0] = 99  # Modify the copy
-
-        result2 = manager.get(token_ids)
-        assert np.asarray(result2)[0] == 42  # Original should be unchanged
-
-    def test_get_promotes_to_mru(self, manager, swa_config):
-        """Verify that get promotes the entry to MRU position."""
-        # Fill with 3 entries
-        for i in range(3):
-            token_ids = _make_token_ids(i * 100)
-            manager.put(token_ids, _make_swa_data(swa_config, value=i))
-
-        # Access the first entry (oldest/LRU) to promote it
-        manager.get(_make_token_ids(0))
-
-        # Now if we trigger eviction, the first entry should be protected (it's MRU)
-        # The second entry (i=1) should be LRU now
-        # Fill remaining slots + 1 to trigger eviction
-        for i in range(3, 9):  # Fill 5 more (pool has 8 slots, 3 used → need 6 to overflow)
-            token_ids = _make_token_ids(i * 100)
-            manager.put(token_ids, _make_swa_data(swa_config, value=i))
-
-        # The first entry (promoted to MRU) should still be available
-        result = manager.get(_make_token_ids(0))
-        assert result is not None
-        assert np.asarray(result)[0] == 0
+    def test_put_none_node(self, manager, swa_config):
+        assert manager.put(None, _data(swa_config)) is False
 
 
-class TestSWAProductionManagerHas:
-    """Test has (availability check) operations."""
+class TestPutCaseAReuse:
+    def test_overwrite_reuses_slot(self, manager, swa_config):
+        n = FakeNode()
+        manager.put(n, _data(swa_config, value=1))
+        slot = n.swa_host_slot
+        used_after_first = manager.pool.num_used
+        manager.put(n, _data(swa_config, value=2))
+        # same slot, no new allocation
+        assert n.swa_host_slot == slot
+        assert manager.pool.num_used == used_after_first
+        out = manager.get(n)
+        assert int(out[0]) == 2
 
-    def test_has_true_after_put(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config))
-        assert manager.has(token_ids) is True
-
-    def test_has_false_no_entry(self, manager):
-        token_ids = _make_token_ids(999)
-        assert manager.has(token_ids) is False
-
-    def test_has_false_after_eviction(self, manager, swa_config):
-        """After all slots used and oldest evicted, has() returns False for evicted entry."""
-        # Fill all 8 slots
-        for i in range(8):
-            token_ids = _make_token_ids(i * 100)
-            manager.put(token_ids, _make_swa_data(swa_config, value=i))
-
-        # Add one more — triggers eviction of LRU entries
-        extra_tokens = _make_token_ids(900)
-        manager.put(extra_tokens, _make_swa_data(swa_config, value=99))
-
-        # The oldest entry should have been evicted
-        assert manager.has(_make_token_ids(0)) is False
-        # The newest entry should be available
-        assert manager.has(extra_tokens) is True
+    def test_overwrite_clears_tombstone(self, manager, swa_config):
+        n = FakeNode()
+        manager.put(n, _data(swa_config))
+        n.swa_tombstone = True  # pretend it got tombstoned
+        # re-put on same node still holding slot -> revive
+        manager.put(n, _data(swa_config))
+        assert n.swa_tombstone is False
 
 
-class TestSWAProductionManagerEviction:
-    """Test LRU eviction behavior."""
+# --------------------------------------------------------------------------- #
+# SWA-only eviction (tombstoning)                                             #
+# --------------------------------------------------------------------------- #
 
-    def test_eviction_on_full_pool(self, manager, swa_config):
-        """Pool full → put triggers LRU eviction."""
-        # Fill all 8 slots
-        for i in range(8):
-            token_ids = _make_token_ids(i * 100)
-            manager.put(token_ids, _make_swa_data(swa_config, value=i))
-
+class TestSwaOnlyEviction:
+    def test_pool_full_tombstones_lru_victim(self, manager, swa_config):
+        nodes = [FakeNode() for _ in range(swa_config.num_slots)]
+        for n in nodes:
+            assert manager.put(n, _data(swa_config)) is True
         assert manager.pool.num_free == 0
-        assert manager.num_entries == 8
 
-        # 9th put should trigger eviction (evict_ratio=0.25 → evict 2)
-        token_ids_9 = _make_token_ids(900)
-        assert manager.put(token_ids_9, _make_swa_data(swa_config, value=9)) is True
-
-        # At least 2 evicted (evict_ratio=0.25 of 8 = 2)
-        assert manager.num_entries <= 7  # 8 - 2 + 1 = 7
-
-    def test_eviction_skips_locked(self, manager, swa_config):
-        """Locked entries are not evicted."""
-        # Fill all 8 slots, lock the first one
-        for i in range(8):
-            token_ids = _make_token_ids(i * 100)
-            manager.put(token_ids, _make_swa_data(swa_config, value=i))
-
-        # Lock the first (LRU) entry
-        manager.lock(_make_token_ids(0))
-
-        # Trigger eviction
-        token_ids_9 = _make_token_ids(900)
-        manager.put(token_ids_9, _make_swa_data(swa_config, value=9))
-
-        # The locked entry should still be available
-        assert manager.has(_make_token_ids(0)) is True
-
-    def test_eviction_all_locked_fails(self, swa_config, tokens_per_block):
-        """When all entries are locked, put fails gracefully."""
-        # Small pool: 2 slots
-        small_config = SWAPoolConfig(
-            enabled=True,
-            num_slots=2,
-            window_size=4,
-            num_swa_layers=2,
-            bytes_per_token_per_layer=8,
-            evict_ratio=1.0,
-            pin_memory=False,
-        )
-        mgr = SWAProductionManager(config=small_config, tokens_per_block=tokens_per_block)
-
-        # Fill and lock both
-        for i in range(2):
-            token_ids = _make_token_ids(i * 100)
-            mgr.put(token_ids, _make_swa_data(small_config, value=i))
-            mgr.lock(token_ids)
-
-        # 3rd put should fail
-        token_ids_3 = _make_token_ids(300)
-        assert mgr.put(token_ids_3, _make_swa_data(small_config, value=3)) is False
-
-
-class TestSWAProductionManagerCascadeEviction:
-    """Test cascade eviction via on_blocks_evicted()."""
-
-    def test_cascade_eviction_basic(self, manager, swa_config):
-        """When endpoint block is evicted from radix tree, SWA entry is invalidated."""
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)  # blocks [500, 501]
-        manager.put(token_ids, _make_swa_data(swa_config, value=42),
-                    physical_block_ids=block_ids)
-
-        assert manager.has(token_ids) is True
-
-        # Evict the endpoint block (last block = 501)
-        evicted = manager.on_blocks_evicted(np.array([501], dtype=np.int64))
-        assert evicted == 1
-        assert manager.has(token_ids) is False
-        assert manager.pool.num_free == 8  # Slot freed
-
-    def test_cascade_eviction_non_endpoint_block(self, manager, swa_config):
-        """Evicting a non-endpoint block does not invalidate the SWA entry."""
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)  # blocks [500, 501]
-        manager.put(token_ids, _make_swa_data(swa_config, value=42),
-                    physical_block_ids=block_ids)
-
-        # Evict block 500 (not the endpoint)
-        evicted = manager.on_blocks_evicted(np.array([500], dtype=np.int64))
-        assert evicted == 0
-        assert manager.has(token_ids) is True  # Still available
-
-    def test_cascade_eviction_multiple_entries(self, manager, swa_config):
-        """Multiple entries evicted in one call."""
-        # Store 3 entries with different endpoint blocks
-        for i in range(3):
-            token_ids = _make_token_ids(i * 100)
-            block_ids = _make_block_ids(i * 10, 2)  # endpoints: 1, 11, 21
-            manager.put(token_ids, _make_swa_data(swa_config, value=i),
-                        physical_block_ids=block_ids)
-
-        # Evict endpoint blocks for entries 0 and 2
-        evicted = manager.on_blocks_evicted(np.array([1, 21], dtype=np.int64))
-        assert evicted == 2
-        assert manager.has(_make_token_ids(0)) is False
-        assert manager.has(_make_token_ids(100)) is True  # Entry 1 unaffected
-        assert manager.has(_make_token_ids(200)) is False
-
-    def test_cascade_eviction_locked_entry_skipped(self, manager, swa_config):
-        """Locked entries are not invalidated even if their endpoint block is evicted."""
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)
-        manager.put(token_ids, _make_swa_data(swa_config, value=42),
-                    physical_block_ids=block_ids)
-        manager.lock(token_ids)
-
-        # Try to cascade-evict
-        evicted = manager.on_blocks_evicted(np.array([501], dtype=np.int64))
-        assert evicted == 0
-        assert manager.has(token_ids) is True
-
-    def test_cascade_eviction_empty_array(self, manager, swa_config):
-        """Empty eviction array is a no-op."""
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config, value=42))
-
-        evicted = manager.on_blocks_evicted(np.array([], dtype=np.int64))
-        assert evicted == 0
-        assert manager.has(token_ids) is True
-
-
-class TestSWAProductionManagerLocking:
-    """Test lock/unlock operations."""
-
-    def test_lock_unlock_basic(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config))
-
-        manager.lock(token_ids)
-        assert manager.stats["num_locked"] == 1
-
-        manager.unlock(token_ids)
-        assert manager.stats["num_locked"] == 0
-
-    def test_lock_reentrant(self, manager, swa_config):
-        """Multiple locks require multiple unlocks."""
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config))
-
-        manager.lock(token_ids)
-        manager.lock(token_ids)
-        assert manager.stats["num_locked"] == 1  # Still one entry locked
-
-        manager.unlock(token_ids)
-        assert manager.stats["num_locked"] == 1  # Still locked (ref count > 0)
-
-        manager.unlock(token_ids)
-        assert manager.stats["num_locked"] == 0  # Now fully unlocked
-
-    def test_lock_nonexistent_is_noop(self, manager):
-        """Locking a non-existent entry is a no-op."""
-        token_ids = _make_token_ids(999)
-        manager.lock(token_ids)  # Should not raise
-        assert manager.stats["num_locked"] == 0
-
-
-class TestSWAProductionManagerStats:
-    """Test statistics tracking."""
-
-    def test_stats_puts(self, manager, swa_config):
-        for i in range(3):
-            manager.put(_make_token_ids(i * 100), _make_swa_data(swa_config, value=i))
-        assert manager.stats["puts"] == 3
-
-    def test_stats_hits_and_misses(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config))
-
-        # Hit
-        manager.get(token_ids)
-        assert manager.stats["hits"] == 1
-        assert manager.stats["misses"] == 0
-
-        # Miss
-        manager.get(_make_token_ids(999))
-        assert manager.stats["hits"] == 1
-        assert manager.stats["misses"] == 1
-
-    def test_stats_evictions(self, manager, swa_config):
-        # Fill all 8 slots
-        for i in range(8):
-            manager.put(_make_token_ids(i * 100), _make_swa_data(swa_config, value=i))
-
-        # Trigger eviction
-        manager.put(_make_token_ids(900), _make_swa_data(swa_config, value=9))
-        assert manager.stats["evictions"] >= 1
-
-    def test_stats_cascade_evictions(self, manager, swa_config):
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)
-        manager.put(token_ids, _make_swa_data(swa_config), physical_block_ids=block_ids)
-
-        manager.on_blocks_evicted(np.array([501], dtype=np.int64))
-        assert manager.stats["cascade_evictions"] == 1
-
-
-class TestSWAProductionManagerEndpointHash:
-    """Test endpoint hash computation behavior."""
-
-    def test_same_tokens_same_hash(self, manager, swa_config):
-        """Same token sequence should always hit the same entry."""
-        token_ids = _make_token_ids(100)
-        manager.put(token_ids, _make_swa_data(swa_config, value=42))
-
-        # Same token_ids → same hash → same data
-        result = manager.get(token_ids)
-        assert result is not None
-        assert np.asarray(result)[0] == 42
-
-    def test_different_last_block_different_hash(self, manager, swa_config, tokens_per_block):
-        """Different last blocks should produce different hashes."""
-        # Two sequences that share a prefix but differ in the last block
-        tokens_a = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64)
-        tokens_b = np.array([1, 2, 3, 4, 5, 6, 7, 9], dtype=np.int64)  # Last token differs
-
-        manager.put(tokens_a, _make_swa_data(swa_config, value=10))
-        manager.put(tokens_b, _make_swa_data(swa_config, value=20))
-
-        assert manager.num_entries == 2
-        result_a = manager.get(tokens_a)
-        result_b = manager.get(tokens_b)
-        assert np.asarray(result_a)[0] == 10
-        assert np.asarray(result_b)[0] == 20
-
-    def test_short_sequence_supported(self, manager, swa_config, tokens_per_block):
-        """Sequences shorter than tokens_per_block still work."""
-        short_tokens = np.array([1, 2], dtype=np.int64)  # Less than tokens_per_block=4
-        manager.put(short_tokens, _make_swa_data(swa_config, value=55))
-        result = manager.get(short_tokens)
-        assert result is not None
-        assert np.asarray(result)[0] == 55
-
-
-class TestSWAProductionManagerThreadSafety:
-    """Test thread safety of the production manager."""
-
-    def test_concurrent_puts(self, swa_config, tokens_per_block):
-        """Multiple threads putting concurrently should not corrupt state."""
-        mgr = SWAProductionManager(config=swa_config, tokens_per_block=tokens_per_block)
-        num_threads = 4
-        puts_per_thread = 50
-        errors = []
-
-        def worker(thread_id):
-            try:
-                for i in range(puts_per_thread):
-                    token_ids = _make_token_ids(thread_id * 1000 + i * 10)
-                    data = _make_swa_data(swa_config, value=(thread_id * 10 + i) % 256)
-                    mgr.put(token_ids, data)
-            except Exception as e:
-                errors.append(e)
-
-        threads = [threading.Thread(target=worker, args=(t,)) for t in range(num_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        assert len(errors) == 0
-        # Total entries should be <= num_threads * puts_per_thread (some may have been evicted)
-        assert mgr.num_entries <= num_threads * puts_per_thread
-        assert mgr.num_entries > 0
-
-    def test_concurrent_put_get(self, swa_config, tokens_per_block):
-        """Concurrent puts and gets should not crash."""
-        mgr = SWAProductionManager(config=swa_config, tokens_per_block=tokens_per_block)
-        errors = []
-
-        # Pre-populate some entries
-        for i in range(4):
-            token_ids = _make_token_ids(i * 100)
-            mgr.put(token_ids, _make_swa_data(swa_config, value=i))
-
-        def writer():
-            try:
-                for i in range(50):
-                    token_ids = _make_token_ids(1000 + i * 10)
-                    mgr.put(token_ids, _make_swa_data(swa_config, value=i % 256))
-            except Exception as e:
-                errors.append(e)
-
-        def reader():
-            try:
-                for i in range(50):
-                    token_ids = _make_token_ids((i % 4) * 100)
-                    mgr.get(token_ids)  # May return None if evicted — that's fine
-            except Exception as e:
-                errors.append(e)
-
-        threads = [
-            threading.Thread(target=writer),
-            threading.Thread(target=reader),
-            threading.Thread(target=reader),
-        ]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        assert len(errors) == 0
-
-
-class TestSWAProductionManagerIntegration:
-    """Integration-level tests simulating the production flow."""
-
-    def test_full_lifecycle(self, manager, swa_config):
-        """Simulate: put → get → evict → cascade."""
-        # 1. Put
-        token_ids = _make_token_ids(100)
-        block_ids = _make_block_ids(500, 2)
-        data = _make_swa_data(swa_config, value=77)
-        assert manager.put(token_ids, data, physical_block_ids=block_ids) is True
-
-        # 2. Get
-        loaded = manager.get(token_ids)
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 77
-
-        # 3. has
-        assert manager.has(token_ids) is True
-
-        # 4. Cascade eviction
-        evicted = manager.on_blocks_evicted(np.array([501], dtype=np.int64))
-        assert evicted == 1
-
-        # 5. Verify gone
-        assert manager.has(token_ids) is False
-        assert manager.get(token_ids) is None
-
-    def test_serve_cycle_simulation(self, manager, swa_config):
-        """Simulate a serving cycle: req1 finishes → req2 arrives with shared prefix."""
-        # Request 1 finishes: store main KV + SWA
-        req1_tokens = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=np.int64)
-        req1_blocks = np.array([100, 101, 102], dtype=np.int64)
-        swa_data = _make_swa_data(swa_config, value=42)
-        assert manager.put(req1_tokens, swa_data, physical_block_ids=req1_blocks) is True
-
-        # Request 2 arrives: shares prefix (same last block of the matched part)
-        # The matched prefix would be [1,2,3,4,5,6,7,8] (first 8 tokens)
-        # But the SWA key is based on the FULL sequence that was stored
-        # So req2 would need to look up by req1's full token_ids
-        assert manager.has(req1_tokens) is True
-        loaded = manager.get(req1_tokens)
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 42
-
-    def test_block_id_update_on_reput(self, manager, swa_config):
-        """Re-putting with different block IDs updates the block tracking."""
-        token_ids = _make_token_ids(100)
-        block_ids_v1 = _make_block_ids(500, 2)  # endpoint = 501
-        block_ids_v2 = _make_block_ids(700, 2)  # endpoint = 701
-
-        manager.put(token_ids, _make_swa_data(swa_config, value=1),
-                    physical_block_ids=block_ids_v1)
-
-        # Update with new block IDs
-        manager.put(token_ids, _make_swa_data(swa_config, value=2),
-                    physical_block_ids=block_ids_v2)
-
-        # Old endpoint block eviction should NOT affect (old mapping removed)
-        evicted = manager.on_blocks_evicted(np.array([501], dtype=np.int64))
-        assert evicted == 0
-        assert manager.has(token_ids) is True
-
-        # New endpoint block eviction SHOULD affect
-        evicted = manager.on_blocks_evicted(np.array([701], dtype=np.int64))
-        assert evicted == 1
-        assert manager.has(token_ids) is False
-
-    def test_torch_tensor_input(self, manager, swa_config):
-        """Verify torch.Tensor inputs are handled correctly."""
-        try:
-            import torch
-        except ImportError:
-            pytest.skip("torch not available")
-
-        token_ids = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.int64)
-        swa_data = torch.full((swa_config.slot_size_bytes,), 55, dtype=torch.uint8)
-
-        assert manager.put(token_ids, swa_data) is True
-        assert manager.has(token_ids) is True
-
-        loaded = manager.get(token_ids)
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 55
-
-
-class TestSWAProductionManagerLoadBackFlow:
-    """Tests simulating the FlexKV connector's SWA load-back path.
-
-    These tests verify the production manager operations used by the connector
-    during the get_new_hit_length → start_load_kv flow:
-    1. has() for backward search (checking SWA availability at different prefix lengths)
-    2. get() for loading SWA data to restore to GPU
-    """
-
-    def test_backward_search_finds_available_prefix(self, manager, swa_config, tokens_per_block):
-        """Simulate backward search: full prefix has no SWA, shorter prefix does.
-
-        Connector logic: If swa_available(full_match) is False, try progressively
-        shorter prefixes (page-aligned) until one has SWA available.
-        """
-        page_size = tokens_per_block  # page_size == tokens_per_block == 4
-
-        # Store SWA for a shorter prefix (8 tokens = 2 pages)
-        short_prefix = _make_token_ids(100, num_tokens=8)
-        manager.put(short_prefix, _make_swa_data(swa_config, value=42))
-
-        # Full prefix is 16 tokens (4 pages) — SWA not stored for this
-        full_prefix = _make_token_ids(100, num_tokens=16)
-        assert manager.has(full_prefix) is False
-
-        # Backward search: try hit_length - page_size each step
-        hit_length = 16
-        found_hit_length = 0
-        while hit_length > 0:
-            hit_length -= page_size
-            if hit_length <= 0:
-                break
-            prefix = _make_token_ids(100, num_tokens=hit_length)
-            if manager.has(prefix):
-                found_hit_length = hit_length
-                break
-
-        # Should find at hit_length=8 (the shorter prefix we stored)
-        assert found_hit_length == 8
-
-        # Verify we can get the data for the found prefix
-        loaded = manager.get(_make_token_ids(100, num_tokens=8))
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 42
-
-    def test_backward_search_no_swa_returns_zero(self, manager, swa_config, tokens_per_block):
-        """When no prefix has SWA available, backward search returns hit_length=0."""
-        page_size = tokens_per_block
-
-        # Don't store any SWA data
-        full_prefix = _make_token_ids(200, num_tokens=16)
-
-        # Backward search
-        hit_length = 16
-        found_hit_length = 0
-        while hit_length > 0:
-            hit_length -= page_size
-            if hit_length <= 0:
-                break
-            prefix = _make_token_ids(200, num_tokens=hit_length)
-            if manager.has(prefix):
-                found_hit_length = hit_length
-                break
-
-        assert found_hit_length == 0
-
-    def test_swa_available_at_full_hit(self, manager, swa_config):
-        """When SWA is available at full hit_length, no backward search needed."""
-        full_prefix = _make_token_ids(300, num_tokens=12)
-        manager.put(full_prefix, _make_swa_data(swa_config, value=77))
-
-        # SWA available at full hit → no reduction needed
-        assert manager.has(full_prefix) is True
-
-        # get() returns the data for load-back
-        loaded = manager.get(full_prefix)
-        assert loaded is not None
-        assert np.asarray(loaded)[0] == 77
-
-    def test_load_back_data_integrity(self, manager, swa_config):
-        """Verify data integrity through the store → check → load cycle.
-
-        Simulates the full connector flow:
-        1. start_store_kv: swa_put (store)
-        2. get_new_hit_length: swa_available (check)
-        3. start_load_kv: swa_get (load for GPU restore)
-        """
-        token_ids = _make_token_ids(400, num_tokens=8)
-        # Simulate distinct data per-byte to verify no corruption
-        data = np.arange(swa_config.slot_size_bytes, dtype=np.uint8)
-        manager.put(token_ids, data)
-
-        # Check availability (connector's get_new_hit_length)
-        assert manager.has(token_ids) is True
-
-        # Load data (connector's start_load_kv → _do_swa_restore_for_op)
-        loaded = manager.get(token_ids)
-        assert loaded is not None
-        loaded_arr = np.asarray(loaded)
-        assert np.array_equal(loaded_arr, data)
-
-    def test_load_back_after_eviction_returns_none(self, manager, swa_config):
-        """If SWA data was evicted between check and load, get returns None gracefully."""
-        token_ids = _make_token_ids(500, num_tokens=8)
-        block_ids = _make_block_ids(900, 2)
-        manager.put(token_ids, _make_swa_data(swa_config, value=33),
-                    physical_block_ids=block_ids)
-
-        # Check: available
-        assert manager.has(token_ids) is True
-
-        # Cascade eviction happens between check and load
-        manager.on_blocks_evicted(np.array([901], dtype=np.int64))
-
-        # Load: should return None (evicted)
-        loaded = manager.get(token_ids)
-        assert loaded is None
-
-    def test_multiple_requests_independent_swa_state(self, manager, swa_config):
-        """Multiple concurrent requests have independent SWA load state."""
-        # Request A
-        tokens_a = _make_token_ids(600, num_tokens=8)
-        data_a = _make_swa_data(swa_config, value=11)
-        manager.put(tokens_a, data_a)
-
-        # Request B
-        tokens_b = _make_token_ids(700, num_tokens=8)
-        data_b = _make_swa_data(swa_config, value=22)
-        manager.put(tokens_b, data_b)
-
-        # Both available independently
-        assert manager.has(tokens_a) is True
-        assert manager.has(tokens_b) is True
-
-        # Load each independently (simulates start_load_kv for different ops)
-        loaded_a = manager.get(tokens_a)
-        loaded_b = manager.get(tokens_b)
-        assert np.asarray(loaded_a)[0] == 11
-        assert np.asarray(loaded_b)[0] == 22
-
-    def test_backward_search_page_alignment(self, swa_config):
-        """Backward search respects page_size alignment."""
-        # Use larger page_size to verify alignment
-        page_size = 4
-        mgr = SWAProductionManager(config=swa_config, tokens_per_block=page_size)
-
-        # Store SWA for exactly 2 pages (8 tokens)
-        short_prefix = _make_token_ids(800, num_tokens=8)
-        mgr.put(short_prefix, _make_swa_data(swa_config, value=55))
-
-        # Full hit is 5 pages (20 tokens), no SWA
-        # Backward search: 20→16→12→8 (found!)
-        hit_length = 20
-        steps = 0
-        found_hit_length = 0
-        while hit_length > 0:
-            hit_length -= page_size
-            steps += 1
-            if hit_length <= 0:
-                break
-            prefix = _make_token_ids(800, num_tokens=hit_length)
-            if mgr.has(prefix):
-                found_hit_length = hit_length
-                break
-
-        assert found_hit_length == 8
-        assert steps == 3  # 20→16, 16→12, 12→8
+        victim = nodes[0]  # LRU end (oldest put, never touched)
+        newn = FakeNode()
+        assert manager.put(newn, _data(swa_config)) is True
+
+        # victim got tombstoned, but the node object itself survives
+        assert victim.swa_tombstone is True
+        assert victim.swa_host_slot == -1
+        # new node took the freed slot
+        assert newn.swa_host_slot != -1
+        assert newn.swa_tombstone is False
+
+    def test_get_promotes_mru_changes_victim(self, manager, swa_config):
+        nodes = [FakeNode() for _ in range(swa_config.num_slots)]
+        for n in nodes:
+            manager.put(n, _data(swa_config))
+        # touch nodes[0] so it is no longer LRU
+        manager.get(nodes[0])
+        newn = FakeNode()
+        manager.put(newn, _data(swa_config))
+        # nodes[0] should survive; nodes[1] (now LRU) should be the victim
+        assert nodes[0].swa_tombstone is False
+        assert nodes[1].swa_tombstone is True
+
+    def test_all_locked_put_fails(self, manager, swa_config):
+        nodes = [FakeNode() for _ in range(swa_config.num_slots)]
+        for n in nodes:
+            manager.put(n, _data(swa_config))
+            n.inc_swa_lock_ref()  # lock every entry
+        newn = FakeNode()
+        assert manager.put(newn, _data(swa_config)) is False
+        assert newn.swa_host_slot == -1
+
+    def test_locked_victim_skipped(self, manager, swa_config):
+        nodes = [FakeNode() for _ in range(swa_config.num_slots)]
+        for n in nodes:
+            manager.put(n, _data(swa_config))
+        nodes[0].inc_swa_lock_ref()  # lock the LRU one
+        newn = FakeNode()
+        assert manager.put(newn, _data(swa_config)) is True
+        # locked node survives; next unlocked LRU (nodes[1]) is evicted
+        assert nodes[0].swa_tombstone is False
+        assert nodes[1].swa_tombstone is True
+
+
+# --------------------------------------------------------------------------- #
+# Stale-entry handling + cascade free_slots                                   #
+# --------------------------------------------------------------------------- #
+
+class TestStaleAndCascade:
+    def test_stale_lru_entry_skipped(self, manager, swa_config):
+        nodes = [FakeNode() for _ in range(swa_config.num_slots)]
+        for n in nodes:
+            manager.put(n, _data(swa_config))
+        # Simulate a cascade that already released nodes[0]'s slot to the pool:
+        # node.swa_host_slot cleared, slot returned, but LRU still has a stale entry.
+        freed_slot = nodes[0].swa_host_slot
+        nodes[0].swa_host_slot = -1
+        nodes[0].swa_tombstone = True
+        manager.free_slots([freed_slot])
+        # Now a put should consume the cascade-freed slot via allocate (no need
+        # to evict), and the stale LRU entry must not cause a double free / crash.
+        newn = FakeNode()
+        assert manager.put(newn, _data(swa_config)) is True
+        assert newn.swa_host_slot != -1
+
+    def test_free_slots_returns_to_pool(self, manager, swa_config):
+        n = FakeNode()
+        manager.put(n, _data(swa_config))
+        slot = n.swa_host_slot
+        used_before = manager.pool.num_used
+        # mimic C++ cascade clearing the node, then engine returning the slot
+        n.swa_host_slot = -1
+        freed = manager.free_slots([slot])
+        assert freed == 1
+        assert manager.pool.num_used == used_before - 1
+
+    def test_free_slots_ignores_negative(self, manager):
+        assert manager.free_slots([-1, None]) == 0
+
+
+# --------------------------------------------------------------------------- #
+# lock / unlock                                                               #
+# --------------------------------------------------------------------------- #
+
+class TestLockUnlock:
+    def test_lock_unlock(self, manager, swa_config):
+        n = FakeNode()
+        manager.put(n, _data(swa_config))
+        manager.lock(n)
+        assert n.swa_lock_ref == 1
+        manager.unlock(n)
+        assert n.swa_lock_ref == 0
+
+    def test_lock_noop_without_slot(self, manager):
+        n = FakeNode()
+        manager.lock(n)  # no slot -> no lock
+        assert n.swa_lock_ref == 0


### PR DESCRIPTION
 ## Description
The original logic of matching SWA using only the last window tokens suffers from precision issues. Refactors SWA caching to be node-attached: SWA snapshot state now lives directly on each radix node instead of a separate side structure. The SWA  manager keeps only the host pool and LRU ordering; cascade eviction is driven by the radix tree.

## Test
<img width="1556" height="494" alt="image" src="https://github.com/user-attachments/assets/9aed9cc5-a95f-4cc7-9715-1cdc956622f3" />