### PR TITLE
fix: support vLLM 0.23+ non-MLA KV layout via new LAYERBLOCK type

### DIFF
--- a/flexkv/common/storage.py
+++ b/flexkv/common/storage.py
@@ -14,11 +14,14 @@ class AccessHandleType(Enum):
     TENSOR_HANDLE = auto()  # single tensor handle or tensor handle list
     GDS_MANAGER = auto()
 
-# NOTE: currently, we assume that the layout type of GPU should always be LAYERFIRST
-# and the layout type of CPU, SSD, remote should be the same, either laywise or BLOCKFIRST
+# NOTE: GPU layout depends on the vLLM version's non-MLA KV cache shape:
+#   vLLM <= 0.21: (kv, num_blocks, ...)  -> LAYERFIRST
+#   vLLM >= 0.23: (num_blocks, kv, ...)  -> LAYERBLOCK
+# CPU, SSD, remote layout should be the same, either LAYERFIRST or BLOCKFIRST.
 class KVCacheLayoutType(Enum):
     LAYERFIRST = "LAYERFIRST"
     BLOCKFIRST = "BLOCKFIRST"
+    LAYERBLOCK = "LAYERBLOCK"
 
 @dataclass
 class KVCacheLayout:
@@ -69,6 +72,13 @@ class KVCacheLayout:
             elif self.type == KVCacheLayoutType.BLOCKFIRST:
                 self._kv_shape = torch.Size([self.num_block,
                                              self.num_layer,
+                                             self._kv_dim,
+                                             self.tokens_per_block,
+                                             self.num_head,
+                                             self.head_size])
+            elif self.type == KVCacheLayoutType.LAYERBLOCK:  # vLLM >= 0.23 non-MLA GPU layout
+                self._kv_shape = torch.Size([self.num_layer,
+                                             self.num_block,
                                              self._kv_dim,
                                              self.tokens_per_block,
                                              self.num_head,
@@ -130,6 +140,8 @@ class KVCacheLayout:
             return self.kv_shape[1:].numel()
         elif self.type == KVCacheLayoutType.BLOCKFIRST:
             return self.kv_shape[2:].numel()
+        elif self.type == KVCacheLayoutType.LAYERBLOCK:
+            return self.kv_shape[1:].numel()
         else:
             raise ValueError(f"Invalid KVCacheLayoutType: {self.type}")
 
@@ -138,6 +150,8 @@ class KVCacheLayout:
             return self.kv_shape[3:].numel()
         elif self.type == KVCacheLayoutType.BLOCKFIRST:
             return self.kv_shape[1:].numel()
+        elif self.type == KVCacheLayoutType.LAYERBLOCK:
+            return self.kv_shape[2:].numel()
         else:
             raise ValueError(f"Invalid KVCacheLayoutType: {self.type}")
 
@@ -145,6 +159,8 @@ class KVCacheLayout:
         if self.type == KVCacheLayoutType.LAYERFIRST:
             return self.kv_shape[2:].numel()
         elif self.type == KVCacheLayoutType.BLOCKFIRST:
+            return self.kv_shape[3:].numel()
+        elif self.type == KVCacheLayoutType.LAYERBLOCK:
             return self.kv_shape[3:].numel()
         else:
             raise ValueError(f"Invalid KVCacheLayoutType: {self.type}")

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -718,6 +718,7 @@ class FlexKVWorkerConnector:
         if self.flexkv_config.model_config.use_mla:
             assert gpu_blocks[0].ndim == 3, (
                 f"expect kv cached tensor has 3 dim but get shape={gpu_blocks[0].shape}.")
+            gpu_layout_type = KVCacheLayoutType.LAYERFIRST
             num_blocks = gpu_blocks[0].shape[0]
             block_size = gpu_blocks[0].shape[1]
             num_kv_heads = 1
@@ -725,12 +726,23 @@ class FlexKVWorkerConnector:
         else:
             assert gpu_blocks[0].ndim == 5, (
                 f"expect kv cached tensor has 5 dim but get shape={gpu_blocks[0].shape}.")
-            num_blocks = gpu_blocks[0].shape[1]
+            # Detect GPU layout from the kv dim position (which holds size 2):
+            #   vLLM <= 0.21: (kv=2, num_blocks, ...)  -> LAYERFIRST
+            #   vLLM >= 0.23: (num_blocks, kv=2, ...)  -> LAYERBLOCK
+            if gpu_blocks[0].shape[1] == 2:
+                gpu_layout_type = KVCacheLayoutType.LAYERBLOCK
+                num_blocks = gpu_blocks[0].shape[0]
+            elif gpu_blocks[0].shape[0] == 2:
+                gpu_layout_type = KVCacheLayoutType.LAYERFIRST
+                num_blocks = gpu_blocks[0].shape[1]
+            else:
+                raise ValueError(
+                    f"cannot infer non-MLA kv layout from shape={tuple(gpu_blocks[0].shape)}")
             block_size = gpu_blocks[0].shape[2]
             num_kv_heads = gpu_blocks[0].shape[3]
             head_size = gpu_blocks[0].shape[4]
         gpu_layout = KVCacheLayout(
-            type=KVCacheLayoutType.LAYERFIRST,
+            type=gpu_layout_type,
             num_layer=num_layer,
             num_block=num_blocks,
             tokens_per_block=block_size,


### PR DESCRIPTION
## Problem

vLLM 0.23 changed the per-layer non-MLA KV cache layout from `(kv, num_block, ...)` to `(num_block, kv, ...)`. FlexKV's `register_to_server` still reads `shape[1]` as num_blocks and hardcodes LAYERFIRST, so on vLLM 0.23+ num_blocks is misread as 2, making all strides wrong and corrupting KV transfers.

## Fix

- Add a new `LAYERBLOCK` layout type for the `(num_layer, num_block, kv, tokens_per_block, num_head, head_size)` shape, with matching layer/block/kv stride formulas.
- In the vLLM adapter's `register_to_server`, detect the layout from the tensor shape (the kv dim holds size 2): `shape[1]==2` → LAYERBLOCK (0.23+), `shape[0]==2` → LAYERFIRST (<=0.21). No version-string hardcoding.
- The transfer layer is untouched: it derives offsets from `get_*_stride()`, which the new LAYERBLOCK formulas cover. The MLA (3D) path is unaffected.

## Verification

Reproduced the broken transfer on vLLM 0.23 locally; confirmed KV transfers are correct after the fix.