### PR TITLE
feat(swa): add SWA hit/miss telemetry

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -2029,7 +2029,27 @@ class GlobalCacheEngine:
             ssd_full_hit_blocks=full_hit_blocks,
             remote_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load)
-        return full_hit_blocks, swa_match.best_hit_blocks
+        swa_hit_blocks = swa_match.best_hit_blocks
+
+        # SWA hit/miss telemetry (peer of the Full-KV record_cache_hit/miss above).
+        # SWA is a subset of Full, so the reusable Full-KV prefix (full_hit_blocks)
+        # is the denominator: the trailing-SWA prefix we reused is the hit, and the
+        # remaining reusable Full-KV prefix that had no matching SWA window is the
+        # miss. hit / full_hit is the SWA reuse rate — the signal that regresses if
+        # SWA-LRU eviction degrades (e.g. toward FIFO), which is otherwise invisible.
+        if self._metrics_collector is not None and swa_hit_blocks > 0:
+            # Attribute the hit to the winning tier (data-plane sources CPU>SSD>REMOTE).
+            if swa_match.cpu_hit_blocks == swa_hit_blocks:
+                swa_device = "cpu"
+            elif swa_match.ssd_hit_blocks == swa_hit_blocks:
+                swa_device = "ssd"
+            else:
+                swa_device = "remote"
+            self._metrics_collector.record_swa_hit(swa_device, swa_hit_blocks)
+        if self._metrics_collector is not None:
+            self._metrics_collector.record_swa_miss(full_hit_blocks - swa_hit_blocks)
+
+        return full_hit_blocks, swa_hit_blocks
 
     # --- SWA slot sources for the get()/put() build chains --------------------
     # Resolve the per-tier SWA-pool slot ids for the current request so the SWA

--- a/flexkv/metrics/collector.py
+++ b/flexkv/metrics/collector.py
@@ -104,6 +104,8 @@ class FlexKVMetricsCollector:
     This collector provides cache engine metrics for GlobalCacheEngine:
     - flexkv_py_cache_hit_blocks_total: Cache hit block counts by device
     - flexkv_py_cache_miss_blocks_total: Cache miss block counts (not found in any cache level)
+    - flexkv_py_swa_hit_blocks_total: SWA hit block counts by device (reused from SWA pool)
+    - flexkv_py_swa_miss_blocks_total: SWA miss block counts (Full-KV hit without a matching SWA window)
     - flexkv_py_transfer_blocks_total: Transfer block counts by transfer type and operation
     - flexkv_py_transfer_ops_total: Transfer operation counts by transfer type and operation
     - flexkv_py_mempool_total_blocks: Memory pool total blocks by device
@@ -158,6 +160,24 @@ class FlexKVMetricsCollector:
         self.cache_miss_blocks_total = Counter(
             name="flexkv_py_cache_miss_blocks_total",
             documentation="Total number of cache miss blocks (not found in any cache level)",
+        )
+
+        # SWA (Sliding Window Attention) hit/miss counters. The SWA hit is the
+        # trailing-window prefix reused from the node-mounted SWA pool, clamped to
+        # the Full-KV hit (SWA subset of Full). Peer of the cache hit/miss counters
+        # above; without these the SWA-LRU reuse rate is unobservable, so a policy
+        # regression (e.g. SWA-LRU degrading toward FIFO) would be invisible.
+        self.swa_hit_blocks_total = Counter(
+            name="flexkv_py_swa_hit_blocks_total",
+            documentation="Total number of SWA hit blocks reused from the SWA pool by device",
+            labelnames=["device"],
+        )
+
+        # SWA miss counter (no device label - miss means the reusable Full-KV prefix
+        # had no matching SWA window on any tier).
+        self.swa_miss_blocks_total = Counter(
+            name="flexkv_py_swa_miss_blocks_total",
+            documentation="Total number of SWA miss blocks (Full-KV hit without a matching SWA window)",
         )
         
         # Allocation failure counter by mode (global/local)
@@ -229,6 +249,8 @@ class FlexKVMetricsCollector:
         # Cache engine dummy metrics
         self.cache_hit_blocks_total = dummy
         self.cache_miss_blocks_total = dummy
