### PR TITLE
test(batch_kvtask): drop stale dp_id kwarg from post-PP-refactor API

### DIFF
--- a/tests/test_batch_kvtask.py
+++ b/tests/test_batch_kvtask.py
@@ -113,8 +113,8 @@ def test_batched_put_and_get_lifecycle(running_kvmanager, cache_config):
 
     # ---- batched PUT (first write -> every sub-task has a non-empty graph) ----
     put_ids, put_slot_mappings = [], []
-    for token_ids, block_ids, dp_id in pairs:
-        task_id, _ = kvmanager.put_match(token_ids=token_ids, token_mask=None, dp_id=dp_id)
+    for token_ids, block_ids, _ in pairs:
+        task_id, _ = kvmanager.put_match(token_ids=token_ids, token_mask=None)
         put_ids.append(task_id)
         put_slot_mappings.append(block_ids_2_slot_mapping(block_ids, tokens_per_block))
     launched_put = kvmanager.launch(put_ids, put_slot_mappings, as_batch=True)
@@ -122,8 +122,8 @@ def test_batched_put_and_get_lifecycle(running_kvmanager, cache_config):
 
     # ---- batched GET of the same tokens -> should fully hit the cache ----
     get_ids, get_slot_mappings = [], []
-    for token_ids, block_ids, dp_id in pairs:
-        task_id, _ = kvmanager.get_match(token_ids=token_ids, token_mask=None, dp_id=dp_id)
+    for token_ids, block_ids, _ in pairs:
+        task_id, _ = kvmanager.get_match(token_ids=token_ids, token_mask=None)
         get_ids.append(task_id)
         get_slot_mappings.append(block_ids_2_slot_mapping(block_ids, tokens_per_block))
     launched_get = kvmanager.launch(get_ids, get_slot_mappings, as_batch=True)


### PR DESCRIPTION
## Summary
- `test_batched_put_and_get_lifecycle` was calling `KVManager.put_match / get_match` with a `dp_id=` keyword that the PP refactor (commit 1a91e7f) removed from those signatures. The test — added by #184 (aa74e39) the same day — never worked against the merged main and has failed with `TypeError: put_match() got an unexpected keyword argument 'dp_id'` since it landed.
- `dp_id` returned by `generate_request_pair` is unused here (`dp_size=1` in this fixture), so the fix is to drop it from the call and ignore it in the tuple unpacking.

## Test plan
- [ ] `pytest tests/test_batch_kvtask.py::test_batched_put_and_get_lifecycle -x -q` — should now PASS (was: `TypeError`).
- [ ] `pytest tests/test_batch_kvtask.py -x -q` — full file green.
- [ ] `pytest tests/test_kvmanager.py -x -q -k "batch or launch"` — sibling batched tests still green (shares the `run_tp_client` fixture).
- [ ] `grep -rn "dp_id=" tests/ benchmarks/ examples/ flexkv/` — no other stale callers introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)