### PR TITLE
Integrate nvcomp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ cover/
 
 # logs
 *.log
+.nfs*
+
+.misc/
+.claude/
+*cache*/
+benchmarks/nvcomp_benchmarks/inputs
+benchmarks/nvcomp_benchmarks/runs

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ FlexKV is released under the **Apache-2.0 License**. See the [LICENSE](LICENSE) 
 
 ## Updates
 
+- **Jun 8, 2026**: Integrate nvcomp into FlexKV.
+
 - **Mar 17, 2026**: 🎉 FlexKV has been officially merged into [vLLM](https://github.com/vllm-project/vllm) mainline ([PR #34328](https://github.com/vllm-project/vllm/pull/34328))! Starting from **vLLM v0.17.2**, `FlexKVConnectorV1` is built in — no patch required. See [docs/vllm_adapter/README_en.md](docs/vllm_adapter/README_en.md) for updated usage.
 
 - **Mar 3, 2026**: 🎉 FlexKV has been officially merged into [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) ([PR #5858](https://github.com/ai-dynamo/dynamo/pull/5858))! FlexKV is now a native KV Cache Offloading option in Dynamo, enabling KV-aware routing + multi-level cache offloading in a unified pipeline. See [docs/dynamo_integration/README_en.md](docs/dynamo_integration/README_en.md).

--- a/benchmarks/nvcomp_benchmarks/benchmark.sh
+++ b/benchmarks/nvcomp_benchmarks/benchmark.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Reproduce FlexKV nvCOMP close-loop end-to-end benchmarks.
+#
+# Typical usage:
+#   DATASET=/path/to/datasets--princeton-nlp--SWE-bench_oracle \
+#   MODEL_PATH=/path/to/GLM-5.1-FP8 \
+#   JIT_CACHE=/path/to/writable/cache \
+#   ISL=128k RUN_ID=run_000 \
+#   bash benchmarks/nvcomp_benchmarks/benchmark.sh
+#
+# Paths users usually need to customize:
+#   MODEL_PATH    Local model directory. Must contain tokenizer.json.
+#                 Default: /tmp/nvidia-mps/GLM-5.1-FP8
+#   DATASET       SWE-bench Oracle dataset id or local HuggingFace cache dir.
+#                 Example: /workspace/develop/datasets/SWE-bench/datasets--princeton-nlp--SWE-bench_oracle
+#                 Default: princeton-nlp/SWE-bench_oracle
+#   JIT_CACHE    Writable cache directory for SGLang/FlexKV JIT/cache files.
+#                 Default: /workspace/develop/envs/taco-sglang/cache
+#   OUT_ROOT      Optional output root. If unset, results go under:
+#                 benchmarks/nvcomp_benchmarks/runs/close_loop/$ISL/$RUN_ID
+#   INPUT         Optional pre-generated conversations JSON. If unset, this
+#                 script auto-generates one under benchmarks/nvcomp_benchmarks/inputs/.
+#
+# Other common knobs:
+#   ISL=128k|64k, RUN_ID=run_000, VARIANTS="baseline nvcomp",
+#   PORT=8000, TP_SIZE=8, SEED=42.
+#
+# By default this runs one baseline sweep and one nvcomp sweep. To run multiple
+# repetitions, wrap this script in an outer RUN_ID loop.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# User paths
+MODEL_PATH="${MODEL_PATH:-/tmp/nvidia-mps/GLM-5.1-FP8}"
+DATASET="${DATASET:-princeton-nlp/SWE-bench_oracle}"
+JIT_CACHE="${JIT_CACHE:-/workspace/develop/envs/taco-sglang/cache}"
+
+# Benchmark selection
+ISL="${ISL:-128k}"
+RUN_ID="${RUN_ID:-run_000}"
+VARIANTS="${VARIANTS:-baseline nvcomp}"
+
+# JIT cache config
+export PYTHONUNBUFFERED=1
+export SGLANG_DG_CACHE_DIR="${SGLANG_DG_CACHE_DIR:-$JIT_CACHE/deep_gemm}"
+export SGLANG_CACHE_DIR="${SGLANG_CACHE_DIR:-$JIT_CACHE/sglang}"
+export FLASHINFER_WORKSPACE_BASE="${FLASHINFER_WORKSPACE_BASE:-$JIT_CACHE/flashinfer_workspace}"
+export CUDA_CACHE_PATH="${CUDA_CACHE_PATH:-$JIT_CACHE/cuda}"
+export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-1}"
+
+
+# SGLang config
+MODEL_NAME="${MODEL_NAME:-glm-5.1-fp8}"
+PORT="${PORT:-8000}"
+TP_SIZE="${TP_SIZE:-8}"
+KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-bfloat16}"
+QUANTIZATION="${QUANTIZATION:-fp8}"
+ATTENTION_BACKEND="${ATTENTION_BACKEND:-nsa}"
+CONTEXT_LENGTH="${CONTEXT_LENGTH:-140000}"
+CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-16384}"
+MAX_PREFILL_TOKENS="${MAX_PREFILL_TOKENS:-16384}"
+PAGE_SIZE="${PAGE_SIZE:-64}"
+MEM_FRACTION_STATIC="${MEM_FRACTION_STATIC:-0.85}"
+
+# Flexkv config
+FLEXKV_CPU_CACHE_GB="${FLEXKV_CPU_CACHE_GB:-400}"
+FLEXKV_SSD_CACHE_GB="${FLEXKV_SSD_CACHE_GB:-0}"
+FLEXKV_CPU_LAYOUT="${FLEXKV_CPU_LAYOUT:-BLOCKFIRST}"
+FLEXKV_KV_CACHE_DTYPE="${FLEXKV_KV_CACHE_DTYPE:-bf16}"
+FLEXKV_ENABLE_MPS="${FLEXKV_ENABLE_MPS:-0}"
+
+# Client/data config
+SEED="${SEED:-42}"
+MAX_TOKENS="${MAX_TOKENS:-512}"
+THINK_TIME_PER_TURN="${THINK_TIME_PER_TURN:-2}"
+WAIT_TIME_PER_CONV="${WAIT_TIME_PER_CONV:-6}"
+REQUEST_TIMEOUT_SEC="${REQUEST_TIMEOUT_SEC:-1800}"
+FLUSH_TIMEOUT_SEC="${FLUSH_TIMEOUT_SEC:-120}"
+READY_TIMEOUT_SEC="${READY_TIMEOUT_SEC:-1800}"
+SKIP_WARMUP="${SKIP_WARMUP:-0}"
+WARMUP_CLIENTS="${WARMUP_CLIENTS:-8}"
+NUM_TURNS="${NUM_TURNS:-5}"
+
+
+case "$(echo "$ISL" | tr '[:upper:]' '[:lower:]')" in
+  64k|64000)
+    ISL_NAME="isl64k"
+    INPUT_BASENAME="swe-bench-oracle-ISL64k-5turns-conversations.json"
+    ISL_TOKENS=64000
+    MAX_CONVS="${MAX_CONVS:-40}"
+    CONCURRENCIES="${CONCURRENCIES:-16 8 4 2 1}"
+    MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-16}"
+    ;;
+  128k|128000)
+    ISL_NAME="isl128k"
+    INPUT_BASENAME="swe-bench-oracle-ISL128k-5turns-conversations.json"
+    ISL_TOKENS=128000
+    MAX_CONVS="${MAX_CONVS:-20}"
+    CONCURRENCIES="${CONCURRENCIES:-8 4 3 2 1}"
+    MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-8}"
+    ;;
+  *)
+    echo "FATAL: unsupported ISL=$ISL; use ISL=64k or ISL=128k" >&2
+    exit 2
+    ;;
+esac
+
+RUN_ROOT="${OUT_ROOT:-$SCRIPT_DIR/runs/close_loop/$ISL_NAME/$RUN_ID}"
+INPUT="${INPUT:-$SCRIPT_DIR/inputs/$INPUT_BASENAME}"
+INPUT_CONVERSATIONS="${INPUT_CONVERSATIONS:-40}"
+
+log_step() {
+  echo
+  echo "[bench] >>> $*"
+}
+
+cleanup_gpu() {
+  log_step "cleanup_gpu: stop stale server processes and clear IPC state"
+  pkill -9 -f "sglang.launch_server"             2>/dev/null || true
+  pkill -9 -f "sglang.srt"                       2>/dev/null || true
+  pkill -9 -fi "Scheduler"                       2>/dev/null || true
+  pkill -9 -fi "TpModelWorker"                   2>/dev/null || true
+  pkill -9 -fi "DetokenizerManager"              2>/dev/null || true
+  pkill -9 -fi "TokenizerManager"                2>/dev/null || true
+  pkill -9 -f "spawn_main"                       2>/dev/null || true
+  pkill -9 -f "multiprocessing.spawn"            2>/dev/null || true
+  pkill -9 -f "multiprocessing.resource_tracker" 2>/dev/null || true
+  pkill -9 -f "flexkv"                           2>/dev/null || true
+  sleep 2
+
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    local a=0 pids
+    while [ "$a" -lt 30 ]; do
+      pids=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | tr -d ' ')
+      [ -z "$pids" ] && break
+      for p in $pids; do kill -9 "$p" 2>/dev/null || true; done
+      sleep 2
+      a=$((a + 1))
+    done
+
+    local b=0 max_used=0
+    while [ "$b" -lt 60 ]; do
+      max_used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null \
+        | awk 'BEGIN{m=0}{if($1+0>m)m=$1+0}END{print m}')
+      [ "${max_used:-0}" -lt 1024 ] && break
+      sleep 2
+      b=$((b + 1))
+    done
+    if [ "${max_used:-0}" -ge 1024 ]; then
+      echo "WARN cleanup_gpu: GPU still has ${max_used} MiB used after 120s"
+    fi
+  fi
+
+  rm -f /tmp/flexkv_* 2>/dev/null || true
+  for pat in 'torch_*' 'nccl-*' 'sglang_*' 'flexkv_*' 'cuda.*' 'mp-*' 'psm_*' 'sem.mp-*'; do
+    find /dev/shm -maxdepth 1 -name "$pat" -delete 2>/dev/null || true
+  done
+  ipcs -m 2>/dev/null | awk -v u="${USER:-root}" '/^0x/ && $3==u {print $2}' \
+    | xargs -r -n1 ipcrm -m 2>/dev/null || true
+  sleep 2
+  echo "[bench] cleanup_gpu: done"
+}
+
+prepare_input() {
+  log_step "prepare_input: ensure SWE-bench conversations exist"
+  echo "[bench] input=$INPUT"
+  echo "[bench] dataset=$DATASET"
+  echo "[bench] tokenizer/model=$MODEL_PATH"
+  if [ -f "$INPUT" ]; then
+    echo "[bench] input exists: $INPUT"
+    return
+  fi
+
+  echo "[bench] input missing, generating: $INPUT"
+  mkdir -p "$(dirname "$INPUT")"
+  python3 "$SCRIPT_DIR/swe-bench-multiturn-setup.py" \
+    --tokenizer "$MODEL_PATH" \
+    --dataset "$DATASET" \
+    --output-file "$INPUT" \
+    --isl "$ISL_TOKENS" \
+    --num-turns "$NUM_TURNS" \
+    --num-conversations "$INPUT_CONVERSATIONS" \
+    --seed "$SEED"
+}
+
+start_server() {
+  local variant="$1" nvcomp="$2" out_dir="$3"
+  local log="$out_dir/server.log"
+  mkdir -p "$out_dir"
+  : > "$log"
+
+  log_step "start_server: variant=$variant nvcomp=$nvcomp"
+  echo "[bench] server log=$log"
+  echo "[bench] model=$MODEL_PATH served_name=$MODEL_NAME port=$PORT tp=$TP_SIZE"
+  echo "[bench] max_running_requests=$MAX_RUNNING_REQUESTS context_length=$CONTEXT_LENGTH"
+  cleanup_gpu
+  echo "[bench] starting server: variant=$variant nvcomp=$nvcomp log=$log"
+
+  FLEXKV_ENABLE_NVCOMP="$nvcomp" \
+  FLEXKV_ENABLE_MPS="$FLEXKV_ENABLE_MPS" \
+  FLEXKV_CPU_CACHE_GB="$FLEXKV_CPU_CACHE_GB" \
+  FLEXKV_SSD_CACHE_GB="$FLEXKV_SSD_CACHE_GB" \
+  FLEXKV_KV_CACHE_DTYPE="$FLEXKV_KV_CACHE_DTYPE" \
+  FLEXKV_CPU_LAYOUT="$FLEXKV_CPU_LAYOUT" \
+  python -m sglang.launch_server \
+    --model-path "$MODEL_PATH" \
+    --served-model-name "$MODEL_NAME" \
+    --host 0.0.0.0 --port "$PORT" \
+    --tp-size "$TP_SIZE" \
+    --quantization "$QUANTIZATION" \
+    --kv-cache-dtype "$KV_CACHE_DTYPE" \
+    --mem-fraction-static "$MEM_FRACTION_STATIC" \
+    --max-running-requests "$MAX_RUNNING_REQUESTS" \
+    --context-length "$CONTEXT_LENGTH" \
+    --chunked-prefill-size "$CHUNKED_PREFILL_SIZE" \
+    --max-prefill-tokens "$MAX_PREFILL_TOKENS" \
+    --page-size "$PAGE_SIZE" \
+    --attention-backend "$ATTENTION_BACKEND" \
+    --kv-connector-cls flexkv \
+    --reasoning-parser glm45 \
+    --tool-call-parser glm47 \
+    --trust-remote-code \
+    --log-level info \
+    2>&1 | tee "$log" &
+  SERVER_PID=$!
+
+  local waited=0
+  until grep -q "fired up and ready" "$log" 2>/dev/null; do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "FATAL: server exited before ready; see $log" >&2
+      exit 1
+    fi
+    if [ "$waited" -ge "$READY_TIMEOUT_SEC" ]; then
+      echo "FATAL: timed out waiting for server readiness; see $log" >&2
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+    echo "[bench] waiting for server... ${waited}s"
+  done
+  echo "[bench] server ready after ${waited}s"
+}
+
+stop_server() {
+  log_step "stop_server"
+  echo "[bench] sending SIGINT to sglang.launch_server"
+  pkill -INT -f "sglang.launch_server" 2>/dev/null || true
+  sleep 10
+  echo "[bench] stop_server: done"
+}
+
+mark_phase() {
+  local out_dir="$1"
+  shift
+  local ts
+  ts=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "$ts  $*" | tee -a "$out_dir/phases.log"
+}
+
+flush_gpu_cache() {
+  local label="$1"
+  log_step "flush_gpu_cache: $label"
+  echo "[bench] flush_cache before $label"
+  local rc
+  rc=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -X POST "http://localhost:$PORT/flush_cache?timeout=$FLUSH_TIMEOUT_SEC" || echo err)
+  echo "[bench]   /flush_cache -> http $rc"
+  sleep 3
+}
+
+run_client() {
+  local out_file="$1"
+  local num_clients="$2"
+  local max_turns="${3:-}"
+  local extra_args=()
+  if [ -n "$max_turns" ]; then
+    extra_args+=(--max-turns-per-conv "$max_turns")
+  fi
+
+  log_step "run_client: clients=$num_clients output=$out_file"
+  if [ -n "$max_turns" ]; then
+    echo "[bench] max_turns_per_conv=$max_turns"
+  fi
+  python3 -u "$SCRIPT_DIR/close_loop_multi_turn_client.py" \
+    --input-file "$INPUT" \
+    --output-file "$out_file" \
+    --base-url "http://localhost:$PORT" \
+    --model-name "$MODEL_NAME" \
+    --num-conversations "$MAX_CONVS" \
+    --num-clients "$num_clients" \
+    --max-tokens "$MAX_TOKENS" \
+    --think-time-per-turn "$THINK_TIME_PER_TURN" \
+    --wait-time-per-conv "$WAIT_TIME_PER_CONV" \
+    --rounds 1 \
+    --seed "$SEED" \
+    --request-timeout-sec "$REQUEST_TIMEOUT_SEC" \
+    "${extra_args[@]}"
+}
+
+run_sweep() {
+  local out_dir="$1"
+  log_step "run_sweep: out_dir=$out_dir"
+  echo "[bench] max_convs=$MAX_CONVS concurrencies=[$CONCURRENCIES]"
+  echo "[bench] think_time=$THINK_TIME_PER_TURN wait_time=$WAIT_TIME_PER_CONV max_tokens=$MAX_TOKENS"
+  mkdir -p "$out_dir"
+  : > "$out_dir/phases.log"
+
+  if ! curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+    echo "FATAL: server /health not OK on port $PORT" >&2
+    exit 2
+  fi
+
+  if [ "$SKIP_WARMUP" = "1" ]; then
+    log_step "warmup: skipped"
+    mark_phase "$out_dir" "WARMUP_SKIPPED"
+  else
+    log_step "warmup: turn-0 only"
+    mark_phase "$out_dir" "WARMUP_START  convs=$MAX_CONVS c=$WARMUP_CLIENTS turn-0-only"
+    echo "[bench] warmup: convs=$MAX_CONVS clients=$WARMUP_CLIENTS"
+    run_client "$out_dir/warmup.json" "$WARMUP_CLIENTS" 1 2>&1 | tee "$out_dir/warmup.log"
+    mark_phase "$out_dir" "WARMUP_END"
+    flush_gpu_cache "sweep"
+  fi
+
+  for c in $CONCURRENCIES; do
+    local run_dir="$out_dir/c${c}"
+    mkdir -p "$run_dir"
+    log_step "sweep: concurrency=$c"
+    mark_phase "$out_dir" "SWEEP_c${c}_START  convs=$MAX_CONVS"
+    echo "[bench] sweep: c=$c convs=$MAX_CONVS"
+    run_client "$run_dir/bench.json" "$c" 2>&1 | tee "$run_dir/client.log"
+    mark_phase "$out_dir" "SWEEP_c${c}_END"
+    flush_gpu_cache "next sweep"
+  done
+}
+
+run_variant() {
+  local variant="$1" nvcomp="$2"
+  local out_dir="$RUN_ROOT/$variant"
+
+  log_step "run_variant: $variant"
+  echo "=== $variant (NVCOMP=$nvcomp, ISL=$ISL_NAME, RUN_ID=$RUN_ID) ==="
+  start_server "$variant" "$nvcomp" "$out_dir"
+  run_sweep "$out_dir"
+  stop_server
+}
+
+main() {
+  log_step "main"
+  echo "[bench] repo=$REPO_ROOT"
+  echo "[bench] isl=$ISL_NAME max_convs=$MAX_CONVS concurrencies=[$CONCURRENCIES]"
+  echo "[bench] output=$RUN_ROOT"
+  prepare_input
+
+  for variant in $VARIANTS; do
+    case "$variant" in
+      baseline) run_variant baseline 0 ;;
+      nvcomp) run_variant nvcomp 1 ;;
+      *)
+        echo "FATAL: unsupported variant=$variant; use baseline and/or nvcomp" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  echo "=== all done. results under $RUN_ROOT ==="
+}
+
+trap stop_server EXIT
+main "$@"

