### PR TITLE
Fix reversed CPU block order in H2REMOTE transfer during global PUT

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -1289,8 +1289,8 @@ class GlobalCacheEngine:
         if put_to_remote:
             if fragment3_num_blocks > fragment12_num_blocks:
                 extra_num_cpu_blocks = fragment3_num_blocks - fragment12_num_blocks
-                fragment3_cpu_blocks = np.concatenate([fragment12_cpu_blocks,
-                                                  cpu_matched_blocks[-extra_num_cpu_blocks:]])
+                fragment3_cpu_blocks = np.concatenate([cpu_matched_blocks[-extra_num_cpu_blocks:],
+                                                       fragment12_cpu_blocks])
             else:
                 fragment3_cpu_blocks = fragment12_cpu_blocks[-fragment3_num_blocks:]
             op_h2remote = TransferOp(


### PR DESCRIPTION
Summary
- Fix a block-ordering bug in `GlobalCacheEngine._put_impl_global` when building the source CPU blocks for the `H2REMOTE` transfer.
- When `fragment3_num_blocks > fragment12_num_blocks` (i.e. the remote-matched prefix is shorter than the CPU-matched prefix), the source blocks were concatenated as `[fragment12_cpu_blocks, cpu_matched_blocks[-extra:]]`, which is the reverse of the required sequence order.
- Reordered to `[cpu_matched_blocks[-extra:], fragment12_cpu_blocks]`, consistent with the existing (correct) H2DISK/SSD path.
Why
`TransferOp` copies `src_block_ids[i] -> dst_block_ids[i]` pairwise, and the remote destination blocks are laid out in sequence-position order `[r, N)`. The source CPU blocks must follow the same order: matched prefix blocks `[r, c)` first, then the newly written `fragment12` blocks `[c, N)`. The old order silently wrote KV data to the wrong remote blocks, corrupting cached KV for that prefix (a correctness issue, not a crash). This triggers whenever the remote cache has matched fewer blocks than the CPU cache.
