### PR TITLE
fix(swa): clamp swa_align to fetched CPU tier + TDD-derived gap tests

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -2029,7 +2029,30 @@ class GlobalCacheEngine:
             ssd_full_hit_blocks=full_hit_blocks,
             remote_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load)
-        return full_hit_blocks, swa_match.best_hit_blocks
+
+        # Tier-consistency (SWA subset of Full, AND graph shape must match the
+        # tier actually fetched). swa_align's return shapes the SWA transfer graph
+        # (kvtask truncates to usable=min(full, this)); but the GET data plane
+        # (_swa_get_slots) currently fetches the CPU tier ONLY. best_hit_blocks is
+        # the cross-tier MAX, so if SSD/REMOTE ever carry a LONGER SWA hit than
+        # CPU, returning best_hit_blocks would shape the graph for blocks the
+        # CPU-only fetch cannot fill -> src/dst block-count mismatch / stale-SWA
+        # read (silent corruption). Today SSD/REMOTE SWA default to 0 slots so
+        # best == cpu_hit and this is a no-op; clamp to the fetched (CPU) tier and
+        # warn once if a longer non-CPU hit is dropped, so enabling SSD/REMOTE SWA
+        # without extending the fetcher fails safe (lose a few SWA hits) instead
+        # of shaping an unfillable graph.
+        cpu_hit = swa_match.cpu_hit_blocks
+        best_hit = swa_match.best_hit_blocks
+        if best_hit > cpu_hit and not getattr(self, "_warned_swa_multitier", False):
+            self._warned_swa_multitier = True
+            flexkv_logger.warning(
+                "SWA multi-tier hit (best=%d blocks) exceeds the CPU tier "
+                "(cpu=%d); GET fetches CPU-only, clamping the SWA graph to the "
+                "CPU hit to avoid an unfillable transfer graph. Extend "
+                "_swa_get_slots to the winning tier before relying on SSD/REMOTE "
+                "SWA loads.", best_hit, cpu_hit)
+        return full_hit_blocks, cpu_hit
 
     # --- SWA slot sources for the get()/put() build chains --------------------
     # Resolve the per-tier SWA-pool slot ids for the current request so the SWA

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -83,6 +83,54 @@ def test_shed_heavy_resources_keeps_status():
     assert t.return_mask is not None
 
 
+# --- M15/M16: get_match_swa's core arithmetic (pure, mirrors kvtask logic) --- #
+
+def _usable_and_swa_mask(full_hit, swa_hit, num_tokens, tpb):
+    """Replicate the arithmetic in KVTaskEngine.get_match_swa (② + ③) so the
+    contract is pinned without standing up a KVTaskEngine (which needs a GPU
+    TransferManager subprocess). usable=min(full,swa) truncates the full_mask
+    BEFORE the graph is built; return_mask_swa marks the trailing SWA window."""
+    usable = min(full_hit, swa_hit)
+    full_mask = np.ones(num_tokens, dtype=np.bool_)
+    truncated = full_mask.copy()
+    truncated[usable * tpb:] = False
+    swa_mask = np.zeros(num_tokens, dtype=np.bool_)
+    if swa_hit > 0:
+        swa_mask[(swa_hit - 1) * tpb: swa_hit * tpb] = True
+    return usable, truncated, swa_mask
+
+
+@pytest.mark.parametrize("full_hit,swa_hit,exp_usable", [
+    (10, 6, 6),   # M15.1: SWA shorter than full -> clamp full to SWA
+    (6, 6, 6),    # M15.4: SWA covers whole full hit -> no truncation loss
+    (10, 0, 0),   # M15.3: no SWA hit -> usable 0 -> empty full graph
+])
+def test_get_match_swa_usable_is_min(full_hit, swa_hit, exp_usable):
+    tpb, num_tokens = 16, 10 * 16
+    usable, truncated, _ = _usable_and_swa_mask(full_hit, swa_hit, num_tokens, tpb)
+    assert usable == exp_usable
+    # The full transfer is shaped to exactly `usable` blocks (truncate-before-build).
+    assert int(truncated.sum()) == exp_usable * tpb
+
+
+@pytest.mark.parametrize("swa_hit", [1, 3, 6])
+def test_get_match_swa_trailing_window_is_one_block(swa_hit):
+    """M16.1: SWA is page-granular (window == tokens_per_block), so return_mask_swa
+    marks exactly ONE block, ending at swa_hit."""
+    tpb, num_tokens = 16, 6 * 16
+    _, _, swa_mask = _usable_and_swa_mask(6, swa_hit, num_tokens, tpb)
+    assert int(swa_mask.sum()) == tpb                       # exactly one block
+    assert swa_mask[(swa_hit - 1) * tpb: swa_hit * tpb].all()  # the trailing one
+
+
+def test_get_match_swa_no_hit_empty_window_no_underflow():
+    """M16.2: swa_hit=0 -> return_mask_swa all-zero, and the (swa_hit-1) index is
+    never evaluated (no negative-index wraparound marking the last block)."""
+    tpb, num_tokens = 16, 6 * 16
+    _, _, swa_mask = _usable_and_swa_mask(6, 0, num_tokens, tpb)
+    assert not swa_mask.any()
+
+
 # --------------------------------------------------------------------------- #
 # 2. SWA load-lock lifecycle on the engine (needs c_ext)                       #
 # --------------------------------------------------------------------------- #

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -138,6 +138,46 @@ def test_swa_align_clamps_full_to_swa_hit():
     assert min(full_hit, swa_hit) == 4
 
 
