### PR TITLE
feat: MLA D2H transfer modes with comprehensive tests

### DIFF
--- a/benchmarks/benchmark_kv_transfer.py
+++ b/benchmarks/benchmark_kv_transfer.py
@@ -1,0 +1,540 @@
+"""
+Benchmark: KV transfer modes — REAL FlexKV API measurement.
+
+Compares 4 transfer strategies:
+  - MHA (non-MLA):    each TP rank owns different head partition (cpu_tp_stride)
+  - MLA sharded:     each GPU writes 1/N shard, H2D all read full KV
+  - MLA all_write:   each GPU writes full KV, H2D each reads own copy
+  - MLA rank0_only:  only rank0 writes, H2D all read from rank0's slot
+
+Matrix:
+  - Strategy: MHA / sharded / all_write / rank0_only  (4 types)
+  - Engine:    CUDA kernel / CE  (probed, unsupported skipped)
+  - Direction: D2H / H2D / H2D-layerwise (layer_granularity=1, looped)
+  - Layout:    LAYERFIRST / BLOCKFIRST  (CPU side)
+  - Size:      small / medium / large  (each gets its own summary)
+
+Uses KVCacheLayout for stride computation (same as production worker.py).
+
+Usage:
+    python benchmarks/benchmark_mla_d2h_modes.py --num-gpus 4 --iters 10
+    python benchmarks/benchmark_mla_d2h_modes.py --sizes small large
+    python benchmarks/benchmark_mla_d2h_modes.py --no-ce --no-layerwise
+"""
+
+import argparse
+import sys
+import time
+from collections import defaultdict
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# GPU / FlexKV detection
+# ---------------------------------------------------------------------------
+try:
+    import torch
+    CUDA_AVAILABLE = torch.cuda.is_available()
+    NUM_GPUS = torch.cuda.device_count() if CUDA_AVAILABLE else 0
+except ImportError:
+    CUDA_AVAILABLE = False
+    NUM_GPUS = 0
+    print("ERROR: PyTorch not available")
+    sys.exit(1)
+
+try:
+    from flexkv.c_ext import TPTransferThreadGroup
+    from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+    FLEXKV_AVAILABLE = True
+except ImportError as e:
+    FLEXKV_AVAILABLE = False
+    print("ERROR: FlexKV not available ({})".format(e))
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Configurations
+# ---------------------------------------------------------------------------
+
+DTYPE = torch.float16
+ES = DTYPE.itemsize
+
+# Model-representative configs: (num_layers, num_blocks, head_dim)
+#   num_blocks = max_batch * max_seq_len / tokens_per_block (tpb=1 for MLA)
+#   head_dim   = MLA latent_dim (the per-head KV size)
+#
+# MLA models (DeepSeek-V2/V3, Kimi-K2, etc.):
+#   DeepSeek-V3:  61 layers, kv_heads=1, latent_dim=512, fp8/bf16
+#   Kimi-K2:      61 layers, kv_heads=1, latent_dim=512, bf16
+# MHA models (Llama-3, Qwen2, etc.):
+#   Llama-3-8B:   32 layers, kv_heads=8, head_dim=128, bf16
+#   Llama-3-70B:  80 layers, kv_heads=8, head_dim=128, bf16
+#   Qwen2-72B:    80 layers, kv_heads=8, head_dim=128, bf16
+#
+# For MHA, num_heads is set to num_gpus at runtime (heads_per_rank=1).
+SIZES = {
+    # Small: ~Llama-3-8B scale
+    "small":  (32,   512,  128),
+    # Medium: ~DeepSeek-V3 / Kimi-K2 (MLA) or Llama-3-70B (MHA)
+    "medium": (61,  2048,  512),
+    # Large: 80-layer model with long context
+    "large":  (80,  8192,  512),
+}
+
+LAYOUTS = {
+    "lfirst": KVCacheLayoutType.LAYERFIRST,
+    "bfirst": KVCacheLayoutType.BLOCKFIRST,
+}
+
+# 4 strategies. MLA modes use is_mla=True; MHA uses is_mla=False.
+STRATEGIES = [
+    ("MHA",         False, "sharded"),     # non-MLA, mode ignored
+    ("MLA-sharded", True,  "sharded"),
+    ("MLA-all_write", True, "all_write"),
+    ("MLA-rank0_only", True, "rank0_only"),
+]
+
+WARMUP_ITERS = 3
+
+
+# ---------------------------------------------------------------------------
+# Engine probe
+# ---------------------------------------------------------------------------
+
+_probe_cache = {}
+
+def probe_engine(use_ce):
+    key = use_ce
+    if key in _probe_cache:
+        return _probe_cache[key]
+    try:
+        layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=1, num_block=1, tokens_per_block=1,
+            num_head=1, head_size=16, is_mla=True)
+        g = torch.zeros((1, 1, 1, 1, 1, 16), dtype=DTYPE, device="cuda:0")
+        c = torch.zeros(tuple(layout.kv_shape), dtype=DTYPE, pin_memory=True)
+        ids = torch.arange(1, dtype=torch.int64).pin_memory()
+        tp = TPTransferThreadGroup(
+            num_gpus=1, gpu_block_ptrs_flat=[g[0].data_ptr()],
+            num_tensors_per_gpu=1, cpu_blocks_ptr=c.data_ptr(), num_layers=1,
+            gpu_kv_strides_in_bytes=[layout.get_kv_stride() * ES],
+            gpu_block_strides_in_bytes=[layout.get_block_stride() * ES],
+            gpu_layer_strides_in_bytes=[layout.get_layer_stride() * ES],
+            gpu_chunk_sizes_in_bytes=[layout.get_chunk_size() * ES],
+            gpu_device_ids=[0], enable_nvcomp=False)
+        tp.tp_group_transfer(
+            gpu_block_id_tensor=ids, cpu_block_id_tensor=ids,
+            cpu_kv_stride_in_bytes=layout.get_kv_stride() * ES,
+            cpu_layer_stride_in_bytes=layout.get_layer_stride() * ES,
+            cpu_block_stride_in_bytes=layout.get_block_stride() * ES,
+            cpu_tp_stride_in_bytes=layout.get_block_stride() * ES,
+            transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=use_ce,
+            layer_id=0, layer_granularity=1, is_mla=True, mla_d2h_mode="sharded")
+        torch.cuda.synchronize()
+        del tp
+        _probe_cache[key] = True
+        return True
+    except Exception:
+        _probe_cache[key] = False
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers (matching production worker.py)
+# ---------------------------------------------------------------------------
+
+def make_layouts(num_layers, num_blocks, head_dim, cpu_layout_type, is_mla, num_gpus):
+    """Create GPU (LAYERFIRST) and CPU layouts.
+
+    MLA: kv_dim=1, head=1 (all ranks identical).
+    MHA: kv_dim=2, head=num_gpus (each rank gets 1 head).
+    GPU uses heads_per_rank (per-rank), CPU uses full num_head.
+    """
+    num_head = 1 if is_mla else num_gpus
+    heads_per_rank = 1  # MLA: 1 shared head; MHA: num_gpus/num_gpus = 1
+    # GPU layout uses per-rank heads (tensor only has heads_per_rank)
+    gpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=1, num_head=heads_per_rank,
+        head_size=head_dim, is_mla=is_mla)
+    # CPU layout uses full heads (all ranks' data on one buffer)
+    cpu_layout = KVCacheLayout(
+        type=cpu_layout_type,
+        num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=1, num_head=num_head,
+        head_size=head_dim, is_mla=is_mla)
+    return gpu_layout, cpu_layout
+
+
+def cpu_strides_for_strategy(cpu_layout, num_layers, num_blocks, head_dim,
+                             is_mla, mode, num_gpus):
+    """Return (cpu_kv_sb, cpu_layer_sb, cpu_block_sb, cpu_tp_sb, total_blocks).
+
+    For MLA all_write: CPU holds N copies, total = num_blocks * num_gpus.
+    For MHA: div_head(tp_size) on BLOCKFIRST for per-rank CPU strides.
+    """
+    total = num_blocks * num_gpus if (is_mla and mode == "all_write") else num_blocks
+    num_head = 1 if is_mla else num_gpus
+
+    layout_for_kv_stride = KVCacheLayout(
+        type=cpu_layout.type,
+        num_layer=num_layers, num_block=total,
+        tokens_per_block=1, num_head=num_head,
+        head_size=head_dim, is_mla=is_mla)
+
+    # For non-MLA BLOCKFIRST, div_head to get per-rank strides
+    if not is_mla and cpu_layout.type == KVCacheLayoutType.BLOCKFIRST:
+        layout_for_kv_stride = layout_for_kv_stride.div_head(num_gpus)
+
+    kv_sb = layout_for_kv_stride.get_kv_stride() * ES
+    layer_sb = layout_for_kv_stride.get_layer_stride() * ES
+    block_sb = cpu_layout.get_block_stride() * ES
+    tp_sb = block_sb // num_gpus
+    return kv_sb, layer_sb, block_sb, tp_sb, total
+
+
+def make_gpu_tensors(num_layers, kv_dim, num_blocks, heads_per_rank, head_dim, device):
+    """Contiguous [num_layers, kv_dim, num_blocks, 1, heads_per_rank, head_dim]."""
+    full = torch.empty(
+        (num_layers, kv_dim, num_blocks, 1, heads_per_rank, head_dim),
+        dtype=DTYPE, device="cuda:{}".format(device))
+    return [full[i] for i in range(num_layers)]
+
+
+def make_cpu_tensor(cpu_layout, num_layers, total_blocks, head_dim, is_mla, num_gpus):
+    num_head = 1 if is_mla else num_gpus
+    layout = KVCacheLayout(
+        type=cpu_layout.type,
+        num_layer=num_layers, num_block=total_blocks,
+        tokens_per_block=1, num_head=num_head,
+        head_size=head_dim, is_mla=is_mla)
+    return torch.empty(tuple(layout.kv_shape), dtype=DTYPE, pin_memory=True)
+
+
+def fill_gpu(all_gpu, gpu_id, num_layers, num_blocks, head_dim):
+    for layer in range(num_layers):
+        torch.manual_seed(gpu_id * 10000 + layer)
+        all_gpu[gpu_id][layer].uniform_()
+
+
+def block_ids(n):
+    return torch.arange(n, dtype=torch.int64).pin_memory()
+
+
+def make_tp_group(cpu_ptr, all_gpu, num_gpus, gpu_layout, num_layers):
+    gpu_ptrs = []
+    for g in range(num_gpus):
+        for l in range(num_layers):
+            gpu_ptrs.append(all_gpu[g][l].data_ptr())
+    return TPTransferThreadGroup(
+        num_gpus=num_gpus, gpu_block_ptrs_flat=gpu_ptrs,
+        num_tensors_per_gpu=num_layers, cpu_blocks_ptr=cpu_ptr,
+        num_layers=num_layers,
+        gpu_kv_strides_in_bytes=[gpu_layout.get_kv_stride() * ES] * num_gpus,
+        gpu_block_strides_in_bytes=[gpu_layout.get_block_stride() * ES] * num_gpus,
+        gpu_layer_strides_in_bytes=[gpu_layout.get_layer_stride() * ES] * num_gpus,
+        gpu_chunk_sizes_in_bytes=[gpu_layout.get_chunk_size() * ES] * num_gpus,
+        gpu_device_ids=list(range(num_gpus)),
+        enable_nvcomp=False)
+
+
+def sync_all(num_gpus):
+    for g in range(num_gpus):
+        torch.cuda.synchronize(g)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark core
+# ---------------------------------------------------------------------------
+
+def bench_one(strategy_label, is_mla, mode, use_ce, cpu_layout_type,
+              num_gpus, num_layers, num_blocks, head_dim, iters):
+    """Run one benchmark configuration: full D2H+H2D round-trip.
+
+    Measures the entire offload+reload path as a single timing:
+      D2H (GPU->CPU) + H2D (CPU->GPU) = one complete round-trip.
+    This matches the real production scenario where a block is offloaded
+    and later reloaded — the total latency is what matters, not D2H alone.
+
+    Returns dict with round-trip timing results.
+    """
+    kv_dim = 1 if is_mla else 2
+    heads_per_rank = 1  # MLA: 1 head shared; MHA: num_gpus heads / num_gpus = 1 per rank
+
+    gpu_layout, cpu_layout = make_layouts(
+        num_layers, num_blocks, head_dim, cpu_layout_type, is_mla, num_gpus)
+    cpu_kv_sb, cpu_ly_sb, cpu_bl_sb, cpu_tp_sb, total_blocks = \
+        cpu_strides_for_strategy(cpu_layout, num_layers, num_blocks, head_dim,
+                                  is_mla, mode, num_gpus)
+
+    all_gpu = [make_gpu_tensors(num_layers, kv_dim, num_blocks, heads_per_rank,
+                                head_dim, g) for g in range(num_gpus)]
+    cpu_kv = make_cpu_tensor(cpu_layout, num_layers, total_blocks, head_dim,
+                             is_mla, num_gpus)
+    tp = make_tp_group(cpu_kv.data_ptr(), all_gpu, num_gpus, gpu_layout, num_layers)
+
+    gpu_ids = block_ids(num_blocks)
+    cpu_ids = block_ids(num_blocks)
+
+    def do_d2h():
+        tp.tp_group_transfer(
+            gpu_block_id_tensor=gpu_ids, cpu_block_id_tensor=cpu_ids,
+            cpu_kv_stride_in_bytes=cpu_kv_sb, cpu_layer_stride_in_bytes=cpu_ly_sb,
+            cpu_block_stride_in_bytes=cpu_bl_sb, cpu_tp_stride_in_bytes=cpu_tp_sb,
+            transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=use_ce,
+            layer_id=0, layer_granularity=num_layers, is_mla=is_mla, mla_d2h_mode=mode)
+
+    def do_h2d():
+        tp.tp_group_transfer(
+            gpu_block_id_tensor=gpu_ids, cpu_block_id_tensor=cpu_ids,
+            cpu_kv_stride_in_bytes=cpu_kv_sb, cpu_layer_stride_in_bytes=cpu_ly_sb,
+            cpu_block_stride_in_bytes=cpu_bl_sb, cpu_tp_stride_in_bytes=cpu_tp_sb,
+            transfer_num_cta=4, is_host_to_device=True, use_ce_transfer=use_ce,
+            layer_id=0, layer_granularity=num_layers, is_mla=is_mla, mla_d2h_mode=mode)
+
+    # Warmup: full D2H + H2D round-trip
+    for _ in range(WARMUP_ITERS):
+        for g in range(num_gpus):
+            fill_gpu(all_gpu, g, num_layers, num_blocks, head_dim)
+        sync_all(num_gpus)
+        do_d2h()
+        for g in range(num_gpus):
+            for l in range(num_layers):
+                all_gpu[g][l].zero_()
+        sync_all(num_gpus)
+        do_h2d()
+        sync_all(num_gpus)
+
+    # Timing: full D2H + H2D round-trip per iteration
+    times = []
+    for _ in range(iters):
+        for g in range(num_gpus):
+            fill_gpu(all_gpu, g, num_layers, num_blocks, head_dim)
+        sync_all(num_gpus)
+        t0 = time.perf_counter()
+        do_d2h()
+        for g in range(num_gpus):
+            for l in range(num_layers):
+                all_gpu[g][l].zero_()
+        sync_all(num_gpus)
+        do_h2d()
+        sync_all(num_gpus)
+        times.append((time.perf_counter() - t0) * 1000)
+
+    del tp
+    return {
+        "avg_ms": float(np.mean(times)),
+        "p99_ms": float(np.percentile(times, 99)),
+        "min_ms": float(np.min(times)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Print helpers
+# ---------------------------------------------------------------------------
+
+def _col(text, width):
+    return str(text).ljust(width)
+
+
+def print_results_table(results):
+    w = [10, 10, 18, 8, 10, 10, 10]
+    hdr = (_col("Size", w[0]) + _col("Layout", w[1]) + _col("Strategy", w[2])
+           + _col("Engine", w[3])
+           + _col("Avg ms", w[4]) + _col("P99 ms", w[5]) + _col("Min ms", w[6]))
+    sep = "-" * len(hdr)
+    print("")
+    print(hdr)
+    print(sep)
+    for r in results:
+        line = (_col(r["size"], w[0]) + _col(r["layout"], w[1])
+                + _col(r["strategy"], w[2]) + _col(r["engine"], w[3])
+                + _col("{:.3f}".format(r["avg_ms"]), w[4])
+                + _col("{:.3f}".format(r["p99_ms"]), w[5])
+                + _col("{:.3f}".format(r["min_ms"]), w[6]))
+        print(line)
+    print(sep)
+
+
+def print_analysis(results):
+    """Per-size analysis: group by engine -> layout -> strategy.
+    For each engine, find best layout for MHA and best layout+mode for MLA."""
+    print("")
+    print("=" * 90)
+    print("Summary (per size, D2H+H2D round-trip)")
+    print("=" * 90)
+
+    sizes_present = sorted(set(r["size"] for r in results))
+
+    for size in sizes_present:
+        size_results = [r for r in results if r["size"] == size]
+        num_layers, num_blocks, head_dim = SIZES[size]
+        kv_bytes = num_layers * 1 * num_blocks * 1 * 1 * head_dim * ES
+
+    print("\n" + "=" * 90)
+    print("Benchmark Results (D2H+H2D round-trip)")
+    print("=" * 90)
+
+    sizes_present = sorted(set(r["size"] for r in results))
+
+    for size in sizes_present:
+        size_results = [r for r in results if r["size"] == size]
+        num_layers, num_blocks, head_dim = SIZES[size]
+        kv_bytes = num_layers * 1 * num_blocks * 1 * 1 * head_dim * ES
+
+        print("\n  === Size: {} ({}L / {}B / hd={} / {:.1f}MB) ===".format(
+            size, num_layers, num_blocks, head_dim, kv_bytes / (1024**2)))
+
+        engines_present = sorted(set(r["engine"] for r in size_results))
+
+        for engine in engines_present:
+            eng_results = [r for r in size_results if r["engine"] == engine]
+
+            print("\n  [{}] Engine: {}".format(engines_present.index(engine) + 1, engine))
+
+            # Group by layout, then list all strategies within each layout
+            layouts_present = sorted(set(r["layout"] for r in eng_results))
+            best_all = min(r["avg_ms"] for r in eng_results) if eng_results else 1
+
+            for layout in layouts_present:
+                lay_results = [r for r in eng_results if r["layout"] == layout]
+
+                print("\n      Layout: {}".format(layout))
+                print("        {:>18} {:>12} {:>10}".format(
+                    "Strategy", "Round-trip ms", "vs best"))
+                print("        " + "-" * 42)
+
+                for r in sorted(lay_results, key=lambda x: x["avg_ms"]):
+                    ratio = r["avg_ms"] / best_all if best_all > 0 else 0
+                    marker = " *" if r["avg_ms"] == best_all else ""
+                    print("        {:>18} {:>12.3f} {:>9.2f}x{}".format(
+                        r["strategy"], r["avg_ms"], ratio, marker))
+
+        # --- Recommendation ---
+        print("\n  [{}] Recommendation for size={}".format(len(engines_present) + 1, size))
+        print("      " + "-" * 60)
+
+        for engine in engines_present:
+            eng_results = [r for r in size_results if r["engine"] == engine]
+
+            # MHA best layout
+            mha = [r for r in eng_results if r["strategy"] == "MHA"]
+            if mha:
+                best_mha = min(mha, key=lambda r: r["avg_ms"])
+                print("      {} MHA:      best layout = {} ({:.3f} ms)".format(
+                    engine, best_mha["layout"], best_mha["avg_ms"]))
+
+            # MLA best layout + mode
+            mla = [r for r in eng_results if r["strategy"] != "MHA"]
+            if mla:
+                best_mla = min(mla, key=lambda r: r["avg_ms"])
+                print("      {} MLA:      best layout = {}, best mode = {} ({:.3f} ms)".format(
+                    engine, best_mla["layout"], best_mla["strategy"], best_mla["avg_ms"]))
+
+    print("\n  Note: Performance depends on hardware (NUMA topology, PCIe/NVLink")
+    print("        bandwidth, GPU model). Always benchmark on your target machine.")
+    print("=" * 90)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark KV transfer strategies (REAL FlexKV API)")
+    parser.add_argument("--num-gpus", type=int, default=0,
+                        help="Number of GPUs (default: 0 = all available)")
+    parser.add_argument("--iters", type=int, default=10,
+                        help="Timing iterations per config (default: 10)")
+    parser.add_argument("--strategies", type=str, nargs="+",
+                        default=[s[0] for s in STRATEGIES],
+                        help="Strategies to test")
+    parser.add_argument("--sizes", type=str, nargs="+",
+                        default=list(SIZES.keys()),
+                        choices=list(SIZES.keys()),
+                        help="Data sizes to test (default: all)")
+    parser.add_argument("--layouts", type=str, nargs="+",
+                        default=list(LAYOUTS.keys()),
+                        choices=list(LAYOUTS.keys()),
+                        help="CPU layouts to test (default: both)")
+    parser.add_argument("--no-kernel", action="store_true",
+                        help="Skip CUDA Kernel tests")
+    parser.add_argument("--no-ce", action="store_true",
+                        help="Skip CE tests")
+    args = parser.parse_args()
+
+    num_gpus = NUM_GPUS if args.num_gpus <= 0 else min(args.num_gpus, NUM_GPUS)
+    if num_gpus < 2:
+        print("ERROR: need at least 2 GPUs, found {}".format(NUM_GPUS))
+        sys.exit(1)
+
+    # Engine probe
+    engines = []
+    if not args.no_kernel:
+        if probe_engine(use_ce=False):
+            engines.append(("CUDA", False))
+        else:
+            print("WARNING: CUDA kernel probe failed, skipping kernel tests")
+    if not args.no_ce:
+        if probe_engine(use_ce=True):
+            engines.append(("CE", True))
+        else:
+            print("WARNING: CE probe failed, skipping CE tests")
+    if not engines:
+        print("ERROR: no transfer engine available")
+        sys.exit(1)
+
+    # Filter strategies
+    active_strategies = [s for s in STRATEGIES if s[0] in args.strategies]
+
+    print("=" * 90)
+    print("  FlexKV KV Transfer Benchmark")
+    print("=" * 90)
+    print("  GPUs:        {}".format(num_gpus))
+    print("  Strategies:  {}".format([s[0] for s in active_strategies]))
+    print("  Sizes:       {}".format(args.sizes))
+    print("  Layouts:     {}".format(args.layouts))
+    print("  Engines:     {}".format([e[0] for e in engines]))
+    print("  Iters:       {}".format(args.iters))
+    print("  Dtype:       {}".format(DTYPE))
+    print("=" * 90)
+
+    results = []
+    for size_name in args.sizes:
+        num_layers, num_blocks, head_dim = SIZES[size_name]
+        kv_bytes = num_layers * 1 * num_blocks * 1 * 1 * head_dim * ES
+        print("\n--- Size: {} ({} layers, {} blocks, hd={}, {:.1f} MB) ---".format(
+            size_name, num_layers, num_blocks, head_dim, kv_bytes / (1024**2)))
+
+        for engine_name, use_ce in engines:
+            for strat_label, is_mla, mode in active_strategies:
+                for layout_name in args.layouts:
+                    cpu_layout_type = LAYOUTS[layout_name]
+                    label = "{} | {} | {} | {}".format(
+                        size_name, engine_name, strat_label, layout_name)
+                    print("  Running: {} ...".format(label), end=" ", flush=True)
+                    try:
+                        r = bench_one(
+                            strat_label, is_mla, mode, use_ce,
+                            cpu_layout_type, num_gpus, num_layers, num_blocks,
+                            head_dim, args.iters)
+                        r.update({
+                            "size": size_name,
+                            "layout": layout_name,
+                            "strategy": strat_label,
+                            "engine": engine_name,
+                        })
+                        results.append(r)
+                        print("avg={:.3f}ms".format(r["avg_ms"]))
+                    except Exception as e:
+                        print("FAILED: {}".format(e))
+
+    print_results_table(results)
+    print_analysis(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_kv_transfer.py
+++ b/benchmarks/benchmark_kv_transfer.py
@@ -361,18 +361,6 @@ def print_results_table(results):
 def print_analysis(results):
     """Per-size analysis: group by engine -> layout -> strategy.
     For each engine, find best layout for MHA and best layout+mode for MLA."""
-    print("")
-    print("=" * 90)
-    print("Summary (per size, D2H+H2D round-trip)")
-    print("=" * 90)
-
-    sizes_present = sorted(set(r["size"] for r in results))
-
-    for size in sizes_present:
-        size_results = [r for r in results if r["size"] == size]
-        num_layers, num_blocks, head_dim = SIZES[size]
-        kv_bytes = num_layers * 1 * num_blocks * 1 * 1 * head_dim * ES
-
     print("\n" + "=" * 90)
     print("Benchmark Results (D2H+H2D round-trip)")
     print("=" * 90)
@@ -510,11 +498,11 @@ def main():
             size_name, num_layers, num_blocks, head_dim, kv_bytes / (1024**2)))
 
         for engine_name, use_ce in engines:
-            for strat_label, is_mla, mode in active_strategies:
-                for layout_name in args.layouts:
+            for layout_name in args.layouts:
+                for strat_label, is_mla, mode in active_strategies:
                     cpu_layout_type = LAYOUTS[layout_name]
                     label = "{} | {} | {} | {}".format(
-                        size_name, engine_name, strat_label, layout_name)
+                        size_name, engine_name, layout_name, strat_label)
                     print("  Running: {} ...".format(label), end=" ", flush=True)
                     try:
                         r = bench_one(

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -476,7 +476,8 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("indexer_ssd_layer_stride_in_bytes") = 0,
            py::arg("indexer_ssd_kv_stride_in_bytes") = 0,
            py::arg("indexer_cpu_chunk_size_in_bytes") = 0,
-           py::arg("indexer_num_blocks_per_file") = 0);
+           py::arg("indexer_num_blocks_per_file") = 0,
+           py::arg("mla_d2h_mode") = "sharded");
 #ifdef FLEXKV_ENABLE_CFS
   m.def("transfer_kv_blocks_remote", &transfer_kv_blocks_remote,
         "Transfer KV blocks between remote and CPU memory",
@@ -543,7 +544,7 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("cpu_tp_stride_in_bytes"), py::arg("transfer_num_cta"),
            py::arg("is_host_to_device"), py::arg("use_ce_transfer"),
            py::arg("layer_id"), py::arg("layer_granularity"),
-           py::arg("is_mla"));
+           py::arg("is_mla"), py::arg("mla_d2h_mode") = "sharded");
 #ifdef FLEXKV_ENABLE_NVCOMP
   // nvcomp ANS variant: tp_group_transfer_ans() lazily initializes from the
   // constructor config and returns total compressed bytes across ranks.

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -329,7 +329,8 @@ void LayerwiseTransferGroup::layerwise_transfer(
     const int64_t indexer_ssd_layer_stride_in_bytes,
     const int64_t indexer_ssd_kv_stride_in_bytes,
     const int64_t indexer_cpu_chunk_size_in_bytes,
-    const int indexer_num_blocks_per_file) {
+    const int indexer_num_blocks_per_file,
+    const std::string &mla_d2h_mode) {
 
   // Set current counter ID for eventfd notification
   current_counter_id_ = counter_id;
@@ -378,6 +379,8 @@ void LayerwiseTransferGroup::layerwise_transfer(
     int sl = b * layer_granularity;
     int ltb = std::min(layer_granularity, num_layers - sl);
     // Calculate data size for this batch: chunk_size * 2 (K+V) * layers * num_blocks
+    // H2D: every GPU reads a full KV copy regardless of mla_d2h_mode (the mode
+    // only controls where on CPU it reads from, not how much).
     int64_t bytes_this_batch = 0;
     for (int g = 0; g < num_gpus_; ++g) {
       bytes_this_batch += gpu_chunk_sizes_in_bytes_[g] * 2 * ltb * num_blocks;
@@ -479,14 +482,37 @@ void LayerwiseTransferGroup::layerwise_transfer(
     // NVTX range for this batch was already started (by main thread for first batch,
     // or by previous batch's callback for subsequent batches)
     
+    // Validate mla_d2h_mode once before the per-GPU loop
+    std::string mode = mla_d2h_mode;
+    if (is_mla && mode != "sharded" && mode != "all_write" && mode != "rank0_only") {
+      fprintf(stderr, "[FlexKV] Warning: Invalid mla_d2h_mode='%s', using default 'sharded'\n",
+              mode.c_str());
+      mode = "sharded";
+    }
+
     for (int i = 0; i < num_gpus_; ++i) {
       cudaSetDevice(gpu_device_ids_[i]);
       int64_t cpu_startoff_inside_chunks = i * cpu_tp_stride_in_bytes;
-      if (is_mla) {
-        cpu_startoff_inside_chunks = 0;
-      }
       int64_t gpu_startoff_inside_chunks = 0;
       int64_t chunk_size = gpu_chunk_sizes_in_bytes_[i];
+
+      // Handle MLA D2H mode for H2D transfer (inlined logic)
+      if (is_mla) {
+        if (mode == "sharded") {
+          cpu_startoff_inside_chunks = 0;
+          gpu_startoff_inside_chunks = 0;
+        } else if (mode == "all_write") {
+          // Each rank's complete KV occupies num_blocks blocks on CPU.
+          // Use cpu_block_stride (not gpu_chunk_size) because BLOCKFIRST's
+          // block_stride includes all layers+kv_dims, while LAYERFIRST's
+          // block_stride == chunk_size (same result).
+          cpu_startoff_inside_chunks = i * num_blocks * cpu_block_stride_in_bytes;
+          gpu_startoff_inside_chunks = 0;
+        } else if (mode == "rank0_only") {
+          cpu_startoff_inside_chunks = 0;
+          gpu_startoff_inside_chunks = 0;
+        }
+      }
 
       switch (backend_type_) {
       case BackendType::VLLM:
@@ -604,7 +630,7 @@ void LayerwiseTransferGroup::layerwise_transfer(
     cudaEventElapsedTime(&elapsed_ms, timing_events[i], timing_events[i + 1]);
 
     // Calculate bytes transferred for this batch
-    // For each GPU: chunk_size * 2 (K+V) * layers * num_blocks
+    // H2D: every GPU reads a full KV copy regardless of mla_d2h_mode
     int64_t bytes_this_batch = 0;
     for (int g = 0; g < num_gpus_; ++g) {
       bytes_this_batch += gpu_chunk_sizes_in_bytes_[g] * 2 * batch_layers_count[i] * num_blocks;

--- a/csrc/layerwise.h
+++ b/csrc/layerwise.h
@@ -72,7 +72,8 @@ public:
       const int64_t indexer_ssd_layer_stride_in_bytes = 0,
       const int64_t indexer_ssd_kv_stride_in_bytes = 0,
       const int64_t indexer_cpu_chunk_size_in_bytes = 0,
-      const int indexer_num_blocks_per_file = 0);
+      const int indexer_num_blocks_per_file = 0,
+      const std::string &mla_d2h_mode = "sharded");
 
 private:
   int num_gpus_;

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -177,7 +177,8 @@ void TPTransferThreadGroup::tp_group_transfer(
     const int64_t cpu_block_stride_in_bytes,
     const int64_t cpu_tp_stride_in_bytes, const int transfer_num_cta,
     const bool is_host_to_device, const bool use_ce_transfer,
-    const int layer_id, const int layer_granularity, const bool is_mla) {
+    const int layer_id, const int layer_granularity, const bool is_mla,
+    const std::string &mla_d2h_mode) {
 
   std::atomic<bool> failed{false};
   std::string error_msg;
@@ -188,9 +189,41 @@ void TPTransferThreadGroup::tp_group_transfer(
   std::vector<std::future<void>> futures;
   futures.reserve(num_gpus_);
 
-  bool enable_sharded_d2h = is_mla && !is_host_to_device;
+  // Validate mla_d2h_mode parameter (only meaningful for MLA)
+  std::string mode = mla_d2h_mode;
+  if (is_mla && mode != "sharded" && mode != "all_write" && mode != "rank0_only") {
+    fprintf(stderr, "[FlexKV] Warning: Invalid mla_d2h_mode='%s', using default 'sharded'\n",
+            mode.c_str());
+    mode = "sharded";
+  }
+
+  // In sharded D2H mode, chunk_size is divided by num_gpus_ and used as both
+  // the per-rank transfer size and the stride between ranks. If chunk_size
+  // is not divisible by num_gpus_, the integer division drops trailing bytes,
+  // leaving a hole in the assembled KV on CPU.
+  // All ranks share the same chunk_size (MLA = identical KV), so check [0] once.
+  if (is_mla && !is_host_to_device && mode == "sharded" && num_gpus_ > 1) {
+    if (gpu_chunk_sizes_in_bytes_[0] % num_gpus_ != 0) {
+      throw std::runtime_error(
+          "sharded MLA D2H mode requires gpu_chunk_size divisible by "
+          "num_gpus, but chunk_size=" +
+          std::to_string(gpu_chunk_sizes_in_bytes_[0]) + " and num_gpus=" +
+          std::to_string(num_gpus_) + ". Use 'all_write' or 'rank0_only' "
+          "mode, or adjust head_dim/tokens_per_block so chunk_size is "
+          "divisible.");
+    }
+  }
 
   for (int i = 0; i < num_gpus_; ++i) {
+    // For rank0_only mode in D2H: only rank 0 performs transfer
+    if (is_mla && !is_host_to_device && mode == "rank0_only" && i != 0) {
+      // Skip D2H transfer for non-rank0 GPUs
+      futures.emplace_back(enqueue_for_gpu(i, [i]() {
+        // Empty task - non-rank0 GPUs do nothing in rank0_only D2H mode
+      }));
+      continue;
+    }
+
     futures.emplace_back(enqueue_for_gpu(i, [&, i]() {
       try {
         int num_blocks = gpu_block_id_tensor.numel();
@@ -201,19 +234,45 @@ void TPTransferThreadGroup::tp_group_transfer(
             static_cast<int64_t *>(cpu_block_id_tensor.data_ptr());
         void *cpu_ptr = cpu_blocks_;
         int64_t cpu_startoff_inside_chunks = 0;
-        if (enable_sharded_d2h)
-          cpu_startoff_inside_chunks =
-              i * gpu_chunk_sizes_in_bytes_[i] / num_gpus_;
-        else if (!is_mla)
+        int64_t gpu_startoff_inside_chunks = 0;
+        int64_t chunk_size = gpu_chunk_sizes_in_bytes_[i];
+
+        if (is_mla) {
+          // MLA offset logic — inlined (was shared via mla_utils.h)
+          if (mode == "sharded") {
+            if (!is_host_to_device) {
+              int64_t shard = gpu_chunk_sizes_in_bytes_[i] / num_gpus_;
+              cpu_startoff_inside_chunks = i * shard;
+              gpu_startoff_inside_chunks = i * shard;
+              chunk_size = shard;
+            } else {
+              cpu_startoff_inside_chunks = 0;
+              gpu_startoff_inside_chunks = 0;
+              chunk_size = gpu_chunk_sizes_in_bytes_[i];
+            }
+          } else if (mode == "all_write") {
+            // Each rank's complete KV occupies num_blocks blocks on CPU
+            // ([GPU0][GPU1]...[GPUN]). Rank i's region starts at i * num_blocks
+            // blocks from the base. Use cpu_block_stride (not gpu_chunk_size)
+            // because BLOCKFIRST's block_stride includes all layers+kv_dims,
+            // while LAYERFIRST's block_stride == chunk_size (same result).
+            cpu_startoff_inside_chunks = i * num_blocks * cpu_block_stride_in_bytes;
+            gpu_startoff_inside_chunks = 0;
+            chunk_size = gpu_chunk_sizes_in_bytes_[i];
+          } else if (mode == "rank0_only") {
+            // D2H: only rank 0 writes (non-rank0 handled by outer continue)
+            // H2D: all GPUs read from offset 0
+            cpu_startoff_inside_chunks = 0;
+            gpu_startoff_inside_chunks = 0;
+            chunk_size = gpu_chunk_sizes_in_bytes_[i];
+          }
+        } else {
+          // Non-MLA scenario: use default logic
           cpu_startoff_inside_chunks = i * cpu_tp_stride_in_bytes;
-        int64_t gpu_startoff_inside_chunks =
-            enable_sharded_d2h ? i * gpu_chunk_sizes_in_bytes_[i] / num_gpus_
-                               : 0;
-        // we assume that the chunk size is the same for all gpus,
-        // even if they have different number of gpu_blocks
-        int64_t chunk_size = enable_sharded_d2h
-                                 ? gpu_chunk_sizes_in_bytes_[i] / num_gpus_
-                                 : gpu_chunk_sizes_in_bytes_[i];
+          gpu_startoff_inside_chunks = 0;
+          chunk_size = gpu_chunk_sizes_in_bytes_[i];
+        }
+        
         // Dispatch to the appropriate template based on backend type
         switch (backend_type_) {
         case BackendType::VLLM:

--- a/csrc/tp_transfer_thread_group.h
+++ b/csrc/tp_transfer_thread_group.h
@@ -63,7 +63,8 @@ public:
                          const int transfer_num_cta,
                          const bool is_host_to_device,
                          const bool use_ce_transfer, const int layer_id,
-                         const int layer_granularity, const bool is_mla);
+                         const int layer_granularity, const bool is_mla,
+                         const std::string &mla_d2h_mode = "sharded");
 
 #ifdef FLEXKV_ENABLE_NVCOMP
 

--- a/docs/flexkv_config_reference/README_en.md
+++ b/docs/flexkv_config_reference/README_en.md
@@ -98,6 +98,7 @@ Some configurations can only be set through environment variables.
 | `FLEXKV_USE_CE_TRANSFER_D2H` | bool | 0 | Whether to use cudaMemcpyAsync for Device→Host transfers. Can avoid occupying SM, but transfer speed will be reduced |
 | `FLEXKV_TRANSFER_NUM_CTA_H2D` | int | 4 | Number of CUDA thread blocks (CTAs) used for H2D transfer, only effective when `FLEXKV_USE_CE_TRANSFER_H2D` is 0 |
 | `FLEXKV_TRANSFER_NUM_CTA_D2H` | int | 4 | Number of CUDA thread blocks (CTAs) used for D2H transfer, only effective when `FLEXKV_USE_CE_TRANSFER_D2H` is 0 |
+| `FLEXKV_MLA_D2H_MODE` | str | "sharded" | **Only applicable to MLA scenarios** (kv_heads=1, all TP ranks have identical KV). Controls how CPU KV Cache is written during D2H transfer. Available options:<br/>• `sharded` - Each GPU writes 1/N shard to form one complete KV<br/>• `all_write` - Each GPU writes complete KV to its own location (Nx CPU memory)<br/>• `rank0_only` - Only rank 0 writes complete KV |
 
 ---
 

--- a/docs/flexkv_config_reference/README_zh.md
+++ b/docs/flexkv_config_reference/README_zh.md
@@ -99,6 +99,7 @@ enable_gds: false
 | `FLEXKV_USE_CE_TRANSFER_D2H` | bool | 0 |  是否使用 cudaMemcpyAsync 实现 Device→Host 传输，可以避免占用 SM，但是传输速度会降低 |
 | `FLEXKV_TRANSFER_NUM_CTA_H2D` | int | 4 | H2D 传输使用的 CUDA thread block (CTA) 数量，仅在`FLEXKV_USE_CE_TRANSFER_H2D`为0时生效 |
 | `FLEXKV_TRANSFER_NUM_CTA_D2H` | int | 4 | D2H 传输使用的 CUDA thread block (CTA) 数量，仅在`FLEXKV_USE_CE_TRANSFER_D2H`为0时生效 |
+| `FLEXKV_MLA_D2H_MODE` | str | "sharded" | **仅适用于 MLA 场景**（kv_heads=1，所有 TP rank 的 KV 相同）。控制 D2H 时 CPU KV Cache 的写入模式。可选值：<br/>• `sharded` - 每个 GPU 写 1/N 分片拼成一个完整 KV<br/>• `all_write` - 每个 GPU 写完整 KV 到各自位置（CPU 内存占用 Nx）<br/>• `rank0_only` - 仅 rank 0 写完整 KV |
 
 ---
 

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -465,6 +465,10 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     renew_lease_ms=int(os.getenv('FLEXKV_RENEW_LEASE_MS', 4000)),
 
     nvcomp_batch_size=int(os.getenv('FLEXKV_NVCOMP_BATCH_SIZE', '0')),  # 0 = auto
+
+    # MLA D2H transfer mode (only effective when kv_heads=1)
+    # Available modes: "sharded" (default), "all_write", "rank0_only"
+    mla_d2h_mode=os.getenv('FLEXKV_MLA_D2H_MODE', 'sharded'),
 )
 
 @dataclass
@@ -554,8 +558,27 @@ def update_default_config_from_user_config(rank_info: RankInfo,
     assert user_config.cpu_cache_gb > 0
     assert user_config.ssd_cache_gb >= 0
 
-    cache_config.num_cpu_blocks = convert_to_block_num(user_config.cpu_cache_gb, block_size_in_bytes)
-    cache_config.num_ssd_blocks = convert_to_block_num(user_config.ssd_cache_gb, block_size_in_bytes)
+    # MLA all_write mode: each logical KV block occupies N× physical space
+    # on CPU/SSD (N GPUs each write a complete KV copy to distinct block slots).
+    # To keep the physical memory budget (cpu_cache_gb / ssd_cache_gb) unchanged,
+    # the logical block capacity must be divided by N.
+    # This mirrors the C++ offset logic in tp_transfer_thread_group.cpp where
+    # GPU i writes to cpu_startoff = i * chunk_size, requiring N slots per logical block.
+    model_config = rank_info.model_config
+    mla_d2h_mode = GLOBAL_CONFIG_FROM_ENV.mla_d2h_mode
+    capacity_divisor = 1
+    if model_config.use_mla and mla_d2h_mode == "all_write":
+        num_gpus_per_node = model_config.effective_tp_size_per_node
+        if num_gpus_per_node > 1:
+            capacity_divisor = num_gpus_per_node
+            flexkv_logger.info(
+                f"[config] MLA all_write mode: logical cpu/ssd capacity "
+                f"÷{num_gpus_per_node} (each block occupies {num_gpus_per_node}× "
+                f"physical space, total memory budget unchanged)"
+            )
+
+    cache_config.num_cpu_blocks = convert_to_block_num(user_config.cpu_cache_gb, block_size_in_bytes) // capacity_divisor
+    cache_config.num_ssd_blocks = convert_to_block_num(user_config.ssd_cache_gb, block_size_in_bytes) // capacity_divisor
 
     cache_config.ssd_cache_dir = user_config.ssd_cache_dir
     cache_config.enable_ssd = user_config.ssd_cache_gb > 0

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -170,6 +170,10 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         self.h2d_cta_num = h2d_cta_num
         self.d2h_cta_num = d2h_cta_num
 
+        # Read MLA D2H mode from global config
+        self.mla_d2h_mode = GLOBAL_CONFIG_FROM_ENV.mla_d2h_mode
+        flexkv_logger.debug(f"[LayerwiseWorker] mla_d2h_mode={self.mla_d2h_mode}")
+
         # initialize SSD storage
         self.enable_ssd = len(ssd_files) > 0
         self.ssd_files = ssd_files
@@ -528,6 +532,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             self.indexer_ssd_kv_stride_in_bytes,
             self.indexer_cpu_chunk_size_in_bytes,
             self.indexer_num_blocks_per_file,
+            self.mla_d2h_mode,  # Pass MLA D2H mode to C++
         )
 
     def launch_transfer(self, transfer_op: WorkerLayerwiseTransferOp) -> bool:

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -496,6 +496,10 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         self.use_ce_transfer_h2d = use_ce_transfer_h2d
         self.use_ce_transfer_d2h = use_ce_transfer_d2h
 
+        # Read MLA D2H mode from global config
+        self.mla_d2h_mode = GLOBAL_CONFIG_FROM_ENV.mla_d2h_mode
+        flexkv_logger.debug(f"[tpGPUCPUTransferWorker] mla_d2h_mode={self.mla_d2h_mode}")
+
         # Resolve pointers in Python (where storage is valid); pass them to C++ so we avoid
         # "Tensor that doesn't have storage" when C++ calls .data_ptr() on tensors passed
         # across the pybind11 boundary from a spawn'd subprocess (shared memory / CUDA IPC).
@@ -569,6 +573,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             0,
             self.num_layers,
             self.is_mla,
+            self.mla_d2h_mode,  # Pass MLA D2H mode to C++
         )
 
 

--- a/tests/test_kv_transfer_correctness.py
+++ b/tests/test_kv_transfer_correctness.py
@@ -1,0 +1,538 @@
+"""
+Comprehensive KV transfer correctness tests for FlexKV.
+
+Tests D2H (GPU->CPU) and H2D (CPU->GPU) data integrity across:
+  - Layout:   LAYERFIRST, BLOCKFIRST (CPU side)
+  - Model:    MLA (kv_heads=1, kv_dim=1), MHA (kv_heads>1, kv_dim=2)
+  - Mode:     sharded, all_write, rank0_only (MLA only)
+  - Engine:   CUDA kernel, CE (cudaMemcpyAsync)
+  - Direction: D2H, H2D, Round-trip
+
+Uses KVCacheLayout for stride computation (same as production code in worker.py).
+GPU is always LAYERFIRST; CPU can be LAYERFIRST or BLOCKFIRST.
+
+Run:
+    pytest tests/test_kv_transfer_correctness.py -v
+    pytest tests/test_kv_transfer_correctness.py -v -k "mla and sharded"
+"""
+
+import pytest
+import torch
+
+from flexkv.c_ext import TPTransferThreadGroup, LayerwiseTransferGroup
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+NUM_GPUS = min(4, torch.cuda.device_count()) if torch.cuda.is_available() else 0
+
+pytestmark = pytest.mark.skipif(
+    NUM_GPUS < 2,
+    reason=f"Need at least 2 GPUs, found {NUM_GPUS}"
+)
+
+
+def _probe_engine(use_ce):
+    """Probe whether a single tiny transfer succeeds with the given engine.
+
+    The custom CUDA kernel requires chunk_size divisible by 16 bytes (float4).
+    CE (cudaMemcpyAsync) works for any size.  We run a throwaway transfer to
+    detect at session start whether each engine is usable; results are cached.
+    """
+    cache_key = f"__probe_{use_ce}"
+    cached = globals().get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=1, num_block=1, tokens_per_block=1,
+            num_head=1, head_size=16, is_mla=True)
+        g = torch.zeros((1, 1, 1, 1, 1, 16), dtype=torch.float16, device="cuda:0")
+        c = torch.zeros(tuple(layout.kv_shape), dtype=torch.float16, pin_memory=True)
+        ids = torch.arange(1, dtype=torch.int64).pin_memory()
+        tp = TPTransferThreadGroup(
+            num_gpus=1, gpu_block_ptrs_flat=[g[0].data_ptr()],
+            num_tensors_per_gpu=1, cpu_blocks_ptr=c.data_ptr(),
+            num_layers=1,
+            gpu_kv_strides_in_bytes=[layout.get_kv_stride() * 2],
+            gpu_block_strides_in_bytes=[layout.get_block_stride() * 2],
+            gpu_layer_strides_in_bytes=[layout.get_layer_stride() * 2],
+            gpu_chunk_sizes_in_bytes=[layout.get_chunk_size() * 2],
+            gpu_device_ids=[0], enable_nvcomp=False)
+        tp.tp_group_transfer(
+            gpu_block_id_tensor=ids, cpu_block_id_tensor=ids,
+            cpu_kv_stride_in_bytes=layout.get_kv_stride() * 2,
+            cpu_layer_stride_in_bytes=layout.get_layer_stride() * 2,
+            cpu_block_stride_in_bytes=layout.get_block_stride() * 2,
+            cpu_tp_stride_in_bytes=layout.get_block_stride() * 2,
+            transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=use_ce,
+            layer_id=0, layer_granularity=1, is_mla=True,
+            mla_d2h_mode="sharded")
+        torch.cuda.synchronize()
+        del tp
+        globals()[cache_key] = True
+        return True
+    except Exception:
+        globals()[cache_key] = False
+        return False
+
+
+def skip_if_engine_unsupported(use_ce):
+    """Skip test if the engine probe failed (kernel needs float4 alignment, CE
+    needs CUDA runtime, etc.)."""
+    if not _probe_engine(use_ce):
+        kind = "CE (cudaMemcpyAsync)" if use_ce else "CUDA kernel"
+        pytest.skip(f"{kind} engine not available on this platform")
+
+
+# ---------------------------------------------------------------------------
+# Test configurations
+# ---------------------------------------------------------------------------
+
+DTYPE = torch.float16
+ES = DTYPE.itemsize
+
+# (num_layers, num_blocks, tokens_per_block, num_heads, head_dim)
+# num_blocks must be divisible by NUM_GPUS (default 4) for sharded mode.
+#
+# MLA models (DeepSeek-V3, Kimi-K2):
+#   kv_heads=1, latent_dim=512, 61 layers, bf16/fp8
+# MHA models (Llama-3, Qwen2):
+#   kv_heads=8, head_dim=128, 32-80 layers, bf16
+#   num_heads must be divisible by NUM_GPUS for non-MLA TP sharding.
+MLA_SIZES = [
+    # DeepSeek-V2/V3 scale: 61 layers, latent_dim=512
+    pytest.param((4, 8, 16, 1, 512), id="ds3-mini"),      # quick smoke test
+    pytest.param((32, 64, 16, 1, 512), id="llama3-8b"),   # 32 layers like Llama-3-8B
+    pytest.param((61, 256, 16, 1, 512), id="ds3"),         # DeepSeek-V3: 61 layers
+    pytest.param((80, 512, 16, 1, 512), id="llama3-70b"), # 80 layers like Llama-3-70B
+    pytest.param((2, 4, 1, 1, 512), id="edge"),           # tpb=1 edge case
+]
+MHA_SIZES = [
+    # Llama-3 scale: 32 layers, kv_heads=8, head_dim=128
+    pytest.param((4, 8, 16, 8, 128), id="llama3-mini"),
+    pytest.param((32, 64, 16, 8, 128), id="llama3-8b"),
+    pytest.param((80, 256, 16, 8, 128), id="llama3-70b"),
+    pytest.param((2, 4, 1, 8, 128), id="edge"),            # tpb=1 edge case
+    pytest.param((4, 4, 16, 16, 128), id="16head"),       # 16 heads variant
+]
+
+CPU_LAYOUTS = [
+    pytest.param("LAYERFIRST", id="lfirst"),
+    pytest.param("BLOCKFIRST", id="bfirst"),
+]
+
+ENGINES = [
+    pytest.param("cuda", False, id="cuda"),
+    pytest.param("ce", True, id="ce"),
+]
+
+MLA_MODES = ["sharded", "all_write", "rank0_only"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers (matching production code in worker.py / layerwise.py)
+# ---------------------------------------------------------------------------
+
+def make_layouts(num_layers, num_blocks, tpb, num_heads, head_dim,
+                 cpu_layout_name, is_mla, tp_size):
+    """Create GPU and CPU KVCacheLayout objects matching production conventions.
+
+    GPU: LAYERFIRST, per-rank heads for non-MLA.
+    CPU: specified layout, full heads.
+    For non-MLA + BLOCKFIRST: CPU strides use div_head(tp_size).
+
+    Returns (gpu_layout, cpu_layout, cpu_layout_tp, kv_dim, heads_per_rank).
+    """
+    kv_dim = 1 if is_mla else 2
+
+    # Non-MLA shards heads across TP ranks, so num_heads must be divisible by
+    # tp_size. This is guaranteed by MHA_SIZES (num_heads=8, tp_size=4) but we
+    # keep the assertion as a safety net against future config changes.
+    if not is_mla:
+        assert num_heads % tp_size == 0, \
+            f"non-MLA requires num_heads % tp_size == 0, got {num_heads} % {tp_size}"
+
+    heads_per_rank = num_heads if is_mla else num_heads // tp_size
+
+    gpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tpb, num_head=heads_per_rank,
+        head_size=head_dim, is_mla=is_mla)
+
+    cpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType[cpu_layout_name.upper()],
+        num_layer=num_layers, num_block=num_blocks,
+        tokens_per_block=tpb, num_head=num_heads,
+        head_size=head_dim, is_mla=is_mla)
+
+    if not is_mla and cpu_layout.type == KVCacheLayoutType.BLOCKFIRST:
+        cpu_layout_tp = cpu_layout.div_head(tp_size)
+    else:
+        cpu_layout_tp = cpu_layout
+
+    return gpu_layout, cpu_layout, cpu_layout_tp, kv_dim, heads_per_rank
+
+
+def make_gpu_tensors(num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim, device):
+    """Create contiguous GPU buffer: [num_layers, kv_dim, num_blocks, tpb, heads_per_rank, head_dim].
+
+    Returns list of per-layer tensor views (matching vLLM convention).
+    """
+    full = torch.zeros(
+        (num_layers, kv_dim, num_blocks, tpb, heads_per_rank, head_dim),
+        dtype=DTYPE, device=f"cuda:{device}")
+    return [full[i] for i in range(num_layers)]
+
+
+def make_cpu_tensor(cpu_layout, num_layers, total_blocks):
+    """Create pinned CPU tensor with the given total_blocks.
+
+    Rebuilds the layout with num_block=total_blocks so strides match the
+    actual allocation (needed for all_write where total = num_gpus * blocks).
+    """
+    layout = KVCacheLayout(
+        type=cpu_layout.type,
+        num_layer=num_layers, num_block=total_blocks,
+        tokens_per_block=cpu_layout.tokens_per_block,
+        num_head=cpu_layout.num_head, head_size=cpu_layout.head_size,
+        is_mla=cpu_layout.is_mla)
+    return torch.zeros(tuple(layout.kv_shape), dtype=DTYPE, pin_memory=True)
+
+
+def fill_gpu(gpu_tensors, gpu_id, num_layers, num_blocks, tpb, heads, hd, kv_dim):
+    """Fill GPU tensors with deterministic per-GPU pattern. K and V differ."""
+    for layer in range(num_layers):
+        dev = gpu_tensors[layer].device
+        kv = torch.arange(kv_dim, device=dev).view(kv_dim, 1, 1, 1, 1)
+        blk = torch.arange(num_blocks, device=dev).view(1, num_blocks, 1, 1, 1)
+        tok = torch.arange(tpb, device=dev).view(1, 1, tpb, 1, 1)
+        h = torch.arange(hd, device=dev).view(1, 1, 1, 1, hd)
+        vals = (gpu_id * 100000 + kv * 500000 + layer * 10000 +
+                blk * 1000 + tok * 10 + h) % 997
+        gpu_tensors[layer][:] = (vals / 997.0).to(DTYPE)
+
+
+def expected_val(gpu_id, layer, block, token, hd, kv_dim_idx=0):
+    """Expected value for (gpu_id, layer, block, token, hd, kv_dim_idx)."""
+    return float(((gpu_id * 100000 + kv_dim_idx * 500000 + layer * 10000 +
+                    block * 1000 + token * 10 + hd) % 997) / 997.0)
+
+
+def make_tp_group(cpu_ptr, all_gpu, num_gpus, gpu_layout, num_layers):
+    """Create TPTransferThreadGroup with strides from KVCacheLayout.
+
+    Matches production worker.py:472 exactly — chunk_size does NOT include kv_dim.
+    The C++ kernel iterates num_chunks = num_layers * kv_dim * num_blocks and
+    copies chunk_size bytes per chunk, so kv_dim is a separate iteration axis.
+    """
+    gpu_ptrs = []
+    for g in range(num_gpus):
+        for l in range(num_layers):
+            gpu_ptrs.append(all_gpu[g][l].data_ptr())
+    return TPTransferThreadGroup(
+        num_gpus=num_gpus, gpu_block_ptrs_flat=gpu_ptrs,
+        num_tensors_per_gpu=num_layers, cpu_blocks_ptr=cpu_ptr,
+        num_layers=num_layers,
+        gpu_kv_strides_in_bytes=[gpu_layout.get_kv_stride() * ES] * num_gpus,
+        gpu_block_strides_in_bytes=[gpu_layout.get_block_stride() * ES] * num_gpus,
+        gpu_layer_strides_in_bytes=[gpu_layout.get_layer_stride() * ES] * num_gpus,
+        gpu_chunk_sizes_in_bytes=[gpu_layout.get_chunk_size() * ES] * num_gpus,
+        gpu_device_ids=list(range(num_gpus)),
+        enable_nvcomp=False,
+    )
+
+
+def make_layerwise_group(cpu_ptr_unused, all_gpu, num_gpus, gpu_layout, num_layers):
+    """Create LayerwiseTransferGroup for H2D-only testing (no SSD, no eventfd).
+
+    Mirrors LayerwiseTransferWorker construction in layerwise.py. GPU chunk_size
+    does NOT include kv_dim (same as tp_group). SSD disabled via empty ssd_files;
+    eventfd disabled via empty layer_eventfds_tensor.
+    """
+    def strides_tensor(getter):
+        return torch.tensor([getter() * ES] * num_gpus, dtype=torch.int64)
+
+    return LayerwiseTransferGroup(
+        num_gpus=num_gpus,
+        gpu_blocks=all_gpu,
+        cpu_blocks=cpu_ptr_unused,  # actual pinned CPU tensor
+        ssd_files={},
+        num_layers=num_layers,
+        gpu_kv_strides_tensor=strides_tensor(gpu_layout.get_kv_stride),
+        gpu_block_strides_tensor=strides_tensor(gpu_layout.get_block_stride),
+        gpu_layer_strides_tensor=strides_tensor(gpu_layout.get_layer_stride),
+        gpu_chunk_sizes_tensor=strides_tensor(gpu_layout.get_chunk_size),
+        iouring_entries=0,
+        iouring_flags=0,
+        layer_eventfds_tensor=torch.empty(0, dtype=torch.int32),
+        tp_size=num_gpus,
+    )
+
+
+def block_ids(n):
+    """Create block-id tensor in PINNED host memory.
+
+    The CUDA kernel dereferences block-id arrays on the DEVICE (via UVA), so
+    pageable CPU tensors trigger 'illegal memory access'. Production uses
+    .pin_memory() (worker.py:173). Must match here.
+    """
+    return torch.arange(n, dtype=torch.int64).pin_memory()
+
+
+def sync_all(num_gpus):
+    for g in range(num_gpus):
+        torch.cuda.synchronize(g)
+
+
+def spot_check_gpu(all_gpu, expected_gpu_id, num_gpus, num_layers, num_blocks,
+                   tpb, hd, kv_dim, label=""):
+    """Spot-check a few GPU values for both K and V."""
+    for g in range(num_gpus):
+        for layer in [0, num_layers - 1]:
+            for block in [0, num_blocks - 1]:
+                for kv in range(kv_dim):
+                    for hd_idx in [0, hd - 1]:
+                        exp = expected_val(expected_gpu_id, layer, block, 0, hd_idx, kv)
+                        act = all_gpu[g][layer][kv, block, 0, 0, hd_idx].item()
+                        assert abs(act - exp) < 1e-3, \
+                            f"{label} mismatch: gpu={g} layer={layer} block={block} " \
+                            f"kv={kv} hd={hd_idx}: expected={exp:.6f} got={act:.6f}"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests (D2H -> clear GPU -> H2D -> verify)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("data_config", MHA_SIZES)
+@pytest.mark.parametrize("cpu_layout_name", CPU_LAYOUTS)
+@pytest.mark.parametrize("engine_name,use_ce", ENGINES)
+def test_non_mla_roundtrip(data_config, cpu_layout_name, engine_name, use_ce):
+    """Non-MLA round-trip: D2H -> clear GPU -> H2D -> verify per-rank data.
+
+    Non-MLA does NOT use mla_d2h_mode — the C++ else-branch uses
+    cpu_tp_stride to place each rank's head partition at a different
+    CPU offset. This tests the default TP-shard path.
+    """
+    skip_if_engine_unsupported(use_ce)
+    num_layers, num_blocks, tpb, num_heads, head_dim = data_config
+    num_gpus = NUM_GPUS
+    is_mla = False
+
+    gpu_layout, cpu_layout, cpu_layout_tp, kv_dim, heads_per_rank = make_layouts(
+        num_layers, num_blocks, tpb, num_heads, head_dim,
+        cpu_layout_name, is_mla, num_gpus)
+
+    all_gpu = [make_gpu_tensors(num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim, g)
+               for g in range(num_gpus)]
+
+    # Each rank owns a different head partition — fill with its own pattern.
+    for g in range(num_gpus):
+        fill_gpu(all_gpu[g], g, num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim)
+    sync_all(num_gpus)
+
+    cpu_kv = make_cpu_tensor(cpu_layout, num_layers, num_blocks)
+
+    tp = make_tp_group(cpu_kv.data_ptr(), all_gpu, num_gpus, gpu_layout, num_layers)
+    gpu_block_ids = block_ids(num_blocks)
+    cpu_block_ids = block_ids(num_blocks)
+
+    # D2H
+    tp.tp_group_transfer(
+        gpu_block_id_tensor=gpu_block_ids, cpu_block_id_tensor=cpu_block_ids,
+        cpu_kv_stride_in_bytes=cpu_layout_tp.get_kv_stride() * ES,
+        cpu_layer_stride_in_bytes=cpu_layout_tp.get_layer_stride() * ES,
+        cpu_block_stride_in_bytes=cpu_layout.get_block_stride() * ES,
+        cpu_tp_stride_in_bytes=cpu_layout.get_block_stride() * ES // num_gpus,
+        transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=use_ce,
+        layer_id=0, layer_granularity=num_layers, is_mla=False,
+        mla_d2h_mode="sharded",  # ignored for non-MLA
+    )
+    sync_all(num_gpus)
+
+    # Clear GPUs
+    for g in range(num_gpus):
+        for l in range(num_layers):
+            all_gpu[g][l].zero_()
+    sync_all(num_gpus)
+
+    # H2D
+    tp.tp_group_transfer(
+        gpu_block_id_tensor=gpu_block_ids, cpu_block_id_tensor=cpu_block_ids,
+        cpu_kv_stride_in_bytes=cpu_layout_tp.get_kv_stride() * ES,
+        cpu_layer_stride_in_bytes=cpu_layout_tp.get_layer_stride() * ES,
+        cpu_block_stride_in_bytes=cpu_layout.get_block_stride() * ES,
+        cpu_tp_stride_in_bytes=cpu_layout.get_block_stride() * ES // num_gpus,
+        transfer_num_cta=4, is_host_to_device=True, use_ce_transfer=use_ce,
+        layer_id=0, layer_granularity=num_layers, is_mla=False,
+        mla_d2h_mode="sharded",  # ignored for non-MLA
+    )
+    sync_all(num_gpus)
+
+    # Verify: each rank should have its own original data back.
+    for g in range(num_gpus):
+        for layer in [0, num_layers - 1]:
+            for block in [0, num_blocks - 1]:
+                for kv in range(kv_dim):
+                    for hd_idx in [0, head_dim - 1]:
+                        exp = expected_val(g, layer, block, 0, hd_idx, kv)
+                        act = all_gpu[g][layer][kv, block, 0, 0, hd_idx].item()
+                        assert abs(act - exp) < 1e-3, \
+                            f"Non-MLA round-trip mismatch: layout={cpu_layout_name} " \
+                            f"gpu={g} layer={layer} block={block} kv={kv} hd={hd_idx}: " \
+                            f"expected={exp:.6f} got={act:.6f}"
+
+    del tp
+
+
+# ---------------------------------------------------------------------------
+# MLA mode tests (sharded / all_write / rank0_only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("data_config", MLA_SIZES)
+@pytest.mark.parametrize("cpu_layout_name", CPU_LAYOUTS)
+@pytest.mark.parametrize("engine_name,use_ce", ENGINES)
+@pytest.mark.parametrize("mode", MLA_MODES)
+def test_mla_roundtrip_modes(data_config, cpu_layout_name, engine_name, use_ce, mode):
+    """MLA round-trip with each D2H mode. Verifies K and V."""
+    skip_if_engine_unsupported(use_ce)
+    num_layers, num_blocks, tpb, num_heads, head_dim = data_config
+    assert num_heads == 1, "MLA_SIZES must only contain num_heads=1 configs"
+
+    num_gpus = NUM_GPUS
+    is_mla = True
+
+    gpu_layout, cpu_layout, cpu_layout_tp, kv_dim, heads_per_rank = make_layouts(
+        num_layers, num_blocks, tpb, num_heads, head_dim,
+        cpu_layout_name, is_mla, num_gpus)
+
+    total_cpu_blocks = num_blocks * num_gpus if mode == "all_write" else num_blocks
+
+    all_gpu = [make_gpu_tensors(num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim, g)
+               for g in range(num_gpus)]
+
+    # MLA: all GPUs have identical data
+    fill_gpu(all_gpu[0], 0, num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim)
+    for g in range(1, num_gpus):
+        for l in range(num_layers):
+            all_gpu[g][l].copy_(all_gpu[0][l])
+    sync_all(num_gpus)
+
+    cpu_kv = make_cpu_tensor(cpu_layout, num_layers, total_cpu_blocks)
+
+    # For all_write the CPU holds N ranks' KV, so kv_stride/layer_stride must
+    # be computed from a layout with num_block=total_cpu_blocks (the per-block
+    # chunk is N*chunk wide). Rebuild a TP-stride layout accordingly.
+    if mode == "all_write":
+        cpu_layout_for_strides = KVCacheLayout(
+            type=cpu_layout.type,
+            num_layer=num_layers, num_block=total_cpu_blocks,
+            tokens_per_block=tpb, num_head=num_heads,
+            head_size=head_dim, is_mla=is_mla)
+        cpu_stride_kv = cpu_layout_for_strides.get_kv_stride() * ES
+        cpu_stride_layer = cpu_layout_for_strides.get_layer_stride() * ES
+    else:
+        cpu_stride_kv = cpu_layout_tp.get_kv_stride() * ES
+        cpu_stride_layer = cpu_layout_tp.get_layer_stride() * ES
+    # block_stride never depends on num_block; tp_stride derived from it.
+    cpu_stride_block = cpu_layout.get_block_stride() * ES
+    cpu_stride_tp = cpu_stride_block // num_gpus
+
+    tp = make_tp_group(cpu_kv.data_ptr(), all_gpu, num_gpus, gpu_layout, num_layers)
+    gpu_block_ids = block_ids(num_blocks)
+    cpu_block_ids = block_ids(num_blocks)
+
+    # D2H
+    tp.tp_group_transfer(
+        gpu_block_id_tensor=gpu_block_ids, cpu_block_id_tensor=cpu_block_ids,
+        cpu_kv_stride_in_bytes=cpu_stride_kv,
+        cpu_layer_stride_in_bytes=cpu_stride_layer,
+        cpu_block_stride_in_bytes=cpu_stride_block,
+        cpu_tp_stride_in_bytes=cpu_stride_tp,
+        transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=use_ce,
+        layer_id=0, layer_granularity=num_layers, is_mla=True,
+        mla_d2h_mode=mode,
+    )
+    sync_all(num_gpus)
+
+    # Clear GPUs
+    for g in range(num_gpus):
+        for l in range(num_layers):
+            all_gpu[g][l].zero_()
+    sync_all(num_gpus)
+
+    # H2D
+    tp.tp_group_transfer(
+        gpu_block_id_tensor=gpu_block_ids, cpu_block_id_tensor=cpu_block_ids,
+        cpu_kv_stride_in_bytes=cpu_stride_kv,
+        cpu_layer_stride_in_bytes=cpu_stride_layer,
+        cpu_block_stride_in_bytes=cpu_stride_block,
+        cpu_tp_stride_in_bytes=cpu_stride_tp,
+        transfer_num_cta=4, is_host_to_device=True, use_ce_transfer=use_ce,
+        layer_id=0, layer_granularity=num_layers, is_mla=True,
+        mla_d2h_mode=mode,
+    )
+    sync_all(num_gpus)
+
+    # Verify: all GPUs should have GPU 0's original data
+    spot_check_gpu(all_gpu, 0, num_gpus, num_layers, num_blocks,
+                   tpb, head_dim, kv_dim, label=f"mode={mode}")
+
+    del tp
+
+
+# ---------------------------------------------------------------------------
+# Invalid mode fallback test
+# ---------------------------------------------------------------------------
+
+def test_invalid_mode_fallback():
+    """Invalid mla_d2h_mode falls back to 'sharded' without crash."""
+    skip_if_engine_unsupported(use_ce=False)
+    num_layers, num_blocks, tpb, num_heads, head_dim = 4, 8, 16, 1, 128
+    num_gpus = NUM_GPUS
+
+    gpu_layout, cpu_layout, cpu_layout_tp, kv_dim, heads_per_rank = make_layouts(
+        num_layers, num_blocks, tpb, num_heads, head_dim,
+        "LAYERFIRST", True, num_gpus)
+
+    all_gpu = [make_gpu_tensors(num_layers, num_blocks, tpb, 1, head_dim, kv_dim, g)
+               for g in range(num_gpus)]
+    fill_gpu(all_gpu[0], 0, num_layers, num_blocks, tpb, 1, head_dim, kv_dim)
+    for g in range(1, num_gpus):
+        for l in range(num_layers):
+            all_gpu[g][l].copy_(all_gpu[0][l])
+    sync_all(num_gpus)
+
+    cpu_kv = make_cpu_tensor(cpu_layout, num_layers, num_blocks)
+    tp = make_tp_group(cpu_kv.data_ptr(), all_gpu, num_gpus, gpu_layout, num_layers)
+
+    gpu_block_ids = block_ids(num_blocks)
+    cpu_block_ids = block_ids(num_blocks)
+
+    tp.tp_group_transfer(
+        gpu_block_id_tensor=gpu_block_ids, cpu_block_id_tensor=cpu_block_ids,
+        cpu_kv_stride_in_bytes=cpu_layout_tp.get_kv_stride() * ES,
+        cpu_layer_stride_in_bytes=cpu_layout_tp.get_layer_stride() * ES,
+        cpu_block_stride_in_bytes=cpu_layout.get_block_stride() * ES,
+        cpu_tp_stride_in_bytes=cpu_layout.get_block_stride() * ES // num_gpus,
+        transfer_num_cta=4, is_host_to_device=False, use_ce_transfer=False,
+        layer_id=0, layer_granularity=num_layers, is_mla=True,
+        mla_d2h_mode="invalid_xyz",
+    )
+    sync_all(num_gpus)
+
+    # Should behave like sharded — just verify no crash
+    del tp
+
+
+# ---------------------------------------------------------------------------
+# Layerwise H2D test (via LayerwiseTransferGroup::layerwise_transfer)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
# Introduce configurable MLA D2H transfer modes (sharded/all_write/rank0_only)

## Summary

Adds a new `FLEXKV_MLA_D2H_MODE` environment variable that controls how MLA (Multi-head Latent Attention) KV cache is transferred between GPU and CPU during offload/reload. Previously only the default `sharded` behavior was available.

### Three modes

| Mode | D2H behavior | H2D behavior | D2H volume | Best for |
|------|-------------|-------------|------------|----------|
| `sharded` | Each TP rank writes its 1/N shard | Each rank reads full KV from shared buffer | 1×KV (split) | Default, balanced |
| `all_write` | Each rank writes full KV to its own slot | Each rank reads its own copy | N×KV | Redundancy, isolated reads |
| `rank0_only` | Only rank0 writes, others skip | Each rank reads full KV from rank0's slot | 1×KV (single source) | PCIe-bottlenecked systems |

### Usage

```bash
# Default (sharded)
export FLEXKV_MLA_D2H_MODE=sharded

# Each rank writes full KV
export FLEXKV_MLA_D2H_MODE=all_write

# Only rank0 writes
export FLEXKV_MLA_D2H_MODE=rank0_only
```

Invalid / unset value falls back to `sharded`.

---

## Benchmark results

Configuration: 8× H20 GPUs, PCIe topology (no NVLink for GPU↔CPU path), fp16, D2H+H2D round-trip, 10 iterations.

### Size: large (80 layers, 8192 blocks, hd=512, ~640 MB)

#### CUDA kernel engine

| Engine | Layout | Strategy | Avg (ms) |
|--------|--------|----------|---------:|
| CUDA | lfirst | MHA | 119.96 |
| CUDA | lfirst | MLA-sharded | 39.79 |
| CUDA | lfirst | MLA-all_write | 62.85 |
| CUDA | lfirst | MLA-rank0_only | 47.92 |
| CUDA | bfirst | MHA | 120.90 |
| CUDA | bfirst | MLA-sharded | 38.87 |
| CUDA | bfirst | MLA-all_write | 62.04 |
| CUDA | bfirst | MLA-rank0_only | 47.05 |

#### CE (Copy Engine) engine

| Engine | Layout | Strategy | Avg (ms) |
|--------|--------|----------|---------:|
| CE | lfirst | MHA | 12993.95 |
| CE | lfirst | MLA-sharded | 5527.08 |
| CE | lfirst | MLA-all_write | 5796.98 |
| CE | lfirst | MLA-rank0_only | 3790.51 |
| CE | bfirst | MHA | 12060.80 |
| CE | bfirst | MLA-sharded | 5690.22 |
| CE | bfirst | MLA-all_write | 6014.44 |
| CE | bfirst | MLA-rank0_only | 4155.45 |

---

## Key findings

### 1. `sharded` is fastest on CUDA kernel

CUDA kernel transfers are short and contention overhead dominates when N ranks issue concurrent DMA. `sharded` wins because each rank writes a small shard and the transfer is so short that overhead is minimal.

- CUDA best: `MLA-sharded + bfirst` = 38.87ms

### 2. `rank0_only` is fastest on CE

CE transfers are long (seconds), and the single-source DMA from rank0 avoids PCIe upstream contention from N concurrent writers.

- CE best: `MLA-rank0_only + lfirst` = 3790.51ms
- vs `MLA-sharded + lfirst` = 5527.08ms → **1.46× faster**

### 3. Layout (lfirst vs bfirst) has minor impact

Within the same engine+mode, the layout difference is typically <10%. Choose based on other system constraints (e.g., CPU-side access patterns during layerwise offload).

---

## Recommendation

| Engine | Best MLA mode | Best layout | Avg (ms) |
|--------|---------------|-------------|---------:|
| CUDA kernel | `sharded` | bfirst | 38.87 |
| CE | `rank0_only` | lfirst | 3790.51 |

> **Note**: Results are hardware-dependent (PCIe topology, GPU model, NVLink availability). Always re-benchmark on the target deployment machine. On NVLink-full-mesh systems (e.g., DGX), `sharded` contention is expected to diminish and the ranking may shift.
