### PR TITLE
fix(swa): make SWA match update SWA LRU list, full-KV evict tombstone cascade, and reuse Full-KV match

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -721,6 +721,8 @@ PYBIND11_MODULE(c_ext, m) {
       // ===== SWA node-mount: store-side mount + SWA-only eviction =====
       .def("set_swa", &flexkv::CRadixTreeIndex::set_swa, py::arg("node"),
            py::arg("slot"))
+      .def("promote_swa", &flexkv::CRadixTreeIndex::promote_swa,
+           py::arg("node"))
       .def("evict_swa", &flexkv::CRadixTreeIndex::evict_swa,
            py::arg("evicted_full_blocks"), py::arg("num_swa_evicted"),
            py::call_guard<py::gil_scoped_release>())

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -2,44 +2,47 @@
 #include <deque>
 #include <errno.h>
 #include <memory>
+#include <optional>
 #include <torch/extension.h>
 #include <type_traits>
-#include <optional>
 
 #include "cache_utils.h"
-#include "radix_tree.h"
 #include "monitoring/metrics_manager.h"
+#include "radix_tree.h"
 
 namespace flexkv {
 
-// Helper function matching Python's get_hash with boundary check and _has_hashes branch
-// Returns std::nullopt if block_id is out of bounds (like Python returning None)
-// If has_hashes is true, reads from block_hashes_ptr; otherwise computes from token_ids
-static std::optional<HashType> get_hash_safe(
-    int64_t *block_hashes_ptr, 
-    int64_t *token_ids_ptr,  // Can be nullptr if has_hashes is true
-    int block_id, 
-    int num_blocks,
-    bool has_hashes,
-    int tokens_per_block) {
+// Helper function matching Python's get_hash with boundary check and
+// _has_hashes branch Returns std::nullopt if block_id is out of bounds (like
+// Python returning None) If has_hashes is true, reads from block_hashes_ptr;
+// otherwise computes from token_ids
+static std::optional<HashType>
+get_hash_safe(int64_t *block_hashes_ptr,
+              int64_t *token_ids_ptr, // Can be nullptr if has_hashes is true
+              int block_id, int num_blocks, bool has_hashes,
+              int tokens_per_block) {
   if (block_id >= num_blocks) {
-    return std::nullopt;  // Out of bounds, return None (similar to Python)
+    return std::nullopt; // Out of bounds, return None (similar to Python)
   }
-  
+
   if (has_hashes) {
-    // Read from pre-computed block_hashes (matching Python: if self._has_hashes)
+    // Read from pre-computed block_hashes (matching Python: if
+    // self._has_hashes)
     return HashType(block_hashes_ptr[block_id]);
   } else {
-    // Compute hash from token_ids (matching Python: hash_array(self.token_ids[...]))
+    // Compute hash from token_ids (matching Python:
+    // hash_array(self.token_ids[...]))
     if (token_ids_ptr == nullptr) {
       // Cannot compute without token_ids, return nullopt
       return std::nullopt;
     }
     // Compute hash for tokens up to (block_id+1)*tokens_per_block
-    // Matching Python: hash_array(self.token_ids[:(block_id+1)*self.tokens_per_block])
+    // Matching Python:
+    // hash_array(self.token_ids[:(block_id+1)*self.tokens_per_block])
     Hasher hasher;
-    hasher.reset();  // Reset hasher (matching Python's _HASHER.reset())
-    hasher.update(token_ids_ptr, (block_id + 1) * tokens_per_block * sizeof(int64_t));
+    hasher.reset(); // Reset hasher (matching Python's _HASHER.reset())
+    hasher.update(token_ids_ptr,
+                  (block_id + 1) * tokens_per_block * sizeof(int64_t));
     return hasher.digest();
   }
 }
@@ -47,43 +50,44 @@ static std::optional<HashType> get_hash_safe(
 bool CRadixNode::Compare::operator()(CRadixNode *a, CRadixNode *b) {
   auto policy = a->get_index()->get_eviction_policy();
   switch (policy) {
-    case EvictionPolicy::LRU:
-      return a->get_time() > b->get_time();
-    case EvictionPolicy::LFU:
-      if (a->get_hit_count() != b->get_hit_count()) {
-        return a->get_hit_count() > b->get_hit_count();
-      }
-      return a->get_last_access_time() > b->get_last_access_time();
-    case EvictionPolicy::FIFO:
-      return a->get_creation_time() > b->get_creation_time();
-    case EvictionPolicy::MRU:
-      return a->get_last_access_time() < b->get_last_access_time();
-    case EvictionPolicy::FILO:
-      return a->get_creation_time() < b->get_creation_time();
-    default:
-      return a->get_time() > b->get_time();
+  case EvictionPolicy::LRU:
+    return a->get_time() > b->get_time();
+  case EvictionPolicy::LFU:
+    if (a->get_hit_count() != b->get_hit_count()) {
+      return a->get_hit_count() > b->get_hit_count();
+    }
+    return a->get_last_access_time() > b->get_last_access_time();
+  case EvictionPolicy::FIFO:
+    return a->get_creation_time() > b->get_creation_time();
+  case EvictionPolicy::MRU:
+    return a->get_last_access_time() < b->get_last_access_time();
+  case EvictionPolicy::FILO:
+    return a->get_creation_time() < b->get_creation_time();
+  default:
+    return a->get_time() > b->get_time();
   }
 }
 
 double CRadixNode::get_priority() {
   auto policy = index->get_eviction_policy();
   switch (policy) {
-    case EvictionPolicy::LRU:
-      return (double)grace_time;
-    case EvictionPolicy::LFU:
-      return (double)hit_count;
-    case EvictionPolicy::FIFO:
-      return (double)creation_time;
-    case EvictionPolicy::MRU:
-      return -(double)last_access_time;
-    case EvictionPolicy::FILO:
-      return -(double)creation_time;
-    default:
-      return (double)grace_time;
+  case EvictionPolicy::LRU:
+    return (double)grace_time;
+  case EvictionPolicy::LFU:
+    return (double)hit_count;
+  case EvictionPolicy::FIFO:
+    return (double)creation_time;
+  case EvictionPolicy::MRU:
+    return -(double)last_access_time;
+  case EvictionPolicy::FILO:
+    return -(double)creation_time;
+  default:
+    return (double)grace_time;
   }
 }
 
-CRadixNode::CRadixNode(CRadixTreeIndex *index, bool ready, int lock_cnt, bool enable_block_node_ids) {
+CRadixNode::CRadixNode(CRadixTreeIndex *index, bool ready, int lock_cnt,
+                       bool enable_block_node_ids) {
   assert(index != nullptr);
 
   this->on_leaf = false;
@@ -118,7 +122,8 @@ CRadixNode::~CRadixNode() {
     delete block_node_ids;
   }
   if (lease_meta != nullptr) {
-    // Avoid returning to pool during teardown to prevent double-free on shutdown
+    // Avoid returning to pool during teardown to prevent double-free on
+    // shutdown
     lease_meta = nullptr;
   }
   index->dec_node_count();
@@ -148,7 +153,8 @@ CRadixNode *CRadixNode::split(int prefix_length) {
   if (enable_block_node_ids) {
     auto old_ids = get_block_node_ids();
     auto new_ids = new_node->get_block_node_ids();
-    new_ids->insert(new_ids->end(), old_ids->cbegin(), old_ids->cbegin() + prefix_length);
+    new_ids->insert(new_ids->end(), old_ids->cbegin(),
+                    old_ids->cbegin() + prefix_length);
     // Erase the moved range from the original deque
     old_ids->erase(old_ids->begin(), old_ids->begin() + prefix_length);
   }
@@ -188,18 +194,21 @@ void CRadixNode::merge_child() {
                          child->get_physical_blocks().cend());
 
   set_time(std::max(get_time(), child->get_time()));
-  set_last_access_time(std::max(get_last_access_time(), child->get_last_access_time()));
+  set_last_access_time(
+      std::max(get_last_access_time(), child->get_last_access_time()));
   set_creation_time(std::min(get_creation_time(), child->get_creation_time()));
   set_hit_count(std::max(get_hit_count(), child->get_hit_count()));
   if (block_node_ids != nullptr) {
-    block_node_ids->insert(block_node_ids->end(), child->get_block_node_ids()->cbegin(),
-           child->get_block_node_ids()->cend());
+    block_node_ids->insert(block_node_ids->end(),
+                           child->get_block_node_ids()->cbegin(),
+                           child->get_block_node_ids()->cend());
   }
   if (lease_meta != nullptr) {
     auto child_lm = child->get_lease_meta();
     if (child_lm != nullptr) {
       lease_meta->state = child_lm->state;
-      lease_meta->lease_time = std::min(lease_meta->lease_time, child_lm->lease_time);
+      lease_meta->lease_time =
+          std::min(lease_meta->lease_time, child_lm->lease_time);
     }
   }
   children.clear();
@@ -209,14 +218,14 @@ void CRadixNode::merge_child() {
   // parent's own (now-stale) SWA, then move the child's SWA onto `this`. The
   // child is about to be deleted, so unthread it from the SWA-LRU without
   // buffering its slot for release (the slot is being kept, not freed).
-  index->record_freed_swa_slot(this);            // release parent's old SWA (if any)
+  index->record_freed_swa_slot(this); // release parent's old SWA (if any)
   int child_slot = child->get_swa_host_slot();
   if (child_slot != -1) {
-    index->swa_lru_remove(child);                // detach child from SWA-LRU
-    child->set_swa_host_slot(-1);                // child no longer owns it
+    index->swa_lru_remove(child); // detach child from SWA-LRU
+    child->set_swa_host_slot(-1); // child no longer owns it
     child->set_swa_tombstone(true);
     if (!index->is_root(this)) {
-      index->set_swa(this, child_slot);          // remount on the merged node
+      index->set_swa(this, child_slot); // remount on the merged node
     } else {
       // root cannot carry SWA; free the slot rather than leak it.
       index->buffer_freed_swa_slot(child_slot);
@@ -228,7 +237,8 @@ void CRadixNode::merge_child() {
   index->remove_node(child);
 }
 
-std::pair<std::deque<int64_t>*, std::deque<HashType>*> CRadixNode::shrink(int length) {
+std::pair<std::deque<int64_t> *, std::deque<HashType> *>
+CRadixNode::shrink(int length) {
   assert(length < size());
   assert(length > 0);
   assert(is_leaf());
@@ -250,13 +260,14 @@ std::pair<std::deque<int64_t>*, std::deque<HashType>*> CRadixNode::shrink(int le
   physical_blocks.erase(physical_blocks.begin() + remaining_length,
                         physical_blocks.end());
   if (block_node_ids != nullptr) {
-    block_node_ids->erase(block_node_ids->begin() + remaining_length, block_node_ids->end());
+    block_node_ids->erase(block_node_ids->begin() + remaining_length,
+                          block_node_ids->end());
   }
 
   return {shrink_blocks, shrink_hashes};
 }
 
-std::deque<int64_t>* CRadixNode::shrink_simple(int length) {
+std::deque<int64_t> *CRadixNode::shrink_simple(int length) {
   assert(length < size());
   assert(length > 0);
   assert(is_leaf());
@@ -274,7 +285,8 @@ std::deque<int64_t>* CRadixNode::shrink_simple(int length) {
   physical_blocks.erase(physical_blocks.begin() + remaining_length,
                         physical_blocks.end());
   if (block_node_ids != nullptr) {
-    block_node_ids->erase(block_node_ids->begin() + remaining_length, block_node_ids->end());
+    block_node_ids->erase(block_node_ids->begin() + remaining_length,
+                          block_node_ids->end());
   }
 
   return shrink_blocks;
@@ -343,18 +355,80 @@ CRadixNode *CRadixTreeIndex::insert(torch::Tensor &physical_block_ids,
   return new_node;
 }
 
+// Detach a leaf: remove it from its parent, collect its full blocks (+ hashes
+// when out_hashes != nullptr), release any SWA slot, unlink from leaf/node
+// lists. Returns the parent. Shared by evict() and evict_swa().
+CRadixNode *
+CRadixTreeIndex::detach_leaf_collect(CRadixNode *node,
+                                     std::vector<int64_t> &out_blocks,
+                                     std::vector<int64_t> *out_hashes) {
+  auto parent = node->get_parent();
+  assert(parent != nullptr);
+  parent->remove_child(node->get_head_hash());
+  auto &blocks = node->get_physical_blocks();
+  for (auto b : blocks) {
+    out_blocks.push_back(b);
+  }
+  if (out_hashes != nullptr) {
+    auto &hashes = node->get_block_hashes();
+    for (auto h : hashes) {
+      out_hashes->push_back(h);
+    }
+  }
+  // SWA: node is being deleted; release its slot if any so it is not leaked.
+  record_freed_swa_slot(node);
+  node->clear_parent();
+  remove_leaf(node);
+  remove_node(node);
+  return parent;
+}
+
+// Walk up from `parent`, deleting each ancestor that is a meaningless tombstone
+// leaf (leaf && swa_tombstone && lock_cnt==0 && ready) — invariant I2. Freed
+// blocks/hashes append to out_blocks/out_hashes. Returns the last surviving
+// ancestor (still-internal node, locked node, non-tombstone leaf, or root) so
+// the caller can reconsider it. Caller gates the SWA-enabled decision.
+CRadixNode *CRadixTreeIndex::cascade_delete_tombstone_leaves(
+    CRadixNode *parent, std::vector<int64_t> &out_blocks,
+    std::vector<int64_t> *out_hashes) {
+  if (parent != nullptr && parent->is_leaf() && !is_root(parent)) {
+    add_leaf(parent);
+  }
+  while (parent != nullptr && !is_root(parent) && parent->is_leaf() &&
+         parent->get_swa_tombstone() && parent->get_lock_cnt() == 0 &&
+         parent->is_ready()) {
+    CRadixNode *grandparent = parent->get_parent();
+    parent = detach_leaf_collect(parent, out_blocks, out_hashes);
+    parent = grandparent;
+    if (parent != nullptr && parent->is_leaf() && !is_root(parent)) {
+      add_leaf(parent);
+    }
+  }
+  return parent;
+}
+
 int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, int num_evicted) {
-  auto options = torch::TensorOptions().dtype(torch::kInt64).device(evicted_blocks.device());
+  auto options = torch::TensorOptions()
+                     .dtype(torch::kInt64)
+                     .device(evicted_blocks.device());
   torch::Tensor dummy_hashes = torch::empty({num_evicted}, options);
   return evict(evicted_blocks, dummy_hashes, num_evicted);
 }
 
-int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted_block_hashes, int num_evicted) {
-  int64_t *evicted_blocks_ptr = evicted_blocks.data_ptr<int64_t>();
-  int64_t *evicted_block_hashes_ptr = evicted_block_hashes.data_ptr<int64_t>();
-  int has_evicted = 0;
+int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks,
+                           torch::Tensor &evicted_block_hashes,
+                           int num_evicted) {
+  // Accumulate ALL freed blocks/hashes in vectors (primary eviction + any I2
+  // tombstone cascade that overflows num_evicted), then resize_ the output
+  // tensors at the end — the cascade can free ancestors beyond num_evicted, so
+  // the pre-sized fixed buffer can no longer be indexed directly (mirrors the
+  // evict_swa() pattern).
+  std::vector<int64_t> freed_blocks;
+  std::vector<int64_t> freed_hashes;
+  int has_evicted = 0; // counts only the primary (num_evicted-bounded) blocks
 
-  // Optimization: Batch build the priority queue to reduce overhead from O(N log N) to O(N)
+  // Optimization: Batch build the priority queue to reduce overhead from O(N
+  // log N) to O(N)
   std::vector<CRadixNode *> candidates;
   candidates.reserve(leaf_list.size());
   for (auto node : leaf_list) {
@@ -373,56 +447,57 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted
 
     if (node->size() > num_evicted - has_evicted) {
       auto [blocks, block_hashes] = node->shrink(num_evicted - has_evicted);
-      auto _has_evicted(has_evicted); // Shadow index
-      for (auto it = blocks->begin(); it != blocks->end(); it++, _has_evicted++) {
-        evicted_blocks_ptr[_has_evicted] = *it;
+      for (auto it = blocks->begin(); it != blocks->end(); it++) {
+        freed_blocks.push_back(*it);
       }
-      for (auto it = block_hashes->begin(); it != block_hashes->end(); it++, has_evicted++) {
-        evicted_block_hashes_ptr[has_evicted] = *it;
+      for (auto it = block_hashes->begin(); it != block_hashes->end();
+           it++, has_evicted++) {
+        freed_hashes.push_back(*it);
       }
       delete blocks;
       delete block_hashes;
       // SWA: node survives but its trailing range was removed, so any snapshot
-      // on it no longer covers the full range. Release the slot.
+      // on it no longer covers the full range. Release the slot. (No cascade:
+      // the node still has children / is not deleted.)
       record_freed_swa_slot(node);
     } else {
-      auto parent = node->get_parent();
-      auto &blocks = node->get_physical_blocks();
-      auto &block_hashes = node->get_block_hashes();
+      has_evicted += node->size();
+      auto parent = detach_leaf_collect(node, freed_blocks, &freed_hashes);
 
-      assert(parent != nullptr);
-      parent->remove_child(node->get_head_hash());
-
-      auto _has_evicted(has_evicted); // Shadow index
-      for (auto it = blocks.begin(); it != blocks.end(); it++, _has_evicted++) {
-        evicted_blocks_ptr[_has_evicted] = *it;
-      }
-      for (auto it = block_hashes.begin(); it != block_hashes.end(); it++, has_evicted++) {
-        evicted_block_hashes_ptr[has_evicted] = *it;
-      }
-
-      if (parent->is_leaf() && !is_root(parent)) {
+      if (swa_enabled_) {
+        // I2: a parent that just became a tombstone leaf (Full but no SWA, not
+        // locked) is meaningless — cascade-delete it and its tombstone
+        // ancestors. Their blocks append beyond num_evicted.
+        parent = cascade_delete_tombstone_leaves(parent, freed_blocks,
+                                                 &freed_hashes);
+      } else if (parent->is_leaf() && !is_root(parent)) {
         add_leaf(parent);
-        if (parent->evictable()) {
-          candidate.push(parent);
-        }
       }
+      if (parent != nullptr && parent->evictable()) {
+        candidate.push(parent);
+      }
+    }
+  }
 
-      // SWA: node is being deleted; release its slot if any so it is not leaked.
-      record_freed_swa_slot(node);
-
-      node->clear_parent();
-      remove_leaf(node);
-      remove_node(node);
+  // Publish all freed blocks/hashes into the (resized) output tensors.
+  int n = static_cast<int>(freed_blocks.size());
+  evicted_blocks.resize_({n});
+  evicted_block_hashes.resize_({n});
+  if (n > 0) {
+    auto *blk = evicted_blocks.data_ptr<int64_t>();
+    auto *hsh = evicted_block_hashes.data_ptr<int64_t>();
+    for (int i = 0; i < n; ++i) {
+      blk[i] = freed_blocks[i];
+      hsh[i] = freed_hashes[i];
     }
   }
   // Record eviction metrics
-  if (has_evicted > 0) {
+  if (n > 0) {
     FLEXKV_CACHE_EVICT();
-    FLEXKV_BLOCKS_EVICTED(has_evicted);
+    FLEXKV_BLOCKS_EVICTED(n);
   }
 
-  return has_evicted;
+  return n;
 }
 
 // SWA-only eviction (node-mount, §6.2). Reclaims up to `num_swa_evicted` SWA
@@ -431,66 +506,38 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks, torch::Tensor &evicted
 //   * internal node  -> free SWA slot + tombstone; Full KV KEPT (multi-turn:
 //                       interior-prefix SWA is dropped first).
 //   * leaf, full-locked -> free SWA slot + tombstone; leaf stays (Full in use).
-//   * leaf, unlocked -> a leaf without SWA is meaningless (I2), delete the whole
-//                       node (Full+SWA) and iteratively delete tombstone leaves.
-// Freed SWA slots are buffered in freed_swa_slots (drain to the pool). The freed
-// full physical blocks (from leaf/tombstone deletions) are written into
+//   * leaf, unlocked -> a leaf without SWA is meaningless (I2), delete the
+//   whole
+//                       node (Full+SWA) and iteratively delete tombstone
+//                       leaves.
+// Freed SWA slots are buffered in freed_swa_slots (drain to the pool). The
+// freed full physical blocks (from leaf/tombstone deletions) are written into
 // `evicted_full_blocks` (resized to the count) so the caller can recycle them.
 int CRadixTreeIndex::evict_swa(torch::Tensor &evicted_full_blocks,
                                int num_swa_evicted) {
   std::vector<int64_t> freed_full;
   int num_swa_freed = 0;
 
-  auto delete_leaf_full = [&](CRadixNode *node) {
-    // Detach a leaf and collect its full blocks (mirrors evict()'s delete arm).
-    auto parent = node->get_parent();
-    assert(parent != nullptr);
-    parent->remove_child(node->get_head_hash());
-    auto &blocks = node->get_physical_blocks();
-    for (auto b : blocks) {
-      freed_full.push_back(b);
-    }
-    node->clear_parent();
-    remove_leaf(node);
-    remove_node(node);
-    return parent;
-  };
-
   while (num_swa_freed < num_swa_evicted) {
     CRadixNode *x = swa_lru_get_lru_unlocked();
     if (x == nullptr) {
       break;
     }
-    assert(x->has_swa());  // nodes on the SWA-LRU always carry a live slot
+    assert(x->has_swa()); // nodes on the SWA-LRU always carry a live slot
     if (!x->is_leaf()) {
       // Internal node: drop SWA only, keep Full KV.
-      record_freed_swa_slot(x);  // also unlinks from SWA-LRU
+      record_freed_swa_slot(x); // also unlinks from SWA-LRU
       num_swa_freed++;
     } else if (x->get_lock_cnt() > 0) {
       // Leaf whose Full is still locked: drop SWA only.
       record_freed_swa_slot(x);
       num_swa_freed++;
     } else {
-      // Leaf, Full unlocked: delete the whole node (Full + SWA), then cascade.
-      record_freed_swa_slot(x);
+      // Leaf, Full unlocked: delete the whole node (Full + SWA), then cascade
+      // the resulting tombstone leaves (I2) via the shared helper.
       num_swa_freed++;
-      CRadixNode *parent = delete_leaf_full(x);
-      if (parent->is_leaf() && !is_root(parent)) {
-        add_leaf(parent);
-      }
-      // Cascade: a parent that just became a tombstone leaf with no Full lock is
-      // meaningless (I2) — delete it and continue up.
-      while (parent != nullptr && !is_root(parent) && parent->is_leaf() &&
-             parent->get_swa_tombstone() && parent->get_lock_cnt() == 0 &&
-             parent->is_ready()) {
-        CRadixNode *grandparent = parent->get_parent();
-        record_freed_swa_slot(parent);  // tombstone has no slot; unlink for safety
-        delete_leaf_full(parent);
-        parent = grandparent;
-        if (parent != nullptr && parent->is_leaf() && !is_root(parent)) {
-          add_leaf(parent);
-        }
-      }
+      CRadixNode *parent = detach_leaf_collect(x, freed_full, nullptr);
+      cascade_delete_tombstone_leaves(parent, freed_full, nullptr);
     }
   }
 
@@ -514,11 +561,11 @@ CRadixNode *CRadixTreeIndex::inc_lock_ref(CRadixNode *node) {
   CRadixNode *swa_boundary = nullptr;
   CRadixNode *cur = node;
   while (cur != nullptr && !is_root(cur)) {
-    cur->lock();  // full_lock on every node from [node, root)
+    cur->lock(); // full_lock on every node from [node, root)
     // SWA-lock only the single deepest node carrying a live SWA.
     if (swa_boundary == nullptr && cur->has_swa()) {
       cur->inc_swa_lock_ref();
-      assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref());  // I3
+      assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref()); // I3
       swa_boundary = cur;
     }
     cur = cur->get_parent();
@@ -530,12 +577,12 @@ void CRadixTreeIndex::dec_lock_ref(CRadixNode *node, CRadixNode *swa_boundary,
                                    bool skip_swa) {
   CRadixNode *cur = node;
   while (cur != nullptr && !is_root(cur)) {
-    cur->unlock();  // asserts lock_cnt > 0
+    cur->unlock(); // asserts lock_cnt > 0
     // Release the SWA lock only on the exact boundary node inc_lock_ref locked.
     if (!skip_swa && cur == swa_boundary && cur->get_swa_lock_ref() > 0) {
       cur->dec_swa_lock_ref();
     }
-    assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref());  // I3
+    assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref()); // I3
     cur = cur->get_parent();
   }
 }
@@ -563,17 +610,20 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
   auto prefix_blocks_num = 0;
   auto ready_prefix_blocks_num = 0;
   auto last_node_matched_length = 0;
-  // SWA (node-mount): deepest fully-matched ready node carrying a live SWA slot.
+  // SWA (node-mount): deepest fully-matched ready node carrying a live SWA
+  // slot.
   CRadixNode *last_swa_node = nullptr;
   int swa_hit_blocks = 0;
-  auto physical_blocks_tensor = torch::empty({num_blocks}, torch::dtype(torch::kInt64));
+  auto physical_blocks_tensor =
+      torch::empty({num_blocks}, torch::dtype(torch::kInt64));
   auto *pb_out = physical_blocks_tensor.data_ptr<int64_t>();
   int64_t pb_write = 0;
   auto block_hashes_ptr = block_hashes.data_ptr<int64_t>();
   HashType child_hash;
-  
+
   // In C++ version, block_hashes is always pre-computed (has_hashes = true)
-  // token_ids_ptr is nullptr since we don't have token_ids in this function signature
+  // token_ids_ptr is nullptr since we don't have token_ids in this function
+  // signature
   bool has_hashes = true;
   int64_t *token_ids_ptr = nullptr;
 
@@ -582,14 +632,16 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
       current_node->update_time(hit_reward_seconds);
     }
 
-    // Avoid out-of-bounds when the current node already consumes all remaining blocks.
-    // Only count the portion that truly matches.
+    // Avoid out-of-bounds when the current node already consumes all remaining
+    // blocks. Only count the portion that truly matches.
     if (prefix_blocks_num + current_node->size() >= num_blocks) {
-      int cmp_len = std::min(current_node->size(), num_blocks - prefix_blocks_num);
+      int cmp_len =
+          std::min(current_node->size(), num_blocks - prefix_blocks_num);
       int matched_length = 0;
       auto &dq = current_node->get_physical_blocks();
       for (int i = 0; i < cmp_len; ++i) {
-        if (current_node->get_hash(i) == HashType(block_hashes_ptr[prefix_blocks_num + i])) {
+        if (current_node->get_hash(i) ==
+            HashType(block_hashes_ptr[prefix_blocks_num + i])) {
           pb_out[pb_write++] = dq[i];
           matched_length++;
         } else {
@@ -611,15 +663,14 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
       break;
     }
 
-    // Use get_hash_safe (matching Python's get_hash with boundary check and _has_hashes branch)
-    auto child_hash_opt = get_hash_safe(
-      block_hashes_ptr, 
-      token_ids_ptr, 
-      prefix_blocks_num + current_node->size(), 
-      num_blocks,
-      has_hashes,
-      tokens_per_block);
-    if (child_hash_opt.has_value() && current_node->lookup_child(child_hash_opt.value())) {
+    // Use get_hash_safe (matching Python's get_hash with boundary check and
+    // _has_hashes branch)
+    auto child_hash_opt =
+        get_hash_safe(block_hashes_ptr, token_ids_ptr,
+                      prefix_blocks_num + current_node->size(), num_blocks,
+                      has_hashes, tokens_per_block);
+    if (child_hash_opt.has_value() &&
+        current_node->lookup_child(child_hash_opt.value())) {
       child_hash = child_hash_opt.value();
       if (current_node->is_ready()) {
         last_ready_node = current_node;
@@ -646,15 +697,13 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
 
         while (left < right) {
           auto mid = (left + right) / 2;
-          // Use get_hash_safe for boundary check (matching Python's get_hash with _has_hashes branch)
-          auto hash_opt = get_hash_safe(
-              block_hashes_ptr, 
-              token_ids_ptr, 
-              prefix_blocks_num + mid, 
-              num_blocks,
-              has_hashes,
-              tokens_per_block);
-          if (hash_opt.has_value() && current_node->get_hash(mid) == hash_opt.value()) {
+          // Use get_hash_safe for boundary check (matching Python's get_hash
+          // with _has_hashes branch)
+          auto hash_opt = get_hash_safe(block_hashes_ptr, token_ids_ptr,
+                                        prefix_blocks_num + mid, num_blocks,
+                                        has_hashes, tokens_per_block);
+          if (hash_opt.has_value() &&
+              current_node->get_hash(mid) == hash_opt.value()) {
             left = mid + 1;
           } else {
             right = mid;
@@ -686,8 +735,10 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
   }
 
   // Record cache match metrics (HIT/MISS/MATCH are mutually exclusive)
-  // - HIT: Full match, all requested blocks found in cache (prefix_blocks_num == num_blocks)
-  // - MATCH: Partial match, some blocks found but not all (0 < prefix_blocks_num < num_blocks)
+  // - HIT: Full match, all requested blocks found in cache (prefix_blocks_num
+  // == num_blocks)
+  // - MATCH: Partial match, some blocks found but not all (0 <
+  // prefix_blocks_num < num_blocks)
   // - MISS: No match, no blocks found in cache (prefix_blocks_num == 0)
   if (prefix_blocks_num == num_blocks) {
     // Full match - all requested blocks are in cache
@@ -704,9 +755,10 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
 
   auto physical_blocks = physical_blocks_tensor.narrow(0, 0, pb_write);
   auto empty_uint32 = torch::Tensor();
-  return std::make_shared<CMatchResult>(ready_prefix_blocks_num, prefix_blocks_num, last_node_matched_length,
-    last_ready_node, current_node, physical_blocks, empty_uint32,
-    last_swa_node, swa_hit_blocks);
+  return std::make_shared<CMatchResult>(
+      ready_prefix_blocks_num, prefix_blocks_num, last_node_matched_length,
+      last_ready_node, current_node, physical_blocks, empty_uint32,
+      last_swa_node, swa_hit_blocks);
 }
 
 } //  namespace flexkv

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -329,6 +329,31 @@ protected:
   CRadixNode *swa_lru_head = nullptr;
   CRadixNode *swa_lru_tail = nullptr;
 
+  // True once any SWA slot has been mounted (set from set_swa). Gates the I2
+  // tombstone-leaf cascade in the always-running full-KV evict(): swa_tombstone
+  // DEFAULTS to true, so in a non-SWA deployment EVERY leaf is a tombstone and
+  // an unconditional cascade would over-evict valid ancestors. evict_swa() needs
+  // no gate (it only runs when the SWA-LRU is non-empty, i.e. SWA is enabled).
+  bool swa_enabled_ = false;
+
+  // Detach a leaf node: remove it from its parent, collect its full physical
+  // blocks into out_blocks (+ hashes into out_hashes when non-null), free any
+  // SWA slot, and unlink it from leaf_list / node_list. Returns the parent.
+  // Shared by evict() and evict_swa().
+  CRadixNode *detach_leaf_collect(CRadixNode *node,
+                                  std::vector<int64_t> &out_blocks,
+                                  std::vector<int64_t> *out_hashes);
+
+  // Walk up from `parent`, deleting each ancestor that is a meaningless
+  // tombstone leaf (leaf && swa_tombstone && lock_cnt==0 && ready) — invariant
+  // I2. Freed blocks/hashes append to out_blocks/out_hashes. Returns the last
+  // surviving ancestor (a non-tombstone leaf, a locked node, root, or a
+  // still-internal node) so the caller can reconsider it for eviction. The
+  // caller gates the SWA-enabled decision (evict() guards on swa_enabled_).
+  CRadixNode *cascade_delete_tombstone_leaves(CRadixNode *parent,
+                                              std::vector<int64_t> &out_blocks,
+                                              std::vector<int64_t> *out_hashes);
+
 public:
   CRadixTreeIndex(int tokens_per_block, int max_num_blocks = 1000000,
                   int hit_reward_seconds = 0,
@@ -506,6 +531,24 @@ public:
     node->set_swa_last_access_time((uint64_t)now.tv_sec * 1000000 +
                                    (uint64_t)now.tv_usec);
     swa_lru_add_mru(node);
+    swa_enabled_ = true;  // arm the I2 cascade in full-KV evict()
+  }
+
+  // Refresh a node's SWA recency on read-hit: splice it to the SWA-LRU MRU.
+  // SWA recency lives in the LRU list position (evict_swa walks the list, never
+  // reads swa_last_access_time), so a hit that only bumped the timestamp would
+  // NOT survive eviction — we must actually move the node. Mirror of the Python
+  // RadixTreeIndex.promote_swa. No-op for root or a node with no live SWA (a
+  // tombstone is not on the SWA-LRU; re-adding it would corrupt the list).
+  void promote_swa(CRadixNode *node) {
+    if (node == root || !node->has_swa()) {
+      return;
+    }
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    node->set_swa_last_access_time((uint64_t)now.tv_sec * 1000000 +
+                                   (uint64_t)now.tv_usec);
+    swa_lru_add_mru(node);  // remove+reinsert = move to MRU (idempotent)
   }
 
   // If the node holds a SWA host-pool slot, record it for release and clear the

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -183,6 +183,9 @@ class CacheEngineAccel:
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
             return 0, -1, -1
+        # Read-hit保温: move the hit node to SWA-LRU MRU (a match-only probe is a
+        # real "use" — this is the LRU-thrash fix). Independent of lock_for_load.
+        self.index.promote_swa(swa_node)
         if lock_for_load:
             # Pin the SWA against eviction until the load completes. Paired
             # unlock is the data-plane completion callback (kept off until wired).
@@ -213,8 +216,54 @@ class CacheEngineAccel:
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
             return 0, -1, -1, None
+        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         swa_node.inc_swa_lock_ref()
         return swa_hit, slot, slot, swa_node
+
+    def match_swa_from_result(self,
+                              match_result,
+                              sequence_meta: SequenceMeta,
+                              upper_bound_blocks: int,
+                              lock_for_load: bool = False,
+                              ) -> Tuple[int, int, int, "CRadixNode"]:
+        """Resolve the SWA hit by REUSING an already-computed Full-KV match
+        instead of re-walking the radix tree.
+
+        ``match_result`` is the tier's Full-KV match (carrying ``last_swa_node`` /
+        ``swa_hit_blocks`` from the same single forward pass). When the SWA hit
+        fits within ``upper_bound_blocks`` (the tier's clamped Full-KV hit) we use
+        it directly — the common case, zero extra traversal. When it EXCEEDS the
+        bound (a masked prefix gap made the reusable Full hit shallower than the
+        deepest SWA node), a plain ``min()`` would point past the reusable prefix,
+        so we fall back to the clamped ``match_swa`` probe to find the deepest SWA
+        node WITHIN the bound.
+
+        Returns ``(swa_hit, slot, swa_key, node)`` (node is the pinned node when
+        ``lock_for_load`` else None); ``(0, -1, -1, None)`` on miss.
+        """
+        if self.swa_pool is None or upper_bound_blocks <= 0:
+            return 0, -1, -1, None
+        swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
+        swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
+        if swa_node is None or swa_hit <= 0:
+            return 0, -1, -1, None
+        if swa_hit > upper_bound_blocks:
+            # Deepest SWA lies past the reusable Full hit — re-probe clamped.
+            if lock_for_load:
+                return self.match_swa_locked(sequence_meta, upper_bound_blocks)
+            swa_hit2, slot2, key2 = self.match_swa(
+                sequence_meta, upper_bound_blocks, lock_for_load=False)
+            return swa_hit2, slot2, key2, None
+        slot = int(swa_node.swa_host_slot)
+        if slot < 0:
+            return 0, -1, -1, None
+        # REUSE branch: promote here. The fallback branch above delegates to
+        # match_swa[_locked], which promote internally — do NOT double-promote.
+        self.index.promote_swa(swa_node)
+        if lock_for_load:
+            swa_node.inc_swa_lock_ref()
+            return swa_hit, slot, slot, swa_node
+        return swa_hit, slot, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -248,6 +297,10 @@ class CacheEngineAccel:
             physical_blocks=phys,
             block_node_ids=bnids_np,
             matched_pos="remote" if self.device_type == DeviceType.REMOTE else "local",
+            # SWA node-mount: pass through the SWA hit found in the SAME forward
+            # pass so swa_align can reuse it (no second match_prefix walk).
+            last_swa_node=getattr(match_result, "last_swa_node", None),
+            swa_hit_blocks=int(getattr(match_result, "swa_hit_blocks", 0) or 0),
         )
 
     def insert(self,
@@ -319,8 +372,12 @@ class CacheEngineAccel:
             if evict_block_num > 0:
                 target_blocks = torch.zeros(evict_block_num, dtype=torch.int64)
                 evicted_block_hashes = torch.zeros(evict_block_num, dtype=torch.int64)
+                # evict() resizes both tensors in-place to the actual freed count
+                # (which may EXCEED evict_block_num when the I2 tombstone cascade
+                # frees ancestors) and returns that count. Trust it, don't assume
+                # evict_block_num.
                 num_evicted = self.index.evict(target_blocks, evicted_block_hashes, evict_block_num)
-                if num_evicted != evict_block_num:
+                if target_blocks.numel() != num_evicted:
                     target_blocks.resize_(num_evicted)
                     evicted_block_hashes.resize_(num_evicted)
                 target_blocks = target_blocks.numpy()
@@ -467,6 +524,7 @@ class CacheEngine:
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
             return 0, -1, -1
+        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         if lock_for_load:
             swa_node.swa_lock_ref += 1
         return swa_hit, slot, slot
@@ -492,8 +550,41 @@ class CacheEngine:
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
             return 0, -1, -1, None
+        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         swa_node.swa_lock_ref += 1
         return swa_hit, slot, slot, swa_node
+
+    def match_swa_from_result(self,
+                              match_result,
+                              sequence_meta: SequenceMeta,
+                              upper_bound_blocks: int,
+                              lock_for_load: bool = False,
+                              ) -> Tuple[int, int, int, "RadixNode"]:
+        """Reuse an already-computed Full-KV match to resolve the SWA hit without
+        re-walking the tree (mirror of CacheEngineAccel.match_swa_from_result;
+        see it for the fallback rationale)."""
+        if self.swa_pool is None or upper_bound_blocks <= 0:
+            return 0, -1, -1, None
+        swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
+        swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
+        if swa_node is None or swa_hit <= 0:
+            return 0, -1, -1, None
+        if swa_hit > upper_bound_blocks:
+            if lock_for_load:
+                return self.match_swa_locked(sequence_meta, upper_bound_blocks)
+            swa_hit2, slot2, key2 = self.match_swa(
+                sequence_meta, upper_bound_blocks, lock_for_load=False)
+            return swa_hit2, slot2, key2, None
+        slot = int(swa_node.swa_host_slot)
+        if slot < 0:
+            return 0, -1, -1, None
+        # REUSE branch: promote here. The fallback branch above delegates to
+        # match_swa[_locked], which promote internally — do NOT double-promote.
+        self.index.promote_swa(swa_node)
+        if lock_for_load:
+            swa_node.swa_lock_ref += 1
+            return swa_hit, slot, slot, swa_node
+        return swa_hit, slot, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -1079,7 +1170,7 @@ class GlobalCacheEngine:
                 graph_id = transfer_graph.graph_id,
                 transfer_type = TransferType.DISK2H,
                 src_block_ids = fragment2_ssd_blocks,
-                dst_block_ids = fragment123_cpu_blocks[fragment1_num_blocks:fragment12_num_blocks],    
+                dst_block_ids = fragment123_cpu_blocks[fragment1_num_blocks:fragment12_num_blocks],
                 dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_disk2h)
@@ -1914,14 +2005,24 @@ class GlobalCacheEngine:
                          cpu_full_hit_blocks: int,
                          ssd_full_hit_blocks: int = 0,
                          remote_full_hit_blocks: int = 0,
-                         lock_for_load: bool = False) -> SWAMatchResult:
-        """Multi-tier SWA prefix match (delegates to SWACacheManager.match_prefix)."""
+                         lock_for_load: bool = False,
+                         cpu_match_result=None,
+                         ssd_match_result=None,
+                         remote_match_result=None) -> SWAMatchResult:
+        """Multi-tier SWA prefix match (delegates to SWACacheManager.match_prefix).
+
+        Per-tier ``*_match_result`` (from the SAME forward pass that produced the
+        full hits) let the SWA match REUSE that pass instead of re-walking.
+        """
         return self.swa_cache.match_prefix(
             sequence_meta,
             cpu_full_hit_blocks=cpu_full_hit_blocks,
             ssd_full_hit_blocks=ssd_full_hit_blocks,
             remote_full_hit_blocks=remote_full_hit_blocks,
             lock_for_load=lock_for_load,
+            cpu_match_result=cpu_match_result,
+            ssd_match_result=ssd_match_result,
+            remote_match_result=remote_match_result,
         )
 
     def swa_align(self,
@@ -1997,6 +2098,7 @@ class GlobalCacheEngine:
             ready = getattr(match_result, "num_ready_matched_blocks", 0)
             return max(0, min(int(ready), block_end_idx) - block_start_idx)
 
+        remote_mr = None
         if not self.cache_config.enable_remote or temp_cache_strategy.ignore_remote:
             if self.index_accel:
                 cpu_mr, ssd_mr = self.match_local_accel(
@@ -2028,7 +2130,12 @@ class GlobalCacheEngine:
             sequence_meta, cpu_full_hit_blocks=full_hit_blocks,
             ssd_full_hit_blocks=full_hit_blocks,
             remote_full_hit_blocks=full_hit_blocks,
-            lock_for_load=lock_for_load)
+            lock_for_load=lock_for_load,
+            # Reuse the Full-KV matches just computed above — the SWA hit rides the
+            # SAME forward pass, so no tier re-walks the tree.
+            cpu_match_result=cpu_mr,
+            ssd_match_result=ssd_mr,
+            remote_match_result=remote_mr)
         return full_hit_blocks, swa_match.best_hit_blocks
 
     # --- SWA slot sources for the get()/put() build chains --------------------

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -91,7 +91,7 @@ class HierarchyLRCacheEngine:
         self.num_total_blocks = num_total_blocks
         self.evict_ratio = evict_ratio
         self.evict_start_threshold = evict_start_threshold
-        
+
         # cumulative statistics: for analyzing distributed KV reuse benefits
         self._stats_total_queried_tokens = 0       # total tokens queried
         self._stats_gpu_matched_tokens = 0         # total tokens matched in GPU memory
@@ -175,13 +175,13 @@ class HierarchyLRCacheEngine:
 
     def match(self, sequence_meta: SequenceMeta) -> MatchResultAccel:
         """Match a sequence against the cache index.
-        
+
         This method provides a simple interface similar to CacheEngine.match(),
         delegating to match_all() for consistency.
-        
+
         Args:
             sequence_meta: The sequence metadata to match
-            
+
         Returns:
             MatchResultAccel: The match result
         """
@@ -205,31 +205,31 @@ class HierarchyLRCacheEngine:
         remote_key = (int(mr_remote.num_matched_blocks), int(mr_remote.num_ready_matched_blocks))
         matched_pos = "local" if local_key >= remote_key else "remote"
         chosen = mr_local if local_key >= remote_key else mr_remote
-        
+
         # update cumulative statistics
         queried_tokens = num_blocks * self.tokens_per_block
         gpu_matched_tokens = gpu_matched_blocks * self.tokens_per_block
         local_matched_tokens = int(mr_local.num_matched_blocks) * self.tokens_per_block
         distributed_matched_tokens = int(chosen.num_matched_blocks) * self.tokens_per_block
-        
+
         self._stats_total_queried_tokens += queried_tokens
         self._stats_gpu_matched_tokens += gpu_matched_tokens
         self._stats_local_matched_tokens += local_matched_tokens
         self._stats_distributed_matched_tokens += distributed_matched_tokens
         self._stats_match_count += 1
-        
+
         # calculate hit ratio for each level
         total = self._stats_total_queried_tokens
         gpu_pct = (self._stats_gpu_matched_tokens * 100 / total) if total > 0 else 0
         local_pct = (self._stats_local_matched_tokens * 100 / total) if total > 0 else 0
         distributed_pct = (self._stats_distributed_matched_tokens * 100 / total) if total > 0 else 0
-        
+
         # calculate extra benefits for each level
         extra_from_local = self._stats_local_matched_tokens - self._stats_gpu_matched_tokens
         extra_from_distributed = self._stats_distributed_matched_tokens - self._stats_local_matched_tokens
         extra_local_pct = (extra_from_local * 100 / total) if total > 0 else 0
         extra_distributed_pct = (extra_from_distributed * 100 / total) if total > 0 else 0
-        
+
         print(
             f"[STATS][REUSE] cnt={self._stats_match_count}, queried={total}, "
             f"gpu={self._stats_gpu_matched_tokens} ({gpu_pct:.2f}%), "
@@ -237,7 +237,7 @@ class HierarchyLRCacheEngine:
             f"flexkv_global={self._stats_distributed_matched_tokens} ({distributed_pct:.2f}%, "
             f"+{extra_distributed_pct:.2f}%)"
         )
-        
+
         # physical blocks
         bnids_np = None
         if chosen is mr_remote:
@@ -307,7 +307,7 @@ class HierarchyLRCacheEngine:
             return None
         out = np.full(phys_np.shape, fill_value=0, dtype=np.uint32)
         rr = max(1, int(self.round_robin))
-        
+
         for i in range(bnids_np.shape[0]):
             nid = int(bnids_np[i])
             #check if node is active
@@ -356,7 +356,7 @@ class HierarchyLRCacheEngine:
         sequence_meta.gen_hashes()
         phys_t = torch.from_numpy(physical_block_ids).to(torch.int64) if isinstance(physical_block_ids, np.ndarray) else physical_block_ids.to(torch.int64)
         hashes_t = torch.from_numpy(sequence_meta.block_hashes).to(torch.int64)
-        
+
         if match_result is None:
             node = self.local_index.insert(
                 phys_t, hashes_t, int(sequence_meta.num_blocks), int(num_insert_blocks), bool(is_ready)
@@ -385,7 +385,7 @@ class HierarchyLRCacheEngine:
 
     def unlock(self, node: CRadixNode) -> None:
         """Unlock a node in the appropriate index (local or remote).
-        
+
         Args:
             node: The radix node to unlock
         """
@@ -416,7 +416,7 @@ class HierarchyLRCacheEngine:
 
     def set_ready(self, node: CRadixNode, ready: bool = True, ready_length: int = -1) -> None:
         """Set the ready state of a node in the appropriate index (local or remote).
-        
+
         Args:
             node: The radix node to set ready state
             ready: Whether the node is ready (default: True)
@@ -439,36 +439,39 @@ class HierarchyLRCacheEngine:
              strict: bool = True) -> torch.Tensor:
         # Calculate current utilization
         utilization = (self.mempool.num_total_blocks - self.mempool.num_free_blocks) / self.mempool.num_total_blocks if self.mempool.num_total_blocks > 0 else 0
-        
+
         # Proactive eviction: trigger when utilization exceeds threshold OR when blocks are needed
         should_evict = (utilization >= self.evict_start_threshold) or (num_required_blocks > self.mempool.num_free_blocks)
-        
+
         if should_evict:
             if protected_node is not None:
                 self.local_index.lock(protected_node)
-            
+
             # Calculate how many blocks to evict
             # Goal: maintain free blocks above (1 - evict_start_threshold) ratio
             target_free_blocks = int(self.mempool.num_total_blocks * (1.0 - self.evict_start_threshold))
             evict_to_reach_target = max(0, target_free_blocks - self.mempool.num_free_blocks)
-            
+
             evict_block_num = max(
                 num_required_blocks - self.mempool.num_free_blocks,  # At least meet current demand
                 evict_to_reach_target,                               # Or reach target free ratio
                 int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0  # Or minimum evict_ratio
             )
-            
+
             if evict_block_num > 0:
                 target_blocks = torch.zeros(evict_block_num, dtype=torch.int64)
+                # evict() resizes target_blocks in-place to the actual freed count
+                # (may EXCEED evict_block_num when the I2 tombstone cascade frees
+                # ancestors) and returns it — trust the returned count.
                 num_evicted = self.local_index.evict(target_blocks, evict_block_num)
-                if num_evicted != evict_block_num:
+                if target_blocks.numel() != num_evicted:
                     target_blocks.resize_(num_evicted)
                 evicted_np = target_blocks.numpy()
                 self.mempool.recycle_blocks(evicted_np)
 
             if protected_node is not None:
                 self.local_index.unlock(protected_node)
-        
+
         if strict and num_required_blocks > self.mempool.num_free_blocks:
             raise ValueError(
                 f"Not enough free blocks to take, required: {num_required_blocks}, available: {self.mempool.num_free_blocks}"
@@ -580,7 +583,7 @@ class HierarchyLRCacheEngine:
             else:
                 raise ValueError(f"Invalid device type: {device_type}")
                 #local_max_num_blocks = int(cache_config.num_local_blocks or 0)
-            
+
             return cls(
                 num_total_blocks=int(local_max_num_blocks or 0),
                 tokens_per_block=int(cache_config.tokens_per_block),

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -234,6 +234,12 @@ class RadixTreeIndex:
         # SWA slots freed by structural changes (split / merge / evict / evict_swa),
         # drained by the cache engine to return them to the SWA host pool.
         self._freed_swa_slots: List[int] = []
+        # True once any SWA slot has been mounted (set from set_swa). Gates the I2
+        # tombstone-leaf cascade in the always-running full-KV evict(): a node's
+        # swa_tombstone DEFAULTS to True, so in a non-SWA deployment EVERY leaf is
+        # a tombstone and an unconditional cascade would over-evict valid
+        # ancestors. evict_swa() needs no gate (it only runs when SWA is enabled).
+        self._swa_enabled: bool = False
 
     def reset(self) -> None:
         self.root_node = RadixNode(block_hashes=np.array([], dtype=np.int64),
@@ -245,6 +251,8 @@ class RadixTreeIndex:
         self._swa_lru_head.swa_lru_next = self._swa_lru_tail
         self._swa_lru_tail.swa_lru_prev = self._swa_lru_head
         self._freed_swa_slots.clear()
+        # keep _swa_enabled sticky across reset (mirrors C++: the pool geometry /
+        # SWA usage is a deployment property, not per-tree-generation state)
 
     def is_empty(self) -> bool:
         return len(self.leaf_nodes) == 0
@@ -312,6 +320,21 @@ class RadixTreeIndex:
         node.swa_tombstone = False
         node.swa_last_access_time = time.time()
         self._swa_lru_add_mru(node)
+        self._swa_enabled = True  # arm the I2 cascade in full-KV evict()
+
+    def promote_swa(self, node: RadixNode) -> None:
+        """Refresh a node's SWA recency on read-hit: splice it to the SWA-LRU MRU.
+
+        SWA recency lives in the LRU *list position* (evict_swa walks the linked
+        list via _swa_lru_get_lru_unlocked and never reads swa_last_access_time),
+        so a hit that only bumped the timestamp would NOT survive eviction — we
+        must actually move the node to MRU. Mirror of set_swa's LRU touch, minus
+        the mount. No-op for root or a node with no live SWA (a tombstone is not
+        on the SWA-LRU; re-adding it would corrupt the list)."""
+        if node is self.root_node or not node.has_swa():
+            return
+        node.swa_last_access_time = time.time()
+        self._swa_lru_add_mru(node)  # remove+reinsert = move to MRU (idempotent)
 
     def merge_child(self, node: RadixNode) -> None:
         """Merge ``node``'s only child into it, moving SWA to follow the child.
@@ -490,19 +513,29 @@ class RadixTreeIndex:
                 # window no longer covers the last page — release it (I1).
                 self.record_freed_swa_slot(node)
             else:
-                assert node.parent is not None  # node is not root
-                node.parent.children.pop(node.head_hash())
+                parent = node.parent
+                assert parent is not None  # node is not root
+                parent.children.pop(node.head_hash())
                 self.leaf_nodes.pop(node.head_hash(), None)
-                if node.parent.is_leaf():
-                    self.leaf_nodes[node.parent.head_hash()] = node.parent
-                if node.parent.evictable():
-                    priority = self._get_eviction_priority(node.parent)
-                    heapq.heappush(candidates, (priority, node.parent))
                 physical_blocks = node.physical_blocks
                 _block_hashes = node.block_hashes
                 # SWA: node is deleted; release its slot so it is not leaked (I1).
                 self.record_freed_swa_slot(node)
                 node.parent = None
+                if parent.is_leaf() and not parent.is_root():
+                    self.leaf_nodes[parent.head_hash()] = parent
+                if self._swa_enabled:
+                    # I2: a parent that just became a tombstone leaf (Full but no
+                    # SWA, not locked) is meaningless — cascade-delete it and its
+                    # tombstone ancestors. Their blocks append beyond num_evicted.
+                    cascade_blocks, cascade_hashes, parent = \
+                        self._iteratively_delete_tombstone_leaf(parent)
+                    if cascade_blocks.size:
+                        physical_blocks = np.concatenate([physical_blocks, cascade_blocks])
+                        _block_hashes = np.concatenate([_block_hashes, cascade_hashes])
+                if parent is not None and parent.evictable():
+                    priority = self._get_eviction_priority(parent)
+                    heapq.heappush(candidates, (priority, parent))
 
             evicted_blocks = np.concatenate([evicted_blocks, physical_blocks])
             evicted_block_hashes = np.concatenate([evicted_block_hashes, _block_hashes])
@@ -557,16 +590,21 @@ class RadixTreeIndex:
                     self.leaf_nodes[parent.head_hash()] = parent
                 # Cascade: a parent that just became a tombstone leaf is
                 # meaningless (I2) — delete it and continue up.
-                freed_full = self._iteratively_delete_tombstone_leaf(parent)
+                freed_full, _freed_hashes, _survivor = \
+                    self._iteratively_delete_tombstone_leaf(parent)
                 if freed_full.size:
                     evicted_full_blocks = np.concatenate([evicted_full_blocks, freed_full])
         return evicted_full_blocks, num_swa_freed
 
-    def _iteratively_delete_tombstone_leaf(self, node: RadixNode) -> np.ndarray:
+    def _iteratively_delete_tombstone_leaf(
+            self, node: RadixNode) -> Tuple[np.ndarray, np.ndarray, Optional[RadixNode]]:
         """Delete ``node`` and its ancestors while they are tombstone leaves with
         no Full lock (a leaf without SWA is meaningless, I2). Returns the Full
-        physical blocks freed (to recycle)."""
+        physical blocks freed, their block hashes, and the last surviving
+        ancestor (a non-tombstone leaf, a locked/unready node, an internal node,
+        or root) so the caller can reconsider it for eviction."""
         freed = np.array([], dtype=np.int64)
+        freed_hashes = np.array([], dtype=np.int64)
         while (node is not None and not node.is_root() and node.is_leaf()
                and node.swa_tombstone and node.lock_cnt == 0 and node.is_ready):
             parent = node.parent
@@ -576,11 +614,12 @@ class RadixTreeIndex:
             # tombstone node has no SWA slot, but call for uniformity / LRU safety
             self.record_freed_swa_slot(node)
             freed = np.concatenate([freed, node.physical_blocks])
+            freed_hashes = np.concatenate([freed_hashes, node.block_hashes])
             node.parent = None
             if parent.is_leaf() and not parent.is_root():
                 self.leaf_nodes[parent.head_hash()] = parent
             node = parent
-        return freed
+        return freed, freed_hashes, node
 
     # ===== SWA dual lock (mirror of sglang inc/dec_lock_ref) ==============
     # FlexKV's SWA window == one page == one node's trailing page, so sglang's

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -137,7 +137,10 @@ class SWACacheManager:
                      cpu_full_hit_blocks: int,
                      ssd_full_hit_blocks: int = 0,
                      remote_full_hit_blocks: int = 0,
-                     lock_for_load: bool = False) -> SWAMatchResult:
+                     lock_for_load: bool = False,
+                     cpu_match_result=None,
+                     ssd_match_result=None,
+                     remote_match_result=None) -> SWAMatchResult:
         """Match the trailing-SWA prefix on each tier, clamped to its Full-KV hit.
 
         Each tier's node-mounted SWA (on its radix tree) is matched independently
@@ -145,12 +148,19 @@ class SWACacheManager:
         CPU is preferred; SSD then REMOTE are the fallbacks whose load needs a
         staging chain (SWA DISK2H / REMOTE2H -> SWA H2D, all is_swa=True).
 
+        When a tier's Full-KV ``*_match_result`` is supplied (from the SAME
+        forward pass that produced its ``*_full_hit_blocks``), the SWA hit is
+        REUSED from it via ``match_swa_from_result`` — no second tree walk. When
+        omitted, it falls back to the standalone ``match_swa`` probe.
+
         Args:
             sequence_meta: the (page-aligned) query prefix.
             cpu_full_hit_blocks: Full-KV CPU hit length in blocks (CPU upper bound).
             ssd_full_hit_blocks: Full-KV SSD hit length in blocks (SSD upper bound).
             remote_full_hit_blocks: Full-KV REMOTE hit length in blocks (upper bound).
             lock_for_load: pin the matched SWA entries against eviction until load.
+            cpu_match_result / ssd_match_result / remote_match_result: the tier's
+                Full-KV match to reuse (optional; carries last_swa_node/swa_hit_blocks).
 
         Returns:
             SWAMatchResult with per-tier hit lengths / slots / keys. SWA is
@@ -161,23 +171,30 @@ class SWACacheManager:
             return result
         sequence_meta.gen_hashes()
 
+        def _match(engine, upper_bound, match_result):
+            """Reuse the Full-KV match when given, else probe. Returns
+            (hit, slot, key) — drops the node handle (callers that need the
+            pinned node use engine.match_swa_locked directly)."""
+            if match_result is not None:
+                hit, slot, key, _node = engine.match_swa_from_result(
+                    match_result, sequence_meta, upper_bound_blocks=upper_bound,
+                    lock_for_load=lock_for_load)
+                return hit, slot, key
+            return engine.match_swa(
+                sequence_meta, upper_bound_blocks=upper_bound,
+                lock_for_load=lock_for_load)
+
         if cpu_full_hit_blocks > 0:
             result.cpu_hit_blocks, result.cpu_slot, result.cpu_key = \
-                self._engine(DeviceType.CPU).match_swa(
-                    sequence_meta, upper_bound_blocks=cpu_full_hit_blocks,
-                    lock_for_load=lock_for_load)
+                _match(self._engine(DeviceType.CPU), cpu_full_hit_blocks, cpu_match_result)
 
         if self._swa_enabled_tier(DeviceType.SSD) and ssd_full_hit_blocks > 0:
             result.ssd_hit_blocks, result.ssd_slot, result.ssd_key = \
-                self._engine(DeviceType.SSD).match_swa(
-                    sequence_meta, upper_bound_blocks=ssd_full_hit_blocks,
-                    lock_for_load=lock_for_load)
+                _match(self._engine(DeviceType.SSD), ssd_full_hit_blocks, ssd_match_result)
 
         if self._swa_enabled_tier(DeviceType.REMOTE) and remote_full_hit_blocks > 0:
             result.remote_hit_blocks, result.remote_slot, result.remote_key = \
-                self._engine(DeviceType.REMOTE).match_swa(
-                    sequence_meta, upper_bound_blocks=remote_full_hit_blocks,
-                    lock_for_load=lock_for_load)
+                _match(self._engine(DeviceType.REMOTE), remote_full_hit_blocks, remote_match_result)
         return result
 
     # --- peer-op graph construction (gated) --------------------------------

--- a/flexkv/common/type.py
+++ b/flexkv/common/type.py
@@ -15,8 +15,13 @@ class MatchResultAccel:
     matched_pos: Optional[str] = None
     matched_node_ids: Optional[np.ndarray] = None #TODO id or ids? should we allow one req match results on multiple nodes?
     insert_to_local_cpu_index: bool = True
+    # ===== SWA (node-mounted) — passed through from CMatchResult so the SWA
+    # control plane can reuse the SAME forward match instead of re-walking the
+    # tree (see GlobalCacheEngine.swa_align / match_swa_from_result). The deepest
+    # fully-matched ready node carrying a live SWA slot, and the ready-prefix
+    # block count ending at it. None / 0 when no SWA on the matched path.
+    last_swa_node: Optional['CRadixNode'] = None
+    swa_hit_blocks: int = 0
 
     def __post_init__(self) -> None:
         assert self.physical_blocks.ndim == 1
-
-

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -246,6 +246,74 @@ def test_py_merge_child_moves_swa_to_merged_node():
     assert 900 in idx2.drain_freed_swa_slots()
 
 
+# --------------------------------------------------------------------------- #
+# promote_swa: read-hit refreshes SWA-LRU (match-promote to MRU)              #
+# --------------------------------------------------------------------------- #
+
+def _three_swa_leaves():
+    """root -> {n1, n2, n3} sibling leaves, each with a live SWA. set_swa order
+    n1,n2,n3 leaves n3 at MRU and n1 at the LRU tail."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    n1 = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    n2 = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    n3 = idx.insert(_seq([9, 10, 11, 12]), _phys(4, 5), is_ready=True)
+    idx.set_swa(n1, slot=100)
+    idx.set_swa(n2, slot=200)
+    idx.set_swa(n3, slot=300)
+    return idx, n1, n2, n3
+
+
+def test_promote_swa_moves_to_mru():
+    """promote_swa splices the hit node to the MRU side (right after head) and
+    refreshes its timestamp."""
+    idx, n1, n2, n3 = _three_swa_leaves()
+    # MRU=n3, LRU=n1 after the set_swa order above.
+    assert idx._swa_lru_head.swa_lru_next is n3
+    assert idx._swa_lru_tail.swa_lru_prev is n1
+    t_before = n1.swa_last_access_time
+
+    idx.promote_swa(n1)
+
+    assert idx._swa_lru_head.swa_lru_next is n1          # n1 is now MRU
+    assert idx._swa_lru_tail.swa_lru_prev is n2          # n2 sank to LRU
+    assert n1.on_swa_lru and n1.has_swa()
+    assert n1.swa_last_access_time >= t_before
+
+
+def test_promote_swa_survives_eviction():
+    """Key regression: a promoted (read-hit) node must NOT be the eviction
+    victim even though it was written least recently. Without promote, n1 (the
+    LRU tail) would be evicted; after promote, n2 is the victim and n1 lives."""
+    idx, n1, n2, n3 = _three_swa_leaves()
+    idx.promote_swa(n1)  # n1 hit -> MRU; new LRU order (MRU..LRU): n1, n3, n2
+
+    _evicted_full, num_freed = idx.evict_swa(1)
+
+    assert num_freed == 1
+    assert n1.has_swa()                                  # the promoted node lives
+    assert 200 in idx.drain_freed_swa_slots()            # n2's slot was reclaimed
+
+
+def test_promote_swa_ignores_dead_node():
+    """promote_swa on a tombstone (SWA already freed) node is a no-op — it must
+    not re-thread a dead node onto the SWA-LRU (would corrupt evict_swa)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    n1 = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.set_swa(n1, slot=100)
+    idx.record_freed_swa_slot(n1)                        # tombstone it
+    assert n1.swa_tombstone and not n1.on_swa_lru
+    idx.drain_freed_swa_slots()                          # clear the buffer
+
+    idx.promote_swa(n1)
+
+    assert not n1.on_swa_lru and n1.swa_tombstone        # still off the list
+    assert idx.drain_freed_swa_slots() == []             # nothing touched
+
+    # root is also a no-op (never on the SWA-LRU).
+    idx.promote_swa(idx.root_node)
+    assert not idx.root_node.on_swa_lru
+
+
 # =========================================================================== #
 # 2. C++ PRODUCTION — CRadixTreeIndex                                         #
 # =========================================================================== #
@@ -654,6 +722,98 @@ def test_workload_pressure_no_leak_no_corruption(cpu_blocks, swa_slots):
     # silent no-op regression that stops mounting/reading SWA is caught).
     assert drv.swa_hits > 0, "workload produced no SWA hits — coverage regressed"
     assert drv.bytes_verified > 0, "no SWA byte round-trip verified"
+
+
+# --------------------------------------------------------------------------- #
+# I2 in FULL eviction: deleting a leaf cascades tombstone-leaf ancestors       #
+# --------------------------------------------------------------------------- #
+
+def _build_prefix_chain():
+    """root -> A(prefix, 2blk) -> {a(leaf w/ SWA), b(divergent leaf)}.
+
+    Returns (idx, A, a, b). A is an internal tombstone (Full, no SWA); a carries
+    SWA and is the leaf we will evict; b is a sibling keeping A internal.
+    """
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4, 5, 6, 7, 8]), _phys(0, 1, 2, 3), is_ready=True)
+    idx.set_swa(a, slot=901)
+    sd = _seq([1, 2, 3, 4, 55, 66, 77, 88])
+    idx.insert(sd, _phys(8, 9), is_ready=True, match_result=idx.match_prefix(sd))
+    A = a.parent
+    b = [c for c in A.children.values() if c is not a][0]
+    return idx, A, a, b
+
+
+def test_full_evict_cascades_tombstone_leaf_parent():
+    """I2 (full-evict): after both children are gone, the parent A is a tombstone
+    leaf (Full, no SWA, unlocked) — meaningless, so it is cascade-deleted and its
+    Full blocks are freed too, even beyond the requested num_evicted."""
+    idx, A, a, b = _build_prefix_chain()
+    # Drop SWA off the divergent sibling b so evicting both leaves leaves A a
+    # tombstone leaf. b starts as a tombstone (no set_swa), a carries SWA=901.
+    # Evict 2 blocks: the LRU leaf gets deleted; then A becomes a tombstone leaf.
+    # Give a smaller grace so it (and b) are the eviction victims; A must cascade.
+    # Force deletion of BOTH leaves by requesting their combined size.
+    a.lock_cnt = 0
+    b.lock_cnt = 0
+    total_before = idx.total_cached_blocks()  # A(2) + a(2) + b(2) = 6
+    assert total_before == 6
+    ev_blocks, ev_hashes = idx.evict(4)  # ask for the two 2-block leaves
+    # Both leaves (4 blocks) + cascaded parent A (2 blocks) = 6 freed, though we
+    # only asked for 4 — the I2 cascade freed A on top.
+    assert len(ev_blocks) == 6
+    assert len(ev_hashes) == 6
+    assert idx.is_empty()
+    assert idx.total_swa_slots() == 0
+    assert 901 in idx.drain_freed_swa_slots()
+
+
+def test_full_evict_keeps_full_locked_tombstone_leaf():
+    """I2 exception: a parent that becomes a tombstone leaf but whose Full is
+    locked is NOT cascade-deleted (its Full KV is still referenced)."""
+    idx, A, a, b = _build_prefix_chain()
+    A.lock_cnt = 1  # pin A's Full
+    ev_blocks, _ = idx.evict(4)  # delete both leaves a, b
+    # A is a tombstone leaf now but full-locked -> survives; only 4 blocks freed.
+    assert len(ev_blocks) == 4
+    assert not idx.is_empty()
+    assert A.is_leaf() and A.swa_tombstone and A.lock_cnt == 1
+    assert A.size() == 2
+
+
+def test_full_evict_no_cascade_when_swa_disabled():
+    """Non-SWA regression: with SWA never enabled (no set_swa), swa_tombstone is
+    True on every node, but the I2 cascade must NOT fire — evict() frees EXACTLY
+    the requested blocks and leaves valid ancestors intact."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4, 5, 6, 7, 8]), _phys(0, 1, 2, 3), is_ready=True)
+    sd = _seq([1, 2, 3, 4, 55, 66, 77, 88])
+    idx.insert(sd, _phys(8, 9), is_ready=True, match_result=idx.match_prefix(sd))
+    A = a.parent
+    assert not idx._swa_enabled  # never armed
+    total_before = idx.total_cached_blocks()  # 6
+    ev_blocks, _ = idx.evict(4)  # delete both leaves
+    # Exactly 4 freed; the tombstone parent A survives (no cascade when disabled).
+    assert len(ev_blocks) == 4
+    assert not idx.is_empty()
+    assert A.is_leaf() and A.size() == 2 and idx.total_cached_blocks() == 2
+
+
+# --------------------------------------------------------------------------- #
+# Double-match elimination: match_swa_from_result reuse + fallback             #
+# --------------------------------------------------------------------------- #
+
+def test_match_swa_from_result_reuses_within_bound():
+    """match_swa_from_result reuses the Full-KV match when swa_hit <= bound."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    n1 = idx.insert(_seq([1, 2, 3, 4, 5, 6, 7, 8]), _phys(0, 1, 2, 3), is_ready=True)
+    idx.set_swa(n1, slot=100)
+    mr = idx.match_prefix(_seq([1, 2, 3, 4, 5, 6, 7, 8]))
+    assert mr.swa_hit_blocks == 4 and mr.last_swa_node is n1
+    # Simulate the reuse logic directly on the match result (engine-independent):
+    # within a bound >= swa_hit, the slot is read straight from last_swa_node.
+    assert mr.swa_hit_blocks <= 4
+    assert int(mr.last_swa_node.swa_host_slot) == 100
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes three SWA node problems and adds one optimization to the SWA cache path.

## Changes

1. Fix SWA-LRU read-hit recency (`promote_swa`) SWA recency is tracked by a node's *position* in th SWA-LRU list — eviction walks the list and never reads `swa_last_access_time`. Previously a SWA read-hit did not re-splice the hit node, so a hot entr could be evicted as if it were the least-recently-used. Added `promote_swa`  ++ and Python) to move a hit node to the MRU end, and call it from ever `match_swa*` path.

2. Run the I2 tombstone-leaf cascade in full-K `evict()` The cascade that deletes meaningless tombstone-lea ancestors previously ran only in `evict_swa()`. It is now also applied in th always-on full-KV `evict()`, gated behind a new sticky `swa_enabled_ flag — `swa_tombstone` defaults to true, so an ungated cascade woul over-evict valid ancestors in non-SWA deployments. Because the cascade can fre blocks beyond `num_evicted`, `evict()` now accumulates freed blocks/hashes int vectors and resizes the output tensors; callers trust the returned/resize count instead of assuming `num_evicted`.

3. Reuse the Full-KV match for SW (`match_swa_from_result`) Added `last_swa_node` / `swa_hit_blocks` t `MatchResultAccel` so the SWA hit found during the Full-KV forward pass is passed throug to `swa_align` and reused, avoiding a redundant second radix-tree walk Falls back to a clamped `match_swa` probe when the SWA hit exceeds the tier' Full-KV bound.

4. Refactor / tests
- Extracted shared C++ helpers `detach_leaf_collect` and `cascade_delete_tombstone_leaves`, used by both `evict()` and `evict_swa()`.
- `_iteratively_delete_tombstone_leaf` (Python) now also returns freed block hashes and the surviving ancestor.
- Added regression tests in `tests/test_swa_node_mount.py` covering `promote_swa` move-to-MRU, survive-eviction, and dead-node no-op cases.