--- a/benchmarks/nvcomp_benchmarks/close_loop_multi_turn_client.py
+++ b/benchmarks/nvcomp_benchmarks/close_loop_multi_turn_client.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""
+Async multi-turn closed-loop OpenAI client for sglang server. Designed for
+SWE-bench Oracle prefix-cache stress tests.
+
+For Poisson open-loop arrival use open_loop-multi_turn_client.py instead.
+
+Closed-loop behavior:
+  - `N = num_clients` async workers each own a conversation and serve its
+    turns *sequentially* — each turn must wait for the previous turn's
+    response to finish before sending the next user message. So real
+    in-flight ≈ min(num_clients, num_active_conversations).
+  - Each turn streams `/v1/chat/completions` with stream_options.include_usage,
+    so we get per-token timing + accurate prompt/completion token counts.
+
+Input: prep JSON (list of {id, messages: [...alternating user/assistant...]}).
+Output: bench.json (list of per-(conv, turn) records).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+import aiohttp
+
+
+@dataclass
+class TurnRecord:
+    conv_id: str
+    turn_idx: int
+    success: bool
+    error: str | None = None
+    ttft_ms: float = 0.0
+    tpot_ms: float = 0.0
+    latency_ms: float = 0.0
+    prompt_num_tokens: int = 0
+    output_num_tokens: int = 0
+    output_num_chunks: int = 0
+    output_text: str = ""           # short, just for sanity-check sampling
+    # Absolute wall-clock timestamps (unix seconds, float, ms-precision) so
+    # bench.json records can be aligned 1:1 with server.log events without
+    # the ±0.5s slop that comes from server.log's second-resolution HTTP
+    # access lines. worker_id = closed-loop worker that owned this turn.
+    worker_id: int = -1
+    t_send_unix: float = 0.0        # right before session.post()
+    t_first_token_unix: float = 0.0 # when first visible delta arrives
+    t_end_unix: float = 0.0         # after streaming finishes / errors out
+    # Sleep actually sampled by the worker before this turn's send.
+    # wait_sleep_s:     uniform[0, wait_time_per_conv], only on turn_idx=0
+    # prev_turn_gap_s:  exp(mean=think_time_per_turn), only on turn_idx>0
+    wait_sleep_s: float = 0.0
+    prev_turn_gap_s: float = 0.0
+
+
+async def _stream_turn(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    model_name: str,
+    messages: list[dict],
+    max_tokens: int,
+    timeout_s: float,
+) -> TurnRecord:
+    """Stream one turn. Returns a fully populated TurnRecord."""
+    payload = {
+        "model": model_name,
+        "messages": messages,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": max_tokens,
+        "temperature": 0.0,        # deterministic-ish, removes sampling noise
+    }
+    rec = TurnRecord(conv_id="", turn_idx=-1, success=False)
+    chunks_text: list[str] = []
+    first_token_time: float | None = None
+    last_chunk_time: float | None = None
+    n_token_chunks = 0
+    usage = None
+
+    t_start = time.perf_counter()
+    rec.t_send_unix = time.time()
+    try:
+        async with session.post(
+            f"{base_url}/v1/chat/completions",
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=timeout_s),
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                rec.error = f"http {resp.status}: {body[:200]}"
+                return rec
+            async for raw in resp.content:
+                # SSE: lines like "data: {...}\n\n"
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                # Usage in final chunk
+                if obj.get("usage"):
+                    usage = obj["usage"]
+                choices = obj.get("choices") or []
+                if choices:
+                    delta = choices[0].get("delta") or {}
+                    # GLM-5.1 reasoning models emit visible tokens via
+                    # `reasoning_content` (chain-of-thought) BEFORE any
+                    # `content` arrives. For TTFT/TPOT purposes, the first
+                    # *visible* token is the first non-empty delta of either
+                    # field — anything else under-reports TTFT badly.
+                    piece = delta.get("content") or delta.get("reasoning_content")
+                    if piece:
+                        now = time.perf_counter()
+                        if first_token_time is None:
+                            first_token_time = now
+                            rec.t_first_token_unix = time.time()
+                        last_chunk_time = now
+                        n_token_chunks += 1
+                        chunks_text.append(piece)
+    except asyncio.TimeoutError:
+        rec.t_end_unix = time.time()
+        rec.error = f"timeout after {timeout_s}s"
+        return rec
+    except Exception as e:
+        rec.t_end_unix = time.time()
+        rec.error = f"{type(e).__name__}: {e}"
+        return rec
+    t_end = time.perf_counter()
+    rec.t_end_unix = time.time()
+
+    rec.success = True
+    rec.latency_ms = (t_end - t_start) * 1e3
+    if first_token_time is not None:
+        rec.ttft_ms = (first_token_time - t_start) * 1e3
+    rec.output_text = "".join(chunks_text)[:120]
+    if usage:
+        rec.prompt_num_tokens = int(usage.get("prompt_tokens", 0))
+        rec.output_num_tokens = int(usage.get("completion_tokens", 0))
+    else:
+        rec.output_num_tokens = n_token_chunks  # fallback
+    rec.output_num_chunks = n_token_chunks
+    # Industry TPOT convention: average time per generated token after the
+    # first token. OpenAI-compatible streaming deltas often map 1:1 to tokens
+    # in practice, but the protocol only guarantees text deltas, so use the
+    # usage token count when available and keep chunk count only as diagnostics.
+    if (
+        first_token_time is not None
+        and last_chunk_time is not None
+        and rec.output_num_tokens > 1
+    ):
+        rec.tpot_ms = (last_chunk_time - first_token_time) * 1e3 / (rec.output_num_tokens - 1)
+    return rec
+
+
+async def _worker(
+    worker_id: int,
+    queue: asyncio.Queue,
+    session: aiohttp.ClientSession,
+    base_url: str,
+    model_name: str,
+    max_tokens: int,
+    timeout_s: float,
+    results: list[TurnRecord],
+    stop_after_reqs: int | None,
+    counter: dict[str, int],
+    max_turns_per_conv: int | None = None,
+    think_time_per_turn: float = 0.0,
+    wait_time_per_conv: float = 0.0,
+    rng: random.Random | None = None,
+):
+    while True:
+        try:
+            conv = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return
+        # Random sleep before EVERY new conv (including the first). This
+        # decorrelates worker timing in two ways: (1) initial burst at T=0
+        # is broken because each worker sleeps a different random amount
+        # before its first conv; (2) ongoing conv-switch events stay
+        # decorrelated since each worker independently stagger after every
+        # conv completion.
+        wait_sleep_sampled = 0.0
+        if wait_time_per_conv > 0 and rng is not None:
+            wait_sleep_sampled = rng.uniform(0, wait_time_per_conv)
+            await asyncio.sleep(wait_sleep_sampled)
+        try:
+            cid: str = conv["id"]
+            messages: list[dict] = list(conv["messages"])  # copy; we'll edit
+            # The prep JSON alternates user/assistant placeholders.
+            # We replay turn by turn: send messages[: 2k+1], read response,
+            # overwrite assistant placeholder at 2k+1, repeat.
+            num_turns = sum(1 for m in messages if m.get("role") == "user")
+            if max_turns_per_conv is not None:
+                num_turns = min(num_turns, max_turns_per_conv)
+            sent_idx = 0          # number of user msgs already sent
+            think_sleep_sampled = 0.0  # gap sampled after turn k, applied to turn k+1
+            for turn in range(num_turns):
+                # Take history up through this user turn (inclusive).
+                next_user_pos = None
+                count = 0
+                for i, m in enumerate(messages):
+                    if m.get("role") == "user":
+                        count += 1
+                        if count == turn + 1:
+                            next_user_pos = i; break
+                assert next_user_pos is not None
+                chat = messages[: next_user_pos + 1]
+                # Don't include the placeholder assistant turns past this point.
+                rec = await _stream_turn(
+                    session, base_url, model_name, chat, max_tokens, timeout_s
+                )
+                rec.conv_id = cid
+                rec.turn_idx = turn
+                rec.worker_id = worker_id
+                rec.wait_sleep_s = wait_sleep_sampled if turn == 0 else 0.0
+                rec.prev_turn_gap_s = think_sleep_sampled if turn > 0 else 0.0
+                results.append(rec)
+                counter["done"] += 1
+                if rec.success and turn + 1 < num_turns:
+                    # Overwrite the next assistant placeholder so subsequent
+                    # turns carry the model's real response in their history.
+                    asst_pos = next_user_pos + 1
+                    if asst_pos < len(messages) and messages[asst_pos]["role"] == "assistant":
+                        messages[asst_pos] = {
+                            "role": "assistant",
+                            "content": rec.output_text or " ",
+                        }
+                    # Simulate user "think time" between turns. Exponential
+                    # so most turns are quick but occasional pauses are long
+                    # — matches measured human chat distribution.
+                    if think_time_per_turn > 0 and rng is not None:
+                        think_sleep_sampled = rng.expovariate(1.0 / think_time_per_turn)
+                        await asyncio.sleep(think_sleep_sampled)
+                    else:
+                        think_sleep_sampled = 0.0
+                if stop_after_reqs is not None and counter["done"] >= stop_after_reqs:
+                    return
+            counter["conv_done"] += 1
+            print(f"[bench] conv {counter['conv_done']}/{counter['total_convs']} done "
+                  f"(worker={worker_id}, id={cid})", flush=True)
+        finally:
+            queue.task_done()
+
+
+def _pct(xs: list[float], q: float) -> float:
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    k = max(0, min(len(s) - 1, int(round(q * (len(s) - 1)))))
+    return s[k]
+
+
+def _print_round_summary(tag: str, results: list[TurnRecord], wall: float) -> None:
+    ok = [r for r in results if r.success]
+    fail = [r for r in results if not r.success]
+    ttfts = [r.ttft_ms for r in ok]
+    tpots = [r.tpot_ms for r in ok if r.tpot_ms > 0]
+    e2es = [r.latency_ms for r in ok]
+    out_tok = sum(r.output_num_tokens for r in ok)
+    in_tok = sum(r.prompt_num_tokens for r in ok)
+    total_tok = in_tok + out_tok
+    print(f"[{tag}] requests done={len(results)} ok={len(ok)} fail={len(fail)}  wall={wall:.1f}s")
+    print(f"[{tag}] tokens prompt={in_tok} completion={out_tok}")
+    if wall > 0:
+        print(f"[{tag}] throughput effective prompt={in_tok / wall:.1f} "
+              f"output={out_tok / wall:.1f} total={total_tok / wall:.1f} tok/s")
+    if ttfts:
+        print(f"[{tag}] ttft  mean={statistics.mean(ttfts):.0f}ms  p50={_pct(ttfts,0.5):.0f}  "
+              f"p95={_pct(ttfts,0.95):.0f}  p99={_pct(ttfts,0.99):.0f}")
+    if tpots:
+        print(f"[{tag}] tpot  mean={statistics.mean(tpots):.1f}ms  p95={_pct(tpots,0.95):.1f}")
+    if e2es:
+        print(f"[{tag}] e2e   mean={statistics.mean(e2es):.0f}ms  p95={_pct(e2es,0.95):.0f}")
+    if fail:
+        sample_errs: dict[str, int] = {}
+        for r in fail:
+            sample_errs.setdefault(r.error or "unknown", 0)
+            sample_errs[r.error or "unknown"] += 1
+        for e, n in sorted(sample_errs.items(), key=lambda x: -x[1])[:5]:
+            print(f"[{tag}] fail x{n}: {e[:120]}")
+
+
+def _stats(xs: list[float]) -> dict:
+    if not xs:
+        return {"n": 0, "mean": 0.0, "p50": 0.0, "p90": 0.0, "p99": 0.0}
+    return {
+        "n": len(xs),
+        "mean": statistics.mean(xs),
+        "p50": _pct(xs, 0.5),
+        "p90": _pct(xs, 0.9),
+        "p99": _pct(xs, 0.99),
+    }
+
+
+def _build_output_doc(args, results: list[TurnRecord], wall: float) -> dict:
+    ok = [r for r in results if r.success]
+    fail = [r for r in results if not r.success]
+    ttfts = [r.ttft_ms for r in ok]
+    tpots = [r.tpot_ms for r in ok if r.tpot_ms > 0]
+    e2es = [r.latency_ms for r in ok]
+    out_tok = sum(r.output_num_tokens for r in ok)
+    in_tok = sum(r.prompt_num_tokens for r in ok)
+    total_tok = in_tok + out_tok
+    turn_indices = sorted({r.turn_idx for r in results})
+    turns_per_conv = (max(turn_indices) + 1) if turn_indices else 0
+    return {
+        "metadata": {
+            "num_conversations": args.num_conversations or 0,
+            "num_clients": args.num_clients,
+            "think_time_per_turn": getattr(args, "think_time_per_turn", 0.0),
+            "wait_time_per_conv": getattr(args, "wait_time_per_conv", 0.0),
+            "seed": getattr(args, "seed", 42),
+            "rounds": args.rounds,
+            "max_tokens": args.max_tokens,
+            "turns_per_conv": turns_per_conv,
+            "total_turns": len(results),
+            "wall_seconds": wall,
+        },
+        "summary": {
+            "ok": len(ok),
+            "fail": len(fail),
+            "ttft_ms": _stats(ttfts),
+            "tpot_ms": _stats(tpots),
+            "latency_ms": _stats(e2es),
+            "prompt_tokens_total": in_tok,
+            "completion_tokens_total": out_tok,
+            "total_tokens_total": total_tok,
+            "throughput": {
+                "round_wall_seconds": wall,
+                "effective_prompt_tok_per_s": in_tok / wall if wall > 0 else 0.0,
+                "effective_output_tok_per_s": out_tok / wall if wall > 0 else 0.0,
+                "effective_total_tok_per_s": total_tok / wall if wall > 0 else 0.0,
+            },
+        },
+        "details": [asdict(r) for r in results],
+    }
+
+
+async def _run_one_round(
+    args,
+    session: aiohttp.ClientSession,
+    convs: list[dict],
+    active: int,
+) -> tuple[list[TurnRecord], float]:
+    """Replay the same conv set once via closed-loop workers. N async
+    workers pull convs from a shared queue, each worker serially runs one
+    conv's turns. Returns (results, wall_seconds).
+
+    Deep-copies each conv so per-turn assistant-placeholder overwrites
+    don't leak into the next round's history.
+    """
+    results: list[TurnRecord] = []
+    counter = {"done": 0, "conv_done": 0, "total_convs": len(convs)}
+    convs_copy = [{"id": c["id"], "messages": [dict(m) for m in c["messages"]]}
+                  for c in convs]
+    max_turns_per_conv = getattr(args, "max_turns_per_conv", None)
+
+    rng = random.Random(args.seed)
+    think_time_per_turn = getattr(args, "think_time_per_turn", 0.0)
+    wait_time_per_conv = getattr(args, "wait_time_per_conv", 0.0)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    for c in convs_copy:
+        queue.put_nowait(c)
+
+    t0 = time.perf_counter()
+    workers = [
+        asyncio.create_task(
+            _worker(
+                i, queue, session, args.base_url, args.model_name,
+                args.max_tokens, args.request_timeout_sec, results,
+                args.max_num_requests, counter, max_turns_per_conv,
+                think_time_per_turn, wait_time_per_conv, rng,
+            )
+        )
+        for i in range(active)
+    ]
+    await asyncio.gather(*workers)
+    wall = time.perf_counter() - t0
+    return results, wall
+
+
+async def run_bench(args) -> int:
+    with open(args.input_file) as f:
+        all_convs: list[dict] = json.load(f)
+
+    # Shuffle the input pool deterministically before cycling. Without
+    # this, conv arrival order is fixed by JSON file order, so any prefix
+    # bias in the dataset shows up as systematic burst pattern. Same seed
+    # → reproducible across baseline/nvcomp runs (so the SAME conv hits
+    # the server at the SAME relative time in both variants).
+    random.Random(args.seed).shuffle(all_convs)
+
+    if args.max_active_conversations is None:
+        active = args.num_clients
+    else:
+        active = min(args.max_active_conversations, args.num_clients)
+
+    # Pick N convs; cycle through input if N > len(all_convs). Recycled
+    # instances get an "#k" id suffix so detail records stay unique while
+    # the underlying prompt prefix (and thus FlexKV cache hit) stays the
+    # same. Useful when sweep arrivals exceed the input-file conv count.
+    N = args.num_conversations or len(all_convs)
+    convs = []
+    for i in range(N):
+        src = all_convs[i % len(all_convs)]
+        if i >= len(all_convs):
+            convs.append({"id": f"{src['id']}#{i // len(all_convs)}",
+                          "messages": src["messages"]})
+        else:
+            convs.append(src)
+
+    rounds = max(1, args.rounds)
+    conn = aiohttp.TCPConnector(limit=max(active * 4, 32))
+    timeout = aiohttp.ClientTimeout(total=None)
+    final_results: list[TurnRecord] = []
+    final_wall = 0.0
+    async with aiohttp.ClientSession(connector=conn, timeout=timeout) as session:
+        for ri in range(1, rounds + 1):
+            tag = f"round {ri}/{rounds}" + (" — warmup" if ri < rounds else " — measure")
+            print(f"\n[bench] === {tag} ===")
+            results, wall = await _run_one_round(args, session, convs, active)
+            _print_round_summary(f"r{ri}", results, wall)
+            if ri == rounds:
+                final_results = results
+                final_wall = wall
+            if ri < rounds and args.inter_round_sleep_sec > 0:
+                print(f"[bench] sleeping {args.inter_round_sleep_sec}s before next round...")
+                await asyncio.sleep(args.inter_round_sleep_sec)
+
+    # Only the LAST round's per-turn records are persisted as bench.json.
+    # Earlier rounds are warmup — their stats live in stdout only. This
+    # matches online_benchmark_client.py's `warmup = round 1, benchmark =
+    # last round` convention.
+    os.makedirs(os.path.dirname(args.output_file) or ".", exist_ok=True)
+    output = _build_output_doc(args, final_results, final_wall)
+    with open(args.output_file, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"\n[bench] === final (round {rounds}) — written to {args.output_file} ===")
+    _print_round_summary("final", final_results, final_wall)
+
+    fail = [r for r in final_results if not r.success]
+    return 0 if not fail else 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input-file", required=True,
+                    help="prep JSON: list of {id, messages}")
+    ap.add_argument("--output-file", required=True,
+                    help="bench.json output")
+    ap.add_argument("--base-url", default="http://127.0.0.1:30001",
+                    help="sglang server base URL")
+    ap.add_argument("--model-name", default="glm-5.1-fp8",
+                    help="served-model-name as configured in sglang server")
+    ap.add_argument("--num-clients", type=int, default=8,
+                    help="async workers (= true in-flight conv concurrency)")
+    ap.add_argument("--max-active-conversations", type=int, default=None,
+                    help="cap (defaults to num_clients)")
+    ap.add_argument("--num-conversations", type=int, default=None,
+                    help="cap on convs taken from input (default all)")
+    ap.add_argument("--max-tokens", type=int, default=64,
+                    help="output max_tokens per turn (long-input/short-output)")
+    ap.add_argument("--max-num-requests", type=int, default=None,
+                    help="early-stop after this many turn requests completed")
+    ap.add_argument("--max-turns-per-conv", type=int, default=None,
+                    help="cap turns sent per conv (default no cap, replay all "
+                         "turns from the input JSON). Set to 1 for warmup runs "
+                         "that only need to populate the cold 128k prefix into "
+                         "the FlexKV CPU pool.")
+    ap.add_argument("--request-timeout-sec", type=float, default=600.0)
+    ap.add_argument("--rounds", type=int, default=1,
+                    help="Number of times to replay the same conv set in one "
+                         "process. Only the LAST round's per-turn records go to "
+                         "the output bench.json (earlier rounds are warmup). "
+                         "Modeled after online_benchmark_client.py's --rounds.")
+    ap.add_argument("--inter-round-sleep-sec", type=float, default=0.0,
+                    help="Seconds to sleep between rounds (default 0). For "
+                         "this design we don't insert /flush_cache between "
+                         "rounds — the workload naturally re-routes through "
+                         "FlexKV CPU pool by round 2 if working set > GPU "
+                         "radix capacity.")
+    ap.add_argument("--think-time-per-turn", type=float, default=0.0,
+                    help="Mean inter-turn delay in seconds (exponential dist). "
+                         "Simulates user reading/thinking between turns. "
+                         "0 (default)=back-to-back torture test; 15s is a "
+                         "reasonable SWE-bench-agent value; 30-60s matches "
+                         "real chat workloads. Decorrelates worker arrivals "
+                         "so scheduler doesn't see synchronized ready bursts.")
+    ap.add_argument("--wait-time-per-conv", type=float, default=0.0,
+                    help="Each worker sleeps uniform [0, N] sec before EVERY "
+                         "new conv (including the first). Decorrelates "
+                         "worker timing: (1) initial T=0 burst is broken "
+                         "since each worker waits a different random "
+                         "amount; (2) conv-switch events stay decorrelated "
+                         "thereafter. Set to ~20s (a typical per-req cycle "
+                         "for ISL=128k) for cleanest de-sync.")
+    ap.add_argument("--seed", type=int, default=42,
+                    help="Random seed for conv shuffling + jitter RNG. Same "
+                         "seed → reproducible across baseline/nvcomp runs.")
+    args = ap.parse_args()
+
+    rc = asyncio.run(run_bench(args))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/nvcomp_benchmarks/swe-bench-multiturn-setup.py
+++ b/benchmarks/nvcomp_benchmarks/swe-bench-multiturn-setup.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Prepare SWE-bench Oracle as a multi-turn JSON conversations file.
+
+Output: JSON list of {"id", "messages": [user, assistant, user, ...]} in the
+shape vLLM's multi_turn benchmark expects. The same file works against
+sglang server via any OpenAI-chat-completions client (e.g. multi_turn_client.py).
+
+--isl N: target turn-0 prompt length in tokens. The script walks the shuffled
+dataset, accumulating oracle texts (concatenated with a visible separator)
+until the running token count reaches N, then encodes the stitched text and
+HARD-TRUNCATES to exactly N tokens (decode back to text). Every emitted conv
+is therefore exactly N tokens (may cut a single oracle mid-sentence, but
+keeps the distribution tight).
+"""
+
+# python3 benchmarks/nvcomp_benchmarks/swe-bench-multiturn-setup.py     --tokenizer /tmp/nvidia-mps/GLM-5.1-FP8     --output-file benchmarks/nvcomp_benchmarks/swe-bench-oracle-ISL128k-5turns-conversations.json     --isl 128000     --num-turns 5    --num-conversations 40 --seed 0
+
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+SUFFIXES = [
+    "Summarize the bug in 3 bullet points.",
+    "List the relevant files that need to be modified and explain why.",
+    "Write a unit test that reproduces this bug.",
+    "Propose a minimal patch that fixes this bug. Output the diff only.",
+    "What edge cases should the fix handle? List them.",
+    "Are there other places in the codebase that may have the same bug pattern?",
+    "Write a short PR description for this fix.",
+    "Explain the root cause to a new contributor in plain English.",
+]
+PREAMBLE = (
+    "You are an expert software engineer. Read the following SWE-bench "
+    "oracle issue carefully; you will be asked several follow-up "
+    "questions about it.\n\n"
+)
+ASSISTANT_PLACEHOLDER = "(assistant response will be filled in at runtime)"
+
+_STITCH_SEPARATOR = "\n\n---\n\nNEXT ISSUE:\n\n---\n\n"
+
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+
+def log(msg: str) -> None:
+    print(f"[prep] {msg}", flush=True)
+
+
+class TokenizersAdapter:
+    def __init__(self, tokenizer: Any) -> None:
+        self.tokenizer = tokenizer
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return self.tokenizer.encode(
+            text, add_special_tokens=add_special_tokens).ids
+
+    def decode(self, ids: list[int]) -> str:
+        return self.tokenizer.decode(ids, skip_special_tokens=False)
+
+
+def load_tokenizer(tokenizer_path: str) -> TokenizersAdapter:
+    path = Path(tokenizer_path)
+    tokenizer_file = path if path.is_file() else path / "tokenizer.json"
+    if not tokenizer_file.is_file():
+        raise FileNotFoundError(
+            f"tokenizer.json not found: {tokenizer_file}. "
+            "Pass either a tokenizer.json file or a model directory containing it.")
+
+    log(f"loading tokenizer: {tokenizer_file}")
+    from tokenizers import Tokenizer
+    tokenizer = Tokenizer.from_file(str(tokenizer_file))
+    log("tokenizer loaded")
+    return TokenizersAdapter(tokenizer)
+
+
+def _resolve_dataset(dataset: str) -> tuple[str, str | None]:
+    # Accept HF cache dirs like .../datasets--<org>--<name> by splitting into
+    # (hf_id, cache_root); load_dataset itself can't open that path directly.
+    p = Path(dataset)
+    if p.is_dir() and p.name.startswith("datasets--"):
+        parts = p.name[len("datasets--"):].split("--", 1)
+        if len(parts) == 2:
+            return f"{parts[0]}/{parts[1]}", str(p.parent)
+    return dataset, None
+
+
+def prepare_swe_dataset(
+    tokenizer: Any,
+    *,
+    dataset: str = "princeton-nlp/SWE-bench_oracle",
+    split: str = "test",
+    isl_tokens: int = 16000,
+    num_conversations: int | None = None,
+    seed: int = 0,
+) -> list[tuple[str, str, int]]:
+    """Return [(conv_id, oracle_text, n_tokens), ...].
+
+    Walks the shuffled dataset and accumulates oracle texts (joined by a
+    visible separator) until the running token count crosses ``isl_tokens``;
+    the stitched text is then encoded and hard-truncated to exactly
+    ``isl_tokens`` tokens. Stops after ``num_conversations`` convs (or when
+    the dataset is exhausted, if None).
+    """
+    hf_id, cache_dir = _resolve_dataset(dataset)
+    log("importing datasets.load_dataset")
+    from datasets import load_dataset
+
+    log(f"loading dataset={hf_id!r} split={split!r} cache_dir={cache_dir!r}")
+    ds = load_dataset(hf_id, split=split, cache_dir=cache_dir)
+    log(f"loaded dataset with {len(ds)} rows")
+    order = list(range(len(ds)))
+    random.Random(seed).shuffle(order)
+    log(f"shuffled dataset with seed={seed}; target_isl={isl_tokens}")
+
+    sep_tokens = len(tokenizer.encode(_STITCH_SEPARATOR, add_special_tokens=False))
+    log(f"separator token count={sep_tokens}")
+
+    kept: list[tuple[str, str, int]] = []
+    buf_pieces: list[str] = []
+    buf_tokens = 0
+    for scanned, idx in enumerate(order, start=1):
+        if num_conversations is not None and len(kept) >= num_conversations:
+            break
+        if scanned == 1 or scanned % 100 == 0:
+            limit = "all" if num_conversations is None else str(num_conversations)
+            log(f"scan progress: rows={scanned} conversations={len(kept)}/{limit} buffer_tokens~{buf_tokens}")
+        text = ds[idx].get("text") or ""
+        if not text:
+            continue
+        n = len(tokenizer.encode(text, add_special_tokens=False))
+        if buf_pieces:
+            buf_tokens += sep_tokens
+        buf_pieces.append(text)
+        buf_tokens += n
+        if buf_tokens >= isl_tokens:
+            stitched = _STITCH_SEPARATOR.join(buf_pieces)
+            # Hard-truncate: re-encode the joined text (per-piece counts are
+            # only an estimate since boundary tokens can merge), then slice
+            # to exactly isl_tokens and decode back.
+            ids = tokenizer.encode(stitched, add_special_tokens=False)
+            if len(ids) >= isl_tokens:
+                ids = ids[:isl_tokens]
+                stitched = tokenizer.decode(ids)
+                kept.append((f"swe_{len(kept):05d}", stitched, len(ids)))
+                log(f"emitted conversation {len(kept)} with {len(ids)} tokens after scanning {scanned} rows")
+                buf_pieces = []
+                buf_tokens = 0
+            # else: boundary merging shaved us below ISL — keep accumulating
+    log(f"finished scan: emitted {len(kept)} conversations")
+    return kept
+
+
+def build_conversations(
+    kept: list[tuple[str, str, int]], num_turns: int
+) -> list[dict]:
+    # Oracle lives in turn 1; later user turns are just the short questions.
+    out = []
+    for conv_id, oracle, n_tokens in kept:
+        messages = [
+            {"role": "user", "content": f"{PREAMBLE}{oracle}\n\nQuestion 1: {SUFFIXES[0]}"},
+            {"role": "assistant", "content": ASSISTANT_PLACEHOLDER},
+        ]
+        for i in range(2, num_turns + 1):
+            messages.append({"role": "user", "content": f"Question {i}: {SUFFIXES[i - 1]}"})
+            messages.append({"role": "assistant", "content": ASSISTANT_PLACEHOLDER})
+        out.append({
+            "id": conv_id,
+            "oracle_tokens": n_tokens,
+            "messages": messages,
+        })
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--tokenizer", required=True)
+    p.add_argument("--output-file", required=True)
+    p.add_argument("--dataset", default="princeton-nlp/SWE-bench_oracle")
+    p.add_argument("--split", default="test")
+    p.add_argument("--isl", type=int, required=True,
+                   help="target turn-0 oracle length in tokens; pieces are "
+                        "accumulated until running total >= ISL, then emitted "
+                        "as one conv.")
+    p.add_argument("--num-conversations", type=int, default=0,
+                   help="0 (default) keeps producing convs until dataset runs out")
+    p.add_argument("--num-turns", type=int, default=5, help=f"1..{len(SUFFIXES)}")
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args(argv)
+
+    if not 1 <= args.num_turns <= len(SUFFIXES):
+        p.error(f"--num-turns must be in [1, {len(SUFFIXES)}]")
+
+    tokenizer = load_tokenizer(args.tokenizer)
+
+    kept = prepare_swe_dataset(
+        tokenizer,
+        dataset=args.dataset, split=args.split,
+        isl_tokens=args.isl,
+        num_conversations=args.num_conversations or None,
+        seed=args.seed,
+    )
+    if args.num_conversations and len(kept) < args.num_conversations:
+        log(f"WARNING: requested {args.num_conversations}, got {len(kept)}")
+
+    if kept:
+        lens = sorted(n for _, _, n in kept)
+        log("oracle tokens over "
+            f"{len(lens)} convs: min={lens[0]} p50={lens[len(lens)//2]} "
+            f"max={lens[-1]} (target ISL={args.isl})")
+
+    log(f"building {len(kept)} conversations with {args.num_turns} turns each")
+    records = build_conversations(kept, args.num_turns)
+
+    out_path = Path(args.output_file)
+    log(f"writing output to {out_path}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(records, f, ensure_ascii=False)
+    try:
+        os.chmod(out_path, 0o666)
+    except OSError:
+        pass
+
+    log(f"Wrote {len(records)} conversations x {args.num_turns} turns -> {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -1,10 +1,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
-#include "transfer.cuh"
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_runtime.h>
 #include <fcntl.h>
@@ -37,6 +38,13 @@
 #include <deque>
 
 namespace py = pybind11;
+
+namespace flexkv {
+#ifdef FLEXKV_ENABLE_NVCOMP
+void register_common_compression_bindings(pybind11::module_& m);
+void register_ans_bindings(pybind11::module_& m);
+#endif
+} // namespace flexkv
 
 void transfer_kv_blocks_binding(
     torch::Tensor &gpu_block_id_tensor, torch::Tensor &gpu_tensor_ptrs_tensor,
@@ -509,18 +517,23 @@ PYBIND11_MODULE(c_ext, m) {
       .def(
           py::init<std::map<int, std::vector<std::string>> &, int, int, int>());
 
-  py::class_<flexkv::TPTransferThreadGroup>(m, "TPTransferThreadGroup")
+  py::class_<flexkv::TPTransferThreadGroup> tp_thread_group(
+      m, "TPTransferThreadGroup");
+  tp_thread_group
       .def(py::init<int, const std::vector<int64_t> &, int, int64_t, int,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
                     const std::vector<int64_t> &, const std::vector<int64_t> &,
-                    const std::vector<int64_t> &>(),
+                    const std::vector<int64_t> &, bool, int, int>(),
            py::arg("num_gpus"), py::arg("gpu_block_ptrs_flat"),
            py::arg("num_tensors_per_gpu"), py::arg("cpu_blocks_ptr"),
            py::arg("num_layers"),
            py::arg("gpu_kv_strides_in_bytes"),
            py::arg("gpu_block_strides_in_bytes"),
            py::arg("gpu_layer_strides_in_bytes"),
-           py::arg("gpu_chunk_sizes_in_bytes"), py::arg("gpu_device_ids"))
+           py::arg("gpu_chunk_sizes_in_bytes"), py::arg("gpu_device_ids"),
+           py::arg("enable_nvcomp") = false,
+           py::arg("nvcomp_batch_size") = 0,
+           py::arg("nvcomp_data_type") = 0)
       .def("tp_group_transfer",
            &flexkv::TPTransferThreadGroup::tp_group_transfer,
            py::arg("gpu_block_id_tensor"), py::arg("cpu_block_id_tensor"),
@@ -529,8 +542,28 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("cpu_block_stride_in_bytes"),
            py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_num_cta"),
            py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
-           py::arg("layer_id"), py::arg("layer_granularity"), py::arg("is_mla")
-           );
+           py::arg("layer_id"), py::arg("layer_granularity"),
+           py::arg("is_mla"));
+#ifdef FLEXKV_ENABLE_NVCOMP
+  // nvcomp ANS variant: tp_group_transfer_ans() lazily initializes from the
+  // constructor config and returns total compressed bytes across ranks.
+  tp_thread_group
+      .def("init_nvcomp", &flexkv::TPTransferThreadGroup::init_nvcomp,
+           py::arg("nvcomp_batch_size"), py::arg("nvcomp_data_type"))
+      .def("tp_group_transfer_ans",
+           &flexkv::TPTransferThreadGroup::tp_group_transfer_ans,
+           py::arg("gpu_block_id_tensor"), py::arg("cpu_block_id_tensor"),
+           py::arg("cpu_kv_stride_in_bytes"),
+           py::arg("cpu_layer_stride_in_bytes"),
+           py::arg("cpu_block_stride_in_bytes"),
+           py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_num_cta"),
+           py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
+           py::arg("layer_id"), py::arg("layer_granularity"), py::arg("is_mla"),
+           py::arg("cpu_size_table_tp_ptr"),
+           py::arg("cpu_size_table_tp_rank_stride"),
+           py::arg("cpu_size_table_block_stride"),
+           py::arg("cpu_size_table_layer_stride"));
+#endif // FLEXKV_ENABLE_NVCOMP
 
 #ifdef FLEXKV_ENABLE_GDS
   py::class_<flexkv::TPGDSTransferThreadGroup>(m, "TPGDSTransferThreadGroup")
@@ -951,4 +984,9 @@ PYBIND11_MODULE(c_ext, m) {
       .def("inc_ref_cnt", &flexkv::RefRadixTree::inc_ref_cnt)
       .def("get_generation", &flexkv::RefRadixTree::get_generation);
 #endif
+
+#ifdef FLEXKV_ENABLE_NVCOMP
+  flexkv::register_common_compression_bindings(m);
+  flexkv::register_ans_bindings(m);
+#endif // FLEXKV_ENABLE_NVCOMP
 }

--- a/csrc/compression/ans/ans_bindings.cpp
+++ b/csrc/compression/ans/ans_bindings.cpp
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include "compression/ans/nvcomp_ans.cuh"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <memory>
+#include <pybind11/pybind11.h>
+#include <stdexcept>
+#include <string>
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+namespace flexkv {
+
+static size_t transfer_kv_blocks_ans_binding(
+    bool is_d2h,
+    flexkv::ANSTransferContext& ctx,
+    torch::Tensor &gpu_block_id_tensor,
+    torch::Tensor &gpu_tensor_ptrs_tensor,
+    int64_t gpu_kv_stride_in_bytes,
+    int64_t gpu_block_stride_in_bytes,
+    int64_t gpu_layer_stride_in_bytes,
+    torch::Tensor &cpu_block_id_tensor,
+    torch::Tensor &cpu_tensor,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int start_layer_id,
+    int num_layers,
+    bool is_mla,
+    int gpu_block_type,
+    int64_t cpu_size_table_ptr,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride) {
+  TORCH_CHECK(gpu_block_id_tensor.dtype() == torch::kInt64,
+              "gpu_block_id_tensor must be int64");
+  TORCH_CHECK(cpu_block_id_tensor.dtype() == torch::kInt64,
+              "cpu_block_id_tensor must be int64");
+  TORCH_CHECK(gpu_tensor_ptrs_tensor.dtype() == torch::kInt64,
+              "gpu_tensor_ptrs_tensor must be int64");
+
+  int num_blocks = gpu_block_id_tensor.numel();
+  int64_t *gpu_block_ids = static_cast<int64_t*>(gpu_block_id_tensor.data_ptr());
+  void **gpu_tensor_ptrs =
+      static_cast<void**>(gpu_tensor_ptrs_tensor.data_ptr());
+  int64_t *cpu_block_ids = static_cast<int64_t*>(cpu_block_id_tensor.data_ptr());
+  void *cpu_ptr = static_cast<void*>(cpu_tensor.data_ptr());
+  uint32_t *cpu_size_table = reinterpret_cast<uint32_t*>(cpu_size_table_ptr);
+  // TODO(nvcomp-guard): external size table is required for true compressed lengths.
+  if (cpu_size_table == nullptr) {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ans_binding: cpu_size_table_ptr must be non-null (the "
+        "external size table is the sole source of nvcomp compressed size)");
+  }
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  flexkv::BackendType bt;
+  if (gpu_block_type == 0) {
+    bt = flexkv::BackendType::VLLM;
+  } else if (gpu_block_type == 1) {
+    bt = flexkv::BackendType::TRTLLM;
+  } else if (gpu_block_type == 2) {
+    bt = flexkv::BackendType::SGLANG;
+  } else {
+    throw std::runtime_error("Unsupported gpu_block_type: " +
+                             std::to_string(gpu_block_type));
+  }
+
+  flexkv::GTensorHandler handler(
+      bt, reinterpret_cast<int64_t**>(gpu_tensor_ptrs), num_layers,
+      gpu_kv_stride_in_bytes, gpu_block_stride_in_bytes,
+      gpu_layer_stride_in_bytes);
+
+  size_t compressed_bytes = 0;
+
+#define ANS_DISPATCH(func, Type)                                             \
+  compressed_bytes = flexkv::func<Type>(                                      \
+      &ctx, num_blocks, start_layer_id, num_layers, gpu_block_ids, handler,   \
+      cpu_block_ids, cpu_ptr, cpu_kv_stride_in_bytes,                         \
+      cpu_layer_stride_in_bytes, cpu_block_stride_in_bytes,                   \
+      chunk_size_in_bytes, is_mla, cpu_size_table,                            \
+      cpu_size_table_block_stride, cpu_size_table_layer_stride, stream)
+#define ANS_SWITCH(func)                                                     \
+  switch (bt) {                                                              \
+    case flexkv::BackendType::VLLM:                                          \
+      ANS_DISPATCH(func, flexkv::BackendType::VLLM);                         \
+      break;                                                                 \
+    case flexkv::BackendType::TRTLLM:                                        \
+      ANS_DISPATCH(func, flexkv::BackendType::TRTLLM);                       \
+      break;                                                                 \
+    case flexkv::BackendType::SGLANG:                                        \
+      ANS_DISPATCH(func, flexkv::BackendType::SGLANG);                       \
+      break;                                                                 \
+  }
+  if (is_d2h) {
+    ANS_SWITCH(transfer_kv_blocks_ans_comp);
+  } else {
+    ANS_SWITCH(transfer_kv_blocks_ans_decomp);
+  }
+#undef ANS_SWITCH
+#undef ANS_DISPATCH
+
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(err));
+  }
+  return compressed_bytes;
+}
+
+static size_t transfer_kv_blocks_ans_comp_binding(
+    flexkv::ANSTransferContext& ctx,
+    torch::Tensor &gpu_block_id_tensor,
+    torch::Tensor &gpu_tensor_ptrs_tensor,
+    int64_t gpu_kv_stride_in_bytes,
+    int64_t gpu_block_stride_in_bytes,
+    int64_t gpu_layer_stride_in_bytes,
+    torch::Tensor &cpu_block_id_tensor,
+    torch::Tensor &cpu_tensor,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int start_layer_id,
+    int num_layers,
+    bool is_mla,
+    int gpu_block_type,
+    int64_t cpu_size_table_ptr,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride) {
+  return transfer_kv_blocks_ans_binding(
+      true, ctx, gpu_block_id_tensor, gpu_tensor_ptrs_tensor,
+      gpu_kv_stride_in_bytes, gpu_block_stride_in_bytes,
+      gpu_layer_stride_in_bytes, cpu_block_id_tensor, cpu_tensor,
+      cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+      cpu_block_stride_in_bytes, chunk_size_in_bytes, start_layer_id,
+      num_layers, is_mla, gpu_block_type, cpu_size_table_ptr,
+      cpu_size_table_block_stride, cpu_size_table_layer_stride);
+}
+
+static size_t transfer_kv_blocks_ans_decomp_binding(
+    flexkv::ANSTransferContext& ctx,
+    torch::Tensor &gpu_block_id_tensor,
+    torch::Tensor &gpu_tensor_ptrs_tensor,
+    int64_t gpu_kv_stride_in_bytes,
+    int64_t gpu_block_stride_in_bytes,
+    int64_t gpu_layer_stride_in_bytes,
+    torch::Tensor &cpu_block_id_tensor,
+    torch::Tensor &cpu_tensor,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int start_layer_id,
+    int num_layers,
+    bool is_mla,
+    int gpu_block_type,
+    int64_t cpu_size_table_ptr,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride) {
+  return transfer_kv_blocks_ans_binding(
+      false, ctx, gpu_block_id_tensor, gpu_tensor_ptrs_tensor,
+      gpu_kv_stride_in_bytes, gpu_block_stride_in_bytes,
+      gpu_layer_stride_in_bytes, cpu_block_id_tensor, cpu_tensor,
+      cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+      cpu_block_stride_in_bytes, chunk_size_in_bytes, start_layer_id,
+      num_layers, is_mla, gpu_block_type, cpu_size_table_ptr,
+      cpu_size_table_block_stride, cpu_size_table_layer_stride);
+}
+
+void register_ans_bindings(py::module_& m) {
+  py::class_<flexkv::ANSTransferContext>(m, "ANSTransferContext")
+      .def(py::init([](size_t max_num_chunks, size_t max_chunk_size,
+                       int data_type, int transfer_sms) {
+             auto ctx = std::make_unique<flexkv::ANSTransferContext>();
+             flexkv::ans_ctx_create(ctx.get(), max_num_chunks, max_chunk_size,
+                                    data_type, transfer_sms);
+             return ctx;
+           }),
+           py::arg("max_num_chunks"), py::arg("max_chunk_size"),
+           py::arg("data_type") = 0, py::arg("transfer_sms") = -1)
+      .def("destroy", [](flexkv::ANSTransferContext& ctx) {
+        flexkv::ans_ctx_destroy(&ctx);
+      })
+      .def_readonly("max_num_chunks",
+                    &flexkv::ANSTransferContext::max_num_chunks)
+      .def_readonly("max_chunk_size",
+                    &flexkv::ANSTransferContext::max_chunk_size)
+      .def_readonly("max_comp_chunk_bytes",
+                    &flexkv::ANSTransferContext::max_comp_chunk_bytes);
+
+  m.def("transfer_kv_blocks_ans_comp", &transfer_kv_blocks_ans_comp_binding,
+        "ANS compress on GPU then D2H transfer", py::arg("ctx"),
+        py::arg("gpu_block_id_tensor"), py::arg("gpu_tensor_ptrs_tensor"),
+        py::arg("gpu_kv_stride_in_bytes"),
+        py::arg("gpu_block_stride_in_bytes"),
+        py::arg("gpu_layer_stride_in_bytes"), py::arg("cpu_block_id_tensor"),
+        py::arg("cpu_tensor"), py::arg("cpu_kv_stride_in_bytes"),
+        py::arg("cpu_layer_stride_in_bytes"),
+        py::arg("cpu_block_stride_in_bytes"), py::arg("chunk_size_in_bytes"),
+        py::arg("start_layer_id"), py::arg("num_layers"), py::arg("is_mla"),
+        py::arg("gpu_block_type"), py::arg("cpu_size_table_ptr"),
+        py::arg("cpu_size_table_block_stride"),
+        py::arg("cpu_size_table_layer_stride"));
+  m.def("transfer_kv_blocks_ans_decomp", &transfer_kv_blocks_ans_decomp_binding,
+        "H2D transfer then ANS decompress on GPU", py::arg("ctx"),
+        py::arg("gpu_block_id_tensor"), py::arg("gpu_tensor_ptrs_tensor"),
+        py::arg("gpu_kv_stride_in_bytes"),
+        py::arg("gpu_block_stride_in_bytes"),
+        py::arg("gpu_layer_stride_in_bytes"), py::arg("cpu_block_id_tensor"),
+        py::arg("cpu_tensor"), py::arg("cpu_kv_stride_in_bytes"),
+        py::arg("cpu_layer_stride_in_bytes"),
+        py::arg("cpu_block_stride_in_bytes"), py::arg("chunk_size_in_bytes"),
+        py::arg("start_layer_id"), py::arg("num_layers"), py::arg("is_mla"),
+        py::arg("gpu_block_type"), py::arg("cpu_size_table_ptr"),
+        py::arg("cpu_size_table_block_stride"),
+        py::arg("cpu_size_table_layer_stride"));
+}
+
+} // namespace flexkv

--- a/csrc/compression/ans/nvcomp_ans.cu
+++ b/csrc/compression/ans/nvcomp_ans.cu
@@ -1,0 +1,480 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include "compression/ans/nvcomp_ans.cuh"
+#include "compression/common/staging_transfer.cuh"
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAFunctions.h>
+#include <algorithm>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+namespace flexkv {
+
+#define ANS_NVCOMP_CHECK(call)                                             \
+  do {                                                                     \
+    nvcompStatus_t _s = (call);                                            \
+    if (_s != nvcompSuccess) {                                             \
+      fprintf(stderr, "[nvcomp] error %d at %s:%d\n", (int)_s, __FILE__,   \
+              __LINE__);                                                   \
+      throw std::runtime_error("nvcomp ANS error");                        \
+    }                                                                      \
+  } while (0)
+
+#define CUDA_CHECK(call)                                                   \
+  do {                                                                     \
+    cudaError_t _e = (call);                                               \
+    if (_e != cudaSuccess) {                                               \
+      fprintf(stderr, "[nvcomp] CUDA error: %s at %s:%d\n",                \
+              cudaGetErrorString(_e), __FILE__, __LINE__);                 \
+      throw std::runtime_error(cudaGetErrorString(_e));                    \
+    }                                                                      \
+  } while (0)
+
+void ans_ctx_create(ANSTransferContext* ctx, size_t max_num_chunks,
+                    size_t max_chunk_size, int data_type, int transfer_sms) {
+  if (ctx == nullptr) {
+    throw std::invalid_argument("ans_ctx_create: ctx must be non-null");
+  }
+  ans_ctx_destroy(ctx);
+
+  if (transfer_sms == -1) {
+    transfer_sms = 4;
+  }
+  if (transfer_sms <= 0) {
+    throw std::invalid_argument(
+        "ans_ctx_create: transfer_sms must be positive or -1 for the default");
+  }
+  ctx->transfer_sms = transfer_sms;
+  if (max_num_chunks == 0 || max_chunk_size == 0) {
+    throw std::invalid_argument(
+        "ans_ctx_create: max_num_chunks and max_chunk_size must be greater "
+        "than zero");
+  }
+
+  CUDA_CHECK(cudaGetDevice(&ctx->device_id));
+  ctx->max_num_chunks = max_num_chunks;
+  ctx->max_chunk_size = max_chunk_size;
+
+  try {
+    ctx->opts = nvcompBatchedANSDefaultOpts;
+    // data_type: 0 = FLOAT16 (bf16/fp16), 1 = UCHAR/UINT8 (fp8)
+    ctx->opts.data_type = (data_type == 0) ? float16 : uint8;
+
+    const size_t max_total = max_num_chunks * max_chunk_size;
+
+    ANS_NVCOMP_CHECK(nvcompBatchedANSCompressGetMaxOutputChunkSize(
+        max_chunk_size, ctx->opts, &ctx->max_comp_chunk_bytes));
+    // Round up to 16-byte alignment so the CPU read/write kernel can use
+    // float4 (16-byte) loads/stores on d_comp_staging + i * max_comp_chunk_bytes.
+    // nvcomp only guarantees 8-byte alignment for output chunk pointers.
+    ctx->max_comp_chunk_bytes = (ctx->max_comp_chunk_bytes + 15) & ~size_t(15);
+    ANS_NVCOMP_CHECK(nvcompBatchedANSCompressGetTempSizeEx(
+        max_num_chunks, max_chunk_size, ctx->opts, &ctx->comp_temp_bytes,
+        max_total));
+    ANS_NVCOMP_CHECK(nvcompBatchedANSDecompressGetTempSizeEx(
+        max_num_chunks, max_chunk_size, &ctx->decomp_temp_bytes, max_total));
+
+    const size_t comp_staging_total =
+        max_num_chunks * ctx->max_comp_chunk_bytes;
+    const size_t ptr_bytes = max_num_chunks * sizeof(void*);
+    const size_t size_bytes = max_num_chunks * sizeof(size_t);
+
+    // GPU compression buffers (double-buffered where needed for D2H pipeline)
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_temp, ctx->comp_temp_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_staging_base, 2 * comp_staging_total));
+    ctx->d_comp_staging[0] = ctx->d_comp_staging_base;
+    ctx->d_comp_staging[1] = ctx->d_comp_staging_base + comp_staging_total;
+    CUDA_CHECK(cudaMalloc(&ctx->d_uncomp_ptrs, ptr_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_uncomp_sizes, size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_ptrs[0], ptr_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_ptrs[1], ptr_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_sizes[0], size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_comp_sizes[1], size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_overflow, sizeof(int)));
+
+    // GPU decompression buffers (double-buffered for H2D pipeline)
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_temp, ctx->decomp_temp_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_ptrs[0], ptr_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_ptrs[1], ptr_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_buf_sizes[0], size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_buf_sizes[1], size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_decomp_act_sizes, size_bytes));
+    CUDA_CHECK(cudaMalloc(&ctx->d_statuses,
+                          max_num_chunks * sizeof(nvcompStatus_t)));
+
+    ctx->h_ptr_scratch.resize(max_num_chunks);
+    ctx->h_size_scratch.resize(max_num_chunks);
+
+    // Pre-fill d_comp_ptrs for both slots.
+    for (int slot = 0; slot < 2; slot++) {
+      for (size_t i = 0; i < max_num_chunks; i++) {
+        ctx->h_ptr_scratch[i] =
+            ctx->d_comp_staging[slot] + i * ctx->max_comp_chunk_bytes;
+      }
+      CUDA_CHECK(cudaMemcpy(ctx->d_comp_ptrs[slot], ctx->h_ptr_scratch.data(),
+                            ptr_bytes, cudaMemcpyHostToDevice));
+    }
+
+    // Pre-fill size arrays: all chunks have the same uncompressed size.
+    for (size_t i = 0; i < max_num_chunks; i++) {
+      ctx->h_size_scratch[i] = max_chunk_size;
+    }
+    CUDA_CHECK(cudaMemcpy(ctx->d_uncomp_sizes, ctx->h_size_scratch.data(),
+                          size_bytes, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(ctx->d_decomp_buf_sizes[0],
+                          ctx->h_size_scratch.data(), size_bytes,
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(ctx->d_decomp_buf_sizes[1],
+                          ctx->h_size_scratch.data(), size_bytes,
+                          cudaMemcpyHostToDevice));
+
+    // Create a high-priority stream for CPU payload read/write kernels so they
+    // can run as soon as compress/decompress dependencies are satisfied.
+    {
+      int least_priority, greatest_priority;
+      CUDA_CHECK(
+          cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
+      CUDA_CHECK(cudaStreamCreateWithPriority(
+          &ctx->cpu_transfer_stream, cudaStreamNonBlocking, greatest_priority));
+    }
+    for (int i = 0; i < 2; i++) {
+      CUDA_CHECK(
+          cudaEventCreateWithFlags(&ctx->compress_done[i], cudaEventDisableTiming));
+      CUDA_CHECK(
+          cudaEventCreateWithFlags(&ctx->slot_done[i], cudaEventDisableTiming));
+    }
+
+    // Compute kernel grid sizes via occupancy API.
+    {
+      int write_cpu_bpsm = 0, read_cpu_bpsm = 0;
+      CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+          &write_cpu_bpsm, staging_transfer_kernel<true>,
+          STAGING_TRANSFER_KERNEL_BLOCK_SIZE, 0));
+      CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+          &read_cpu_bpsm, staging_transfer_kernel<false>,
+          STAGING_TRANSFER_KERNEL_BLOCK_SIZE, 0));
+      ctx->write_cpu_grid = ctx->transfer_sms * std::max(write_cpu_bpsm, 1);
+      ctx->read_cpu_grid = ctx->transfer_sms * std::max(read_cpu_bpsm, 1);
+    }
+    ctx->initialized = true;
+  } catch (...) {
+    ans_ctx_destroy(ctx);
+    throw;
+  }
+}
+
+void ans_ctx_destroy(ANSTransferContext* ctx) {
+  if (ctx == nullptr) {
+    return;
+  }
+
+  const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
+  if (ctx->device_id >= 0) {
+    cudaSetDevice(ctx->device_id);
+  }
+
+  if (ctx->d_comp_temp != nullptr) cudaFree(ctx->d_comp_temp);
+  if (ctx->d_comp_staging_base != nullptr) cudaFree(ctx->d_comp_staging_base);
+  for (int i = 0; i < 2; i++) {
+    if (ctx->d_comp_ptrs[i] != nullptr) cudaFree(ctx->d_comp_ptrs[i]);
+    if (ctx->d_comp_sizes[i] != nullptr) cudaFree(ctx->d_comp_sizes[i]);
+    if (ctx->compress_done[i] != nullptr) cudaEventDestroy(ctx->compress_done[i]);
+    if (ctx->slot_done[i] != nullptr) cudaEventDestroy(ctx->slot_done[i]);
+  }
+  if (ctx->d_overflow != nullptr) cudaFree(ctx->d_overflow);
+  if (ctx->cpu_transfer_stream != nullptr)
+    cudaStreamDestroy(ctx->cpu_transfer_stream);
+  if (ctx->d_uncomp_ptrs != nullptr) cudaFree(ctx->d_uncomp_ptrs);
+  if (ctx->d_uncomp_sizes != nullptr) cudaFree(ctx->d_uncomp_sizes);
+  if (ctx->d_decomp_temp != nullptr) cudaFree(ctx->d_decomp_temp);
+  for (int i = 0; i < 2; i++) {
+    if (ctx->d_decomp_ptrs[i] != nullptr) cudaFree(ctx->d_decomp_ptrs[i]);
+    if (ctx->d_decomp_buf_sizes[i] != nullptr)
+      cudaFree(ctx->d_decomp_buf_sizes[i]);
+  }
+  if (ctx->d_decomp_act_sizes != nullptr) cudaFree(ctx->d_decomp_act_sizes);
+  if (ctx->d_statuses != nullptr) cudaFree(ctx->d_statuses);
+
+  ctx->initialized = false;
+  ctx->device_id = -1;
+  ctx->max_num_chunks = 0;
+  ctx->max_chunk_size = 0;
+  ctx->max_comp_chunk_bytes = 0;
+  ctx->comp_temp_bytes = 0;
+  ctx->decomp_temp_bytes = 0;
+  ctx->opts = {};
+  ctx->d_comp_temp = nullptr;
+  ctx->d_comp_staging_base = nullptr;
+  ctx->d_uncomp_ptrs = nullptr;
+  ctx->d_uncomp_sizes = nullptr;
+  ctx->d_overflow = nullptr;
+  ctx->d_decomp_temp = nullptr;
+  ctx->d_decomp_act_sizes = nullptr;
+  ctx->d_statuses = nullptr;
+  ctx->cpu_transfer_stream = nullptr;
+  ctx->write_cpu_grid = 0;
+  ctx->read_cpu_grid = 0;
+  ctx->transfer_sms = 0;
+  for (int i = 0; i < 2; i++) {
+    ctx->d_comp_staging[i] = nullptr;
+    ctx->d_comp_ptrs[i] = nullptr;
+    ctx->d_comp_sizes[i] = nullptr;
+    ctx->d_decomp_ptrs[i] = nullptr;
+    ctx->d_decomp_buf_sizes[i] = nullptr;
+    ctx->compress_done[i] = nullptr;
+    ctx->slot_done[i] = nullptr;
+  }
+  ctx->h_ptr_scratch.clear();
+  ctx->h_size_scratch.clear();
+}
+
+ANSTransferContext::~ANSTransferContext() {
+  ans_ctx_destroy(this);
+}
+
+static void sync_streams(ANSTransferContext* ctx, cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  CUDA_CHECK(cudaStreamSynchronize(ctx->cpu_transfer_stream));
+}
+
+static size_t sum_compressed_bytes_from_size_table(
+    const uint32_t* cpu_size_table_base,
+    const int64_t* cpu_block_ids,
+    int num_blocks,
+    int start_layer_id,
+    int num_layers,
+    int kv_dim,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride) {
+  size_t total_comp = 0;
+  const int total_chunks = num_layers * kv_dim * num_blocks;
+  for (int g = 0; g < total_chunks; g++) {
+    int layer = g / (kv_dim * num_blocks);
+    int kv = (g % (kv_dim * num_blocks)) / num_blocks;
+    int b = g % num_blocks;
+    const uint32_t* entry =
+        cpu_size_table_base +
+        cpu_block_ids[b] * cpu_size_table_block_stride +
+        (int64_t)(start_layer_id + layer) * cpu_size_table_layer_stride +
+        (int64_t)kv;
+    total_comp += static_cast<size_t>(*entry);
+  }
+  return total_comp;
+}
+
+static void require_initialized_ans_ctx(const ANSTransferContext* ctx,
+                                        const char* caller) {
+  if (ctx == nullptr || !ctx->initialized) {
+    throw std::invalid_argument(std::string(caller) +
+                                ": ANSTransferContext is not initialized");
+  }
+}
+
+template <BackendType Type>
+size_t transfer_kv_blocks_ans_comp(
+    ANSTransferContext* ctx,
+    int num_blocks,
+    int start_layer_id,
+    int num_layers,
+    int64_t* gpu_block_ids,
+    GTensorHandler gpu_handler,
+    int64_t* cpu_block_ids,
+    void* cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    bool is_mla,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    cudaStream_t stream) {
+  require_initialized_ans_ctx(ctx, "transfer_kv_blocks_ans_comp");
+
+  const int kv_dim = is_mla ? 1 : 2;
+  const int total_chunks = num_layers * kv_dim * num_blocks;
+  const int batch_cap = static_cast<int>(ctx->max_num_chunks);
+  const int num_batches = (total_chunks + batch_cap - 1) / batch_cap;
+
+  if (chunk_size_in_bytes <= 0 ||
+      static_cast<size_t>(chunk_size_in_bytes) != ctx->max_chunk_size) {
+    throw std::invalid_argument(
+        "transfer_kv_blocks_ans_comp: chunk_size_in_bytes must equal "
+        "ctx->max_chunk_size");
+  }
+
+  CUDA_CHECK(cudaMemset(ctx->d_overflow, 0, sizeof(int)));
+
+  for (int bi = 0; bi < num_batches; bi++) {
+    const int bs = bi * batch_cap;
+    const int bsz = std::min(batch_cap, total_chunks - bs);
+    const int cur = bi % 2;
+
+    if (bi >= 2) {
+      CUDA_CHECK(cudaStreamWaitEvent(stream, ctx->slot_done[cur], 0));
+    }
+
+    {
+      int threads = 256;
+      int blocks = std::min((bsz + threads - 1) / threads, ctx->transfer_sms);
+      build_gpu_chunk_ptrs_kernel<Type><<<blocks, threads, 0, stream>>>(
+          ctx->d_uncomp_ptrs, gpu_handler, gpu_block_ids, start_layer_id,
+          kv_dim, num_blocks, bs, bsz);
+
+      ANS_NVCOMP_CHECK(nvcompBatchedANSCompressAsync(
+          (const void* const*)ctx->d_uncomp_ptrs, ctx->d_uncomp_sizes,
+          chunk_size_in_bytes, bsz, ctx->d_comp_temp, ctx->comp_temp_bytes,
+          ctx->d_comp_ptrs[cur], ctx->d_comp_sizes[cur], ctx->opts, stream));
+      CUDA_CHECK(cudaEventRecord(ctx->compress_done[cur], stream));
+    }
+
+    {
+      CUDA_CHECK(cudaStreamWaitEvent(ctx->cpu_transfer_stream,
+                                     ctx->compress_done[cur], 0));
+      int grid = std::min(bsz, ctx->write_cpu_grid);
+      staging_transfer_kernel<true>
+          <<<grid, STAGING_TRANSFER_KERNEL_BLOCK_SIZE, 0,
+             ctx->cpu_transfer_stream>>>(
+              ctx->d_comp_staging[cur], ctx->max_comp_chunk_bytes,
+              ctx->d_comp_sizes[cur], static_cast<uint8_t*>(cpu_ptr),
+              static_cast<size_t>(chunk_size_in_bytes), ctx->d_overflow,
+              cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+              cpu_block_stride_in_bytes, cpu_block_ids, cpu_size_table_base,
+              cpu_size_table_block_stride, cpu_size_table_layer_stride,
+              start_layer_id, kv_dim, num_blocks, bs, bsz);
+      CUDA_CHECK(cudaEventRecord(ctx->slot_done[cur],
+                                 ctx->cpu_transfer_stream));
+    }
+  }
+
+  sync_streams(ctx, stream);
+  int overflow = 0;
+  CUDA_CHECK(
+      cudaMemcpy(&overflow, ctx->d_overflow, sizeof(int), cudaMemcpyDeviceToHost));
+  // TODO(nvcomp-guard): keep CPU-slot overflow protection before reporting sizes.
+  if (overflow != 0) {
+    throw std::runtime_error(
+        "nvcomp compressed payload exceeded the CPU chunk slot; "
+        "increase chunk size, use more compressible data, or disable nvcomp "
+        "for this layout");
+  }
+
+  // TODO: can be removed in the future. Now only for log CR.
+  return sum_compressed_bytes_from_size_table(
+      cpu_size_table_base, cpu_block_ids, num_blocks, start_layer_id,
+      num_layers, kv_dim, cpu_size_table_block_stride,
+      cpu_size_table_layer_stride);
+}
+
+template <BackendType Type>
+size_t transfer_kv_blocks_ans_decomp(
+    ANSTransferContext* ctx,
+    int num_blocks,
+    int start_layer_id,
+    int num_layers,
+    int64_t* gpu_block_ids,
+    GTensorHandler gpu_handler,
+    int64_t* cpu_block_ids,
+    void* cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    bool is_mla,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    cudaStream_t stream) {
+  require_initialized_ans_ctx(ctx, "transfer_kv_blocks_ans_decomp");
+
+  const int kv_dim = is_mla ? 1 : 2;
+  const int total_chunks = num_layers * kv_dim * num_blocks;
+  const int batch_cap = static_cast<int>(ctx->max_num_chunks);
+  const int num_batches = (total_chunks + batch_cap - 1) / batch_cap;
+
+  if (chunk_size_in_bytes <= 0 ||
+      static_cast<size_t>(chunk_size_in_bytes) != ctx->max_chunk_size) {
+    throw std::invalid_argument(
+        "transfer_kv_blocks_ans_decomp: chunk_size_in_bytes must equal "
+        "ctx->max_chunk_size");
+  }
+
+  for (int bi = 0; bi < num_batches; bi++) {
+    const int bs = bi * batch_cap;
+    const int bsz = std::min(batch_cap, total_chunks - bs);
+    const int cur = bi % 2;
+
+    if (bi >= 2) {
+      CUDA_CHECK(cudaStreamWaitEvent(ctx->cpu_transfer_stream,
+                                     ctx->slot_done[cur], 0));
+    }
+
+    {
+      int threads = 256;
+      int blocks = std::min((bsz + threads - 1) / threads, ctx->transfer_sms);
+      build_gpu_chunk_ptrs_kernel<Type><<<blocks, threads, 0, stream>>>(
+          ctx->d_decomp_ptrs[cur], gpu_handler, gpu_block_ids,
+          start_layer_id, kv_dim, num_blocks, bs, bsz);
+    }
+
+    {
+      int grid = std::min(bsz, ctx->read_cpu_grid);
+      staging_transfer_kernel<false>
+          <<<grid, STAGING_TRANSFER_KERNEL_BLOCK_SIZE, 0,
+             ctx->cpu_transfer_stream>>>(
+              ctx->d_comp_staging[cur], ctx->max_comp_chunk_bytes,
+              ctx->d_comp_sizes[cur],
+              const_cast<uint8_t*>(static_cast<const uint8_t*>(cpu_ptr)),
+              static_cast<size_t>(chunk_size_in_bytes), nullptr,
+              cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+              cpu_block_stride_in_bytes, cpu_block_ids, cpu_size_table_base,
+              cpu_size_table_block_stride, cpu_size_table_layer_stride,
+              start_layer_id, kv_dim, num_blocks, bs, bsz);
+    }
+
+    CUDA_CHECK(cudaEventRecord(ctx->compress_done[cur],
+                               ctx->cpu_transfer_stream));
+
+    {
+      CUDA_CHECK(cudaStreamWaitEvent(stream, ctx->compress_done[cur], 0));
+      ANS_NVCOMP_CHECK(nvcompBatchedANSDecompressAsync(
+          (const void* const*)ctx->d_comp_ptrs[cur], ctx->d_comp_sizes[cur],
+          ctx->d_decomp_buf_sizes[cur], ctx->d_decomp_act_sizes, bsz,
+          ctx->d_decomp_temp, ctx->decomp_temp_bytes, ctx->d_decomp_ptrs[cur],
+          ctx->d_statuses, stream));
+      CUDA_CHECK(cudaEventRecord(ctx->slot_done[cur], stream));
+    }
+  }
+
+  sync_streams(ctx, stream);
+
+  // TODO: can be removed in the future. Now only for log CR.
+  return sum_compressed_bytes_from_size_table(
+      cpu_size_table_base, cpu_block_ids, num_blocks, start_layer_id,
+      num_layers, kv_dim, cpu_size_table_block_stride,
+      cpu_size_table_layer_stride);
+}
+
+#define ANS_INSTANTIATE(Type)                                               \
+  template size_t transfer_kv_blocks_ans_comp<Type>(                         \
+      ANSTransferContext*, int, int, int, int64_t*, GTensorHandler, int64_t*, \
+      void*, int64_t, int64_t, int64_t, int64_t, bool, uint32_t*, int64_t,    \
+      int64_t, cudaStream_t);                                                \
+  template size_t transfer_kv_blocks_ans_decomp<Type>(                       \
+      ANSTransferContext*, int, int, int, int64_t*, GTensorHandler, int64_t*, \
+      void*, int64_t, int64_t, int64_t, int64_t, bool, uint32_t*, int64_t,    \
+      int64_t, cudaStream_t);
+
+ANS_INSTANTIATE(BackendType::VLLM)
+ANS_INSTANTIATE(BackendType::TRTLLM)
+ANS_INSTANTIATE(BackendType::SGLANG)
+#undef ANS_INSTANTIATE
+
+#undef CUDA_CHECK
+#undef ANS_NVCOMP_CHECK
+
+} // namespace flexkv

--- a/csrc/compression/ans/nvcomp_ans.cuh
+++ b/csrc/compression/ans/nvcomp_ans.cuh
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "transfer.cuh"
+
+#include "nvcomp/ans.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <vector>
+
+namespace flexkv {
+
+struct ANSTransferContext {
+  ANSTransferContext() = default;
+  ~ANSTransferContext();
+
+  ANSTransferContext(const ANSTransferContext&) = delete;
+  ANSTransferContext& operator=(const ANSTransferContext&) = delete;
+
+  // Chunk geometry -- fixed at ctx_create, used to size every buffer below.
+  bool initialized = false;
+  int device_id = -1;
+  size_t max_num_chunks = 0;
+  size_t max_chunk_size = 0;
+  size_t max_comp_chunk_bytes = 0;
+  size_t comp_temp_bytes = 0;
+  size_t decomp_temp_bytes = 0;
+
+  nvcompBatchedANSOpts_t opts{};
+
+  // GPU buffers -- compression (D2H: compress on GPU, then copy payload to CPU)
+  void* d_comp_temp = nullptr;
+  uint8_t* d_comp_staging_base = nullptr;
+  uint8_t* d_comp_staging[2] = {nullptr, nullptr};
+  void** d_uncomp_ptrs = nullptr;
+  size_t* d_uncomp_sizes = nullptr;
+  void** d_comp_ptrs[2] = {nullptr, nullptr};
+  size_t* d_comp_sizes[2] = {nullptr, nullptr};
+  int* d_overflow = nullptr;
+
+  // GPU buffers -- decompression (H2D: copy payload from CPU, then decompress)
+  void* d_decomp_temp = nullptr;
+  void** d_decomp_ptrs[2] = {nullptr, nullptr};
+  size_t* d_decomp_buf_sizes[2] = {nullptr, nullptr};
+  size_t* d_decomp_act_sizes = nullptr;
+  nvcompStatus_t* d_statuses = nullptr;
+
+  // Host scratch -- staged on host then copied H2D once during ctx_create.
+  std::vector<void*> h_ptr_scratch;
+  std::vector<size_t> h_size_scratch;
+
+  // Kernel launch config.
+  int write_cpu_grid = 0;
+  int read_cpu_grid = 0;
+  int transfer_sms = 0;
+
+  // Double-buffer pipeline.
+  cudaStream_t cpu_transfer_stream = nullptr;
+  cudaEvent_t compress_done[2] = {nullptr, nullptr};
+  cudaEvent_t slot_done[2] = {nullptr, nullptr};
+};
+
+void ans_ctx_create(ANSTransferContext* ctx, size_t max_num_chunks,
+                    size_t max_chunk_size, int data_type,
+                    int transfer_sms = -1);
+
+void ans_ctx_destroy(ANSTransferContext* ctx);
+
+template <BackendType Type>
+size_t transfer_kv_blocks_ans_comp(
+    ANSTransferContext* ctx,
+    int num_blocks,
+    int start_layer_id,
+    int num_layers,
+    int64_t* gpu_block_ids,
+    GTensorHandler gpu_handler,
+    int64_t* cpu_block_ids,
+    void* cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    bool is_mla,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    cudaStream_t stream);
+
+template <BackendType Type>
+size_t transfer_kv_blocks_ans_decomp(
+    ANSTransferContext* ctx,
+    int num_blocks,
+    int start_layer_id,
+    int num_layers,
+    int64_t* gpu_block_ids,
+    GTensorHandler gpu_handler,
+    int64_t* cpu_block_ids,
+    void* cpu_ptr,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_block_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    bool is_mla,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    cudaStream_t stream);
+
+} // namespace flexkv

--- a/csrc/compression/ans/nvcomp_ans_tp.cpp
+++ b/csrc/compression/ans/nvcomp_ans_tp.cpp
@@ -1,0 +1,337 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include "compression/ans/nvcomp_ans_tp.h"
+#include "tp_transfer_thread_group.h"
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAFunctions.h>
+#include <atomic>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace flexkv {
+
+void TPTransferThreadGroup::ensure_nvcomp_initialized() {
+  if (nvcomp_state_ && nvcomp_state_->ready) {
+    return;
+  }
+  if (!nvcomp_state_ || nvcomp_state_->batch_size <= 0) {
+    throw std::runtime_error(
+        "TPTransferThreadGroup: nvcomp config missing; construct with "
+        "enable_nvcomp=True and nvcomp batch/data type before calling "
+        "tp_group_transfer_ans");
+  }
+  init_nvcomp(nvcomp_state_->batch_size, nvcomp_state_->data_type);
+}
+
+void TPTransferThreadGroup::destroy_nvcomp_state() {
+  if (!nvcomp_state_) {
+    return;
+  }
+
+  const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
+
+  for (int i = 0; i < static_cast<int>(nvcomp_state_->ans_contexts.size()); i++) {
+    if (nvcomp_state_->ans_contexts[i] != nullptr) {
+      cudaSetDevice(gpu_device_ids_[i]);
+      delete nvcomp_state_->ans_contexts[i];
+      nvcomp_state_->ans_contexts[i] = nullptr;
+    }
+  }
+  nvcomp_state_->ans_contexts.clear();
+
+  if (nvcomp_state_->owned_gpu_block_ids != nullptr || nvcomp_state_->owned_cpu_block_ids != nullptr) {
+    for (int i = 0; i < num_gpus_; i++) {
+      if (nvcomp_state_->owned_gpu_block_ids != nullptr && nvcomp_state_->owned_gpu_block_ids[i] != nullptr)
+        cudaFreeHost(nvcomp_state_->owned_gpu_block_ids[i]);
+      if (nvcomp_state_->owned_cpu_block_ids != nullptr && nvcomp_state_->owned_cpu_block_ids[i] != nullptr)
+        cudaFreeHost(nvcomp_state_->owned_cpu_block_ids[i]);
+    }
+    delete[] nvcomp_state_->owned_gpu_block_ids;
+    delete[] nvcomp_state_->owned_cpu_block_ids;
+    delete[] nvcomp_state_->owned_block_id_capacity;
+    nvcomp_state_->owned_gpu_block_ids = nullptr;
+    nvcomp_state_->owned_cpu_block_ids = nullptr;
+    nvcomp_state_->owned_block_id_capacity = nullptr;
+  }
+
+  nvcomp_state_->ready = false;
+}
+
+void TPTransferThreadGroup::init_nvcomp(int nvcomp_batch_size,
+                                        int nvcomp_data_type) {
+  if (nvcomp_batch_size <= 0) {
+    throw std::invalid_argument(
+        "TPTransferThreadGroup: nvcomp_batch_size must be positive");
+  }
+  if (!nvcomp_state_) {
+    nvcomp_state_ = std::make_unique<NvcompTPState>();
+  }
+  if (nvcomp_state_->ready && nvcomp_state_->batch_size == nvcomp_batch_size &&
+      nvcomp_state_->data_type == nvcomp_data_type) {
+    return;
+  }
+  nvcomp_state_->batch_size = nvcomp_batch_size;
+  nvcomp_state_->data_type = nvcomp_data_type;
+
+  const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
+
+  try {
+    destroy_nvcomp_state();
+    nvcomp_state_->ans_contexts.resize(num_gpus_, nullptr);
+    nvcomp_state_->owned_gpu_block_ids = new int64_t *[num_gpus_]();
+    nvcomp_state_->owned_cpu_block_ids = new int64_t *[num_gpus_]();
+    nvcomp_state_->owned_block_id_capacity = new int64_t[num_gpus_]();
+    for (int i = 0; i < num_gpus_; i++) {
+      cudaError_t err = cudaSetDevice(gpu_device_ids_[i]);
+      if (err != cudaSuccess)
+        throw std::runtime_error(
+            std::string("cudaSetDevice failed for nvcomp ctx: ") +
+            cudaGetErrorString(err));
+      nvcomp_state_->ans_contexts[i] = new ANSTransferContext();
+      // Non-MLA ranks use per-rank chunks. MLA ranks use the full canonical
+      // chunk because MLA KV is replicated across TP ranks, not head-sharded.
+      ans_ctx_create(nvcomp_state_->ans_contexts[i], (size_t)nvcomp_batch_size,
+                     (size_t)gpu_chunk_sizes_in_bytes_[i], nvcomp_data_type);
+    }
+    nvcomp_state_->ready = true;
+  } catch (...) {
+    destroy_nvcomp_state();
+    throw;
+  }
+}
+
+size_t TPTransferThreadGroup::tp_group_transfer_ans(
+    const torch::Tensor &gpu_block_id_tensor,
+    const torch::Tensor &cpu_block_id_tensor,
+    const int64_t cpu_kv_stride_in_bytes,
+    const int64_t cpu_layer_stride_in_bytes,
+    const int64_t cpu_block_stride_in_bytes,
+    const int64_t cpu_tp_stride_in_bytes, const int transfer_num_cta,
+    const bool is_host_to_device, const bool use_ce_transfer,
+    const int layer_id, const int layer_granularity, const bool is_mla,
+    const int64_t cpu_size_table_tp_ptr,
+    const int64_t cpu_size_table_tp_rank_stride,
+    const int64_t cpu_size_table_block_stride,
+    const int64_t cpu_size_table_layer_stride) {
+  (void)transfer_num_cta;
+  (void)use_ce_transfer;
+
+  ensure_nvcomp_initialized();
+  if (cpu_size_table_tp_ptr == 0 ||
+      (!is_mla && cpu_size_table_tp_rank_stride == 0) ||
+      cpu_size_table_block_stride == 0 ||
+      cpu_size_table_layer_stride == 0) {
+    throw std::runtime_error(
+        "TPTransferThreadGroup: nvcomp TP requires a non-null "
+        "cpu_size_table/cpu_size_table_tp pointer and non-zero required "
+        "size-table strides.");
+  }
+
+  // Accumulates compressed payload bytes across all TP ranks' ans_* calls so
+  // Python can compute the per-op compression ratio (uncomp / wire).
+  std::atomic<size_t> total_compressed_bytes{0};
+  std::atomic<bool> failed{false};
+  std::mutex error_mutex;
+  std::string error_msg;
+  auto record_error = [&](const std::string& msg) {
+    std::lock_guard<std::mutex> lock(error_mutex);
+    if (!failed.exchange(true)) {
+      error_msg = msg;
+    }
+  };
+  std::vector<std::future<void>> futures;
+  futures.reserve(num_gpus_);
+
+  for (int i = 0; i < num_gpus_; ++i) {
+    futures.emplace_back(enqueue_for_gpu(i, [&, i]() {
+      try {
+        int num_blocks = gpu_block_id_tensor.numel();
+
+        int64_t *gpu_block_ids =
+            static_cast<int64_t *>(gpu_block_id_tensor.data_ptr());
+        int64_t *cpu_block_ids =
+            static_cast<int64_t *>(cpu_block_id_tensor.data_ptr());
+        void *cpu_ptr = cpu_blocks_;
+
+        auto dispatch_nvcomp = [&](auto backend_tag, int cur_num_blocks,
+                                   int64_t *cur_gpu_block_ids,
+                                   int64_t *cur_cpu_block_ids,
+                                   void *cur_cpu_ptr,
+                                   int64_t cur_cpu_kv_stride,
+                                   int64_t cur_cpu_layer_stride,
+                                   int64_t cur_cpu_block_stride,
+                                   int64_t cur_chunk_size,
+                                   uint32_t *cur_size_table_base) {
+          constexpr BackendType BT = decltype(backend_tag)::value;
+          size_t comp = 0;
+          if (is_host_to_device) {
+            comp = transfer_kv_blocks_ans_decomp<BT>(
+                nvcomp_state_->ans_contexts[i], cur_num_blocks, layer_id, layer_granularity,
+                cur_gpu_block_ids, gpu_tensor_handlers_[i], cur_cpu_block_ids,
+                cur_cpu_ptr, cur_cpu_kv_stride, cur_cpu_layer_stride,
+                cur_cpu_block_stride, cur_chunk_size, is_mla,
+                cur_size_table_base, cpu_size_table_block_stride,
+                cpu_size_table_layer_stride, streams_[i]);
+          } else {
+            comp = transfer_kv_blocks_ans_comp<BT>(
+                nvcomp_state_->ans_contexts[i], cur_num_blocks, layer_id, layer_granularity,
+                cur_gpu_block_ids, gpu_tensor_handlers_[i], cur_cpu_block_ids,
+                cur_cpu_ptr, cur_cpu_kv_stride, cur_cpu_layer_stride,
+                cur_cpu_block_stride, cur_chunk_size, is_mla,
+                cur_size_table_base, cpu_size_table_block_stride,
+                cpu_size_table_layer_stride, streams_[i]);
+          }
+          // Per-rank accumulation so sum-across-ranks == system total compressed
+          // bytes. MHA: each rank holds a unique 1/N slice. MLA D2H: owner-
+          // sharded, each rank handles its own blocks. MLA H2D: every rank reads
+          // the same canonical table and returns the identical full sum, so only
+          // rank 0 contributes to avoid over-counting by N.
+          const bool skip_accumulate = is_mla && is_host_to_device && i != 0;
+          if (!skip_accumulate) {
+            total_compressed_bytes.fetch_add(comp, std::memory_order_relaxed);
+          }
+        };
+
+        auto run_dispatch = [&](int cur_num_blocks, int64_t *cur_gpu_block_ids,
+                                int64_t *cur_cpu_block_ids, void *cur_cpu_ptr,
+                                int64_t cur_cpu_kv_stride,
+                                int64_t cur_cpu_layer_stride,
+                                int64_t cur_cpu_block_stride,
+                                int64_t cur_chunk_size,
+                                uint32_t *cur_size_table_base) {
+          switch (backend_type_) {
+          case BackendType::VLLM:
+            dispatch_nvcomp(
+                std::integral_constant<BackendType, BackendType::VLLM>{},
+                cur_num_blocks, cur_gpu_block_ids, cur_cpu_block_ids,
+                cur_cpu_ptr, cur_cpu_kv_stride, cur_cpu_layer_stride,
+                cur_cpu_block_stride, cur_chunk_size, cur_size_table_base);
+            break;
+          case BackendType::TRTLLM:
+            dispatch_nvcomp(
+                std::integral_constant<BackendType, BackendType::TRTLLM>{},
+                cur_num_blocks, cur_gpu_block_ids, cur_cpu_block_ids,
+                cur_cpu_ptr, cur_cpu_kv_stride, cur_cpu_layer_stride,
+                cur_cpu_block_stride, cur_chunk_size, cur_size_table_base);
+            break;
+          case BackendType::SGLANG:
+            dispatch_nvcomp(
+                std::integral_constant<BackendType, BackendType::SGLANG>{},
+                cur_num_blocks, cur_gpu_block_ids, cur_cpu_block_ids,
+                cur_cpu_ptr, cur_cpu_kv_stride, cur_cpu_layer_stride,
+                cur_cpu_block_stride, cur_chunk_size, cur_size_table_base);
+            break;
+          }
+        };
+
+        if (is_mla) {
+          // MLA KV is replicated across TP ranks. One canonical compressed full
+          // chunk lives in the size table. D2H is distributed by cpu_block_id
+          // owner so all ranks contribute without splitting the chunk; H2D fans out — every rank reads
+          // the same canonical table.
+          uint32_t *canonical_size_table_base =
+              reinterpret_cast<uint32_t *>(cpu_size_table_tp_ptr);
+
+          if (is_host_to_device) {
+            run_dispatch(num_blocks, gpu_block_ids, cpu_block_ids, cpu_ptr,
+                         cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                         cpu_block_stride_in_bytes,
+                         gpu_chunk_sizes_in_bytes_[i],
+                         canonical_size_table_base);
+          } else {
+            // Allocate enough pinned scratch for the block-id list owned by
+            // this rank during MLA D2H owner-sharding.
+            if (num_blocks > nvcomp_state_->owned_block_id_capacity[i]) {
+              int64_t *new_gpu_ids = nullptr;
+              cudaError_t err = cudaMallocHost(
+                  reinterpret_cast<void **>(&new_gpu_ids),
+                  static_cast<size_t>(num_blocks) * sizeof(int64_t));
+              if (err != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("owned_gpu_block_ids: cudaMallocHost failed: ") +
+                    cudaGetErrorString(err));
+              }
+
+              int64_t *new_cpu_ids = nullptr;
+              err = cudaMallocHost(reinterpret_cast<void **>(&new_cpu_ids),
+                                   static_cast<size_t>(num_blocks) *
+                                       sizeof(int64_t));
+              if (err != cudaSuccess) {
+                cudaFreeHost(new_gpu_ids);
+                throw std::runtime_error(
+                    std::string("owned_cpu_block_ids: cudaMallocHost failed: ") +
+                    cudaGetErrorString(err));
+              }
+
+              if (nvcomp_state_->owned_gpu_block_ids[i] != nullptr)
+                cudaFreeHost(nvcomp_state_->owned_gpu_block_ids[i]);
+              if (nvcomp_state_->owned_cpu_block_ids[i] != nullptr)
+                cudaFreeHost(nvcomp_state_->owned_cpu_block_ids[i]);
+              nvcomp_state_->owned_gpu_block_ids[i] = new_gpu_ids;
+              nvcomp_state_->owned_cpu_block_ids[i] = new_cpu_ids;
+              nvcomp_state_->owned_block_id_capacity[i] = num_blocks;
+            }
+
+            int owned_blocks = 0;
+            for (int b = 0; b < num_blocks; b++) {
+              int64_t owner = cpu_block_ids[b] % num_gpus_;
+              if (owner < 0) owner += num_gpus_;
+              if (owner != i) continue;
+              nvcomp_state_->owned_gpu_block_ids[i][owned_blocks] = gpu_block_ids[b];
+              nvcomp_state_->owned_cpu_block_ids[i][owned_blocks] = cpu_block_ids[b];
+              owned_blocks++;
+            }
+            if (owned_blocks > 0) {
+              run_dispatch(owned_blocks, nvcomp_state_->owned_gpu_block_ids[i],
+                           nvcomp_state_->owned_cpu_block_ids[i], cpu_ptr,
+                           cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                           cpu_block_stride_in_bytes,
+                           gpu_chunk_sizes_in_bytes_[i],
+                           canonical_size_table_base);
+            }
+          }
+        } else {
+          // MHA: each rank uses a non-TP ANSTransferContext on its per-rank
+          // slice of the CPU buffer. The table is
+          // [tp_size, num_cpu_blocks, num_layers, kv_dim] uint32; each rank
+          // gets a 3-D slice the non-TP kernels treat like a regular table.
+          void *cpu_ptr_offset =
+              static_cast<uint8_t *>(cpu_ptr) + i * cpu_tp_stride_in_bytes;
+          uint32_t *rank_size_table_base =
+              reinterpret_cast<uint32_t *>(cpu_size_table_tp_ptr) +
+              (int64_t)i * cpu_size_table_tp_rank_stride;
+
+          run_dispatch(num_blocks, gpu_block_ids, cpu_block_ids, cpu_ptr_offset,
+                       cpu_kv_stride_in_bytes, cpu_layer_stride_in_bytes,
+                       cpu_block_stride_in_bytes, gpu_chunk_sizes_in_bytes_[i],
+                       rank_size_table_base);
+        }
+
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+          record_error(cudaGetErrorString(err));
+        }
+      } catch (const std::exception &e) {
+        record_error(e.what());
+      }
+    }));
+  }
+
+  for (auto &f : futures) {
+    f.get();
+  }
+
+  if (failed) {
+    throw std::runtime_error("tp_group_transfer_ans failed: " + error_msg);
+  }
+  return total_compressed_bytes.load(std::memory_order_relaxed);
+}
+
+} // namespace flexkv

--- a/csrc/compression/ans/nvcomp_ans_tp.h
+++ b/csrc/compression/ans/nvcomp_ans_tp.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "compression/ans/nvcomp_ans.cuh"
+
+#include <cstdint>
+#include <vector>
+
+namespace flexkv {
+
+struct NvcompTPState {
+  bool ready = false;
+  int batch_size = 0;
+  int data_type = 0;
+  std::vector<ANSTransferContext*> ans_contexts;
+
+  // Per-rank scratch for MLA D2H owner-sharding (block b is owned by rank
+  // cpu_block_ids[b] % num_gpus). Grown on demand by tp_group_transfer_ans().
+  int64_t** owned_gpu_block_ids = nullptr;
+  int64_t** owned_cpu_block_ids = nullptr;
+  int64_t* owned_block_id_capacity = nullptr;
+};
+
+} // namespace flexkv

--- a/csrc/compression/common/common_bindings.cpp
+++ b/csrc/compression/common/common_bindings.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include "compression/common/transfer_ssd_packed.h"
+
+#include <pybind11/pybind11.h>
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+namespace flexkv {
+
+void register_common_compression_bindings(py::module_& m) {
+  m.def("transfer_kv_blocks_ssd_packed",
+        [](flexkv::SSDIOCTX &ioctx, const torch::Tensor &cpu_layer_id_list,
+           int64_t cpu_tensor_ptr, const torch::Tensor &ssd_block_ids,
+           const torch::Tensor &cpu_block_ids,
+           int64_t cpu_layer_stride_in_bytes,
+           int64_t cpu_kv_stride_in_bytes, int64_t chunk_size_in_bytes,
+           int64_t block_stride_in_bytes, bool is_read,
+           int num_blocks_per_file, const std::string &layout_type,
+           int total_layers, int64_t cpu_size_table_ptr,
+           int64_t cpu_size_table_block_stride,
+           int64_t cpu_size_table_layer_stride, int64_t ssd_size_table_ptr,
+           int64_t ssd_size_table_block_stride,
+           int64_t ssd_size_table_layer_stride, int round_robin,
+           int num_threads_per_device, bool is_mla, int tp_size,
+           int64_t cpu_tp_rank_stride_in_bytes,
+           int64_t cpu_size_table_rank_stride,
+           int64_t ssd_size_table_rank_stride) {
+          return flexkv::transfer_kv_blocks_ssd_packed(
+              ioctx, cpu_layer_id_list, cpu_tensor_ptr, ssd_block_ids,
+              cpu_block_ids, cpu_layer_stride_in_bytes,
+              cpu_kv_stride_in_bytes, chunk_size_in_bytes,
+              block_stride_in_bytes, is_read, num_blocks_per_file,
+              round_robin, num_threads_per_device, is_mla, layout_type,
+              total_layers, reinterpret_cast<uint32_t*>(cpu_size_table_ptr),
+              cpu_size_table_block_stride, cpu_size_table_layer_stride,
+              reinterpret_cast<uint32_t*>(ssd_size_table_ptr),
+              ssd_size_table_block_stride, ssd_size_table_layer_stride,
+              tp_size, cpu_tp_rank_stride_in_bytes,
+              cpu_size_table_rank_stride, ssd_size_table_rank_stride);
+        },
+        "Transfer compressed KV blocks between SSD and CPU using "
+        "one packed compressed range per block.",
+        py::arg("ioctx"), py::arg("cpu_layer_id_list"),
+        py::arg("cpu_tensor_ptr"), py::arg("ssd_block_ids"),
+        py::arg("cpu_block_ids"), py::arg("cpu_layer_stride_in_bytes"),
+        py::arg("cpu_kv_stride_in_bytes"), py::arg("chunk_size_in_bytes"),
+        py::arg("block_stride_in_bytes"), py::arg("is_read"),
+        py::arg("num_blocks_per_file"), py::arg("layout_type"),
+        py::arg("total_layers"), py::arg("cpu_size_table_ptr"),
+        py::arg("cpu_size_table_block_stride"),
+        py::arg("cpu_size_table_layer_stride"),
+        py::arg("ssd_size_table_ptr"),
+        py::arg("ssd_size_table_block_stride"),
+        py::arg("ssd_size_table_layer_stride"), py::arg("round_robin") = 1,
+        py::arg("num_threads_per_device") = 16, py::arg("is_mla") = false,
+        py::arg("tp_size") = 1, py::arg("cpu_tp_rank_stride_in_bytes") = 0,
+        py::arg("cpu_size_table_rank_stride") = 0,
+        py::arg("ssd_size_table_rank_stride") = 0);
+}
+
+} // namespace flexkv

--- a/csrc/compression/common/packed_ssd.cpp
+++ b/csrc/compression/common/packed_ssd.cpp
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include "compression/common/packed_ssd.h"
+#include "monitoring/metrics_manager.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+
+namespace flexkv {
+
+static constexpr int64_t PACKED_DIRECT_IO_ALIGN = 512;
+static constexpr int64_t PACKED_DIRECT_IO_BUFFER_ALIGN = 4096;
+
+AlignedDirectIOBuffer::AlignedDirectIOBuffer(int64_t bytes)
+    : ptr_(nullptr), bytes_(bytes) {
+  if (bytes_ <= 0) {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ssd_packed: invalid buffer size");
+  }
+  int rc = posix_memalign(&ptr_,
+                          static_cast<size_t>(PACKED_DIRECT_IO_BUFFER_ALIGN),
+                          static_cast<size_t>(bytes_));
+  if (rc != 0 || ptr_ == nullptr) {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ssd_packed: posix_memalign failed");
+  }
+}
+
+AlignedDirectIOBuffer::~AlignedDirectIOBuffer() { free(ptr_); }
+
+void *AlignedDirectIOBuffer::ptr() { return ptr_; }
+
+int64_t AlignedDirectIOBuffer::bytes() const { return bytes_; }
+
+static inline uint32_t checked_comp_bytes(
+    uint32_t value, int64_t chunk_size, bool is_read,
+    int cpu_block_id, int ssd_block_id, const PackedCoord &coord) {
+  const std::string where =
+      std::string(is_read ? "DISK2H" : "H2DISK") +
+      " cpu_block=" + std::to_string(cpu_block_id) +
+      " ssd_block=" + std::to_string(ssd_block_id) +
+      " rank=" + std::to_string(coord.rank) +
+      " layer=" + std::to_string(coord.lid) +
+      " kv=" + std::to_string(coord.kv);
+  if (value == 0) {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ssd_packed: size-table entry is 0 (" +
+        where + ")");
+  }
+  if (static_cast<int64_t>(value) > chunk_size) {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ssd_packed: compressed payload is larger than "
+        "the CPU/SSD chunk slot, value=" + std::to_string(value) +
+        " chunk_size=" + std::to_string(chunk_size) + " (" + where + ")");
+  }
+  return value;
+}
+
+void do_transfer_packed_blocks(
+    int fd,
+    int64_t ssd_off,
+    int64_t transfer_bytes,
+    bool is_read,
+    void *staging_buffer,
+    const std::vector<PackedSpan> &spans) {
+  char *staging = reinterpret_cast<char *>(staging_buffer);
+
+  // H2DISK gather (host memory only, no I/O yet): the compressed chunks are
+  // scattered across the CPU tensor (one per chunk-size slot). memcpy each into
+  // the contiguous host staging buffer, then zero-pad the tail up to the
+  // 512-aligned transfer length, so the whole block can go out in one write.
+  if (!is_read) {
+    int64_t cursor = 0;
+    for (const auto &span : spans) {
+      memcpy(staging + cursor, span.cpu_ptr,
+             static_cast<size_t>(span.comp_bytes));
+      *span.dst_table_entry = span.comp_bytes;
+      cursor += span.comp_bytes;
+    }
+    if (transfer_bytes > cursor) {
+      memset(staging + cursor, 0, static_cast<size_t>(transfer_bytes - cursor));
+    }
+  }
+
+  // The one block I/O: a single full pread/pwrite of the packed range, looping
+  // over partial transfers and retrying on EINTR.
+  int64_t done = 0;
+  while (done < transfer_bytes) {
+    ssize_t rc;
+    do {
+      rc = is_read
+               ? pread(fd, staging + done, transfer_bytes - done, ssd_off + done)
+               : pwrite(fd, staging + done, transfer_bytes - done, ssd_off + done);
+    } while (rc < 0 && errno == EINTR);
+    if (rc <= 0) {
+      throw std::runtime_error(
+          is_read ? "transfer_kv_blocks_ssd_packed: read failed"
+                  : "transfer_kv_blocks_ssd_packed: write failed");
+    }
+    done += rc;
+  }
+
+  // DISK2H scatter (host memory only): the pread above filled the host staging
+  // buffer with this block's tightly-packed compressed chunks. Walk the spans in
+  // the same order they were packed and, for each chunk: memcpy its comp_bytes
+  // from the running staging cursor back to its slot in the CPU tensor
+  // (span.cpu_ptr), record comp_bytes into the CPU-side size table
+  // (span.dst_table_entry), and advance the cursor tightly by comp_bytes. Any
+  // 512-aligned tail left in staging is O_DIRECT padding and is ignored.
+  if (is_read) {
+    int64_t cursor = 0;
+    for (const auto &span : spans) {
+      memcpy(span.cpu_ptr, staging + cursor,
+             static_cast<size_t>(span.comp_bytes));
+      *span.dst_table_entry = span.comp_bytes;
+      cursor += span.comp_bytes;
+    }
+  }
+
+  FLEXKV_CPU_SSD_TRANSFER(is_read, transfer_bytes);
+}
+
+// One worker thread of the packed nvcomp SSD path, shared by BLOCKFIRST and
+// LAYERFIRST. The two layouts differ only in `span_order` (the on-disk byte
+// order of the spans) and `disk_block_stride_in_bytes` (the on-disk slot size
+// per block); everything else is identical. It owns a contiguous slice
+// [start_block, end_block) of a single device's block list and, for each block:
+//   1. resolves which file the block lives in and that file's (direct, buffered)
+//      fds  (round-robin: file_index = ssd_block_id % num_files_per_device);
+//   2. converts the device-local ssd block id into an in-file block id;
+//   3. builds the per-block packed span layout (the rank/layer/kv compressed
+//      payloads laid out contiguously in span_order) and issues the single SSD
+//      read/write.
+// The staging buffer and spans vector are allocated once and reused across all
+// blocks this thread processes.
+int64_t transfer_packed_thread_impl(
+    const std::vector<int> &direct_fd_list,
+    const std::vector<int> &buffered_fd_list,
+    const std::vector<int> &cpu_block_ids,
+    const std::vector<int> &ssd_block_ids_in_device,
+    const std::vector<int> &ssd_block_ids_orig,
+    const std::vector<PackedCoord> &span_order,
+    int start_block, int end_block, int64_t cpu_tensor_ptr,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t block_stride_in_bytes,
+    int64_t disk_block_stride_in_bytes,
+    int64_t cpu_tp_rank_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int num_files_per_device, bool is_read,
+    uint32_t *cpu_size_table_base,
+    int64_t cpu_size_table_rank_stride,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    uint32_t *ssd_size_table_base,
+    int64_t ssd_size_table_rank_stride,
+    int64_t ssd_size_table_block_stride,
+    int64_t ssd_size_table_layer_stride,
+    const char *layout_name) {
+  if (end_block <= start_block) return 0;
+
+  // Sum of this thread's compressed payload across its block range. Mirrors
+  // tp_group_transfer_ans: the compressed (packed) bytes, excluding O_DIRECT
+  // tail padding (transfer_bytes - packed_bytes).
+  int64_t thread_packed_bytes = 0;
+  AlignedDirectIOBuffer staging(disk_block_stride_in_bytes);
+  std::vector<PackedSpan> spans;
+  spans.reserve(span_order.size());
+  for (int bid = start_block; bid < end_block; bid++) {
+    int cpu_block_id = cpu_block_ids[bid];
+    int ssd_block_id = ssd_block_ids_in_device[bid];
+    int ssd_block_id_orig = ssd_block_ids_orig[bid]; // pre-remap id for size-table indexing
+    int file_index = ssd_block_id % num_files_per_device;
+    int direct_fd = direct_fd_list[file_index];
+    int buffered_fd = buffered_fd_list[file_index];
+    ssd_block_id /= num_files_per_device; // block id in single file
+
+    // Build this block's packed layout in memory: one span per rank/layer/kv
+    // compressed payload, appended in on-disk (span_order) order.
+    spans.clear();
+    int64_t packed_bytes = 0;
+    for (const PackedCoord &c : span_order) {
+      uint32_t *cpu_entry = cpu_size_table_base
+          + static_cast<int64_t>(c.rank) * cpu_size_table_rank_stride
+          + static_cast<int64_t>(cpu_block_id) * cpu_size_table_block_stride
+          + static_cast<int64_t>(c.lid) * cpu_size_table_layer_stride
+          + static_cast<int64_t>(c.kv);
+      uint32_t *ssd_entry = ssd_size_table_base
+          + static_cast<int64_t>(c.rank) * ssd_size_table_rank_stride
+          + static_cast<int64_t>(ssd_block_id_orig) * ssd_size_table_block_stride
+          + static_cast<int64_t>(c.lid) * ssd_size_table_layer_stride
+          + static_cast<int64_t>(c.kv);
+
+      uint32_t comp_bytes = checked_comp_bytes(
+          is_read ? *ssd_entry : *cpu_entry, chunk_size_in_bytes, is_read,
+          cpu_block_id, ssd_block_id_orig, c);
+      if (is_read) {
+        *cpu_entry = comp_bytes;
+      } else {
+        *ssd_entry = comp_bytes;
+      }
+
+      void *cpu_ptr = reinterpret_cast<char *>(cpu_tensor_ptr)
+          + static_cast<int64_t>(cpu_block_id) * block_stride_in_bytes
+          + static_cast<int64_t>(c.rank) * cpu_tp_rank_stride_in_bytes
+          + static_cast<int64_t>(c.lid) * cpu_layer_stride_in_bytes
+          + static_cast<int64_t>(c.kv) * cpu_kv_stride_in_bytes;
+      spans.push_back({
+          cpu_ptr,
+          comp_bytes,
+          is_read ? cpu_entry : ssd_entry,
+      });
+      packed_bytes += comp_bytes;
+    }
+
+    // Spans are packed tightly (no per-chunk padding); only the single block
+    // I/O needs alignment. O_DIRECT requires the offset and transfer length to
+    // be 512-aligned, so round the packed total up (the tail is zero-padded)
+    // when the block qualifies; buffered I/O has no such constraint and writes
+    // the exact total.
+    int64_t ssd_off =
+        static_cast<int64_t>(ssd_block_id) * disk_block_stride_in_bytes;
+    int64_t direct_io_bytes =
+        (packed_bytes + PACKED_DIRECT_IO_ALIGN - 1) & ~(PACKED_DIRECT_IO_ALIGN - 1);
+    bool use_direct_io =
+        (ssd_off % PACKED_DIRECT_IO_ALIGN == 0) &&
+        direct_io_bytes <= disk_block_stride_in_bytes &&
+        direct_io_bytes <= staging.bytes();
+    int64_t transfer_bytes = use_direct_io ? direct_io_bytes : packed_bytes;
+    if (transfer_bytes > disk_block_stride_in_bytes ||
+        transfer_bytes > staging.bytes()) {
+      throw std::runtime_error(
+          std::string("transfer_kv_blocks_ssd_packed ") + layout_name +
+          ": packed block exceeds raw block slot");
+    }
+
+    // Execute the SSD transfer once for this block. H2DISK gathers all spans
+    // into the staging buffer then pwrite()s the packed range; DISK2H pread()s
+    // the packed range then scatters each span back into its CPU slot.
+    do_transfer_packed_blocks(
+        use_direct_io ? direct_fd : buffered_fd, ssd_off, transfer_bytes,
+        is_read, staging.ptr(), spans);
+    thread_packed_bytes += packed_bytes;
+  }
+  return thread_packed_bytes;
+}
+
+} // namespace flexkv

--- a/csrc/compression/common/packed_ssd.h
+++ b/csrc/compression/common/packed_ssd.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace flexkv {
+
+class AlignedDirectIOBuffer {
+public:
+  explicit AlignedDirectIOBuffer(int64_t bytes);
+  ~AlignedDirectIOBuffer();
+
+  void *ptr();
+  int64_t bytes() const;
+
+private:
+  void *ptr_;
+  int64_t bytes_;
+};
+
+// Describes one compressed chunk inside a block's packed on-disk layout, i.e.
+// how to scatter/gather it between the CPU slot and the contiguous staging
+// buffer during a single SSD read/write.
+struct PackedSpan {
+  void *cpu_ptr;             // this chunk's address in the CPU tensor
+  uint32_t comp_bytes;       // compressed payload size: the memcpy length, the
+                             // value recorded in the size table, and (spans are
+                             // packed contiguously) its on-disk footprint
+  uint32_t *dst_table_entry; // size-table slot to write comp_bytes into
+};
+
+// One (tp-rank, layer, kv) coordinate of a compressed chunk in a block's packed
+// layout. The order of these in a list defines the on-disk byte order of the
+// spans (BLOCKFIRST nests rank outermost, LAYERFIRST nests layer outermost).
+struct PackedCoord {
+  int rank;
+  int lid;
+  int kv;
+};
+
+void do_transfer_packed_blocks(
+    int fd, int64_t ssd_off, int64_t transfer_bytes, bool is_read,
+    void *staging_buffer, const std::vector<PackedSpan> &spans);
+
+int64_t transfer_packed_thread_impl(
+    const std::vector<int> &direct_fd_list,
+    const std::vector<int> &buffered_fd_list,
+    const std::vector<int> &cpu_block_ids,
+    const std::vector<int> &ssd_block_ids_in_device,
+    const std::vector<int> &ssd_block_ids_orig,
+    const std::vector<PackedCoord> &span_order,
+    int start_block, int end_block, int64_t cpu_tensor_ptr,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t block_stride_in_bytes,
+    int64_t disk_block_stride_in_bytes,
+    int64_t cpu_tp_rank_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int num_files_per_device, bool is_read,
+    uint32_t *cpu_size_table_base,
+    int64_t cpu_size_table_rank_stride,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    uint32_t *ssd_size_table_base,
+    int64_t ssd_size_table_rank_stride,
+    int64_t ssd_size_table_block_stride,
+    int64_t ssd_size_table_layer_stride,
+    const char *layout_name);
+
+} // namespace flexkv

--- a/csrc/compression/common/staging_transfer.cuh
+++ b/csrc/compression/common/staging_transfer.cuh
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "transfer.cuh"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace flexkv {
+
+static constexpr int STAGING_TRANSFER_KERNEL_BLOCK_SIZE = 1024;
+
+template <bool is_write_cpu>
+__global__ void staging_transfer_kernel(
+    uint8_t* __restrict__ d_comp_staging,
+    size_t staging_stride,
+    size_t* __restrict__ d_comp_sizes,
+    uint8_t* __restrict__ cpu_ptr,
+    size_t chunk_capacity,
+    int* __restrict__ d_overflow,
+    int64_t cpu_kv_stride,
+    int64_t cpu_layer_stride,
+    int64_t cpu_block_stride,
+    const int64_t* __restrict__ cpu_block_ids,
+    uint32_t* __restrict__ cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    int start_layer_id,
+    int kv_dim,
+    int num_blocks,
+    int batch_start,
+    int bsz) {
+  const int lane = threadIdx.x & 31;
+  const int warp_id = threadIdx.x >> 5;
+  const int warps_per_block = blockDim.x >> 5;
+  const size_t global_warp = (size_t)blockIdx.x * warps_per_block + warp_id;
+  const size_t total_warps = (size_t)gridDim.x * warps_per_block;
+
+  for (size_t i = global_warp; i < (size_t)bsz; i += total_warps) {
+    int g = batch_start + i;
+    int layer = g / (kv_dim * num_blocks);
+    int kv = (g % (kv_dim * num_blocks)) / num_blocks;
+    int b = g % num_blocks;
+
+    uint8_t* chunk_base =
+        cpu_ptr +
+        (int64_t)(layer + start_layer_id) * cpu_layer_stride +
+        (int64_t)kv * cpu_kv_stride +
+        cpu_block_ids[b] * cpu_block_stride;
+
+    uint32_t* table_entry =
+        cpu_size_table_base +
+        cpu_block_ids[b] * cpu_size_table_block_stride +
+        (int64_t)(start_layer_id + layer) * cpu_size_table_layer_stride +
+        (int64_t)kv;
+
+    size_t sz;
+    if constexpr (is_write_cpu) {
+      sz = d_comp_sizes[i];
+      if (sz > chunk_capacity) {
+        if (lane == 0) {
+          atomicAdd(d_overflow, 1);
+          *table_entry = 0;
+        }
+        continue;
+      }
+      if (lane == 0) {
+        *table_entry = static_cast<uint32_t>(sz);
+      }
+    } else {
+      sz = static_cast<size_t>(*table_entry);
+      // TODO(nvcomp-guard): validate H2D size-table entries before copying.
+      // A stale/corrupt size of 0 or > staging_stride can feed invalid
+      // compressed payloads to nvcomp or overrun staging.
+      if (lane == 0) {
+        d_comp_sizes[i] = sz;
+      }
+    }
+
+    uint8_t* staging = d_comp_staging + (size_t)i * staging_stride;
+    uint8_t* cpu_data = chunk_base;
+    const float4* src =
+        reinterpret_cast<const float4*>(is_write_cpu ? staging : cpu_data);
+    float4* dst = reinterpret_cast<float4*>(is_write_cpu ? cpu_data : staging);
+
+    int64_t n_f4 = sz / sizeof(float4);
+    for (int64_t j = lane; j < n_f4; j += 32) {
+      dst[j] = __ldg(&src[j]);
+    }
+
+    size_t tail = n_f4 * sizeof(float4);
+    const uint8_t* src_tail = reinterpret_cast<const uint8_t*>(src) + tail;
+    uint8_t* dst_tail = reinterpret_cast<uint8_t*>(dst) + tail;
+    for (size_t j = lane; j < sz - tail; j += 32) {
+      dst_tail[j] = src_tail[j];
+    }
+  }
+}
+
+template <BackendType Type>
+__global__ void build_gpu_chunk_ptrs_kernel(
+    void** __restrict__ d_uncomp_ptrs,
+    GTensorHandler gpu_handler,
+    const int64_t* __restrict__ gpu_block_ids,
+    int start_layer_id,
+    int kv_dim,
+    int num_blocks,
+    int batch_start,
+    int bsz) {
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < bsz;
+       i += gridDim.x * blockDim.x) {
+    int g = batch_start + i;
+    int layer = g / (kv_dim * num_blocks);
+    int kv = (g % (kv_dim * num_blocks)) / num_blocks;
+    int b = g % num_blocks;
+    d_uncomp_ptrs[i] = static_cast<void*>(
+        ptr_at<Type>(gpu_handler, start_layer_id + layer, kv, gpu_block_ids[b]));
+  }
+}
+
+} // namespace flexkv

--- a/csrc/compression/common/transfer_ssd_packed.cpp
+++ b/csrc/compression/common/transfer_ssd_packed.cpp
@@ -1,0 +1,258 @@
+#include "compression/common/transfer_ssd_packed.h"
+#include "compression/common/packed_ssd.h"
+
+#include <algorithm>
+#include <atomic>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace flexkv {
+
+static void partition_and_remap_blocks_by_device_packed(
+    const int64_t *cpu_block_ids, const int64_t *ssd_block_ids, int num_blocks,
+    int num_devices, int round_robin,
+    std::vector<std::vector<int>> &cpu_blocks_partition,
+    std::vector<std::vector<int>> &ssd_blocks_partition,
+    std::vector<std::vector<int>> &ssd_orig_blocks_partition) {
+  for (int i = 0; i < num_blocks; i++) {
+    int64_t ssd_block_id = ssd_block_ids[i];
+    int64_t cpu_block_id = cpu_block_ids[i];
+    int device_id = (ssd_block_id / round_robin) % num_devices;
+    int block_id_in_device =
+        ((ssd_block_id / round_robin) / num_devices) * round_robin +
+        (ssd_block_id % round_robin);
+    ssd_blocks_partition[device_id].push_back(block_id_in_device);
+    cpu_blocks_partition[device_id].push_back(cpu_block_id);
+    ssd_orig_blocks_partition[device_id].push_back(
+        static_cast<int>(ssd_block_id));
+  }
+}
+
+static void validate_size_table_args(
+    uint32_t *cpu_size_table_base,
+    uint32_t *ssd_size_table_base,
+    int tp_size,
+    int64_t cpu_tp_rank_stride_in_bytes,
+    int64_t cpu_size_table_rank_stride,
+    int64_t ssd_size_table_rank_stride) {
+  const std::string prefix = "transfer_kv_blocks_ssd_packed: ";
+
+  if (cpu_size_table_base == nullptr || ssd_size_table_base == nullptr) {
+    throw std::runtime_error(prefix + "size tables are mandatory");
+  }
+  if (tp_size <= 0) {
+    throw std::runtime_error(prefix + "tp_size must be > 0");
+  }
+  if (tp_size > 1 &&
+      (cpu_tp_rank_stride_in_bytes <= 0 ||
+       cpu_size_table_rank_stride <= 0 ||
+       ssd_size_table_rank_stride <= 0)) {
+    throw std::runtime_error(
+        prefix + "TP calls require non-zero rank strides");
+  }
+}
+
+static int64_t transfer_kv_blocks_ssd_packed_impl(
+    SSDIOCTX &ioctx, const torch::Tensor &cpu_layer_id_list,
+    int64_t cpu_tensor_ptr, const torch::Tensor &ssd_block_ids,
+    const torch::Tensor &cpu_block_ids,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int64_t block_stride_in_bytes,
+    bool is_read, int num_blocks_per_file,
+    int round_robin,
+    int num_threads_per_device,
+    bool is_mla,
+    // --- nvcomp packed-specific ---
+    bool blockfirst, // true = BLOCKFIRST, false = LAYERFIRST
+    int total_layers,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    uint32_t* ssd_size_table_base,
+    int64_t ssd_size_table_block_stride,
+    int64_t ssd_size_table_layer_stride,
+    int tp_size,
+    int64_t cpu_tp_rank_stride_in_bytes,
+    int64_t cpu_size_table_rank_stride,
+    int64_t ssd_size_table_rank_stride) {
+  validate_size_table_args(
+      cpu_size_table_base, ssd_size_table_base, tp_size,
+      cpu_tp_rank_stride_in_bytes, cpu_size_table_rank_stride,
+      ssd_size_table_rank_stride);
+
+  const int num_devices = ioctx.get_num_devices();
+  const int num_files_per_device = ioctx.get_num_files_per_device();
+
+  const int64_t *ssd_block_id_ptr = ssd_block_ids.data_ptr<int64_t>();
+  const int64_t *cpu_block_id_ptr = cpu_block_ids.data_ptr<int64_t>();
+
+  const int num_blocks = ssd_block_ids.size(0);
+  const int num_layers = cpu_layer_id_list.size(0);
+  if (num_layers == 0) return 0;
+  const int32_t *cpu_layer_id_list_ptr = cpu_layer_id_list.data_ptr<int32_t>();
+  const int start_layer = cpu_layer_id_list_ptr[0];
+  const int end_layer = start_layer + num_layers;
+
+  // TODO(nvcomp-guard): packed SSD requires a transfer starting at layer 0;
+  // LAYERFIRST additionally requires the full layer range (its on-disk block
+  // slot is sized for all layers).
+  const char *layout_name = blockfirst ? "blockfirst" : "layerfirst";
+  if (start_layer != 0 || (!blockfirst && num_layers != total_layers)) {
+    throw std::runtime_error(
+        std::string("transfer_kv_blocks_ssd_packed: ") + layout_name +
+        (blockfirst ? " requires layer_id == 0"
+                    : " requires a full-layer transfer starting at layer 0"));
+  }
+
+  const int kv_dim = is_mla ? 1 : 2;
+  // On-disk slot size per block.
+  // BLOCKFIRST's block_stride already spans the whole block;
+  // LAYERFIRST's block_stride is per-layer/kv, so scale it up.
+  const int64_t disk_block_stride_in_bytes =
+      blockfirst ? block_stride_in_bytes
+                 : static_cast<int64_t>(total_layers) * kv_dim *
+                       block_stride_in_bytes;
+
+  // BLOCKFIRST nests rank outermost,
+  // LAYERFIRST nests layer outermost -- each matches its CPU memory layout so
+  // the per-block gather/scatter walks CPU memory sequentially.
+  std::vector<PackedCoord> span_order;
+  span_order.reserve(static_cast<size_t>(tp_size) *
+                     static_cast<size_t>(end_layer - start_layer) *
+                     static_cast<size_t>(kv_dim));
+  if (blockfirst) {
+    for (int rank = 0; rank < tp_size; rank++)
+      for (int lid = start_layer; lid < end_layer; lid++)
+        for (int kv = 0; kv < kv_dim; kv++)
+          span_order.push_back({rank, lid, kv});
+  } else {
+    for (int lid = start_layer; lid < end_layer; lid++)
+      for (int kv = 0; kv < kv_dim; kv++)
+        for (int rank = 0; rank < tp_size; rank++)
+          span_order.push_back({rank, lid, kv});
+  }
+
+  auto &direct_fds = ioctx.get_fds(is_read, true);    // O_DIRECT
+  auto &buffered_fds = ioctx.get_fds(is_read, false); // buffered
+
+  std::vector<std::vector<int>> cpu_blocks_partition(num_devices);
+  std::vector<std::vector<int>> ssd_blocks_partition(num_devices);
+  std::vector<std::vector<int>> ssd_orig_blocks_partition(num_devices);
+  partition_and_remap_blocks_by_device_packed(
+      cpu_block_id_ptr, ssd_block_id_ptr, num_blocks, num_devices, round_robin,
+      cpu_blocks_partition, ssd_blocks_partition, ssd_orig_blocks_partition);
+
+  // Compressed payload bytes summed across all threads/devices for this op
+  // (per-block packed_bytes). Returned so Python can log the real transferred
+  // size, mirroring tp_group_transfer_ans.
+  std::atomic<int64_t> total_packed_bytes{0};
+  std::vector<std::thread> threads;
+  std::vector<std::future<std::exception_ptr>> futures;
+  for (int t = 0; t < num_threads_per_device; t++) {
+    for (int d = 0; d < num_devices; d++) {
+      int num_transfer_blocks = cpu_blocks_partition[d].size();
+      int num_blocks_per_thread =
+          (num_transfer_blocks + num_threads_per_device - 1) /
+          num_threads_per_device;
+      int start_block = t * num_blocks_per_thread;
+      int end_block =
+          std::min(start_block + num_blocks_per_thread, num_transfer_blocks);
+      if (start_block >= end_block) continue;
+
+      std::promise<std::exception_ptr> prom;
+      futures.push_back(prom.get_future());
+      threads.emplace_back(
+          [d, &total_packed_bytes, &direct_fds, &buffered_fds, &cpu_blocks_partition,
+           &ssd_blocks_partition, &ssd_orig_blocks_partition, &span_order,
+           start_block, end_block, cpu_tensor_ptr, cpu_layer_stride_in_bytes,
+           cpu_kv_stride_in_bytes, block_stride_in_bytes,
+           disk_block_stride_in_bytes, cpu_tp_rank_stride_in_bytes,
+           chunk_size_in_bytes, num_files_per_device, is_read,
+           cpu_size_table_base, cpu_size_table_rank_stride,
+           cpu_size_table_block_stride, cpu_size_table_layer_stride,
+           ssd_size_table_base, ssd_size_table_rank_stride,
+           ssd_size_table_block_stride, ssd_size_table_layer_stride,
+           layout_name, prom = std::move(prom)]() mutable {
+            try {
+              total_packed_bytes.fetch_add(
+                  transfer_packed_thread_impl(
+                      direct_fds[d], buffered_fds[d], cpu_blocks_partition[d],
+                      ssd_blocks_partition[d], ssd_orig_blocks_partition[d],
+                      span_order, start_block, end_block, cpu_tensor_ptr,
+                      cpu_layer_stride_in_bytes, cpu_kv_stride_in_bytes,
+                      block_stride_in_bytes, disk_block_stride_in_bytes,
+                      cpu_tp_rank_stride_in_bytes, chunk_size_in_bytes,
+                      num_files_per_device, is_read, cpu_size_table_base,
+                      cpu_size_table_rank_stride, cpu_size_table_block_stride,
+                      cpu_size_table_layer_stride, ssd_size_table_base,
+                      ssd_size_table_rank_stride, ssd_size_table_block_stride,
+                      ssd_size_table_layer_stride, layout_name),
+                  std::memory_order_relaxed);
+              prom.set_value(nullptr);
+            } catch (...) {
+              prom.set_value(std::current_exception());
+            }
+          });
+    }
+  }
+
+  for (auto &th : threads) th.join();
+  for (auto &f : futures) {
+    if (auto e = f.get()) std::rethrow_exception(e);
+  }
+  return total_packed_bytes.load(std::memory_order_relaxed);
+}
+
+int64_t transfer_kv_blocks_ssd_packed(
+    SSDIOCTX &ioctx, const torch::Tensor &cpu_layer_id_list,
+    int64_t cpu_tensor_ptr, const torch::Tensor &ssd_block_ids,
+    const torch::Tensor &cpu_block_ids,
+    int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes,
+    int64_t chunk_size_in_bytes,
+    int64_t block_stride_in_bytes,
+    bool is_read, int num_blocks_per_file,
+    int round_robin,
+    int num_threads_per_device,
+    bool is_mla,
+    // --- nvcomp packed-specific ---
+    const std::string &layout_type,
+    int total_layers,
+    uint32_t* cpu_size_table_base,
+    int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride,
+    uint32_t* ssd_size_table_base,
+    int64_t ssd_size_table_block_stride,
+    int64_t ssd_size_table_layer_stride,
+    int tp_size,
+    int64_t cpu_tp_rank_stride_in_bytes,
+    int64_t cpu_size_table_rank_stride,
+    int64_t ssd_size_table_rank_stride) {
+  bool blockfirst;
+  if (layout_type == "BLOCKFIRST") {
+    blockfirst = true;
+  } else if (layout_type == "LAYERFIRST") {
+    blockfirst = false;
+  } else {
+    throw std::runtime_error(
+        "transfer_kv_blocks_ssd_packed: unsupported layout_type: " +
+        layout_type);
+  }
+  return transfer_kv_blocks_ssd_packed_impl(
+      ioctx, cpu_layer_id_list, cpu_tensor_ptr, ssd_block_ids, cpu_block_ids,
+      cpu_layer_stride_in_bytes, cpu_kv_stride_in_bytes, chunk_size_in_bytes,
+      block_stride_in_bytes, is_read, num_blocks_per_file, round_robin,
+      num_threads_per_device, is_mla, blockfirst, total_layers,
+      cpu_size_table_base, cpu_size_table_block_stride,
+      cpu_size_table_layer_stride, ssd_size_table_base,
+      ssd_size_table_block_stride, ssd_size_table_layer_stride, tp_size,
+      cpu_tp_rank_stride_in_bytes, cpu_size_table_rank_stride,
+      ssd_size_table_rank_stride);
+}
+
+} // namespace flexkv

--- a/csrc/compression/common/transfer_ssd_packed.h
+++ b/csrc/compression/common/transfer_ssd_packed.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "transfer_ssd.h"
+
+#include <cstdint>
+#include <string>
+#include <torch/extension.h>
+
+namespace flexkv {
+
+int64_t transfer_kv_blocks_ssd_packed(
+    SSDIOCTX &ioctx, const torch::Tensor &cpu_layer_id_list,
+    int64_t cpu_tensor_ptr, const torch::Tensor &ssd_block_ids,
+    const torch::Tensor &cpu_block_ids, int64_t cpu_layer_stride_in_bytes,
+    int64_t cpu_kv_stride_in_bytes, int64_t chunk_size_in_bytes,
+    int64_t block_stride_in_bytes, bool is_read, int num_blocks_per_file,
+    int round_robin, int num_threads_per_device, bool is_mla,
+    const std::string &layout_type, int total_layers,
+    uint32_t* cpu_size_table_base, int64_t cpu_size_table_block_stride,
+    int64_t cpu_size_table_layer_stride, uint32_t* ssd_size_table_base,
+    int64_t ssd_size_table_block_stride,
+    int64_t ssd_size_table_layer_stride, int tp_size = 1,
+    int64_t cpu_tp_rank_stride_in_bytes = 0,
+    int64_t cpu_size_table_rank_stride = 0,
+    int64_t ssd_size_table_rank_stride = 0);
+
+} // namespace flexkv

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -16,7 +16,13 @@
  */
 #include "tp_transfer_thread_group.h"
 #include "transfer.cuh"
+#ifdef FLEXKV_ENABLE_NVCOMP
+#include "compression/ans/nvcomp_ans_tp.h"
+#endif
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAFunctions.h>
 #include <stdexcept>
+#include <type_traits>
 
 namespace flexkv {
 
@@ -27,7 +33,10 @@ TPTransferThreadGroup::TPTransferThreadGroup(
     const std::vector<int64_t> &gpu_block_strides_in_bytes,
     const std::vector<int64_t> &gpu_layer_strides_in_bytes,
     const std::vector<int64_t> &gpu_chunk_sizes_in_bytes,
-    const std::vector<int64_t> &gpu_device_ids) {
+    const std::vector<int64_t> &gpu_device_ids,
+    bool enable_nvcomp, int nvcomp_batch_size, int nvcomp_data_type) {
+  const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
+
   num_gpus_ = num_gpus;
   num_tensors_per_gpu_ = num_tensors_per_gpu;
 
@@ -116,9 +125,18 @@ TPTransferThreadGroup::TPTransferThreadGroup(
       }
     });
   }
+
+#ifdef FLEXKV_ENABLE_NVCOMP
+  if (enable_nvcomp) {
+    init_nvcomp(nvcomp_batch_size, nvcomp_data_type);
+  }
+#endif
+
 }
 
 TPTransferThreadGroup::~TPTransferThreadGroup() {
+  const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
+
   stop_pool_ = true;
   for (auto &cv : cvs_)
     cv.notify_all();
@@ -127,6 +145,10 @@ TPTransferThreadGroup::~TPTransferThreadGroup() {
       t.join();
 
   cudaFreeHost(gpu_blocks_);
+
+#ifdef FLEXKV_ENABLE_NVCOMP
+  destroy_nvcomp_state();
+#endif
 
   gpu_tensor_handlers_.clear();
   delete[] gpu_kv_strides_in_bytes_;

--- a/csrc/tp_transfer_thread_group.h
+++ b/csrc/tp_transfer_thread_group.h
@@ -33,6 +33,10 @@
 
 namespace flexkv {
 
+#ifdef FLEXKV_ENABLE_NVCOMP
+struct NvcompTPState;
+#endif
+
 class TPTransferThreadGroup {
 public:
   TPTransferThreadGroup(int num_gpus,
@@ -43,7 +47,10 @@ public:
                         const std::vector<int64_t> &gpu_block_strides_in_bytes,
                         const std::vector<int64_t> &gpu_layer_strides_in_bytes,
                         const std::vector<int64_t> &gpu_chunk_sizes_in_bytes,
-                        const std::vector<int64_t> &gpu_device_ids);
+                        const std::vector<int64_t> &gpu_device_ids,
+                        bool enable_nvcomp = false,
+                        int nvcomp_batch_size = 0,
+                        int nvcomp_data_type = 0);
 
   ~TPTransferThreadGroup();
 
@@ -57,6 +64,28 @@ public:
                          const bool is_host_to_device,
                          const bool use_ce_transfer, const int layer_id,
                          const int layer_granularity, const bool is_mla);
+
+#ifdef FLEXKV_ENABLE_NVCOMP
+
+  void init_nvcomp(int nvcomp_batch_size, int nvcomp_data_type);
+  void destroy_nvcomp_state();
+  void ensure_nvcomp_initialized();
+
+  size_t tp_group_transfer_ans(const torch::Tensor &gpu_block_id_tensor,
+                               const torch::Tensor &cpu_block_id_tensor,
+                               const int64_t cpu_kv_stride_in_bytes,
+                               const int64_t cpu_layer_stride_in_bytes,
+                               const int64_t cpu_block_stride_in_bytes,
+                               const int64_t cpu_tp_stride_in_bytes,
+                               const int transfer_num_cta,
+                               const bool is_host_to_device,
+                               const bool use_ce_transfer, const int layer_id,
+                               const int layer_granularity, const bool is_mla,
+                               const int64_t cpu_size_table_tp_ptr,
+                               const int64_t cpu_size_table_tp_rank_stride,
+                               const int64_t cpu_size_table_block_stride,
+                               const int64_t cpu_size_table_layer_stride);
+#endif
 
 private:
   using Task = std::function<void()>;
@@ -83,6 +112,10 @@ private:
   std::vector<std::mutex> mtxs_;
   std::vector<std::condition_variable> cvs_;
   std::atomic<bool> stop_pool_;
+
+#ifdef FLEXKV_ENABLE_NVCOMP
+  std::unique_ptr<NvcompTPState> nvcomp_state_;
+#endif
 };
 
 } // namespace flexkv

--- a/csrc/transfer_ssd.cpp
+++ b/csrc/transfer_ssd.cpp
@@ -8,7 +8,6 @@
 #include <mutex>
 #include <sys/mman.h>
 #include <thread>
-#include <unistd.h>
 
 #include "transfer_ssd.h"
 #include "monitoring/metrics_manager.h"
@@ -19,7 +18,11 @@ static void partition_and_remap_blocks_by_device(
     const int64_t *cpu_block_ids, const int64_t *ssd_block_ids, int num_blocks,
     int num_devices, int round_robin,
     std::vector<std::vector<int>> &cpu_blocks_partition,
-    std::vector<std::vector<int>> &ssd_blocks_partition) {
+    std::vector<std::vector<int>> &ssd_blocks_partition,
+    // Optional: when non-null, also collect the original (pre-remap) ssd block
+    // ids per device. The packed-nvcomp path needs them to index the SSD size
+    // table.
+    std::vector<std::vector<int>> *ssd_orig_blocks_partition = nullptr) {
   for (int i = 0; i < num_blocks; i++) {
     int64_t ssd_block_id = ssd_block_ids[i];
     int64_t cpu_block_id = cpu_block_ids[i];
@@ -29,6 +32,9 @@ static void partition_and_remap_blocks_by_device(
         (ssd_block_id % round_robin);
     ssd_blocks_partition[device_id].push_back(block_id_in_device);
     cpu_blocks_partition[device_id].push_back(cpu_block_id);
+    if (ssd_orig_blocks_partition)
+      (*ssd_orig_blocks_partition)[device_id].push_back(
+          static_cast<int>(ssd_block_id));
   }
 }
 

--- a/csrc/transfer_ssd.cpp
+++ b/csrc/transfer_ssd.cpp
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <fcntl.h>
+#include <cstdio>
 #include <torch/extension.h>
 #include <unistd.h>
 #include <vector>
@@ -256,9 +257,25 @@ void transfer_kv_blocks_ssd(
   const int num_blocks = ssd_block_ids.size(0);
   const int num_layers = cpu_layer_id_list.size(0);
   const int32_t *cpu_layer_id_list_ptr = cpu_layer_id_list.data_ptr<int32_t>();
-  bool is_direct = chunk_size_in_bytes % 4096 == 0;
+
+  const bool cpu_is_block_first =
+      block_stride_in_bytes > cpu_layer_stride_in_bytes;
+  const bool ssd_is_block_first =
+      block_stride_in_bytes > ssd_layer_stride_in_bytes;
+  const bool enable_block_first_transfer =
+      cpu_is_block_first && ssd_is_block_first;
 
   IOUring &iouring = ioctx.get_iouring();
+
+  bool is_direct;
+  if (iouring.enabled() && enable_block_first_transfer) {
+    int64_t io_size = cpu_layer_stride_in_bytes * num_layers;
+    is_direct = (io_size % 4096 == 0) &&
+                (block_stride_in_bytes % 4096 == 0);
+  } else {
+    is_direct = chunk_size_in_bytes % 4096 == 0;
+  }
+  
   std::vector<std::vector<int>> &fds = ioctx.get_fds(is_read, is_direct);
 
   std::vector<std::vector<int>> cpu_blocks_partition(num_devices,
@@ -268,13 +285,6 @@ void transfer_kv_blocks_ssd(
   partition_and_remap_blocks_by_device(
       cpu_block_id_ptr, ssd_block_id_ptr, num_blocks, num_devices, round_robin,
       cpu_blocks_partition, ssd_blocks_partition);
-
-  const bool cpu_is_block_first =
-      block_stride_in_bytes > cpu_layer_stride_in_bytes;
-  const bool ssd_is_block_first =
-      block_stride_in_bytes > ssd_layer_stride_in_bytes;
-  const bool enable_block_first_transfer =
-      cpu_is_block_first && ssd_is_block_first;
 
   std::vector<std::thread> threads;
   std::vector<std::future<std::exception_ptr>> futures;

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -458,6 +458,8 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     lease_ttl_ms=int(os.getenv('FLEXKV_LEASE_TTL_MS', 30000)),
     safety_ttl_ms=int(os.getenv('FLEXKV_SAFETY_TTL_MS', 100)),
     renew_lease_ms=int(os.getenv('FLEXKV_RENEW_LEASE_MS', 4000)),
+
+    nvcomp_batch_size=int(os.getenv('FLEXKV_NVCOMP_BATCH_SIZE', '0')),  # 0 = auto
 )
 
 @dataclass

--- a/flexkv/transfer/compression/__init__.py
+++ b/flexkv/transfer/compression/__init__.py
@@ -1,0 +1,13 @@
+from flexkv.transfer.compression.ans import ans_utils
+from flexkv.transfer.compression.common.strategy import (
+    CompressionStrategy,
+    NullCompressionStrategy,
+)
+from flexkv.transfer.compression.factory import build_compressors
+
+__all__ = [
+    "ans_utils",
+    "CompressionStrategy",
+    "NullCompressionStrategy",
+    "build_compressors",
+]

--- a/flexkv/transfer/compression/ans/__init__.py
+++ b/flexkv/transfer/compression/ans/__init__.py
@@ -1,0 +1,3 @@
+from flexkv.transfer.compression.ans import ans_utils
+
+__all__ = ["ans_utils"]

--- a/flexkv/transfer/compression/ans/ans_strategy.py
+++ b/flexkv/transfer/compression/ans/ans_strategy.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+import nvtx
+import torch
+
+from flexkv.common.storage import KVCacheLayoutType
+from flexkv.common.transfer import TransferType
+from flexkv.c_ext import (
+    transfer_kv_blocks_ans_comp,
+    transfer_kv_blocks_ans_decomp,
+    transfer_kv_blocks_ssd_packed,
+)
+from flexkv.transfer.compression.ans import ans_utils
+from flexkv.transfer.compression.common.size_table import bind_size_table
+from flexkv.transfer.compression.common.strategy import CompressionStrategy
+
+
+class NvcompGpuCpuStrategy(CompressionStrategy):
+    def __init__(self, cpu_size_table: torch.Tensor):
+        self._cpu_size_table = cpu_size_table
+        self._ans_ctx: Optional[Any] = None
+        self._table_ptr = 0
+        self._table_block_stride = 0
+        self._table_layer_stride = 0
+
+    def attach(self, worker) -> None:
+        (self._table_ptr, _,
+         self._table_block_stride,
+         self._table_layer_stride) = bind_size_table(
+            self._cpu_size_table,
+            "[GPUCPUTransferWorker] cpu_size_table",
+            register=True,
+            expected_dims=(3,),
+        )
+        if self._table_ptr == 0:
+            raise RuntimeError(
+                "GPUCPUTransferWorker: nvcomp is enabled but "
+                "cpu_size_table was not supplied.")
+        self._ans_ctx = ans_utils.create_ans_context(
+            chunk_size_bytes=worker.chunk_size_in_bytes,
+            dtype=worker.dtype,
+            is_mla=worker.is_mla,
+            log_prefix="[nvcomp]",
+        )
+
+    def run(self, worker, op, src_block_ids, dst_block_ids) -> None:
+        start_time = time.time()
+        compressed_bytes = self._dispatch(
+            worker, src_block_ids, dst_block_ids, op.transfer_type)
+        end_time = time.time()
+        uncomp_size = (
+            worker.chunk_size_in_bytes
+            * worker.num_layers
+            * op.valid_block_num
+            * worker.kv_dim
+        )
+        worker._log_transfer_performance(
+            op, int(compressed_bytes), start_time, end_time,
+            uncompressed_size=uncomp_size)
+
+    def _dispatch(self, worker, src_block_ids, dst_block_ids, transfer_type) -> int:
+        if transfer_type == TransferType.H2D:
+            gpu_block_id_list, cpu_block_id_list = dst_block_ids, src_block_ids
+        elif transfer_type == TransferType.D2H:
+            gpu_block_id_list, cpu_block_id_list = src_block_ids, dst_block_ids
+        else:
+            raise ValueError(
+                f"Invalid transfer type: {transfer_type} for GPUCPUTransferWorker")
+        if len(gpu_block_id_list) == 0:
+            return 0
+
+        nvtx_range = nvtx.start_range(
+            message=f"NvcompGpuCpuStrategy.run[{transfer_type.name}]",
+            color="purple")
+        try:
+            gpu_tensor_ptrs = worker.gpu_blocks_ptrs
+            if transfer_type == TransferType.D2H:
+                ans_range = nvtx.start_range(
+                    message="D2H_nvcomp:transfer_kv_blocks_ans_comp",
+                    color="orange")
+                try:
+                    compressed_bytes = transfer_kv_blocks_ans_comp(
+                        self._ans_ctx, gpu_block_id_list, gpu_tensor_ptrs,
+                        worker.gpu_kv_stride_in_bytes,
+                        worker.gpu_block_stride_in_bytes,
+                        worker.gpu_layer_stride_in_bytes, cpu_block_id_list,
+                        worker.cpu_tensor, worker.cpu_kv_stride_in_bytes,
+                        worker.cpu_layer_stride_in_bytes,
+                        worker.cpu_block_stride_in_bytes,
+                        worker.chunk_size_in_bytes, 0, worker.num_layers,
+                        worker.is_mla, worker.gpu_block_type_,
+                        self._table_ptr, self._table_block_stride,
+                        self._table_layer_stride)
+                finally:
+                    nvtx.end_range(ans_range)
+            else:
+                ans_range = nvtx.start_range(
+                    message="H2D_nvcomp:transfer_kv_blocks_ans_decomp",
+                    color="orange")
+                try:
+                    compressed_bytes = transfer_kv_blocks_ans_decomp(
+                        self._ans_ctx, gpu_block_id_list, gpu_tensor_ptrs,
+                        worker.gpu_kv_stride_in_bytes,
+                        worker.gpu_block_stride_in_bytes,
+                        worker.gpu_layer_stride_in_bytes, cpu_block_id_list,
+                        worker.cpu_tensor, worker.cpu_kv_stride_in_bytes,
+                        worker.cpu_layer_stride_in_bytes,
+                        worker.cpu_block_stride_in_bytes,
+                        worker.chunk_size_in_bytes, 0, worker.num_layers,
+                        worker.is_mla, worker.gpu_block_type_,
+                        self._table_ptr, self._table_block_stride,
+                        self._table_layer_stride)
+                finally:
+                    nvtx.end_range(ans_range)
+            return int(compressed_bytes)
+        finally:
+            nvtx.end_range(nvtx_range)
+
+    def shutdown(self) -> None:
+        if self._ans_ctx is not None:
+            self._ans_ctx.destroy()
+            self._ans_ctx = None
+
+
+class NvcompGpuCpuTpStrategy(CompressionStrategy):
+    def __init__(self, cpu_size_table_tp: torch.Tensor):
+        self._cpu_size_table_tp = cpu_size_table_tp
+        self._table_ptr = 0
+        self._table_rank_stride = 0
+        self._table_block_stride = 0
+        self._table_layer_stride = 0
+
+    def attach(self, worker) -> None:
+        batch_size, data_type = ans_utils.tp_worker_config(
+            gpu_chunk_sizes_in_bytes=worker.gpu_chunk_sizes_in_bytes,
+            dtype=worker.dtype,
+            tp_size=worker.num_gpus,
+        )
+        (self._table_ptr, self._table_rank_stride,
+         self._table_block_stride,
+         self._table_layer_stride) = bind_size_table(
+            self._cpu_size_table_tp,
+            "[tpGPUCPUTransferWorker] cpu_size_table_tp",
+            register=True,
+            expected_dims=(3,) if worker.is_mla else (4,),
+        )
+        worker.tp_transfer_thread_group.init_nvcomp(batch_size, data_type)
+
+    def run(self, worker, op, src_block_ids, dst_block_ids) -> None:
+        start_time = time.time()
+        compressed_bytes = self._dispatch(
+            worker, src_block_ids, dst_block_ids, op.transfer_type)
+        end_time = time.time()
+        uncomp_size = (
+            worker.chunk_size_in_bytes
+            * worker.num_layers
+            * op.valid_block_num
+            * worker.kv_dim
+        )
+        worker._log_transfer_performance(
+            op, int(compressed_bytes), start_time, end_time,
+            uncompressed_size=uncomp_size)
+
+    def _dispatch(self, worker, src_block_ids, dst_block_ids, transfer_type) -> int:
+        assert src_block_ids.dtype == torch.int64
+        assert dst_block_ids.dtype == torch.int64
+        assert len(src_block_ids) == len(dst_block_ids)
+
+        if transfer_type == TransferType.H2D:
+            gpu_block_id_list = dst_block_ids
+            cpu_block_id_list = src_block_ids
+            use_ce_transfer = worker.use_ce_transfer_h2d
+            transfer_num_cta = worker.transfer_num_cta_h2d
+        elif transfer_type == TransferType.D2H:
+            gpu_block_id_list = src_block_ids
+            cpu_block_id_list = dst_block_ids
+            use_ce_transfer = worker.use_ce_transfer_d2h
+            transfer_num_cta = worker.transfer_num_cta_d2h
+        else:
+            raise ValueError(
+                f"Invalid transfer type: {transfer_type} for tpGPUCPUTransferWorker")
+
+        if len(gpu_block_id_list) == 0:
+            return 0
+
+        nvtx_range = nvtx.start_range(
+            message=f"NvcompGpuCpuTpStrategy.run[{transfer_type.name}]",
+            color="purple")
+        try:
+            return int(worker.tp_transfer_thread_group.tp_group_transfer_ans(
+                gpu_block_id_list, cpu_block_id_list,
+                worker.cpu_kv_stride_in_bytes,
+                worker.cpu_layer_stride_in_bytes,
+                worker.cpu_block_stride_in_bytes,
+                worker.cpu_tp_stride_in_bytes,
+                transfer_num_cta,
+                transfer_type == TransferType.H2D,
+                use_ce_transfer,
+                0,
+                worker.num_layers,
+                worker.is_mla,
+                self._table_ptr,
+                self._table_rank_stride,
+                self._table_block_stride,
+                self._table_layer_stride,
+            ))
+        finally:
+            nvtx.end_range(nvtx_range)
+
+
+class NvcompCpuSsdStrategy(CompressionStrategy):
+    def __init__(
+        self,
+        *,
+        cpu_size_table,
+        ssd_size_table,
+        cpu_size_table_tp,
+        ssd_size_table_tp,
+        tp_size: int,
+    ):
+        self._cpu_size_table = cpu_size_table
+        self._ssd_size_table = ssd_size_table
+        self._cpu_size_table_tp = cpu_size_table_tp
+        self._ssd_size_table_tp = ssd_size_table_tp
+        self._tp_size = tp_size
+
+    def attach(self, worker) -> None:
+        (self._write_threads,
+         self._read_threads) = ans_utils.ssd_packed_threads(worker.is_mla)
+
+        selected_cpu = (self._cpu_size_table_tp
+                        if self._cpu_size_table_tp is not None
+                        else self._cpu_size_table)
+        selected_ssd = (self._ssd_size_table_tp
+                        if self._ssd_size_table_tp is not None
+                        else self._ssd_size_table)
+        ans_utils.check_worker_nvcomp_enable(
+            True,
+            path="cpu_ssd",
+            cpu_size_table=selected_cpu,
+            ssd_size_table=selected_ssd,
+            tp_size=self._tp_size if self._cpu_size_table_tp is not None else 1,
+        )
+
+        (self._cpu_table_ptr, _,
+         self._cpu_table_block_stride,
+         self._cpu_table_layer_stride) = bind_size_table(
+            self._cpu_size_table,
+            "[CPUSSDDiskTransferWorker] cpu_size_table",
+            expected_dims=(3,),
+        )
+        (self._ssd_table_ptr, _,
+         self._ssd_table_block_stride,
+         self._ssd_table_layer_stride) = bind_size_table(
+            self._ssd_size_table,
+            "[CPUSSDDiskTransferWorker] ssd_size_table",
+            expected_dims=(3,),
+        )
+
+        self._per_rank_chunk_in_bytes = 0
+        self._cpu_table_rank_stride_tp = 0
+        self._ssd_table_rank_stride_tp = 0
+        if self._cpu_size_table_tp is not None:
+            assert self._ssd_size_table_tp is not None, \
+                "cpu_size_table_tp and ssd_size_table_tp must be supplied together"
+            self._per_rank_chunk_in_bytes = (
+                worker.chunk_size_in_bytes // self._tp_size)
+            (_, self._cpu_table_rank_stride_tp,
+             self._cpu_table_block_stride_tp,
+             self._cpu_table_layer_stride_tp) = bind_size_table(
+                self._cpu_size_table_tp,
+                "[CPUSSDDiskTransferWorker] cpu_size_table_tp",
+                expected_dims=(4,),
+            )
+            (_, self._ssd_table_rank_stride_tp,
+             self._ssd_table_block_stride_tp,
+             self._ssd_table_layer_stride_tp) = bind_size_table(
+                self._ssd_size_table_tp,
+                "[CPUSSDDiskTransferWorker] ssd_size_table_tp",
+                expected_dims=(4,),
+            )
+
+    def run(self, worker, op, src_block_ids, dst_block_ids) -> None:
+        start_time = time.time()
+        transfer_size = self._dispatch(
+            worker, src_block_ids, dst_block_ids, op.transfer_type)
+        end_time = time.time()
+        uncomp_size = (
+            worker.chunk_size_in_bytes
+            * worker.num_layers
+            * op.valid_block_num
+            * worker.kv_dim
+        )
+        worker._log_transfer_performance(
+            op, int(transfer_size), start_time, end_time,
+            uncompressed_size=uncomp_size)
+
+    def _build_ssd_packed_kwargs(
+        self,
+        worker,
+        transfer_type: TransferType,
+    ) -> Dict[str, Any]:
+        num_threads = (
+            self._read_threads
+            if transfer_type == TransferType.DISK2H
+            else self._write_threads
+        )
+        use_ranked_table = self._cpu_size_table_tp is not None and not worker.is_mla
+        use_canonical_rank0_table = self._cpu_size_table_tp is not None and worker.is_mla
+
+        if use_ranked_table:
+            if worker.cpu_layout_type == KVCacheLayoutType.BLOCKFIRST:
+                cpu_layer_stride = worker.cpu_layer_stride_in_bytes // self._tp_size
+                cpu_kv_stride = worker.cpu_kv_stride_in_bytes // self._tp_size
+                cpu_tp_rank_stride = worker.block_stride_in_bytes // self._tp_size
+            elif worker.cpu_layout_type == KVCacheLayoutType.LAYERFIRST:
+                cpu_layer_stride = worker.cpu_layer_stride_in_bytes
+                cpu_kv_stride = worker.cpu_kv_stride_in_bytes
+                cpu_tp_rank_stride = self._per_rank_chunk_in_bytes
+            else:
+                raise RuntimeError(
+                    "CPUSSDDiskTransferWorker: nvcomp+SSD only supports "
+                    "BLOCKFIRST/LAYERFIRST layouts; requested "
+                    f"layout={worker.cpu_layout_type.name}.")
+
+            return {
+                "cpu_layer_stride_in_bytes": cpu_layer_stride,
+                "cpu_kv_stride_in_bytes": cpu_kv_stride,
+                "chunk_size_in_bytes": self._per_rank_chunk_in_bytes,
+                "num_threads_per_device": num_threads,
+                "cpu_size_table_ptr": self._cpu_size_table_tp.data_ptr(),
+                "cpu_size_table_rank_stride": self._cpu_table_rank_stride_tp,
+                "cpu_size_table_block_stride": self._cpu_table_block_stride_tp,
+                "cpu_size_table_layer_stride": self._cpu_table_layer_stride_tp,
+                "ssd_size_table_ptr": self._ssd_size_table_tp.data_ptr(),
+                "ssd_size_table_rank_stride": self._ssd_table_rank_stride_tp,
+                "ssd_size_table_block_stride": self._ssd_table_block_stride_tp,
+                "ssd_size_table_layer_stride": self._ssd_table_layer_stride_tp,
+                "is_mla": False,
+                "tp_size": self._tp_size,
+                "cpu_tp_rank_stride_in_bytes": cpu_tp_rank_stride,
+            }
+
+        if use_canonical_rank0_table:
+            cpu_table_ptr = self._cpu_size_table_tp.data_ptr()
+            ssd_table_ptr = self._ssd_size_table_tp.data_ptr()
+            cpu_block_stride = self._cpu_table_block_stride_tp
+            cpu_layer_stride_tbl = self._cpu_table_layer_stride_tp
+            ssd_block_stride = self._ssd_table_block_stride_tp
+            ssd_layer_stride_tbl = self._ssd_table_layer_stride_tp
+        else:
+            cpu_table_ptr = self._cpu_table_ptr
+            ssd_table_ptr = self._ssd_table_ptr
+            cpu_block_stride = self._cpu_table_block_stride
+            cpu_layer_stride_tbl = self._cpu_table_layer_stride
+            ssd_block_stride = self._ssd_table_block_stride
+            ssd_layer_stride_tbl = self._ssd_table_layer_stride
+
+        return {
+            "cpu_layer_stride_in_bytes": worker.cpu_layer_stride_in_bytes,
+            "cpu_kv_stride_in_bytes": worker.cpu_kv_stride_in_bytes,
+            "chunk_size_in_bytes": worker.chunk_size_in_bytes,
+            "num_threads_per_device": num_threads,
+            "cpu_size_table_ptr": cpu_table_ptr,
+            "cpu_size_table_rank_stride": 0,
+            "cpu_size_table_block_stride": cpu_block_stride,
+            "cpu_size_table_layer_stride": cpu_layer_stride_tbl,
+            "ssd_size_table_ptr": ssd_table_ptr,
+            "ssd_size_table_rank_stride": 0,
+            "ssd_size_table_block_stride": ssd_block_stride,
+            "ssd_size_table_layer_stride": ssd_layer_stride_tbl,
+            "is_mla": worker.is_mla,
+            "tp_size": 1,
+            "cpu_tp_rank_stride_in_bytes": 0,
+        }
+
+    def _dispatch(self, worker, src_block_ids, dst_block_ids, transfer_type) -> int:
+        assert src_block_ids.dtype == torch.int64
+        assert dst_block_ids.dtype == torch.int64
+        assert len(src_block_ids) == len(dst_block_ids)
+
+        if transfer_type == TransferType.H2DISK:
+            ssd_block_id_list = dst_block_ids
+            cpu_block_id_list = src_block_ids
+        elif transfer_type == TransferType.DISK2H:
+            ssd_block_id_list = src_block_ids
+            cpu_block_id_list = dst_block_ids
+        else:
+            raise ValueError(
+                f"Invalid transfer type: {transfer_type} for CPUSSDDiskTransferWorker")
+
+        layer_id_list = torch.arange(worker.num_layers, dtype=torch.int32)
+        packed_kwargs = self._build_ssd_packed_kwargs(worker, transfer_type)
+        compressed_bytes = transfer_kv_blocks_ssd_packed(
+            ioctx=worker.ioctx,
+            cpu_layer_id_list=layer_id_list,
+            cpu_tensor_ptr=worker.cpu_layer_ptrs[0].item(),
+            ssd_block_ids=ssd_block_id_list,
+            cpu_block_ids=cpu_block_id_list,
+            block_stride_in_bytes=worker.block_stride_in_bytes,
+            is_read=(transfer_type == TransferType.DISK2H),
+            num_blocks_per_file=worker.num_blocks_per_file,
+            layout_type=worker.cpu_layout_type.value,
+            total_layers=worker.num_layers,
+            round_robin=worker.round_robin,
+            **packed_kwargs,
+        )
+        worker._last_nvcomp_ssd_path = (
+            "packed_blockfirst"
+            if worker.cpu_layout_type == KVCacheLayoutType.BLOCKFIRST
+            else "packed_layerfirst")
+        return int(compressed_bytes)

--- a/flexkv/transfer/compression/ans/ans_utils.py
+++ b/flexkv/transfer/compression/ans/ans_utils.py
@@ -1,0 +1,458 @@
+import os
+import uuid
+from typing import Tuple, List, Dict, Optional, Any
+
+import torch
+
+from flexkv.common.debug import flexkv_logger
+from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
+
+try:
+    from flexkv.c_ext import ANSTransferContext, transfer_kv_blocks_ans_comp
+    _NVCOMP_AVAILABLE = True
+except ImportError:
+    ANSTransferContext = None
+    transfer_kv_blocks_ans_comp = None
+    _NVCOMP_AVAILABLE = False
+
+
+AVAILABLE = _NVCOMP_AVAILABLE
+SUPPORTED_DTYPES = (
+    torch.bfloat16, torch.float16,
+    torch.float8_e4m3fn, torch.float8_e5m2,
+)
+
+MIN_CHUNK_BYTES = 4096
+# Below this per-device chunk the compression ratio drops noticeably
+# (it plateaus around 16KB). Advisory threshold used only for a warning.
+RATIO_PLATEAU_BYTES = 16 * 1024
+SSD_PACKED_IO_ALIGN = 512
+
+
+def check_dtype(dtype) -> None:
+    if dtype not in SUPPORTED_DTYPES:
+        raise RuntimeError(
+            f"nvcomp only supports bf16/fp16/fp8, got {dtype}")
+
+
+def data_type(dtype) -> int:
+    """nvcomp ANS data type: 0 = FLOAT16 (bf16/fp16), 1 = UCHAR (fp8)."""
+    check_dtype(dtype)
+    return 0 if dtype.itemsize == 2 else 1
+
+
+def check_engine_nvcomp_enable(
+    gpu_handle_groups: Dict[Any, List[Any]],
+    *,
+    layerwise_enabled: bool,
+    cpu_handle: Optional[Any],
+) -> bool:
+    """Engine-level enable/fallback policy for nvcomp ANS."""
+    if os.environ.get("FLEXKV_ENABLE_NVCOMP", "0") != "1":
+        return False
+    if not AVAILABLE:
+        flexkv_logger.warning(
+            "[nvcomp-fallback] FLEXKV_ENABLE_NVCOMP=1 but the extension "
+            "was not compiled with nvcomp support; disabling nvcomp.")
+        return False
+
+    gpu_handles = [
+        gpu_handle
+        for tp_gpu_handles in gpu_handle_groups.values()
+        for gpu_handle in tp_gpu_handles
+    ]
+
+    # TODO(nvcomp-guard): layerwise transfer is not supported yet
+    if layerwise_enabled:
+        flexkv_logger.warning(
+            "[nvcomp-fallback] FLEXKV_ENABLE_NVCOMP=1 but layerwise "
+            "transfer is enabled; disabling nvcomp because layerwise "
+            "H2D currently consumes uncompressed CPU cache blocks.")
+        return False
+
+    chunk_sizes = [
+        gpu_handle.kv_layout.get_chunk_size() * gpu_handle.dtype.itemsize
+        for gpu_handle in gpu_handles
+    ]
+    if not chunk_sizes:
+        flexkv_logger.warning(
+            "[nvcomp-fallback] FLEXKV_ENABLE_NVCOMP=1 but no GPU chunk sizes "
+            "were available; disabling nvcomp.")
+        return False
+
+    unsupported_dtypes = sorted(
+        {str(gpu_handle.dtype) for gpu_handle in gpu_handles
+         if gpu_handle.dtype not in SUPPORTED_DTYPES})
+    if unsupported_dtypes:
+        flexkv_logger.warning(
+            "[nvcomp-fallback] FLEXKV_ENABLE_NVCOMP=1 but unsupported "
+            f"GPU cache dtypes were found: {unsupported_dtypes}; "
+            "disabling nvcomp.")
+        return False
+
+    if min(chunk_sizes) < MIN_CHUNK_BYTES:
+        flexkv_logger.warning(
+            f"[nvcomp-fallback] min_chunk_size={min(chunk_sizes)}B "
+            f"is below the {MIN_CHUNK_BYTES}B ANS minimum. "
+            "Disabling nvcomp for GPU<->CPU and CPU<->SSD so all "
+            "paths use uncompressed transfers consistently.")
+        return False
+    return True
+
+
+def check_worker_nvcomp_enable(
+    flag: Optional[bool],
+    *,
+    path: str,
+    cpu_size_table: Optional[torch.Tensor] = None,
+    ssd_size_table: Optional[torch.Tensor] = None,
+    tp_size: int = 1,
+    gpu_chunk_sizes_in_bytes: Optional[List[int]] = None,
+) -> bool:
+    if flag is None:
+        flag = os.environ.get("FLEXKV_ENABLE_NVCOMP", "0") == "1"
+    enabled = AVAILABLE and bool(flag)
+    if not enabled:
+        return False
+
+    if path not in ("gpu_cpu", "cpu_ssd"):
+        raise RuntimeError(f"Unknown nvcomp worker path: {path}")
+
+    if cpu_size_table is None:
+        raise RuntimeError(
+            "nvcomp is enabled but the corresponding CPU size table "
+            "was not supplied.")
+
+    if path == "cpu_ssd" and ssd_size_table is None:
+        raise RuntimeError(
+            "nvcomp+SSD is enabled but the corresponding SSD size table "
+            "was not supplied.")
+
+    if tp_size > 1:
+        if (gpu_chunk_sizes_in_bytes is not None and
+                len(set(gpu_chunk_sizes_in_bytes)) > 1):
+            raise RuntimeError(
+                f"nvcomp TP requires all ranks to have identical chunk "
+                f"sizes, got {gpu_chunk_sizes_in_bytes}. "
+                f"Per-rank GPU layouts must be head-equally-partitioned.")
+    return True
+
+
+def size_table_shape(
+    num_blocks: int, num_layers: int, kv_dim: int, tp_size: int,
+    *, canonical: bool,
+) -> Tuple[int, ...]:
+    """uint32 compressed-size-table shape. Same interface for the CPU and
+    SSD tables -- only num_blocks differs. canonical (tp==1 or MLA, where KV
+    is replicated / not head-sharded) -> [blocks, layers, kv]; otherwise a
+    per-rank stack -> [tp, blocks, layers, kv]."""
+    if canonical:
+        return (num_blocks, num_layers, kv_dim)
+    return (tp_size, num_blocks, num_layers, kv_dim)
+
+
+def allocate_size_table(
+    *,
+    num_blocks: int,
+    num_layers: int,
+    kv_dim: int,
+    tp_size: int,
+    canonical: bool,
+    name: str,
+) -> torch.Tensor:
+    shape = size_table_shape(
+        num_blocks, num_layers, kv_dim, tp_size, canonical=canonical)
+    table = torch.zeros(shape, dtype=torch.uint32)
+    flexkv_logger.info(
+        f"[nvcomp-size-table] {name} allocated: "
+        f"shape={tuple(table.shape)} dtype=uint32 "
+        f"size={table.numel() * 4 / (1024**2):.1f} MB")
+    return table
+
+
+def allocate_engine_size_tables(
+    *,
+    cpu_handle: Any,
+    ssd_handle: Optional[Any],
+    cache_config: Any,
+    model_config: Any,
+) -> Tuple[
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
+    layout = cpu_handle.kv_layout
+    num_layers = layout.num_layer
+    kv_dim = 1 if layout.is_mla else 2
+    tp_size = model_config.effective_tp_size_per_node
+    canonical = (tp_size == 1 or layout.is_mla)
+
+    cpu_table = allocate_size_table(
+        num_blocks=cache_config.num_cpu_blocks,
+        num_layers=num_layers,
+        kv_dim=kv_dim,
+        tp_size=tp_size,
+        canonical=canonical,
+        name="cpu_size_table" if canonical else "cpu_size_table_tp",
+    ).share_memory_()
+
+    # SSD table keeps compressed sizes by SSD block, so DISK2H can restore
+    # them even when data lands in a different CPU slot:
+    #   H2DISK: ssd_size_table[s] = cpu_size_table[c]
+    #   DISK2H: cpu_size_table[c'] = ssd_size_table[s]
+    # TODO(persistence): persist this table if packed SSD cache must survive restart.
+    ssd_table = (
+        allocate_size_table(
+            num_blocks=ssd_handle.kv_layout.num_block,
+            num_layers=num_layers,
+            kv_dim=kv_dim,
+            tp_size=tp_size,
+            canonical=canonical,
+            name="ssd_size_table" if canonical else "ssd_size_table_tp",
+        ).share_memory_()
+        if ssd_handle is not None else None
+    )
+
+    if canonical:
+        return cpu_table, None, ssd_table, None
+    return None, cpu_table, None, ssd_table
+
+
+def ssd_packed_threads(is_mla: bool) -> Tuple[int, int]:
+    """(write_threads, read_threads) for the nvcomp SSD packed path.
+
+    Per-direction env (FLEXKV_NVCOMP_SSD_PACKED_WRITE_THREADS / _READ_THREADS)
+    overrides the is_mla default. MLA reads/writes the replicated canonical
+    chunk, so it benefits from more threads than head-sharded MHA.
+    """
+    default_write = 16
+    default_read = 8
+    write = int(os.environ.get(
+        "FLEXKV_NVCOMP_SSD_PACKED_WRITE_THREADS", default_write))
+    read = int(os.environ.get(
+        "FLEXKV_NVCOMP_SSD_PACKED_READ_THREADS", default_read))
+    return write, read
+
+
+def get_nvcomp_batch_size(
+    chunk_size_bytes: int, data_type: int = 0
+) -> Tuple[int, str]:
+    """Resolve the nvcomp batch_size. The env var FLEXKV_NVCOMP_BATCH_SIZE
+    (> 0) overrides; otherwise auto-calibrate. Returns (batch_size, source)
+    where source is "env" or "auto"."""
+    if GLOBAL_CONFIG_FROM_ENV.nvcomp_batch_size > 0:
+        return GLOBAL_CONFIG_FROM_ENV.nvcomp_batch_size, "env"
+    return optimal_batch_size(
+        chunk_size_bytes, data_type=data_type), "auto"
+
+
+def create_ans_context(
+    *,
+    chunk_size_bytes: int,
+    dtype: torch.dtype,
+    is_mla: bool,
+    log_prefix: str,
+) -> Any:
+    if chunk_size_bytes < RATIO_PLATEAU_BYTES:
+        flexkv_logger.warning(
+            f"{log_prefix} per-device chunk_size={chunk_size_bytes}B "
+            f"< {RATIO_PLATEAU_BYTES // 1024}KB plateau; "
+            "compression ratio may be low. Consider increasing "
+            "tokens_per_block.")
+
+    kv_dim = 1 if is_mla else 2
+    ans_data_type = data_type(dtype)
+    batch_size, batch_size_source = get_nvcomp_batch_size(
+        chunk_size_bytes, data_type=ans_data_type)
+    ctx = ANSTransferContext(batch_size, chunk_size_bytes, ans_data_type)
+    flexkv_logger.info(
+        f"{log_prefix} ANSTransferContext created: "
+        f"max_chunks={ctx.max_num_chunks}, "
+        f"chunk_size={ctx.max_chunk_size}, "
+        f"max_comp_chunk={ctx.max_comp_chunk_bytes}, "
+        f"batch_size={batch_size} ({batch_size_source}), "
+        f"dtype={dtype}, kv_dim={kv_dim}")
+    return ctx
+
+
+def tp_worker_config(
+    *,
+    gpu_chunk_sizes_in_bytes: List[int],
+    dtype: torch.dtype,
+    tp_size: int,
+) -> Tuple[int, int]:
+    chunk_size = gpu_chunk_sizes_in_bytes[0]
+    ans_data_type = data_type(dtype)
+    if chunk_size < RATIO_PLATEAU_BYTES:
+        flexkv_logger.warning(
+            f"[nvcomp-tp] per-device chunk={chunk_size}B "
+            f"< {RATIO_PLATEAU_BYTES // 1024}KB plateau; "
+            "compression ratio may be low. Consider increasing "
+            f"tokens_per_block or lowering tp_size (current tp={tp_size}).")
+
+    batch_size, batch_size_source = get_nvcomp_batch_size(
+        chunk_size, data_type=ans_data_type)
+    flexkv_logger.info(
+        f"[nvcomp-tp] Enabled: tp={tp_size} "
+        f"chunk={chunk_size}B batch_size={batch_size} "
+        f"({batch_size_source}) data_type={ans_data_type}")
+    return batch_size, ans_data_type
+
+
+def optimal_batch_size(
+    chunk_size_bytes: int,
+    data_type: int = 0,
+    calibration_chunks: int = 2048,
+    calibration_iters: int = 3,
+) -> int:
+    """Find the optimal nvcomp batch size (chunks per batch) via calibration."""
+    if not _NVCOMP_AVAILABLE:
+        return 4096
+
+    NUM_WARPS_PER_CTA = 4
+    MAX_SUB_CHUNKS = 64
+    MIN_SUB_CHUNK = 2048
+    NUM_WAVES_PER_SM = 1
+
+    dev = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(dev)
+    num_warps = props.multi_processor_count * (
+        props.max_threads_per_multi_processor // 32)
+
+    def _nvcomp_sub_chunk_size(bsz: int) -> int:
+        target = (num_warps * NUM_WAVES_PER_SM + bsz - 1) // bsz
+        target = min(target, MAX_SUB_CHUNKS)
+        target = max(target, NUM_WARPS_PER_CTA)
+        unrounded = (chunk_size_bytes + target - 1) // target
+        p = 0
+        v = unrounded
+        while v >> 1:
+            p += 1
+            v >>= 1
+        lower = 1 << p
+        if (chunk_size_bytes + lower - 1) // lower <= MAX_SUB_CHUNKS:
+            sub_chunk_size = lower
+        else:
+            sub_chunk_size = 1 << (p + 1)
+        return max(MIN_SUB_CHUNK, sub_chunk_size)
+
+    seen_configs: dict[int, int] = {}
+    for batch_size in range(64, num_warps + 1, 8):
+        sub_chunk_size = _nvcomp_sub_chunk_size(batch_size)
+        if sub_chunk_size not in seen_configs:
+            seen_configs[sub_chunk_size] = batch_size
+
+    if not seen_configs:
+        return 4096
+
+    candidates: list[tuple[int, int]] = []
+    sorted_sub_chunks = sorted(seen_configs.keys())
+    for idx, sub_chunk_size in enumerate(sorted_sub_chunks):
+        first_batch_size = seen_configs[sub_chunk_size]
+        if idx + 1 < len(sorted_sub_chunks):
+            last_batch_size = seen_configs[sorted_sub_chunks[idx + 1]] - 1
+        else:
+            last_batch_size = num_warps
+        midpoint = ((first_batch_size + last_batch_size) // 2) & ~63
+        midpoint = max(midpoint, first_batch_size)
+        midpoint = min(midpoint, last_batch_size)
+        candidates.append((midpoint, sub_chunk_size))
+
+    if len(candidates) == 1:
+        flexkv_logger.warning(
+            f"nvcomp calibration: only 1 sub-chunk config found for "
+            f"chunk_size={chunk_size_bytes} on this GPU; selection is trivial")
+        return candidates[0][0]
+
+    num_layers = 4
+    num_blocks = max(1, calibration_chunks // (num_layers * 2))
+    elem = 2 if data_type == 0 else 1
+    tpb = chunk_size_bytes // elem
+    nh = 1
+    hs = 1
+    dtype = torch.bfloat16 if data_type == 0 else torch.float8_e4m3fn
+
+    shape_per_layer = (2, num_blocks, tpb, nh, hs)
+    gpu_cache = torch.randn(
+        (num_layers,) + shape_per_layer,
+        dtype=torch.bfloat16,
+        device=f"cuda:{dev}")
+    if dtype != torch.bfloat16:
+        gpu_cache = gpu_cache.to(dtype)
+    gpu_blocks = [gpu_cache[i] for i in range(num_layers)]
+    cpu_shape = (num_blocks, num_layers, 2, tpb, nh, hs)
+    cpu_data = torch.zeros(cpu_shape, dtype=dtype, device="cpu").pin_memory()
+    gpu_ptrs = torch.tensor(
+        [block.data_ptr() for block in gpu_blocks],
+        dtype=torch.int64).pin_memory()
+
+    chunk_size = chunk_size_bytes
+    gpu_kv_stride = num_blocks * tpb * nh * hs * elem
+    gpu_block_stride = chunk_size
+    gpu_layer_stride = 2 * gpu_kv_stride
+    cpu_kv_stride = chunk_size
+    cpu_layer_stride = 2 * chunk_size
+    cpu_block_stride = num_layers * 2 * chunk_size
+
+    gpu_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
+    cpu_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
+    stream = torch.cuda.Stream(device=dev)
+
+    size_table = torch.zeros(
+        (num_blocks, num_layers, 2), dtype=torch.uint32).pin_memory()
+    size_table_ptr = size_table.data_ptr()
+    size_table_block_stride = size_table.stride(0)
+    size_table_layer_stride = size_table.stride(1)
+
+    best_batch_size = candidates[0][0]
+    best_time = float("inf")
+    results = []
+
+    start_evt = torch.cuda.Event(enable_timing=True)
+    end_evt = torch.cuda.Event(enable_timing=True)
+
+    assert ANSTransferContext is not None
+    assert transfer_kv_blocks_ans_comp is not None
+    for batch_size, sub_chunk_size in candidates:
+        ctx = ANSTransferContext(batch_size, chunk_size, data_type)
+        for _ in range(2):
+            with torch.cuda.stream(stream):
+                transfer_kv_blocks_ans_comp(
+                    ctx, gpu_ids, gpu_ptrs, gpu_kv_stride, gpu_block_stride,
+                    gpu_layer_stride, cpu_ids, cpu_data, cpu_kv_stride,
+                    cpu_layer_stride, cpu_block_stride, chunk_size, 0,
+                    num_layers, False, 0, size_table_ptr,
+                    size_table_block_stride, size_table_layer_stride)
+            stream.synchronize()
+
+        start_evt.record(stream)
+        for _ in range(calibration_iters):
+            with torch.cuda.stream(stream):
+                transfer_kv_blocks_ans_comp(
+                    ctx, gpu_ids, gpu_ptrs, gpu_kv_stride, gpu_block_stride,
+                    gpu_layer_stride, cpu_ids, cpu_data, cpu_kv_stride,
+                    cpu_layer_stride, cpu_block_stride, chunk_size, 0,
+                    num_layers, False, 0, size_table_ptr,
+                    size_table_block_stride, size_table_layer_stride)
+        end_evt.record(stream)
+        stream.synchronize()
+        elapsed = start_evt.elapsed_time(end_evt)
+        ctx.destroy()
+        results.append((batch_size, sub_chunk_size, elapsed))
+
+        if elapsed < best_time:
+            best_time = elapsed
+            best_batch_size = batch_size
+
+    del gpu_cache, gpu_blocks, cpu_data, gpu_ptrs, gpu_ids, cpu_ids, size_table
+    torch.cuda.empty_cache()
+
+    detail = ", ".join(
+        f"bsz={batch_size} sc={sub_chunk_size} {elapsed:.2f}ms"
+        for batch_size, sub_chunk_size, elapsed in results)
+    flexkv_logger.info(
+        f"nvcomp batch_size calibration: [{detail}], "
+        f"selected bsz={best_batch_size}")
+
+    return best_batch_size

--- a/flexkv/transfer/compression/common/__init__.py
+++ b/flexkv/transfer/compression/common/__init__.py
@@ -1,0 +1,7 @@
+from flexkv.transfer.compression.common.size_table import bind_size_table
+from flexkv.transfer.compression.common.strategy import (
+    CompressionStrategy,
+    NullCompressionStrategy,
+)
+
+__all__ = ["bind_size_table", "CompressionStrategy", "NullCompressionStrategy"]

--- a/flexkv/transfer/compression/common/size_table.py
+++ b/flexkv/transfer/compression/common/size_table.py
@@ -1,0 +1,32 @@
+from typing import Tuple
+
+import torch
+
+from flexkv.common.debug import flexkv_logger
+from flexkv.transfer.host_buffer import cudaHostRegister
+
+
+def bind_size_table(
+    table,
+    label,
+    *,
+    register: bool = False,
+    expected_dims: Tuple[int, ...] = (3, 4),
+):
+    """Return (ptr, rank_stride, block_stride, layer_stride) for a uint32 table."""
+    if table is None:
+        return 0, 0, 0, 0
+    assert table.dtype == torch.uint32, f"{label} must be uint32"
+    assert table.dim() in expected_dims, \
+        f"{label}: expected dim in {expected_dims}, got {table.dim()}"
+    if register:
+        cudaHostRegister(table)
+    if table.dim() == 3:
+        rank_stride, block_stride, layer_stride = 0, table.stride(0), table.stride(1)
+    else:
+        rank_stride, block_stride, layer_stride = (
+            table.stride(0), table.stride(1), table.stride(2))
+    tbl_mb = table.numel() * table.element_size() / (1024 ** 2)
+    flexkv_logger.info(
+        f"{label}: shape={tuple(table.shape)} dtype=uint32 size={tbl_mb:.2f} MB")
+    return table.data_ptr(), rank_stride, block_stride, layer_stride

--- a/flexkv/transfer/compression/common/strategy.py
+++ b/flexkv/transfer/compression/common/strategy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+    from flexkv.transfer.worker import TransferWorkerBase
+    from flexkv.transfer.worker_op import WorkerTransferOp
+
+
+class CompressionStrategy(ABC):
+    @abstractmethod
+    def attach(self, worker: "TransferWorkerBase") -> None:
+        ...
+
+    @abstractmethod
+    def run(
+        self,
+        worker: "TransferWorkerBase",
+        op: "WorkerTransferOp",
+        src_block_ids: "torch.Tensor",
+        dst_block_ids: "torch.Tensor",
+    ) -> None:
+        ...
+
+    def shutdown(self) -> None:
+        pass
+
+class NullCompressionStrategy(CompressionStrategy):
+    def attach(self, worker: "TransferWorkerBase") -> None:
+        pass
+
+    def run(
+        self,
+        worker: "TransferWorkerBase",
+        op: "WorkerTransferOp",
+        src_block_ids: "torch.Tensor",
+        dst_block_ids: "torch.Tensor",
+    ) -> None:
+        start_time = time.time()
+        worker._transfer_impl(src_block_ids, dst_block_ids, op.transfer_type)
+        end_time = time.time()
+        transfer_size = (
+            worker.chunk_size_in_bytes
+            * worker.num_layers
+            * op.valid_block_num
+            * worker.kv_dim
+        )
+        worker._log_transfer_performance(op, transfer_size, start_time, end_time)

--- a/flexkv/transfer/compression/factory.py
+++ b/flexkv/transfer/compression/factory.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from flexkv.transfer.compression.ans import ans_utils
+from flexkv.transfer.compression.common.strategy import (
+    CompressionStrategy,
+    NullCompressionStrategy,
+)
+
+
+WORKER_KINDS = (
+    "gpu_cpu",
+    "gpu_cpu_tp",
+    "cpu_ssd",
+    "indexer_gpu_cpu",
+    "indexer_gpu_cpu_tp",
+    "indexer_cpu_ssd",
+)
+
+
+def _null_compressors() -> Dict[str, CompressionStrategy]:
+    return {kind: NullCompressionStrategy() for kind in WORKER_KINDS}
+
+
+def build_compressors(
+    *,
+    cpu_handle,
+    ssd_handle,
+    cache_config,
+    model_config,
+    gpu_handle_groups,
+    layerwise_enabled: bool = False,
+) -> Dict[str, CompressionStrategy]:
+    enable_nvcomp = ans_utils.check_engine_nvcomp_enable(
+        gpu_handle_groups,
+        layerwise_enabled=layerwise_enabled,
+        cpu_handle=cpu_handle,
+    )
+    if not enable_nvcomp:
+        return _null_compressors()
+
+    (cpu_table, cpu_table_tp,
+     ssd_table, ssd_table_tp) = ans_utils.allocate_engine_size_tables(
+        cpu_handle=cpu_handle,
+        ssd_handle=ssd_handle,
+        cache_config=cache_config,
+        model_config=model_config,
+    )
+
+    from flexkv.transfer.compression.ans.ans_strategy import (
+        NvcompCpuSsdStrategy,
+        NvcompGpuCpuStrategy,
+        NvcompGpuCpuTpStrategy,
+    )
+
+    is_mla = cpu_handle.kv_layout.is_mla
+    tp_size = model_config.effective_tp_size_per_node
+
+    compressors = _null_compressors()
+    compressors["gpu_cpu"] = NvcompGpuCpuStrategy(cpu_size_table=cpu_table)
+    compressors["gpu_cpu_tp"] = NvcompGpuCpuTpStrategy(
+        cpu_size_table_tp=(cpu_table if is_mla else cpu_table_tp))
+    compressors["cpu_ssd"] = NvcompCpuSsdStrategy(
+        cpu_size_table=cpu_table,
+        ssd_size_table=ssd_table,
+        cpu_size_table_tp=cpu_table_tp,
+        ssd_size_table_tp=ssd_table_tp,
+        tp_size=tp_size,
+    )
+    return compressors

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -40,6 +40,7 @@ from flexkv.transfer.worker import (
     tpGDSTransferWorker,
     PEER2CPUTransferWorker,
 )
+from flexkv.transfer.compression import build_compressors
 from flexkv.transfer.layerwise import (
     LayerwiseTransferWorker,
     build_layerwise_eventfd_socket_path,
@@ -154,6 +155,15 @@ class TransferEngine:
         self._child_id_to_child: Dict[int, TransferOp] = {}
         self._child_to_parent_op_id: Dict[int, int] = {}
 
+        self._compressors = build_compressors(
+            cpu_handle=self._cpu_handle,
+            ssd_handle=self._ssd_handle,
+            cache_config=self.cache_config,
+            model_config=self.model_config,
+            gpu_handle_groups=self.gpu_handle_groups,
+            layerwise_enabled=GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer,
+        )
+
     def _init_workers(self) -> None:
         if self._running:
             return
@@ -182,6 +192,7 @@ class TransferEngine:
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                        compressor=self._compressors["gpu_cpu"],
                     )
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
@@ -201,6 +212,7 @@ class TransferEngine:
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                        compressor=self._compressors["gpu_cpu_tp"],
                     )
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
@@ -223,6 +235,7 @@ class TransferEngine:
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                    compressor=self._compressors["gpu_cpu"],
                 )
                 for worker_key, gpu_handles in self.gpu_handle_groups.items()
             }
@@ -242,6 +255,7 @@ class TransferEngine:
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                    compressor=self._compressors["gpu_cpu_tp"],
                 )
                 for worker_key, gpu_handles in self.gpu_handle_groups.items()
             }
@@ -261,6 +275,7 @@ class TransferEngine:
                     dtype=self._cpu_handle.dtype,
                     num_blocks_per_file=self._ssd_handle.num_blocks_per_file,
                     cache_config=self._cache_config,
+                    compressor=self._compressors["cpu_ssd"],
                 )
                 self._worker_map[TransferType.DISK2H] = self.cpussd_read_worker
 
@@ -276,6 +291,7 @@ class TransferEngine:
                 dtype=self._cpu_handle.dtype,
                 num_blocks_per_file=self._ssd_handle.num_blocks_per_file,
                 cache_config=self._cache_config,
+                compressor=self._compressors["cpu_ssd"],
             )
             self._worker_map[TransferType.H2DISK] = self.cpussd_write_worker
         if self._remote_handle is not None and self._cpu_handle is not None:
@@ -448,6 +464,7 @@ class TransferEngine:
                             use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                             transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                            compressor=self._compressors["indexer_gpu_cpu"],
                         )
                         for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     }
@@ -467,6 +484,7 @@ class TransferEngine:
                             use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                             transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                             transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                            compressor=self._compressors["indexer_gpu_cpu_tp"],
                         )
                         for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     }
@@ -489,6 +507,7 @@ class TransferEngine:
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                        compressor=self._compressors["indexer_gpu_cpu"],
                     )
                     for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                 }
@@ -508,6 +527,7 @@ class TransferEngine:
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                         transfer_num_cta_d2h=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                        compressor=self._compressors["indexer_gpu_cpu_tp"],
                     )
                     for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                 }
@@ -525,6 +545,7 @@ class TransferEngine:
                     dtype=self._indexer_cpu_handle.dtype,
                     num_blocks_per_file=self._indexer_ssd_handle.num_blocks_per_file,
                     cache_config=self._cache_config,
+                    compressor=self._compressors["indexer_cpu_ssd"],
                 )
                 self._indexer_worker_map[TransferType.H2DISK] = self._indexer_h2disk_worker
                 # DISK2H indexer worker
@@ -540,6 +561,7 @@ class TransferEngine:
                         dtype=self._indexer_cpu_handle.dtype,
                         num_blocks_per_file=self._indexer_ssd_handle.num_blocks_per_file,
                         cache_config=self._cache_config,
+                        compressor=self._compressors["indexer_cpu_ssd"],
                     )
                     self._indexer_worker_map[TransferType.DISK2H] = self._indexer_disk2h_worker
                 flexkv_logger.info("TransferEngine: indexer SSD workers initialized")

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -38,6 +38,10 @@ from flexkv.transfer.host_buffer import (
     allocate_host_buffer,
     cudaHostRegister,
 )
+from flexkv.transfer.compression.common.strategy import (
+    CompressionStrategy,
+    NullCompressionStrategy,
+)
 from flexkv.transfer.worker_op import WorkerTransferOp, WorkerLayerwiseTransferOp
 
 from flexkv.mooncakeEngineWrapper import MoonCakeTransferEngineWrapper
@@ -165,11 +169,19 @@ class TransferWorkerBase(ABC):
                                   transfer_op: WorkerTransferOp,
                                   transfer_size: int,
                                   start_time: float,
-                                  end_time: float) -> None:
+                                  end_time: float,
+                                  uncompressed_size: Optional[int] = None) -> None:
         """Common method to log transfer performance"""
+        size_text = (
+            f"comp_ratio: {uncompressed_size / transfer_size:.3f}x "
+            f"comp_size: {transfer_size / (1024 * 1024 * 1024):.3f} GB "
+            f"uncomp_size: {uncompressed_size / (1024 * 1024 * 1024):.3f} GB "
+            if uncompressed_size is not None and transfer_size > 0
+            else f"transfer data size: {transfer_size / (1024 * 1024 * 1024)} GB "
+        )
         flexkv_logger.info(
             f"{transfer_op.transfer_type.name} transfer request: {transfer_op.transfer_op_id} finished "
-            f"transfer data size: {transfer_size / (1024 * 1024 * 1024)} GB "
+            f"{size_text}"
             f"transfer time: {end_time - start_time:.4f} s "
             f"transfer bandwidth: {transfer_size / (end_time - start_time) / 1e9:.2f} GB/s"
         )
@@ -268,7 +280,9 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
                  transfer_num_cta_h2d: int = 4,
-                 transfer_num_cta_d2h: int = 4) -> None:
+                 transfer_num_cta_d2h: int = 4,
+                 compressor: Optional[CompressionStrategy] = None,
+                 ) -> None:
         # initialize worker in a new process
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
         # Register CPU tensors with CUDA
@@ -315,6 +329,9 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         self.use_ce_transfer_h2d = use_ce_transfer_h2d
         self.use_ce_transfer_d2h = use_ce_transfer_d2h
 
+        self._compressor = compressor or NullCompressionStrategy()
+        self._compressor.attach(self)
+
     def _transfer_impl(
         self,
         src_block_ids: torch.Tensor,
@@ -358,6 +375,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             self.cpu_layer_stride_in_bytes,
             self.cpu_block_stride_in_bytes,
             self.chunk_size_in_bytes,
+            0,
             self.num_layers,
             transfer_num_cta,
             transfer_type == TransferType.H2D,
@@ -373,23 +391,13 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
 
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
 
-        with torch.cuda.stream(self.transfer_stream):
-            start_time = time.time()
-            self._transfer_impl(
-                src_block_ids,
-                dst_block_ids,
-                transfer_op.transfer_type,
-            )
-            end_time = time.time()
-            transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
-
-            self._log_transfer_performance(
-                transfer_op,
-                transfer_size,
-                start_time,
-                end_time,
-            )
-        nvtx.end_range(nvtx_range)
+        try:
+            with torch.cuda.stream(self.transfer_stream):
+                self._compressor.run(
+                    self, src_block_ids=src_block_ids,
+                    dst_block_ids=dst_block_ids, op=transfer_op)
+        finally:
+            nvtx.end_range(nvtx_range)
 
         return True
 
@@ -408,7 +416,8 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
                  transfer_num_cta_h2d: int = 4,
-                 transfer_num_cta_d2h: int = 4):
+                 transfer_num_cta_d2h: int = 4,
+                 compressor: Optional[CompressionStrategy] = None):
 
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
         assert len(gpu_blocks) == tp_group_size
@@ -444,6 +453,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
 
         self.cpu_block_stride_in_bytes = cpu_kv_layout.get_block_stride() * self.dtype.itemsize
         self.cpu_chunk_size_in_bytes = cpu_kv_layout.get_chunk_size() * self.dtype.itemsize
+        self.chunk_size_in_bytes = self.cpu_chunk_size_in_bytes
         # tp has effect on the layout of the cpu tensor
         # the tp dim should always be right after the block dim
         # on both blockfirst layout and layerfirst layout
@@ -485,6 +495,9 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             self.gpu_chunk_sizes_in_bytes,
             gpu_device_ids,
         )
+
+        self._compressor = compressor or NullCompressionStrategy()
+        self._compressor.attach(self)
 
 
     def _transfer_impl(self,
@@ -534,22 +547,9 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
         src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
-
-        start_time = time.time()
-        self._transfer_impl(
-            src_block_ids,
-            dst_block_ids,
-            transfer_op.transfer_type,
-        )
-        end_time = time.time()
-        transfer_size = self.cpu_chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
-
-        self._log_transfer_performance(
-            transfer_op,
-            transfer_size,
-            start_time,
-            end_time,
-        )
+        self._compressor.run(
+            self, src_block_ids=src_block_ids,
+            dst_block_ids=dst_block_ids, op=transfer_op)
         return True
 
 class CPUSSDDiskTransferWorker(TransferWorkerBase):
@@ -564,7 +564,8 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
                  ssd_kv_layout: KVCacheLayout,
                  dtype: torch.dtype,
                  num_blocks_per_file: int,
-                 cache_config: CacheConfig):
+                 cache_config: CacheConfig,
+                 compressor: Optional[CompressionStrategy] = None):
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
         cpu_blocks = materialize_worker_tensor(cpu_blocks)
         self.ssd_files = ssd_files
@@ -582,6 +583,7 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
 
         self.is_mla = cpu_kv_layout.is_mla
         self.kv_dim = cpu_kv_layout.kv_dim
+        self.cpu_layout_type = cpu_kv_layout.type
 
         if cpu_kv_layout.type != ssd_kv_layout.type:
             raise ValueError("no support for different CPU and SSD KV cache layout type")
@@ -601,6 +603,9 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
         except Exception as e:
             flexkv_logger.error(f"Error setting ssd ioctx: {e}\n")
             raise RuntimeError("SSD Worker init failed") from e
+
+        self._compressor = compressor or NullCompressionStrategy()
+        self._compressor.attach(self)
 
     def _transfer_impl(
         self,
@@ -645,24 +650,10 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
         )
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
-        src_block_ids , dst_block_ids = self.get_transfer_block_ids(transfer_op)
-
-        start_time = time.time()
-        self._transfer_impl(
-            src_block_ids,
-            dst_block_ids,
-            transfer_op.transfer_type,
-        )
-        end_time = time.time()
-        transfer_size = self.chunk_size_in_bytes * self.num_layers * transfer_op.valid_block_num * self.kv_dim
-
-        self._log_transfer_performance(
-            transfer_op,
-            transfer_size,
-            start_time,
-            end_time,
-        )
-
+        src_block_ids, dst_block_ids = self.get_transfer_block_ids(transfer_op)
+        self._compressor.run(
+            self, src_block_ids=src_block_ids,
+            dst_block_ids=dst_block_ids, op=transfer_op)
         return True
 
 class CPURemoteTransferWorker(TransferWorkerBase):

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,37 @@
+import importlib.util
 import os
 import shutil
-import sys
+from pathlib import Path
+from typing import NamedTuple
 
 
 from setuptools import find_packages, setup
-from setuptools.command.build_ext import build_ext
 from torch.utils import cpp_extension
+
+
+class NvcompInfo(NamedTuple):
+    include_dirs: list
+    lib_dir: str
+    link_name: str
+    source: str
+
+
+NVCOMP_SOURCES = [
+    "csrc/compression/common/packed_ssd.cpp",
+    "csrc/compression/common/transfer_ssd_packed.cpp",
+    "csrc/compression/common/common_bindings.cpp",
+    "csrc/compression/ans/nvcomp_ans.cu",
+    "csrc/compression/ans/nvcomp_ans_tp.cpp",
+    "csrc/compression/ans/ans_bindings.cpp",
+]
+
+NVCOMP_HEADERS = [
+    "csrc/compression/common/staging_transfer.cuh",
+    "csrc/compression/common/packed_ssd.h",
+    "csrc/compression/common/transfer_ssd_packed.h",
+    "csrc/compression/ans/nvcomp_ans.cuh",
+    "csrc/compression/ans/nvcomp_ans_tp.h",
+]
 
 
 def detect_cuda_arch():
@@ -28,6 +54,94 @@ def detect_cuda_arch():
     fallback = "8.0;8.6;9.0"
     print(f"No GPU detected, using fallback architectures: {fallback}")
     return fallback
+
+
+def _probe_nvcomp_root(root, source):
+    root = Path(root)
+    include_dirs = [
+        str(path)
+        for path in (root / "include", root / "build" / "include")
+        if path.is_dir()
+    ]
+    if not any((Path(path) / "nvcomp" / "ans.h").exists()
+               for path in include_dirs):
+        return None
+
+    for subdir in ("build/lib", "lib/x86_64-linux-gnu", "lib64", "lib", ""):
+        lib_dir = root / subdir if subdir else root
+        if not lib_dir.is_dir():
+            continue
+        if (lib_dir / "libnvcomp.so").exists():
+            return NvcompInfo(include_dirs, str(lib_dir), "nvcomp", source)
+        versioned = sorted(lib_dir.glob("libnvcomp.so.*"))
+        if versioned:
+            return NvcompInfo(
+                include_dirs,
+                str(lib_dir),
+                ":" + versioned[-1].name,
+                source,
+            )
+    return None
+
+
+def _find_nvcomp(nvcomp_root):
+    """Locate public nvcomp headers and library.
+
+    Probing priority:
+      1. NVCOMP_ROOT (error if set but not usable; no silent fallback).
+      2. pip-installed nvidia-nvcomp-cu12 (via importlib.find_spec).
+      3. System /usr.
+    """
+    if nvcomp_root:
+        if not os.path.exists(nvcomp_root):
+            raise ValueError(f"NVCOMP_ROOT={nvcomp_root} does not exist")
+        result = _probe_nvcomp_root(nvcomp_root, f"NVCOMP_ROOT={nvcomp_root}")
+        if not result:
+            raise ValueError(
+                f"NVCOMP_ROOT={nvcomp_root} does not contain a usable nvcomp "
+                "install (need include/nvcomp/ans.h and libnvcomp.so*)"
+            )
+        return result
+
+    spec = importlib.util.find_spec("nvidia.nvcomp")
+    if spec and spec.origin:
+        pip_root = os.path.dirname(spec.origin)
+        result = _probe_nvcomp_root(
+            pip_root,
+            f"pip nvidia-nvcomp-cu12 ({pip_root})",
+        )
+        if result:
+            return result
+
+    result = _probe_nvcomp_root("/usr", "system (/usr)")
+    if result:
+        return result
+
+    raise ValueError(
+        "nvcomp not found. Install via one of:\n"
+        "  pip install nvidia-nvcomp-cu12==4.2.0.14   (recommended)\n"
+        "  a system/distro nvcomp package\n"
+        "Or set NVCOMP_ROOT=/path/to/nvcomp manually."
+    )
+
+
+def _enable_nvcomp_build(cpp_sources, hpp_sources, include_dirs, library_dirs,
+                         extra_link_args, extra_compile_args,
+                         nvcc_compile_args):
+    nvcomp = _find_nvcomp(os.environ.get("NVCOMP_ROOT"))
+    print(f"ENABLE_NVCOMP = true: Compiling with nvcomp ANS support "
+          f"(source={nvcomp.source}, lib={nvcomp.lib_dir})")
+
+    cpp_sources.extend(NVCOMP_SOURCES)
+    hpp_sources.extend(NVCOMP_HEADERS)
+    include_dirs.extend(nvcomp.include_dirs)
+    library_dirs.append(nvcomp.lib_dir)
+    extra_link_args.extend([
+        f"-l{nvcomp.link_name}",
+        f"-Wl,-rpath,{nvcomp.lib_dir}",
+    ])
+    extra_compile_args.append("-DFLEXKV_ENABLE_NVCOMP")
+    nvcc_compile_args.append("-DFLEXKV_ENABLE_NVCOMP")
 
 def get_version():
     import subprocess
@@ -63,6 +177,7 @@ enable_cfs = os.environ.get("FLEXKV_ENABLE_CFS", "0") == "1"
 enable_gds = os.environ.get("FLEXKV_ENABLE_GDS", "0") == "1"
 enable_p2p = os.environ.get("FLEXKV_ENABLE_P2P", "0") == "1"
 enable_cputest = os.environ.get("FLEXKV_ENABLE_CPUTEST", "0") == "1"
+enable_nvcomp = os.environ.get("FLEXKV_ENABLE_NVCOMP", "0") == "1"
 # FLEXKV_ENABLE_METRICS=0: build without Prometheus (no prometheus-cpp dependency)
 enable_metrics = os.environ.get("FLEXKV_ENABLE_METRICS", "0") == "1"
 
@@ -88,6 +203,8 @@ hpp_sources = [
 ]
 
 # extra_link_args: dist/Redis (libhiredis) only when FLEXKV_ENABLE_P2P=1
+lib_dir = os.path.join(build_dir, "lib")
+library_dirs = [lib_dir]
 extra_link_args = ["-lcuda", "-lxxhash", "-lpthread", "-lrt", "-luring"]
 if enable_p2p:
     extra_link_args.append("-lhiredis")
@@ -111,10 +228,12 @@ print(f"TORCH_CUDA_ARCH_LIST = {os.environ['TORCH_CUDA_ARCH_LIST']}")
 extra_compile_args = ["-std=c++17", "-O3"]
 if enable_metrics:
     extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
-include_dirs = [os.path.abspath(os.path.join(build_dir, "include"))]
+include_dirs = [
+    os.path.abspath(os.path.join(build_dir, "include")),
+    os.path.abspath("csrc"),
+]
 
 # Add rpath to find libraries at runtime
-lib_dir = os.path.join(build_dir, "lib")
 if os.path.exists(lib_dir):
     extra_link_args.extend([f"-Wl,-rpath,{lib_dir}", "-Wl,-rpath,$ORIGIN"])
     # Also add the current package directory to rpath for installed libraries
@@ -155,6 +274,12 @@ if enable_p2p:
         "csrc/dist/lease_meta_mempool.cpp",
     ])
     extra_compile_args.append("-DFLEXKV_ENABLE_P2P")
+if enable_nvcomp:
+    _enable_nvcomp_build(cpp_sources, hpp_sources, include_dirs, library_dirs,
+                         extra_link_args, extra_compile_args,
+                         nvcc_compile_args)
+else:
+    print("ENABLE_NVCOMP = false: Skipping nvcomp ANS compression")
 if not enable_gds:
     print("ENABLE_GDS = false: Skipping GDS code")
 if not enable_p2p:
@@ -164,7 +289,7 @@ cpp_extensions = [
     cpp_extension.CUDAExtension(
         name="flexkv.c_ext",
         sources=cpp_sources,
-        library_dirs=[os.path.join(build_dir, "lib")],
+        library_dirs=library_dirs,
         include_dirs=include_dirs,
         depends=hpp_sources,
         extra_compile_args={"nvcc": nvcc_compile_args, "cxx": extra_compile_args},

--- a/tests/nvcomp/nvcomp_common_utils.py
+++ b/tests/nvcomp/nvcomp_common_utils.py
@@ -1,0 +1,88 @@
+import torch
+
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+
+DEFUALT_MHA_CONFIG = dict(num_head=8, head_dim=128)
+DEFUALT_MLA_SHAPE = dict(num_head=1, head_dim=576)
+
+
+def resolve_case(chunk_size_per_device, tp, is_mla, dtype):
+    elem = dtype.itemsize
+    shape = DEFUALT_MLA_SHAPE if is_mla else DEFUALT_MHA_CONFIG
+    num_head, head_dim = shape["num_head"], shape["head_dim"]
+    kv_dim = 1 if is_mla else 2
+    heads_per_device = num_head if is_mla else num_head // tp
+    tpb = max(
+        1,
+        1 << (
+            (chunk_size_per_device // (heads_per_device * head_dim * elem))
+            .bit_length() - 1
+        ),
+    )
+    return dict(
+        num_head=num_head,
+        head_dim=head_dim,
+        kv_dim=kv_dim,
+        tokens_per_block=tpb,
+        chunk_bytes=tpb * heads_per_device * head_dim * elem,
+    )
+
+
+def make_gpu_cache(shape, dtype, device):
+    """randn cache on `device`, FP8-aware.
+
+    torch.randn has no FP8 path -> generate bf16 then cast (matches real model
+    quantization: bf16_tensor.to(float8_e4m3fn)).
+    """
+    if dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        return torch.randn(shape, dtype=torch.bfloat16, device=device).to(dtype)
+    return torch.randn(shape, dtype=dtype, device=device)
+
+
+def make_kv_cache(num_layers, num_blocks, tokens_per_block, num_heads, head_size,
+                  dtype=torch.bfloat16, device="cuda:0",
+                  cpu_layout_name="BLOCKFIRST", is_mla=False):
+    """Create GPU (LAYERFIRST per-layer list) and CPU (cpu_layout) KV caches.
+
+    GPU: list of per-layer tensors, each [kv_dim, num_blocks, tpb, nh, hs],
+         backed by one contiguous tensor (like vLLM's KV cache pool).
+    CPU: a single tensor shaped by KVCacheLayout (BLOCKFIRST or LAYERFIRST).
+    """
+    kv_dim = 1 if is_mla else 2
+    shape = (num_layers, kv_dim, num_blocks, tokens_per_block, num_heads, head_size)
+    gpu_cache = make_gpu_cache(shape, dtype, device)
+    gpu_blocks = [gpu_cache[i] for i in range(num_layers)]
+
+    cpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType[cpu_layout_name.upper()],
+        num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tokens_per_block, num_head=num_heads,
+        head_size=head_size, is_mla=is_mla)
+    cpu_blocks = torch.zeros(tuple(cpu_layout.kv_shape), dtype=dtype).pin_memory()
+    return gpu_blocks, cpu_blocks
+
+def compute_strides(num_layers, num_blocks, tokens_per_block, num_heads, head_size,
+                    dtype, cpu_layout_name="BLOCKFIRST", is_mla=False):
+    """Byte strides via KVCacheLayout (GPU=LAYERFIRST, CPU=cpu_layout).
+
+    Returns (chunk_size,
+             gpu_kv_stride, gpu_block_stride, gpu_layer_stride,
+             cpu_kv_stride, cpu_layer_stride, cpu_block_stride).
+    """
+    elem = dtype.itemsize
+    gpu = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST, num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tokens_per_block, num_head=num_heads,
+        head_size=head_size, is_mla=is_mla)
+    cpu = KVCacheLayout(
+        type=KVCacheLayoutType[cpu_layout_name.upper()], num_layer=num_layers,
+        num_block=num_blocks, tokens_per_block=tokens_per_block, num_head=num_heads,
+        head_size=head_size, is_mla=is_mla)
+    return (gpu.get_chunk_size() * elem,
+            gpu.get_kv_stride() * elem,
+            gpu.get_block_stride() * elem,
+            gpu.get_layer_stride() * elem,
+            cpu.get_kv_stride() * elem,
+            cpu.get_layer_stride() * elem,
+            cpu.get_block_stride() * elem)
+

--- a/tests/nvcomp/test_nvcomp_cpu.py
+++ b/tests/nvcomp/test_nvcomp_cpu.py
@@ -1,0 +1,323 @@
+import pytest
+import torch
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.transfer.compression.common.strategy import NullCompressionStrategy
+from nvcomp_common_utils import (
+    make_kv_cache, make_gpu_cache, compute_strides,
+    DEFUALT_MHA_CONFIG, resolve_case,
+)
+
+try:
+    from flexkv.c_ext import (
+        ANSTransferContext,
+        transfer_kv_blocks_ans_comp,
+        transfer_kv_blocks_ans_decomp,
+        TPTransferThreadGroup,
+    )
+    NVCOMP_AVAILABLE = True
+except ImportError:
+    NVCOMP_AVAILABLE = False
+
+from flexkv.transfer.compression.ans import ans_utils
+
+device = "cuda:0"
+
+
+@pytest.mark.parametrize("cpu_layout_name", [pytest.param("BLOCKFIRST", id="bfirst"), pytest.param("LAYERFIRST", id="lfirst")])
+@pytest.mark.parametrize("dtype", [pytest.param(torch.bfloat16, id="bf16"), pytest.param(torch.float8_e4m3fn, id="fp8"),])
+@pytest.mark.parametrize("tp_size", [pytest.param(1, id="tp_1")])
+@pytest.mark.parametrize("is_mla", [pytest.param(False, id="mha"), pytest.param(True, id="mla")])
+@pytest.mark.parametrize("chunk_size_per_device", [
+    pytest.param(8 * 1024, id="cpd_8KB"),
+    pytest.param(16 * 1024, id="cpd_16KB"),
+    pytest.param(32 * 1024, id="cpd_32KB"),
+    pytest.param(18 * 1024, id="cpd_18KB"), # MLA
+])
+def test_roundtrip(cpu_layout_name, dtype, tp_size, is_mla, chunk_size_per_device,
+                   num_layers=4, num_blocks=2):
+    if not NVCOMP_AVAILABLE:
+        pytest.skip("nvcomp not available")
+    if is_mla != (chunk_size_per_device == 18 * 1024):
+        pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+
+    case = resolve_case(chunk_size_per_device, tp_size, is_mla, dtype)
+
+    transfer_stream = torch.cuda.Stream()
+
+    num_heads, head_size = case["num_head"], case["head_dim"]
+    tokens_per_block, kv_dim = case["tokens_per_block"], case["kv_dim"]
+    print(f"\n{'='*60}")
+    print(f"    {"MLA" if is_mla else "MHA"} roundtrip test: layout={cpu_layout_name},chunk_size_per_device={case['chunk_bytes']}, layers={num_layers}, blocks={num_blocks}, kv_dim={kv_dim}, "
+          f"tokens_per_block={tokens_per_block}, num_heads={num_heads}, head_size={head_size}, "
+          f"dtype={dtype}, tp_size={tp_size}")
+    
+
+    gpu_blocks, cpu_blocks = make_kv_cache(
+        num_layers, num_blocks, tokens_per_block, num_heads, head_size,
+        dtype, device, cpu_layout_name, is_mla)
+    # int64 pointer table, pinned (C++ reads it as an array of GPU pointers).
+    gpu_ptrs = torch.tensor(
+        [b.data_ptr() for b in gpu_blocks], dtype=torch.int64).pin_memory()
+    (chunk_size,
+     gpu_kv_stride, gpu_block_stride, gpu_layer_stride,
+     cpu_kv_stride, cpu_layer_stride, cpu_block_stride) = compute_strides(
+        num_layers, num_blocks, tokens_per_block, num_heads, head_size,
+        dtype, cpu_layout_name, is_mla)
+    assert chunk_size == case["chunk_bytes"]
+
+    block_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
+    original = [b.clone() for b in gpu_blocks]
+
+    # External per-(block, layer, kv) compressed-size table.
+    size_table = torch.zeros(
+        (num_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+    st_ptr, st_block_stride, st_layer_stride = (
+        size_table.data_ptr(), size_table.stride(0), size_table.stride(1))
+
+    data_type = ans_utils.data_type(dtype)
+    batch_size, _ = ans_utils.get_nvcomp_batch_size(
+        chunk_size, data_type=data_type)
+    ctx = ANSTransferContext(batch_size, chunk_size, data_type)
+
+    # --- D2H: compress GPU -> CPU ---
+    with torch.cuda.stream(transfer_stream):
+        d2h_bytes = transfer_kv_blocks_ans_comp(
+            ctx, block_ids, gpu_ptrs,
+            gpu_kv_stride, gpu_block_stride, gpu_layer_stride,
+            block_ids, cpu_blocks,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride,
+            chunk_size, 0, num_layers, is_mla, 0,
+            st_ptr, st_block_stride, st_layer_stride)
+    transfer_stream.synchronize()
+    
+    # Every (block, layer, kv) entry must be > 0 -> kernel actually wrote it.
+    table_i64 = size_table.to(torch.int64)
+    assert (table_i64 > 0).all(), "size_table has zero entries after D2H"
+    expected_bytes = int(table_i64.sum().item())
+    assert d2h_bytes == expected_bytes
+
+    uncompressed_bytes = size_table.numel() * chunk_size
+    print(f"    compression ratio: {uncompressed_bytes / d2h_bytes:.3f}x "
+          f"({uncompressed_bytes} -> {d2h_bytes} B)")
+    print(f"{'='*60}")
+
+    # Zero GPU so a no-op H2D can't masquerade as a passing roundtrip.
+    for b in gpu_blocks:
+        b.zero_()
+
+    # --- H2D: decompress CPU -> GPU ---
+    with torch.cuda.stream(transfer_stream):
+        h2d_bytes = transfer_kv_blocks_ans_decomp(
+            ctx, block_ids, gpu_ptrs,
+            gpu_kv_stride, gpu_block_stride, gpu_layer_stride,
+            block_ids, cpu_blocks,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride,
+            chunk_size, 0, num_layers, is_mla, 0,
+            st_ptr, st_block_stride, st_layer_stride)
+    transfer_stream.synchronize()
+    assert h2d_bytes == expected_bytes
+
+    ctx.destroy()
+    for li in range(num_layers):
+        assert torch.equal(gpu_blocks[li], original[li]), \
+            f"roundtrip mismatch at layer {li}"
+
+
+@pytest.mark.parametrize("cpu_layout_name", [pytest.param("BLOCKFIRST", id="bfirst"), pytest.param("LAYERFIRST", id="lfirst")])
+@pytest.mark.parametrize("dtype", [pytest.param(torch.bfloat16, id="bf16"), pytest.param(torch.float8_e4m3fn, id="fp8"),])
+@pytest.mark.parametrize("tp_size", [pytest.param(2, id="tp_2"), pytest.param(4, id="tp_4"), pytest.param(8, id="tp_8")])
+@pytest.mark.parametrize("is_mla", [pytest.param(False, id="mha"), pytest.param(True, id="mla")])
+@pytest.mark.parametrize("chunk_size_per_device", [
+    pytest.param(8 * 1024, id="cpd_8KB"),
+    pytest.param(16 * 1024, id="cpd_16KB"),
+    pytest.param(32 * 1024, id="cpd_32KB"),
+    pytest.param(18 * 1024, id="cpd_18KB"), # MLA
+])
+def test_roundtrip_tp(cpu_layout_name, dtype, tp_size, is_mla, chunk_size_per_device,
+                           num_layers=4, num_blocks=2):
+    if not NVCOMP_AVAILABLE:
+        pytest.skip("nvcomp not available")
+    if is_mla != (chunk_size_per_device == 18 * 1024):
+        pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+    if torch.cuda.device_count() < tp_size:
+        pytest.skip(f"tp_size={tp_size} needs {tp_size} GPUs, "
+                    f"have {torch.cuda.device_count()}")
+
+    case = resolve_case(chunk_size_per_device, tp_size, is_mla, dtype)
+    num_head, head_dim = case["num_head"], case["head_dim"]
+    tokens_per_block, kv_dim = case["tokens_per_block"], case["kv_dim"]
+    elem = dtype.itemsize
+    layout_type = KVCacheLayoutType[cpu_layout_name.upper()]
+    data_type = ans_utils.data_type(dtype)
+
+    print(f"\n{'='*60}")
+    print(f"    {"MLA" if is_mla else "MHA"} TP roundtrip: layout={cpu_layout_name}, chunk_size_per_device={chunk_size_per_device}, "
+          f"tp_size={tp_size}, layers={num_layers}, blocks={num_blocks}, kv_dim={kv_dim}, "
+          f"tokens_per_block={tokens_per_block}, num_heads={num_head}, head_size={head_dim}, dtype={dtype}")
+
+    # Per-rank GPU caches (LAYERFIRST). MHA shards heads across ranks; MLA
+    # replicates the KV so every rank starts with *identical* data -- required
+    # because D2H compresses each block from its owner rank (cpu_block_id % tp)
+    # into one canonical copy and H2D fans that copy back to all ranks.
+    heads_per_gpu = num_head if is_mla else num_head // tp_size
+    shape_per_layer = (kv_dim, num_blocks, tokens_per_block, heads_per_gpu, head_dim)
+    all_gpu = []
+    if is_mla:
+        # Stage through host so replication is bit-exact on every device
+        # (device-to-device copies can silently fail across NVLink islands).
+        base = make_gpu_cache((num_layers,) + shape_per_layer, dtype, "cuda:0").cpu()
+        for gi in range(tp_size):
+            c = base.to(f"cuda:{gi}")
+            all_gpu.append([c[li] for li in range(num_layers)])
+    else:
+        for gi in range(tp_size):
+            c = make_gpu_cache((num_layers,) + shape_per_layer, dtype, f"cuda:{gi}")
+            all_gpu.append([c[li] for li in range(num_layers)])
+    originals = [[b.clone() for b in all_gpu[gi]] for gi in range(tp_size)]
+
+    # Full-head CPU cache (shared across ranks), shaped by cpu_layout.
+    cpu_layout = KVCacheLayout(
+        type=layout_type, num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tokens_per_block, num_head=num_head,
+        head_size=head_dim, is_mla=is_mla)
+    cpu = torch.zeros(tuple(cpu_layout.kv_shape), dtype=dtype).pin_memory()
+
+    # Per-rank GPU strides (LAYERFIRST; MHA divides heads across ranks).
+    gpu_per_rank = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST, num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tokens_per_block, num_head=num_head,
+        head_size=head_dim, is_mla=is_mla)
+    if not is_mla:
+        gpu_per_rank = gpu_per_rank.div_head(tp_size)
+    per_rank_chunk = gpu_per_rank.get_chunk_size() * elem
+    assert per_rank_chunk == case["chunk_bytes"]
+
+    # CPU strides: BLOCKFIRST MHA needs the in-chunk head subview (div_head);
+    # LAYERFIRST and MLA keep chunks contiguous so no division.
+    if not is_mla and layout_type == KVCacheLayoutType.BLOCKFIRST:
+        cpu_stride_layout = cpu_layout.div_head(tp_size)
+    else:
+        cpu_stride_layout = cpu_layout
+    cpu_kv_stride = cpu_stride_layout.get_kv_stride() * elem
+    cpu_layer_stride = cpu_stride_layout.get_layer_stride() * elem
+    cpu_block_stride = cpu_layout.get_block_stride() * elem
+    cpu_tp_stride = cpu_block_stride // tp_size
+
+    # External size table. MHA: per-rank [tp, blocks, layers, kv]. MLA: canonical
+    # (KV replicated) [blocks, layers, 1] with rank_stride=0.
+    if is_mla:
+        size_table = torch.zeros(
+            (num_blocks, num_layers, 1), dtype=torch.uint32).pin_memory()
+        st_args = (size_table.data_ptr(), 0,
+                   size_table.stride(0), size_table.stride(1))
+    else:
+        size_table = torch.zeros(
+            (tp_size, num_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+        st_args = (size_table.data_ptr(), size_table.stride(0),
+                   size_table.stride(1), size_table.stride(2))
+
+    gpu_block_ptrs_flat = [all_gpu[i][l].data_ptr()
+                           for i in range(tp_size) for l in range(num_layers)]
+    gpu_device_ids = [all_gpu[i][0].device.index for i in range(tp_size)]
+    batch_size, _ = ans_utils.get_nvcomp_batch_size(
+        per_rank_chunk, data_type=data_type)
+    tg = TPTransferThreadGroup(
+        tp_size, gpu_block_ptrs_flat, num_layers, cpu.data_ptr(), num_layers,
+        [gpu_per_rank.get_kv_stride() * elem] * tp_size,
+        [gpu_per_rank.get_block_stride() * elem] * tp_size,
+        [gpu_per_rank.get_layer_stride() * elem] * tp_size,
+        [per_rank_chunk] * tp_size,
+        gpu_device_ids,
+        True,
+        batch_size,
+        data_type,
+    )
+
+    block_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
+    transfer_num_cta = 4  # thread blocks the transfer kernel launches
+    layer_id = 0          # start layer; with layer_granularity=num_layers -> all layers
+    try:
+        # D2H: compress GPU -> CPU.
+        tg.tp_group_transfer_ans(
+            block_ids, block_ids,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride, cpu_tp_stride,
+            transfer_num_cta, False, False, layer_id, num_layers, is_mla, *st_args)
+        for g in range(tp_size):
+            torch.cuda.synchronize(g)
+
+        assert (size_table.to(torch.int64) > 0).all(), \
+            "size_table has zero entries after D2H"
+
+        compressed_bytes = int(size_table.to(torch.int64).sum().item())
+        uncompressed_bytes = size_table.numel() * per_rank_chunk
+        print(f"    compression ratio: {uncompressed_bytes / compressed_bytes:.3f}x "
+              f"({uncompressed_bytes} -> {compressed_bytes} B)")
+        print(f"{'='*60}")
+        
+        # Zero every rank so a no-op H2D can't masquerade as a passing roundtrip.
+        for gi in range(tp_size):
+            for b in all_gpu[gi]:
+                b.zero_()
+
+        # H2D: decompress CPU -> GPU.
+        tg.tp_group_transfer_ans(
+            block_ids, block_ids,
+            cpu_kv_stride, cpu_layer_stride, cpu_block_stride, cpu_tp_stride,
+            transfer_num_cta, True, False, layer_id, num_layers, is_mla, *st_args)
+        for g in range(tp_size):
+            torch.cuda.synchronize(g)
+
+        for gi in range(tp_size):
+            for li in range(num_layers):
+                assert torch.equal(all_gpu[gi][li], originals[gi][li]), \
+                    f"TP roundtrip mismatch: rank={gi} layer={li}"
+    finally:
+        del tg
+
+
+def test_nvcomp_engine_rejects_too_small_chunks(monkeypatch):
+    """Engine disables nvcomp when per-device chunks are below ANS minimum."""
+    if not NVCOMP_AVAILABLE:
+        pytest.skip("nvcomp not available")
+
+    from flexkv.common.config import CacheConfig, ModelConfig
+    from flexkv.common.storage import AccessHandleType, StorageHandle
+    from flexkv.transfer.transfer_engine import TransferEngine
+
+    monkeypatch.setenv("FLEXKV_ENABLE_NVCOMP", "1")
+
+    dtype = torch.float8_e4m3fn
+    num_layers, num_blocks = 1, 4
+    num_heads, head_size = DEFUALT_MHA_CONFIG["num_head"], DEFUALT_MHA_CONFIG["head_dim"]
+    # 1 * 1 * 128 * 1B = 128B per-device chunk with tp_size=8.
+    tokens_per_block, tp_size = 1, 8
+    heads_per_rank = num_heads // tp_size
+    gpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST, num_layer=num_layers,
+        num_block=1, tokens_per_block=tokens_per_block,
+        num_head=heads_per_rank, head_size=head_size, is_mla=False)
+    cpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.BLOCKFIRST, num_layer=num_layers,
+        num_block=num_blocks, tokens_per_block=tokens_per_block,
+        num_head=heads_per_rank, head_size=head_size, is_mla=False)
+    gpu_handle = StorageHandle(
+        AccessHandleType.TENSOR, [torch.empty((1,), dtype=dtype)],
+        gpu_layout, dtype, gpu_device_id=0)
+    cpu_handle = StorageHandle(
+        AccessHandleType.TENSOR,
+        torch.empty((cpu_layout.get_total_elements(),), dtype=dtype),
+        cpu_layout, dtype)
+
+    engine = TransferEngine(
+        {0: [gpu_handle]},
+        ModelConfig(num_layers=num_layers, num_kv_heads=num_heads,
+                    head_size=head_size, dtype=dtype, tp_size=tp_size,
+                    dp_size=1),
+        CacheConfig(tokens_per_block=tokens_per_block, enable_cpu=True,
+                    num_cpu_blocks=num_blocks),
+        cpu_handle=cpu_handle)
+
+    assert isinstance(engine._compressors["gpu_cpu"], NullCompressionStrategy)
+    assert isinstance(engine._compressors["gpu_cpu_tp"], NullCompressionStrategy)
+    assert isinstance(engine._compressors["cpu_ssd"], NullCompressionStrategy)
+

--- a/tests/nvcomp/test_nvcomp_ssd.py
+++ b/tests/nvcomp/test_nvcomp_ssd.py
@@ -1,0 +1,629 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+import torch
+
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.transfer.compression.ans import ans_utils
+from nvcomp_common_utils import (
+    make_gpu_cache,
+    resolve_case,
+)
+
+try:
+    from flexkv.c_ext import (
+        ANSTransferContext,
+        SSDIOCTX,
+        TPTransferThreadGroup,
+        transfer_kv_blocks_ans_comp,
+        transfer_kv_blocks_ssd_packed,
+    )
+    NVCOMP_AVAILABLE = True
+except ImportError:
+    NVCOMP_AVAILABLE = False
+
+
+DEVICE = "cuda:0"
+
+
+def setup_ssd_files(num_blocks, file_size_bytes, tmpdir=None):
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp(prefix="flexkv_ssd_test_")
+    dev_dir = os.path.join(tmpdir, "dev0")
+    os.makedirs(dev_dir, exist_ok=True)
+    fpath = os.path.join(dev_dir, "ssd_cache_0_0.bin")
+    with open(fpath, "wb+", buffering=0) as f:
+        os.truncate(f.fileno(), file_size_bytes)
+        os.fsync(f.fileno())
+    return {0: [fpath]}, tmpdir, num_blocks
+
+
+def ssd_file_size(layout, dtype):
+    return layout.get_total_elements() * dtype.itemsize
+
+
+def cpu_payload_offset(block_id, rank, layer_id, kv_id, *, block_stride,
+                       layer_stride, kv_stride, rank_stride=0):
+    return (
+        int(block_id) * block_stride
+        + int(rank) * rank_stride
+        + layer_id * layer_stride
+        + kv_id * kv_stride
+    )
+
+
+def table_comp_bytes(table_i64, table_ranked, rank, block_id, layer_id, kv_id):
+    if table_ranked:
+        return int(table_i64[rank, block_id, layer_id, kv_id].item())
+    return int(table_i64[block_id, layer_id, kv_id].item())
+
+
+def snapshot_compressed_slots(
+    cpu_cache, size_table, block_ids, *, ranks, table_ranked, num_layers,
+    kv_dim, block_stride, layer_stride, kv_stride, rank_stride=0,
+):
+    cpu_bytes = cpu_cache.view(torch.uint8).reshape(-1)
+    table_i64 = size_table.to(torch.int64)
+    snapshot = {}
+    for block_idx, block_id in enumerate(block_ids.tolist()):
+        for rank in ranks:
+            for layer_id in range(num_layers):
+                for kv_id in range(kv_dim):
+                    comp_bytes = table_comp_bytes(
+                        table_i64, table_ranked, rank, block_id, layer_id, kv_id)
+                    offset = cpu_payload_offset(
+                        block_id, rank, layer_id, kv_id,
+                        block_stride=block_stride,
+                        layer_stride=layer_stride,
+                        kv_stride=kv_stride,
+                        rank_stride=rank_stride)
+                    snapshot[(block_idx, rank, layer_id, kv_id)] = cpu_bytes[
+                        offset:offset + comp_bytes].clone()
+    return snapshot
+
+
+def assert_compressed_slots_equal(
+    cpu_cache, size_table, block_ids, expected, *, ranks, table_ranked,
+    num_layers, kv_dim, block_stride, layer_stride, kv_stride, rank_stride=0,
+):
+    cpu_bytes = cpu_cache.view(torch.uint8).reshape(-1)
+    table_i64 = size_table.to(torch.int64)
+    for block_idx, block_id in enumerate(block_ids.tolist()):
+        for rank in ranks:
+            for layer_id in range(num_layers):
+                for kv_id in range(kv_dim):
+                    comp_bytes = table_comp_bytes(
+                        table_i64, table_ranked, rank, block_id, layer_id, kv_id)
+                    expected_payload = expected[(block_idx, rank, layer_id, kv_id)]
+                    assert comp_bytes == expected_payload.numel(), (
+                        f"compressed size mismatch: block={block_id}, "
+                        f"rank={rank}, layer={layer_id}, kv={kv_id}")
+                    offset = cpu_payload_offset(
+                        block_id, rank, layer_id, kv_id,
+                        block_stride=block_stride,
+                        layer_stride=layer_stride,
+                        kv_stride=kv_stride,
+                        rank_stride=rank_stride)
+                    actual = cpu_bytes[offset:offset + comp_bytes]
+                    assert torch.equal(actual, expected_payload), (
+                        f"compressed payload mismatch: block={block_id}, "
+                        f"rank={rank}, layer={layer_id}, kv={kv_id}")
+
+
+@pytest.mark.parametrize("cpu_layout_name", [
+    pytest.param("BLOCKFIRST", id="bfirst"),
+    pytest.param("LAYERFIRST", id="lfirst"),
+])
+@pytest.mark.parametrize("dtype", [
+    pytest.param(torch.bfloat16, id="bf16"),
+    pytest.param(torch.float8_e4m3fn, id="fp8"),
+])
+@pytest.mark.parametrize("tp_size", [pytest.param(1, id="tp_1")])
+@pytest.mark.parametrize("is_mla", [
+    pytest.param(False, id="mha"),
+    pytest.param(True, id="mla"),
+])
+@pytest.mark.parametrize("chunk_size_per_device", [
+    pytest.param(8 * 1024, id="cpd_8KB"),
+    pytest.param(16 * 1024, id="cpd_16KB"),
+    pytest.param(32 * 1024, id="cpd_32KB"),
+    pytest.param(18 * 1024, id="cpd_18KB"),  # MLA
+])
+def test_ssd_roundtrip_non_tp(
+    cpu_layout_name, dtype, tp_size, is_mla, chunk_size_per_device,
+    num_layers=4, transfer_blocks=2,
+):
+    if not NVCOMP_AVAILABLE:
+        pytest.skip("nvcomp not available")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if is_mla != (chunk_size_per_device == 18 * 1024):
+        pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+
+    case = resolve_case(chunk_size_per_device, tp_size, is_mla, dtype)
+    num_heads, head_size = case["num_head"], case["head_dim"]
+    tokens_per_block, kv_dim = case["tokens_per_block"], case["kv_dim"]
+    elem = dtype.itemsize
+    layout_type = KVCacheLayoutType[cpu_layout_name.upper()]
+
+    num_cpu_blocks = transfer_blocks * 2
+    num_ssd_blocks = transfer_blocks
+
+    gpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=num_layers,
+        num_block=transfer_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+    cpu_layout = KVCacheLayout(
+        type=layout_type,
+        num_layer=num_layers,
+        num_block=num_cpu_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+    ssd_layout = KVCacheLayout(
+        type=layout_type,
+        num_layer=num_layers,
+        num_block=num_ssd_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+
+    shape_per_layer = (
+        kv_dim, transfer_blocks, tokens_per_block, num_heads, head_size)
+    gpu_cache = make_gpu_cache(
+        (num_layers,) + shape_per_layer, dtype, DEVICE)
+    gpu_blocks = [gpu_cache[layer] for layer in range(num_layers)]
+    gpu_ptrs = torch.tensor(
+        [block.data_ptr() for block in gpu_blocks],
+        dtype=torch.int64,
+    ).pin_memory()
+
+    cpu_cache = torch.zeros(tuple(cpu_layout.kv_shape), dtype=dtype).pin_memory()
+    cpu_size_table = torch.zeros(
+        (num_cpu_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+    ssd_size_table = torch.zeros(
+        (num_ssd_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+
+    ssd_files, tmpdir, num_blocks_per_file = setup_ssd_files(
+        num_ssd_blocks, ssd_file_size(ssd_layout, dtype))
+
+    gpu_block_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+    write_cpu_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+    read_cpu_ids = torch.arange(
+        transfer_blocks, transfer_blocks * 2, dtype=torch.int64).pin_memory()
+    ssd_block_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+
+    chunk_bytes = gpu_layout.get_chunk_size() * elem
+    assert chunk_bytes == case["chunk_bytes"]
+
+    data_type = ans_utils.data_type(dtype)
+    batch_size, _ = ans_utils.get_nvcomp_batch_size(
+        chunk_bytes, data_type=data_type)
+    ctx = ANSTransferContext(batch_size, chunk_bytes, data_type)
+    stream = torch.cuda.Stream(device=0)
+
+    try:
+        ioctx = SSDIOCTX(ssd_files, len(ssd_files), 0, 0)
+
+        with torch.cuda.stream(stream):
+            d2h_bytes = transfer_kv_blocks_ans_comp(
+                ctx,
+                gpu_block_ids,
+                gpu_ptrs,
+                gpu_layout.get_kv_stride() * elem,
+                gpu_layout.get_block_stride() * elem,
+                gpu_layout.get_layer_stride() * elem,
+                write_cpu_ids,
+                cpu_cache,
+                cpu_layout.get_kv_stride() * elem,
+                cpu_layout.get_layer_stride() * elem,
+                cpu_layout.get_block_stride() * elem,
+                chunk_bytes,
+                0,
+                num_layers,
+                is_mla,
+                0,
+                cpu_size_table.data_ptr(),
+                cpu_size_table.stride(0),
+                cpu_size_table.stride(1),
+            )
+        stream.synchronize()
+        assert d2h_bytes == int(cpu_size_table.to(torch.int64)[write_cpu_ids].sum().item())
+        assert (cpu_size_table.to(torch.int64)[write_cpu_ids] > 0).all()
+        assert (cpu_size_table.to(torch.int64)[read_cpu_ids] == 0).all()
+        expected_payloads = snapshot_compressed_slots(
+            cpu_cache, cpu_size_table, write_cpu_ids,
+            ranks=[0],
+            table_ranked=False,
+            num_layers=num_layers,
+            kv_dim=kv_dim,
+            block_stride=cpu_layout.get_block_stride() * elem,
+            layer_stride=cpu_layout.get_layer_stride() * elem,
+            kv_stride=cpu_layout.get_kv_stride() * elem)
+
+        h2disk_bytes = transfer_kv_blocks_ssd_packed(
+            ioctx=ioctx,
+            cpu_layer_id_list=torch.arange(num_layers, dtype=torch.int32),
+            cpu_tensor_ptr=cpu_cache.data_ptr(),
+            ssd_block_ids=ssd_block_ids,
+            cpu_block_ids=write_cpu_ids,
+            cpu_layer_stride_in_bytes=cpu_layout.get_layer_stride() * elem,
+            cpu_kv_stride_in_bytes=cpu_layout.get_kv_stride() * elem,
+            chunk_size_in_bytes=chunk_bytes,
+            block_stride_in_bytes=cpu_layout.get_block_stride() * elem,
+            is_read=False,
+            num_blocks_per_file=num_blocks_per_file,
+            layout_type=cpu_layout.type.value,
+            total_layers=num_layers,
+            is_mla=is_mla,
+            cpu_size_table_ptr=cpu_size_table.data_ptr(),
+            cpu_size_table_block_stride=cpu_size_table.stride(0),
+            cpu_size_table_layer_stride=cpu_size_table.stride(1),
+            ssd_size_table_ptr=ssd_size_table.data_ptr(),
+            ssd_size_table_block_stride=ssd_size_table.stride(0),
+            ssd_size_table_layer_stride=ssd_size_table.stride(1),
+        )
+        assert h2disk_bytes == int(ssd_size_table.to(torch.int64)[ssd_block_ids].sum().item())
+        assert torch.equal(
+            cpu_size_table.to(torch.int64)[write_cpu_ids],
+            ssd_size_table.to(torch.int64)[ssd_block_ids],
+        )
+
+        cpu_cache.zero_()
+        cpu_size_table.zero_()
+        disk2h_bytes = transfer_kv_blocks_ssd_packed(
+            ioctx=ioctx,
+            cpu_layer_id_list=torch.arange(num_layers, dtype=torch.int32),
+            cpu_tensor_ptr=cpu_cache.data_ptr(),
+            ssd_block_ids=ssd_block_ids,
+            cpu_block_ids=read_cpu_ids,
+            cpu_layer_stride_in_bytes=cpu_layout.get_layer_stride() * elem,
+            cpu_kv_stride_in_bytes=cpu_layout.get_kv_stride() * elem,
+            chunk_size_in_bytes=chunk_bytes,
+            block_stride_in_bytes=cpu_layout.get_block_stride() * elem,
+            is_read=True,
+            num_blocks_per_file=num_blocks_per_file,
+            layout_type=cpu_layout.type.value,
+            total_layers=num_layers,
+            is_mla=is_mla,
+            cpu_size_table_ptr=cpu_size_table.data_ptr(),
+            cpu_size_table_block_stride=cpu_size_table.stride(0),
+            cpu_size_table_layer_stride=cpu_size_table.stride(1),
+            ssd_size_table_ptr=ssd_size_table.data_ptr(),
+            ssd_size_table_block_stride=ssd_size_table.stride(0),
+            ssd_size_table_layer_stride=ssd_size_table.stride(1),
+        )
+        assert disk2h_bytes == h2disk_bytes
+        assert torch.equal(
+            cpu_size_table.to(torch.int64)[read_cpu_ids],
+            ssd_size_table.to(torch.int64)[ssd_block_ids],
+        )
+        assert (cpu_size_table.to(torch.int64)[write_cpu_ids] == 0).all()
+        assert_compressed_slots_equal(
+            cpu_cache, cpu_size_table, read_cpu_ids, expected_payloads,
+            ranks=[0],
+            table_ranked=False,
+            num_layers=num_layers,
+            kv_dim=kv_dim,
+            block_stride=cpu_layout.get_block_stride() * elem,
+            layer_stride=cpu_layout.get_layer_stride() * elem,
+            kv_stride=cpu_layout.get_kv_stride() * elem)
+    finally:
+        ctx.destroy()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.parametrize("cpu_layout_name", [
+    pytest.param("BLOCKFIRST", id="bfirst"),
+    pytest.param("LAYERFIRST", id="lfirst"),
+])
+@pytest.mark.parametrize("dtype", [
+    pytest.param(torch.bfloat16, id="bf16"),
+    pytest.param(torch.float8_e4m3fn, id="fp8"),
+])
+@pytest.mark.parametrize("tp_size", [
+    pytest.param(2, id="tp_2"),
+    pytest.param(4, id="tp_4"),
+    pytest.param(8, id="tp_8"),
+])
+@pytest.mark.parametrize("is_mla", [
+    pytest.param(False, id="mha"),
+    pytest.param(True, id="mla"),
+])
+@pytest.mark.parametrize("chunk_size_per_device", [
+    pytest.param(8 * 1024, id="cpd_8KB"),
+    pytest.param(16 * 1024, id="cpd_16KB"),
+    pytest.param(32 * 1024, id="cpd_32KB"),
+    pytest.param(18 * 1024, id="cpd_18KB"),  # MLA
+])
+def test_ssd_roundtrip_tp(
+    cpu_layout_name, dtype, tp_size, is_mla, chunk_size_per_device,
+    num_layers=4, transfer_blocks=2,
+):
+    if not NVCOMP_AVAILABLE:
+        pytest.skip("nvcomp not available")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if torch.cuda.device_count() < tp_size:
+        pytest.skip(f"tp_size={tp_size} needs {tp_size} GPUs")
+    if is_mla != (chunk_size_per_device == 18 * 1024):
+        pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+
+    case = resolve_case(chunk_size_per_device, tp_size, is_mla, dtype)
+    num_heads, head_size = case["num_head"], case["head_dim"]
+    tokens_per_block, kv_dim = case["tokens_per_block"], case["kv_dim"]
+    elem = dtype.itemsize
+    layout_type = KVCacheLayoutType[cpu_layout_name.upper()]
+
+    num_cpu_blocks = transfer_blocks * 2
+    num_ssd_blocks = transfer_blocks
+    heads_per_rank = num_heads if is_mla else num_heads // tp_size
+
+    gpu_full_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=num_layers,
+        num_block=transfer_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+    gpu_rank_layout = gpu_full_layout if is_mla else gpu_full_layout.div_head(tp_size)
+    cpu_layout = KVCacheLayout(
+        type=layout_type,
+        num_layer=num_layers,
+        num_block=num_cpu_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+    ssd_layout = KVCacheLayout(
+        type=layout_type,
+        num_layer=num_layers,
+        num_block=num_ssd_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=num_heads,
+        head_size=head_size,
+        is_mla=is_mla,
+    )
+
+    shape_per_layer = (
+        kv_dim, transfer_blocks, tokens_per_block, heads_per_rank, head_size)
+    all_gpu = []
+    if is_mla:
+        base_cache = make_gpu_cache(
+            (num_layers,) + shape_per_layer, dtype, DEVICE).cpu()
+        for rank in range(tp_size):
+            cache = base_cache.to(f"cuda:{rank}")
+            all_gpu.append([cache[layer] for layer in range(num_layers)])
+    else:
+        for rank in range(tp_size):
+            cache = make_gpu_cache(
+                (num_layers,) + shape_per_layer, dtype, f"cuda:{rank}")
+            all_gpu.append([cache[layer] for layer in range(num_layers)])
+
+    cpu_cache = torch.zeros(tuple(cpu_layout.kv_shape), dtype=dtype).pin_memory()
+    if is_mla:
+        cpu_size_table = torch.zeros(
+            (num_cpu_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+        ssd_size_table = torch.zeros(
+            (num_ssd_blocks, num_layers, kv_dim), dtype=torch.uint32).pin_memory()
+        cpu_size_table_tp = None
+        ssd_size_table_tp = None
+    else:
+        cpu_size_table = None
+        ssd_size_table = None
+        cpu_size_table_tp = torch.zeros(
+            (tp_size, num_cpu_blocks, num_layers, kv_dim),
+            dtype=torch.uint32).pin_memory()
+        ssd_size_table_tp = torch.zeros(
+            (tp_size, num_ssd_blocks, num_layers, kv_dim),
+            dtype=torch.uint32).pin_memory()
+
+    ssd_files, tmpdir, num_blocks_per_file = setup_ssd_files(
+        num_ssd_blocks, ssd_file_size(ssd_layout, dtype))
+
+    block_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+    write_cpu_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+    read_cpu_ids = torch.arange(
+        transfer_blocks, transfer_blocks * 2, dtype=torch.int64).pin_memory()
+    ssd_block_ids = torch.arange(transfer_blocks, dtype=torch.int64).pin_memory()
+
+    per_rank_chunk = gpu_rank_layout.get_chunk_size() * elem
+    assert per_rank_chunk == case["chunk_bytes"]
+    data_type = ans_utils.data_type(dtype)
+    batch_size, _ = ans_utils.get_nvcomp_batch_size(
+        per_rank_chunk, data_type=data_type)
+    gpu_block_ptrs_flat = [
+        all_gpu[rank][layer].data_ptr()
+        for rank in range(tp_size)
+        for layer in range(num_layers)
+    ]
+    gpu_device_ids = [all_gpu[rank][0].device.index for rank in range(tp_size)]
+    tg = TPTransferThreadGroup(
+        tp_size,
+        gpu_block_ptrs_flat,
+        num_layers,
+        cpu_cache.data_ptr(),
+        num_layers,
+        [gpu_rank_layout.get_kv_stride() * elem] * tp_size,
+        [gpu_rank_layout.get_block_stride() * elem] * tp_size,
+        [gpu_rank_layout.get_layer_stride() * elem] * tp_size,
+        [per_rank_chunk] * tp_size,
+        gpu_device_ids,
+        True,
+        batch_size,
+        data_type,
+    )
+
+    if cpu_layout.type == KVCacheLayoutType.BLOCKFIRST and not is_mla:
+        cpu_stride_layout = cpu_layout.div_head(tp_size)
+    else:
+        cpu_stride_layout = cpu_layout
+    cpu_kv_stride = cpu_stride_layout.get_kv_stride() * elem
+    cpu_layer_stride = cpu_stride_layout.get_layer_stride() * elem
+    cpu_block_stride = cpu_layout.get_block_stride() * elem
+    cpu_tp_stride = cpu_block_stride // tp_size
+
+    if is_mla:
+        st_args = (
+            cpu_size_table.data_ptr(),
+            0,
+            cpu_size_table.stride(0),
+            cpu_size_table.stride(1),
+        )
+    else:
+        st_args = (
+            cpu_size_table_tp.data_ptr(),
+            cpu_size_table_tp.stride(0),
+            cpu_size_table_tp.stride(1),
+            cpu_size_table_tp.stride(2),
+        )
+
+    try:
+        ioctx = SSDIOCTX(ssd_files, len(ssd_files), 0, 0)
+
+        tg.tp_group_transfer_ans(
+            block_ids,
+            write_cpu_ids,
+            cpu_kv_stride,
+            cpu_layer_stride,
+            cpu_block_stride,
+            cpu_tp_stride,
+            4,
+            False,
+            False,
+            0,
+            num_layers,
+            is_mla,
+            *st_args,
+        )
+        for rank in range(tp_size):
+            torch.cuda.synchronize(rank)
+        if is_mla:
+            assert (cpu_size_table.to(torch.int64)[write_cpu_ids] > 0).all()
+        else:
+            assert (cpu_size_table_tp.to(torch.int64)[:, write_cpu_ids] > 0).all()
+        expected_payloads = snapshot_compressed_slots(
+            cpu_cache,
+            cpu_size_table if is_mla else cpu_size_table_tp,
+            write_cpu_ids,
+            ranks=[0] if is_mla else list(range(tp_size)),
+            table_ranked=not is_mla,
+            num_layers=num_layers,
+            kv_dim=kv_dim,
+            block_stride=cpu_block_stride,
+            layer_stride=cpu_layer_stride,
+            kv_stride=cpu_kv_stride,
+            rank_stride=0 if is_mla else cpu_tp_stride)
+
+        h2disk_bytes = transfer_kv_blocks_ssd_packed(
+            ioctx=ioctx,
+            cpu_layer_id_list=torch.arange(num_layers, dtype=torch.int32),
+            cpu_tensor_ptr=cpu_cache.data_ptr(),
+            ssd_block_ids=ssd_block_ids,
+            cpu_block_ids=write_cpu_ids,
+            cpu_layer_stride_in_bytes=cpu_layer_stride,
+            cpu_kv_stride_in_bytes=cpu_kv_stride,
+            chunk_size_in_bytes=per_rank_chunk,
+            block_stride_in_bytes=cpu_block_stride,
+            is_read=False,
+            num_blocks_per_file=num_blocks_per_file,
+            layout_type=cpu_layout.type.value,
+            total_layers=num_layers,
+            is_mla=is_mla,
+            cpu_size_table_ptr=(cpu_size_table if is_mla else cpu_size_table_tp).data_ptr(),
+            cpu_size_table_block_stride=(cpu_size_table if is_mla else cpu_size_table_tp).stride(0 if is_mla else 1),
+            cpu_size_table_layer_stride=(cpu_size_table if is_mla else cpu_size_table_tp).stride(1 if is_mla else 2),
+            ssd_size_table_ptr=(ssd_size_table if is_mla else ssd_size_table_tp).data_ptr(),
+            ssd_size_table_block_stride=(ssd_size_table if is_mla else ssd_size_table_tp).stride(0 if is_mla else 1),
+            ssd_size_table_layer_stride=(ssd_size_table if is_mla else ssd_size_table_tp).stride(1 if is_mla else 2),
+            tp_size=1 if is_mla else tp_size,
+            cpu_tp_rank_stride_in_bytes=0 if is_mla else cpu_tp_stride,
+            cpu_size_table_rank_stride=0 if is_mla else cpu_size_table_tp.stride(0),
+            ssd_size_table_rank_stride=0 if is_mla else ssd_size_table_tp.stride(0),
+        )
+
+        if is_mla:
+            assert h2disk_bytes == int(ssd_size_table.to(torch.int64)[ssd_block_ids].sum().item())
+            assert torch.equal(
+                cpu_size_table.to(torch.int64)[write_cpu_ids],
+                ssd_size_table.to(torch.int64)[ssd_block_ids],
+            )
+            cpu_size_table.zero_()
+        else:
+            assert h2disk_bytes == int(ssd_size_table_tp.to(torch.int64)[:, ssd_block_ids].sum().item())
+            assert torch.equal(
+                cpu_size_table_tp.to(torch.int64)[:, write_cpu_ids],
+                ssd_size_table_tp.to(torch.int64)[:, ssd_block_ids],
+            )
+            cpu_size_table_tp.zero_()
+
+        cpu_cache.zero_()
+        disk2h_bytes = transfer_kv_blocks_ssd_packed(
+            ioctx=ioctx,
+            cpu_layer_id_list=torch.arange(num_layers, dtype=torch.int32),
+            cpu_tensor_ptr=cpu_cache.data_ptr(),
+            ssd_block_ids=ssd_block_ids,
+            cpu_block_ids=read_cpu_ids,
+            cpu_layer_stride_in_bytes=cpu_layer_stride,
+            cpu_kv_stride_in_bytes=cpu_kv_stride,
+            chunk_size_in_bytes=per_rank_chunk,
+            block_stride_in_bytes=cpu_block_stride,
+            is_read=True,
+            num_blocks_per_file=num_blocks_per_file,
+            layout_type=cpu_layout.type.value,
+            total_layers=num_layers,
+            is_mla=is_mla,
+            cpu_size_table_ptr=(cpu_size_table if is_mla else cpu_size_table_tp).data_ptr(),
+            cpu_size_table_block_stride=(cpu_size_table if is_mla else cpu_size_table_tp).stride(0 if is_mla else 1),
+            cpu_size_table_layer_stride=(cpu_size_table if is_mla else cpu_size_table_tp).stride(1 if is_mla else 2),
+            ssd_size_table_ptr=(ssd_size_table if is_mla else ssd_size_table_tp).data_ptr(),
+            ssd_size_table_block_stride=(ssd_size_table if is_mla else ssd_size_table_tp).stride(0 if is_mla else 1),
+            ssd_size_table_layer_stride=(ssd_size_table if is_mla else ssd_size_table_tp).stride(1 if is_mla else 2),
+            tp_size=1 if is_mla else tp_size,
+            cpu_tp_rank_stride_in_bytes=0 if is_mla else cpu_tp_stride,
+            cpu_size_table_rank_stride=0 if is_mla else cpu_size_table_tp.stride(0),
+            ssd_size_table_rank_stride=0 if is_mla else ssd_size_table_tp.stride(0),
+        )
+        assert disk2h_bytes == h2disk_bytes
+        if is_mla:
+            assert torch.equal(
+                cpu_size_table.to(torch.int64)[read_cpu_ids],
+                ssd_size_table.to(torch.int64)[ssd_block_ids],
+            )
+            assert (cpu_size_table.to(torch.int64)[write_cpu_ids] == 0).all()
+        else:
+            assert torch.equal(
+                cpu_size_table_tp.to(torch.int64)[:, read_cpu_ids],
+                ssd_size_table_tp.to(torch.int64)[:, ssd_block_ids],
+            )
+            assert (cpu_size_table_tp.to(torch.int64)[:, write_cpu_ids] == 0).all()
+        assert_compressed_slots_equal(
+            cpu_cache,
+            cpu_size_table if is_mla else cpu_size_table_tp,
+            read_cpu_ids,
+            expected_payloads,
+            ranks=[0] if is_mla else list(range(tp_size)),
+            table_ranked=not is_mla,
+            num_layers=num_layers,
+            kv_dim=kv_dim,
+            block_stride=cpu_block_stride,
+            layer_stride=cpu_layer_stride,
+            kv_stride=cpu_kv_stride,
+            rank_stride=0 if is_mla else cpu_tp_stride)
+    finally:
+        del tg
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -131,8 +131,8 @@ def shutdown_tp_client(tp_client_processes):
     {'enable_cpu': True, 'enable_ssd': False, 'num_cpu_blocks': 1024},
     {'enable_cpu': True, 'enable_ssd': True, 'num_cpu_blocks': 256, 'num_ssd_blocks': 2048},
     # GDS test configs
-    {'enable_cpu': True, 'enable_gds': True, 'enable_ssd': True, \
-        'enable_remote': False, 'num_cpu_blocks':256, 'num_ssd_blocks': 1024},
+    # {'enable_cpu': True, 'enable_gds': True, 'enable_ssd': True, \
+    #     'enable_remote': False, 'num_cpu_blocks':256, 'num_ssd_blocks': 1024},
 ], indirect=True)
 @pytest.mark.parametrize("test_config", [
     {'num_gpu_blocks': 512, 'requests_per_block': 16, 'initial_write_ratio': 0.4},


### PR DESCRIPTION

## 背景

本 PR 为 FlexKV 引入基于 NVIDIA nvCOMP ANS 的 KV cache 无损压缩传输路径，并把压缩相关代码重组为独立的 `compression` 模块。目标是在不改变 KV cache 语义的前提下，减少 GPU↔CPU 以及 CPU↔SSD offload / reload 的实际搬运字节数，改善长上下文场景下的 transfer 开销。

1. 本 PR 覆盖的传输路径：

    - GPU↔CPU：D2H 压缩 GPU KV chunk 到 CPU cache slot，H2D 从 CPU compressed payload 解压回 GPU KV cache
    - CPU↔SSD：复用 CPU cache slot 里的 compressed payload，H2DISK 时 gather 成 packed range 写入 SSD，DISK2H 时读取 packed range 并 scatter 回目标 CPU slot
    - 支持 non-TP / TP，MHA / GQA / MLA，以及 BLOCKFIRST / LAYERFIRST CPU/SSD layout

2. 当前实现的一个重要边界是：**不会减少 CPU cache 的内存预留**。ANS 的压缩率由输入数据分布决定，不是固定值，因此每个 CPU slot 仍然按未压缩 KV cache 的原始大小分配；nvCOMP 路径只是在 slot 内写入 compressed payload，slot 不一定会被放满。也就是说，本 PR 的主要收益来自减少 GPU↔CPU / CPU↔SSD 的实际传输数据量，而不是降低 CPU cache capacity 预留。

3. ANS 无损压缩率 `CR = 压缩前原始数据大小 / 压缩后数据大小`，在真实 kvcache 数据的压缩率情况：

    - bf16：～1.4x
    - fp8：～1.1x

4. 启用方式：

    - Build time：设置 `FLEXKV_ENABLE_NVCOMP=1` 编译 FlexKV extension。构建脚本会查找 nvCOMP 头文件和动态库，优先使用 `NVCOMP_ROOT`，否则尝试 pip 安装的 `nvidia-nvcomp-cu12` 或系统路径。如果 build time 找不到可用 nvCOMP，会直接构建失败。
    - Inference time：启动推理服务时同样设置 `FLEXKV_ENABLE_NVCOMP=1`。例如 SGLang 场景下：

        ```bash
        FLEXKV_ENABLE_NVCOMP=1 python -m sglang.launch_server \
          --kv-connector-cls flexkv \
          ...
        ```

    - Runtime 启用后，`TransferEngine` 会通过 compression strategy 注入对应路径：GPU↔CPU non-TP 使用 `NvcompGpuCpuStrategy`，GPU↔CPU TP 使用 `NvcompGpuCpuTpStrategy`，CPU↔SSD 使用 `NvcompCpuSsdStrategy`；未启用或 guard 不满足时使用 `NullCompressionStrategy`，即 baseline transfer。
    - 当前会 fallback 到 baseline 的情况包括：extension 没有编译 nvCOMP 支持、`FLEXKV_ENABLE_NVCOMP` 未设置为 `1`、layerwise transfer 启用、GPU cache dtype 不在支持范围内（bf16 / fp16 / fp8）、per-device chunk size 小于 ANS 最小要求（4096B）。



## 主要改动

- C++ compression 模块重组：
  - 新增 `csrc/compression/common/` 存放算法无关基础设施：
    - `staging_transfer.cuh`：GPU↔CPU staging copy kernel 和 GPU chunk pointer builder
    - `packed_ssd.{cpp,h}`：packed SSD block 的 POD、aligned staging buffer、单 block packed I/O 和 per-thread helper
    - `transfer_ssd_packed.{cpp,h}`：CPU↔SSD packed transfer public entry 和线程调度
    - `common_bindings.cpp`：common compression binding 注册入口
  - 新增 `csrc/compression/ans/` 存放 ANS 专属实现：
    - `nvcomp_ans.{cu,cuh}`：ANS context、D2H compress、H2D decompress
    - `nvcomp_ans_tp.{cpp,h}`：TP ANS context 管理和 TP compressed transfer
    - `ans_bindings.cpp`：ANS binding 注册入口

- GPU↔CPU nvCOMP ANS transfer：
  - non-TP：D2H 调 nvCOMP ANS compress，H2D 调 nvCOMP ANS decompress
  - TP：每个 rank 使用自己的 ANS context，支持 MHA/GQA per-rank chunk 和 MLA canonical chunk
  - size table 记录每个 block/layer/kv/rank 的 compressed payload size，供 H2D / SSD packed path 复用

- CPU↔SSD packed compressed transfer：
  - H2DISK：根据 CPU size table 收集 CPU cache slot 中的 compressed chunks，打包成单个 packed range 写入 SSD
  - DISK2H：读取 SSD packed range，根据 SSD size table scatter 回目标 CPU cache slot
  - 使用 `ssd_size_table` 保存 SSD block 侧 compressed size metadata，解决 CPU slot 被复用后读回到不同 CPU slot 的问题
  - 支持 BLOCKFIRST / LAYERFIRST 的 chunk order；LAYERFIRST 目前要求 full-layer transfer

- Python compression strategy 重构：
  - 新增 `flexkv/transfer/compression/common/`：
    - `strategy.py`：`CompressionStrategy` / `NullCompressionStrategy`
    - `size_table.py`：size table pointer/stride binding
  - 新增 `flexkv/transfer/compression/ans/`：
    - `ans_utils.py`：nvCOMP availability、dtype/chunk guard、batch size、size table allocation、ANS context config
    - `ans_strategy.py`：`NvcompGpuCpuStrategy` / `NvcompGpuCpuTpStrategy` / `NvcompCpuSsdStrategy`
  - `TransferEngine` 通过 `build_compressors()` 统一构造并注入 strategy；worker 不再维护 `enable_nvcomp` 分支和 `_transfer_impl_nvcomp` 双方法

- size table 管理：
  - engine 初始化时自动分配 CPU / SSD size table
  - non-TP / MLA 使用 canonical 3D table：`[block, layer, kv]`
  - TP + MHA/GQA 使用 per-rank 4D table：`[rank, block, layer, kv]`
  - CPU↔SSD packed path 额外维护 SSD-side mirror table，用于跨 CPU slot restore compressed metadata

- build / binding 支持：
  - `setup.py` 在 `FLEXKV_ENABLE_NVCOMP=1` 时条件编译 compression common + ANS 源文件
  - nvCOMP 查找顺序：`NVCOMP_ROOT` → pip `nvidia-nvcomp-cu12` → system `/usr`
  - pybind 拆分为 common compression bindings 和 ANS bindings
  - `TPTransferThreadGroup` 支持 baseline / nvCOMP 两种模式；baseline TP 构造不会初始化 nvCOMP context

- 测试与 benchmark：
  - 增加 GPU↔CPU nvCOMP roundtrip 测试
  - 增加 CPU↔SSD packed nvCOMP roundtrip 测试，覆盖 CPU slot 与 SSD slot 重新映射
  - 更新 SSD standalone benchmark 和 close-loop benchmark 脚本以适配 strategy 重构

## Performance

Benchmark 硬件与配置：

- GPU architecture: 8*H200
- GPU PCIe link：Gen5
- NVMe SSD link：Gen4
- KV layout：BLOCKFIRST
- dtype：bf16 / fp8，取决于模型配置

### Standalone benchmark

Standalone benchmark 只测试数据传输路径，不包含调度、prefill/decode 计算或上层 serving 开销。这里的 speedup 均为 `baseline_time / nvcomp_time`，因此大于 1 表示 nvCOMP 更快。

- baseline：不启用 nvCOMP，直接传输未压缩的 bf16 KV cache 原始数据
- nvCOMP：压缩路径传输同等原始数据的总耗时（包括压缩解压等步骤）

- GQA / MHA （`llama-3.1-70b, TP=4`）：random测试数据的压缩率 CR=1.42x


| Raw data | H2DISK speedup | DISK2H speedup | D2H speedup | H2D speedup |
| -------- | -------------- | -------------- | ----------- | ----------- |
| 1.34 GB  | 1.39x          | 1.38x          | 1.30x       | 1.33x       |
| 5.37 GB  | 1.40x          | 1.44x          | 1.37x       | 1.37x       |
| 10.74 GB | 1.34x          | 1.43x          | 1.38x       | 1.38x       |
| 21.47 GB | 1.30x          | 1.45x          | 1.38x       | 1.38x       |


- MLA （`glm-5.1, TP=8`）：random测试数据的压缩率 CR=1.75x


| Raw data | H2DISK speedup | DISK2H speedup | D2H speedup | H2D speedup |
| -------- | -------------- | -------------- | ----------- | ----------- |
| 0.18 GB  | 1.80x          | 1.37x          | 1.53x       | 1.29x       |
| 0.74 GB  | 1.72x          | 1.40x          | 1.59x       | 1.61x       |
| 1.47 GB  | 1.65x          | 1.42x          | 1.68x       | 1.63x       |
| 2.94 GB  | 1.59x          | 1.44x          | 1.73x       | 1.63x       |


### End-to-end Performance (Flexkv CPU only)

运行配置：

- Framework：SGLang + FlexKV
- Model：`glm-5.1-fp8`
- SGLang config：
  - TP size：8
  - KV cache dtype：bf16
  - Attention backend：NSA
  - Context length：140K
  - Chunked prefill / max prefill tokens：16K / 16K
  - Page size：64
  - Max running requests：8
- Workload：
  - ISL：128K
  - Max output tokens：512 per request
  - Close-loop conversations：20
  - Concurrency sweep：`c=8/4/3/2/1`

指标：

- Latency speedup：`baseline / nvcomp - 1`，正数表示 nvCOMP 更快。
- Throughput speedup：`nvcomp / baseline - 1`，正数表示 nvCOMP 吞吐更高。
- 表中数值为 `mean ± std`。


| concurrency | TTFT mean speedup | TTFT p90 speedup    | TPOT mean speedup | Output throughput speedup | Total throughput speedup |
| ----------- | ----------------- | ------------------- | ----------------- | ------------------------- | ------------------------ |
| 1           | +5.7% ± 2.5%      | +16.9% ± 2.3%       | -0.2% ± 0.2%      | +0.1% ± 0.1%              | -0.5% ± 0.8%             |
| 2           | +8.2% ± 1.0%      | +18.7% ± 0.5%       | +0.0% ± 0.5%      | +0.2% ± 0.2%              | +0.5% ± 1.5%             |
| 3           | +1.8% ± 2.2%      | +4.2% ± 13.9% (抖动)  | +1.0% ± 0.4%      | +1.4% ± 0.2%              | +0.9% ± 1.1%             |
| 4           | +3.2% ± 2.7%      | +3.0% ± 0.1%        | +1.0% ± 0.3%      | +2.4% ± 0.6%              | +2.0% ± 1.9%             |
| 8           | -5.6% ± 7.4%      | +2.1% ± 21.9% (抖动) | +3.7% ± 2.3%      | -1.9% ± 4.9%              | -3.0% ± 4.8%             |

#### Reproduction

Setup:

- Container：`nvcr.io/nvidia/pytorch:25.05-py3`
- SGLang：https://github.com/zhuofan1123/sglang/tree/taco_sglang
- nvCOMP 版本：4.2.0.11
- FlexKV install:
```bash
apt update && apt install -y liburing-dev libxxhash0 libxxhash-dev
FLEXKV_ENABLE_NVCOMP=1 FLEXKV_ENABLE_METRICS=0 FLEXKV_DEBUG=1 \
  pip install -v --no-build-isolation -e .
```

Benchmark:

- `DATASET`: local HuggingFace cache directory for `princeton-nlp/SWE-bench_oracle`, or the dataset id if network access is available
- `MODEL_PATH`: local `GLM-5.1-FP8` model directory
- `JIT_CACHE`: writable directory for SGLang / CUDA / FlashInfer / DeepGEMM JIT caches

Example:

```bash
DATASET=/workspace/develop/datasets/SWE-bench/datasets--princeton-nlp--SWE-bench_oracle \
MODEL_PATH=/tmp/nvidia-mps/GLM-5.1-FP8 \
JIT_CACHE=/workspace/develop/envs/taco-sglang/cache \
ISL=128k RUN_ID=run_000 \
bash benchmarks/nvcomp_benchmarks/benchmark.sh
```

如果需要重复多次实验，可以通过 `RUN_ID` 区分每次运行；每个 `RUN_ID` 会写入独立的结果目录：

```bash
for RUN_ID in run_000 run_001 run_002; do
  DATASET=/workspace/develop/datasets/SWE-bench/datasets--princeton-nlp--SWE-bench_oracle \
  MODEL_PATH=/tmp/nvidia-mps/GLM-5.1-FP8 \
  JIT_CACHE=/workspace/develop/envs/taco-sglang/cache \
  ISL=128k RUN_ID="$RUN_ID" \
  bash benchmarks/nvcomp_benchmarks/benchmark.sh
done
```

## TODO / 后续优化

- 优化 CPU-SSD H2DISK 路径。目前 packed H2DISK 需要先把 scattered compressed chunks gather 到 staging buffer，再写入 SSD；后续可以继续优化 gather / write pipeline、线程模型或 I/O 提交方式，降低写路径额外开销。
- 优化变长 CPU memory 管理。当前每个 CPU slot 仍按未压缩大小预留，后续可以探索 variable-size allocation / compacted memory pool / page-based allocator，真正利用 compressed payload 的变长特性来节省 CPU 内存。
- 优化 size table 与 metadata 管理。当前 size table 能保证 correctness，但后续可以评估 metadata layout、cache locality 和 TP/MLA 场景下的访问开销。
- 继续完善 benchmark 覆盖。补充更多模型、dtype、TP size、ISL/OSL 组合下的 micro-benchmark 与 end-to-end benchmark，确认收益边界。

## 单元测试

- `FLEXKV_ENABLE_NVCOMP=1 pytest -v -s tests/nvcomp/test_nvcomp_cpu.py`
- `FLEXKV_ENABLE_NVCOMP=1 pytest -v -s tests/nvcomp/test_nvcomp_ssd.py`
- `FLEXKV_ENABLE_NVCOMP=1 pytest -v -s tests/test_kvmanager.py`