+        self.swa_hit_blocks_total = dummy
+        self.swa_miss_blocks_total = dummy
         self.allocation_failures_total = dummy
         self.transfer_blocks_total = dummy
         self.transfer_ops_total = dummy
@@ -256,13 +278,41 @@ class FlexKVMetricsCollector:
     def record_cache_miss(self, num_blocks: int):
         """
         Record cache miss blocks (not found in any cache level).
-        
+
         Args:
             num_blocks: Number of miss blocks
         """
         if not self.enabled or num_blocks <= 0:
             return
         self.cache_miss_blocks_total.inc(num_blocks)
+
+    def record_swa_hit(self, device: str, num_blocks: int):
+        """
+        Record SWA hit blocks for a device.
+
+        A SWA hit is the trailing-window prefix reused from the node-mounted SWA
+        pool on the given tier, clamped to that tier's Full-KV hit (SWA subset of
+        Full). Peer of :meth:`record_cache_hit`.
+
+        Args:
+            device: Device type ("cpu", "ssd", "remote")
+            num_blocks: Number of SWA hit blocks
+        """
+        if not self.enabled or num_blocks <= 0:
+            return
+        self.swa_hit_blocks_total.labels(device=device).inc(num_blocks)
+
+    def record_swa_miss(self, num_blocks: int):
+        """
+        Record SWA miss blocks (reusable Full-KV prefix without a matching SWA
+        window on any tier). Peer of :meth:`record_cache_miss`.
+
+        Args:
+            num_blocks: Number of SWA miss blocks
+        """
+        if not self.enabled or num_blocks <= 0:
+            return
+        self.swa_miss_blocks_total.inc(num_blocks)
     
     def record_allocation_failure(self, mode: str):
         """

--- a/tests/test_swa_metrics.py
+++ b/tests/test_swa_metrics.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SWA hit/miss telemetry on FlexKVMetricsCollector.
+
+Pure-logic coverage (no torch / GPU / prometheus_client needed): asserts the
+record_swa_hit / record_swa_miss methods gate on ``enabled`` and non-positive
+counts exactly like their Full-KV peers (record_cache_hit / record_cache_miss),
+and route to the right counter with the right device label.
+
+Why this matters: without a SWA reuse-rate signal, an SWA-LRU eviction regression
+(e.g. the list degrading toward FIFO because a hit never re-promotes the node to
+MRU) is invisible in production — no gauge would ever move. These counters are the
+denominator/numerator of that signal, so the recording contract is worth pinning.
+The swa_align emission path itself needs a GlobalCacheEngine (CUDA) and is covered
+by the e2e control-plane test; here we pin the collector contract.
+"""
+import pytest
+
+from flexkv.metrics.collector import FlexKVMetricsCollector
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCounter:
+    """Minimal Counter stand-in: records .labels()/.inc() calls.
+
+    Mirrors the prometheus_client Counter surface the collector uses so the test
+    is independent of whether prometheus_client is installed.
+    """
+
+    def __init__(self):
+        self.total = 0.0
+        self.by_label = {}
+        self._pending_label = None
+
+    def labels(self, **kwargs):
+        # single-label counters here: device=...
+        self._pending_label = tuple(sorted(kwargs.items()))
+        return self
+
+    def inc(self, amount=1):
+        if self._pending_label is not None:
+            self.by_label[self._pending_label] = (
+                self.by_label.get(self._pending_label, 0.0) + amount)
+            self._pending_label = None
+        else:
+            self.total += amount
+
+
+def _make_collector(enabled: bool) -> FlexKVMetricsCollector:
+    """Build a collector without touching the metrics server / prometheus, then
+    swap in fake counters so we can inspect calls. Bypasses __init__ (which would
+    try to auto-start the metrics server)."""
+    c = FlexKVMetricsCollector.__new__(FlexKVMetricsCollector)
+    c.enabled = enabled
+    c.swa_hit_blocks_total = _FakeCounter()
+    c.swa_miss_blocks_total = _FakeCounter()
+    return c
+
+
+def test_record_swa_hit_increments_by_device():
+    c = _make_collector(enabled=True)
+    c.record_swa_hit("cpu", 3)
+    c.record_swa_hit("cpu", 2)
+    c.record_swa_hit("ssd", 4)
+    assert c.swa_hit_blocks_total.by_label[(("device", "cpu"),)] == 5
+    assert c.swa_hit_blocks_total.by_label[(("device", "ssd"),)] == 4
+
+
+def test_record_swa_miss_increments_total():
+    c = _make_collector(enabled=True)
+    c.record_swa_miss(7)
+    c.record_swa_miss(1)
+    assert c.swa_miss_blocks_total.total == 8
+
+
+@pytest.mark.parametrize("num_blocks", [0, -1, -100])
+def test_non_positive_counts_are_noops(num_blocks):
+    c = _make_collector(enabled=True)
+    c.record_swa_hit("cpu", num_blocks)
+    c.record_swa_miss(num_blocks)
+    assert c.swa_hit_blocks_total.by_label == {}
+    assert c.swa_miss_blocks_total.total == 0.0
+
+
+def test_disabled_collector_records_nothing():
+    c = _make_collector(enabled=False)
+    c.record_swa_hit("cpu", 5)
+    c.record_swa_miss(5)
+    assert c.swa_hit_blocks_total.by_label == {}
+    assert c.swa_miss_blocks_total.total == 0.0
+
+
+def test_dummy_metrics_have_swa_attributes():
+    """When prometheus is unavailable the collector installs dummy metrics; the
+    SWA counters must be among them so record_swa_* never AttributeErrors."""
+    c = FlexKVMetricsCollector.__new__(FlexKVMetricsCollector)
+    c._init_dummy_metrics()
+    assert hasattr(c, "swa_hit_blocks_total")
+    assert hasattr(c, "swa_miss_blocks_total")
+    # dummy .labels().inc() must be a no-op that does not raise
+    c.swa_hit_blocks_total.labels(device="cpu").inc(3)
+    c.swa_miss_blocks_total.inc(3)