+def test_swa_align_hit_equals_fetched_cpu_tier(monkeypatch):
+    """#9 tier-consistency guard: swa_align's returned SWA hit shapes the transfer
+    graph, but the GET data plane (_swa_get_slots) fetches the CPU tier ONLY.
+    match_swa_prefix reports best_hit_blocks = cross-tier MAX. If a non-CPU tier
+    ever reports a LONGER hit than CPU, returning best would shape a graph the
+    CPU-only fetch cannot fill (src/dst mismatch / stale SWA). swa_align must
+    clamp its return to the CPU (fetched) tier. We fake a longer SSD hit and
+    assert the returned hit stays at the CPU tier's value."""
+    eng = GlobalCacheEngine(_cache_config(True), _model_config())
+    tok = _tokens(4, base=7)
+    mask = np.ones_like(tok, dtype=np.int64)
+    slot_mapping = np.arange(tok.shape[0], dtype=np.int64)
+    _g, _rm, cb, op_cb, _e = eng.put(1, tok, mask, slot_mapping, dp_client_id=0)
+    _complete(op_cb, cb)
+
+    # CPU-only truth: best == cpu == 4.
+    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
+    assert swa_hit == 4
+
+    # Simulate a future SSD/REMOTE tier reporting a LONGER SWA hit than CPU.
+    real_match = eng.match_swa_prefix
+
+    def _fake_match(sequence_meta, cpu_full_hit_blocks, ssd_full_hit_blocks=0,
+                    remote_full_hit_blocks=0, lock_for_load=False):
+        r = real_match(sequence_meta, cpu_full_hit_blocks=cpu_full_hit_blocks,
+                       ssd_full_hit_blocks=ssd_full_hit_blocks,
+                       remote_full_hit_blocks=remote_full_hit_blocks,
+                       lock_for_load=lock_for_load)
+        r.ssd_hit_blocks = r.cpu_hit_blocks + 2  # SSD claims a longer hit
+        r.ssd_slot = 999
+        return r
+
+    monkeypatch.setattr(eng, "match_swa_prefix", _fake_match)
+    full_hit2, swa_hit2 = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
+    # Must clamp to the fetched CPU tier (4), NOT the cross-tier max (6).
+    assert swa_hit2 == 4, (
+        f"swa_align returned {swa_hit2} (cross-tier best) but GET fetches CPU-only "
+        f"(cpu_hit=4); graph would be shaped for blocks the fetch cannot fill")
+
+
 def test_get_builds_full_plus_swa_load_chain():
     eng = GlobalCacheEngine(_cache_config(True), _model_config())
     tok = _tokens(4, base=3)

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -145,6 +145,57 @@ def test_py_evict_swa_leaf_with_full_lock_keeps_full():
     assert not idx.is_empty()
 
 
+def test_py_match_probe_does_not_promote_swa_lru():
+    """M1.5 (regression guard): a match-only PROBE (update_cache_info=False, the
+    engine's swa_align path) must NOT reorder the SWA-LRU. A probe may never lead
+    to actual reuse (usable=min(full,swa) can truncate it to 0), so promoting on a
+    probe would pollute eviction. Passes today; must keep passing after the
+    reuse-promotion fix (which should gate on update_cache_info=True only)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.set_swa(a, slot=10)
+    b = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    idx.set_swa(b, slot=11)
+    # SWA-LRU order (LRU tail -> MRU head): A, B. Probe A without cache-info update.
+    idx.match_prefix(_seq([1, 2, 3, 4]), update_cache_info=False)
+    # A must still be the LRU victim — the probe did not promote it.
+    assert idx._swa_lru_get_lru_unlocked() is a
+
+
+@pytest.mark.xfail(reason="LRU-on-match promotion not yet wired (colleague's fix "
+                          "target): match/reuse of an SWA node does not promote "
+                          "it on the SWA-LRU, so a reused entry can be evicted "
+                          "before a never-reused one. Acceptance test for M6.6.",
+                   strict=False)
+def test_py_reuse_promotes_swa_over_never_reused():
+    """M6.6 (acceptance, xfail): the SWA-LRU reuse contract, separate from any
+    correctness invariant — no leak/corruption occurs either way, only hit-rate.
+
+    A (older) and B (newer) each hold an SWA slot; SWA-LRU order tail->head = A,B.
+    We then REUSE A via a real match (update_cache_info=True — the actual-reuse
+    path, mirroring how full-KV match already bumps its own last_access_time). A
+    correct SWA-LRU promotes the reused node to MRU, making B (never reused) the
+    true LRU victim. On the next single-slot SWA eviction, B must go and A must
+    survive.
+
+    Currently match does NOT promote the SWA-LRU, so A stays at the LRU tail and
+    is wrongly evicted — this test fails until the promotion is wired. The whole
+    'evict interior/public-prefix SWA first' policy actively works against a hot
+    reused prefix without this promotion (see 场景与覆盖矩阵 §I.1)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.set_swa(a, slot=10)
+    b = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    idx.set_swa(b, slot=11)
+    # Reuse A (real match, not a probe).
+    mr = idx.match_prefix(_seq([1, 2, 3, 4]), update_cache_info=True)
+    assert mr.last_swa_node is a  # A was indeed matched/reused
+    # Evict one SWA slot: must drop the never-reused B, not the just-reused A.
+    idx.evict_swa(1)
+    assert a.has_swa(), "reused SWA A was evicted (SWA-LRU not promoted on match)"
+    assert not b.has_swa()
+
+
 def test_py_dual_lock_invariant():
     """I3: full_lock_ref (lock_cnt) >= swa_lock_ref, with paired inc/dec."""
     idx = RadixTreeIndex(tokens_per_block=TPB)


### PR DESCRIPTION
## 修复：#9 多 tier tier 一致性（latent bug）

`swa_align` 的返回值决定 SWA 传输图形状（kvtask 按 `usable=min(full, 该值)` 截断 full）。但 `match_swa_prefix` 返回的 `best_hit_blocks` 是**跨 tier 最大**，而 GET 数据面 `_swa_get_slots` **只取 CPU tier**。

- **当前无害**：DSv4 下 SSD/REMOTE SWA 默认 0 slots → `best == cpu_hit`，是 no-op。
- **一旦启用**更长的非 CPU SWA 命中：图按更长命中定型，但 CPU-only fetch 填不满 → **src/dst 块数不等 / 读到陈旧 SWA（静默损坏）**。

**修法（fail-safe，不 fail-loud）**：`swa_align` 把返回的 SWA 命中 clamp 到实际会 fetch 的 CPU tier，并在丢弃更长非 CPU 命中时 warn 一次。遵循"绝不崩 scheduler"——宁可少几个 SWA 命中，也不定型一张填不满的图。将来把 `_swa_get_slots` 扩到 winning tier 后即可解除。

## 测试

| 测试 | 场景 | 结果 |
|---|---|---|
| `test_swa_align_hit_equals_fetched_cpu_tier` | #9 回归守护：伪造更长 SSD 命中，断言 swa_align 仍 clamp 到 CPU | ✅ pass |
| `test_py_reuse_promotes_swa_over_never_reused` | **M6.6 验收（xfail）**：复用过的 SWA 应比未复用的更晚被驱逐。当前 match 不提升 SWA-LRU → xfail；同事接上提升后自动转 pass | ⚠️ xfail |
| `test_py_match_probe_does_not_promote_swa_lru` | M1.5：match-only 探测（update_cache_info=False）**不得**重排 SWA-LRU（保证将来的提升修复只在真实复用时触发） | ✅ pass |
| `test_get_match_swa_usable_is_min` / `_trailing_window_is_one_block` / `_no_hit_empty_window` | M15/M16：kvtask `usable=min` 截断、尾窗恰一 block、swa_hit=0 无负索引回绕 | ✅ pass |

## 验证
DSv4 容器（torch 2.11/cu130, c_ext）：`-m unit` **72 passed / 1 skipped / 1 xfailed**（xfailed = M6.6），`-m smoke` **9 passed / 1 skipped**，无回归。