### PR DESCRIPTION
observing what would otherwise be an invisible policy regression.

## 背景
node-mount SWA pool 此前**没有命中率可观测性**：Full-KV 匹配会发 `FLEXKV_CACHE_HIT/MISS`，但 SWA 复用完全没有埋点。后果很实际——如果 SWA-LRU 驱逐策略退化（例如因为命中时从不把节点重新提升到 MRU 端，链表退化成 FIFO），命中率下降在生产里**没有任何指标能反映**，问题会一直隐形。

这是 SWA 可观测性缺口的修复（LRU-on-match 提升本身由同事在另一个改动里处理；本 MR 只补指标，让那类退化**可见**）。

## 改动
新增两个与 Full-KV 对等的 counter，并在**唯一的 SWA 匹配决策点**发出：

- `flexkv_py_swa_hit_blocks_total{device}`：从 SWA pool 复用的尾窗前缀块数，按命中的 tier（CPU>SSD>REMOTE，对齐数据面取源优先级）打 label。
- `flexkv_py_swa_miss_blocks_total`：可复用的 Full-KV 前缀里、没有对应 SWA 窗口的部分（分母 = `full_hit_blocks`，因为 SWA ⊆ Full）。

二者之和 = Full-KV 命中，`hit / full_hit` 即 SWA 复用率——正是策略退化时会掉的信号。

## 埋点位置
`GlobalCacheEngine.swa_align`——SWA 复用决策**唯一**落地的地方，经 `kvtask.get_match_swa` 同时覆盖进程内模式与 server 模式，无重复计数。**不在** `match_swa`（`swa_align` 内部的 probe）里发，避免把探测但未使用的节点误记为命中。

## 测试
`tests/test_swa_metrics.py`（`@pytest.mark.unit`，纯逻辑、无需 torch/GPU/prometheus）钉住 collector 契约：enabled 门控、非正数 no-op、device 路由、prometheus 缺席时 dummy 指标齐全。已在远端 torch 环境对真实 `collector.py` 逻辑跑通（5/5 通过，`PROMETHEUS_AVAILABLE=False` 时 dummy 路径也覆盖）。`swa_align` 发射路径需 `GlobalCacheEngine`（CUDA），由 e2e 控制面测试覆盖。