### PR TITLE
feat(swa): multi-tier SSD/REMOTE SWA + single-pass fold

### DIFF
--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -755,6 +755,16 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
 
   auto physical_blocks = physical_blocks_tensor.narrow(0, 0, pb_write);
   auto empty_uint32 = torch::Tensor();
+  // Read-hit heat update: on a real match (update_cache_info=true), promote the
+  // matched SWA node to its SWA-LRU MRU — the SWA peer of the per-node Full-KV
+  // update_time() bump above, so a reused SWA copy survives eviction over a
+  // never-reused one. last_swa_node is the deepest fully-matched ready node with
+  // a live SWA slot (or nullptr); promote_swa no-ops on root / no-SWA. A probe
+  // (update_cache_info=false) must NOT touch the SWA-LRU. Mirrors Python
+  // RadixTreeIndex.match_prefix.
+  if (update_cache_info && last_swa_node != nullptr) {
+    promote_swa(last_swa_node);
+  }
   return std::make_shared<CMatchResult>(
       ready_prefix_blocks_num, prefix_blocks_num, last_node_matched_length,
       last_ready_node, current_node, physical_blocks, empty_uint32,

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -900,7 +900,7 @@ class GlobalCacheEngine:
         # SWA hit is clamped to it (SWA subset of Full).
         num_full_hit = block_start_idx + num_gpu_blocks_to_transfer
         (swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots,
-         swa_key, swa_lock_node) = \
+         swa_key, swa_lock_node, swa_staging_slot) = \
             self._swa_get_slots(request_id, sequence_meta, block_start_idx,
                                 block_end_idx, num_full_hit)
         swa_h2d_id = self.swa_cache.build_get_chain(
@@ -948,9 +948,14 @@ class GlobalCacheEngine:
         # (lock_for_load) so it can't be evicted before the SWA H2D reads it. When
         # that H2D completes, release the pin. Keyed on the SWA H2D op so it fires
         # exactly once on completion, alongside the full-KV op callbacks.
-        if swa_h2d_id is not None and swa_lock_node is not None:
+        # The SWA H2D completion callback releases the source-tier pin and, for a
+        # staged (SSD/REMOTE) source, frees the transient CPU staging slot. Keyed
+        # on the SWA H2D op so it fires exactly once, alongside the full-KV ops.
+        if swa_h2d_id is not None and (swa_lock_node is not None
+                                       or swa_staging_slot >= 0):
             op_callback_dict[swa_h2d_id] = partial(
-                self._swa_release_load_lock, node=swa_lock_node)
+                self._swa_release_load_lock, node=swa_lock_node,
+                staging_slot=swa_staging_slot)
 
         # Record metrics for GET operation
         if self._metrics_collector is not None:
@@ -1442,11 +1447,9 @@ class GlobalCacheEngine:
         # set_swa); the GPU slot is a placeholder bound LATE from the request's
         # swa_slot_mapping. The stored tail node is node_to_unlock[CPU] (the new
         # ready prefix's deepest node); its trailing page is the SWA window.
-        cpu_store_node = node_to_unlock[DeviceType.CPU][0] \
-            if DeviceType.CPU in node_to_unlock else None
         swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots, swa_key = \
             self._swa_put_slots(request_id, sequence_meta, block_start_idx,
-                                block_end_idx, cpu_store_node)
+                                block_end_idx, node_to_unlock)
         swa_d2h_id = self.swa_cache.build_put_chain(
             transfer_graph,
             gpu_slot_ids=swa_gpu_slots,
@@ -2030,29 +2033,18 @@ class GlobalCacheEngine:
             remote_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load)
 
-        # Tier-consistency (SWA subset of Full, AND graph shape must match the
-        # tier actually fetched). swa_align's return shapes the SWA transfer graph
-        # (kvtask truncates to usable=min(full, this)); but the GET data plane
-        # (_swa_get_slots) currently fetches the CPU tier ONLY. best_hit_blocks is
-        # the cross-tier MAX, so if SSD/REMOTE ever carry a LONGER SWA hit than
-        # CPU, returning best_hit_blocks would shape the graph for blocks the
-        # CPU-only fetch cannot fill -> src/dst block-count mismatch / stale-SWA
-        # read (silent corruption). Today SSD/REMOTE SWA default to 0 slots so
-        # best == cpu_hit and this is a no-op; clamp to the fetched (CPU) tier and
-        # warn once if a longer non-CPU hit is dropped, so enabling SSD/REMOTE SWA
-        # without extending the fetcher fails safe (lose a few SWA hits) instead
-        # of shaping an unfillable graph.
-        cpu_hit = swa_match.cpu_hit_blocks
+        # Return the best (longest) reusable SWA hit across tiers. This shapes the
+        # SWA transfer graph (kvtask truncates full to usable=min(full, this)),
+        # and the GET data plane (_swa_get_slots) now sources the window from the
+        # highest-priority tier that holds it (CPU > SSD > REMOTE, staging
+        # SSD/REMOTE -> CPU -> GPU), so any tier's hit is fetchable. best is
+        # already clamped per tier to that tier's Full-KV hit (SWA subset of Full)
+        # inside match_swa_prefix, so best <= full_hit_blocks always holds.
         best_hit = swa_match.best_hit_blocks
-        if best_hit > cpu_hit and not getattr(self, "_warned_swa_multitier", False):
-            self._warned_swa_multitier = True
-            flexkv_logger.warning(
-                "SWA multi-tier hit (best=%d blocks) exceeds the CPU tier "
-                "(cpu=%d); GET fetches CPU-only, clamping the SWA graph to the "
-                "CPU hit to avoid an unfillable transfer graph. Extend "
-                "_swa_get_slots to the winning tier before relying on SSD/REMOTE "
-                "SWA loads.", best_hit, cpu_hit)
-        return full_hit_blocks, cpu_hit
+        assert best_hit <= full_hit_blocks, (
+            f"SWA hit {best_hit} exceeds Full-KV hit {full_hit_blocks} "
+            "(SWA-subset-of-Full violated)")
+        return full_hit_blocks, best_hit
 
     # --- SWA slot sources for the get()/put() build chains --------------------
     # Resolve the per-tier SWA-pool slot ids for the current request so the SWA
@@ -2071,48 +2063,97 @@ class GlobalCacheEngine:
     def _empty_swa_slots(self, with_node: bool = False):
         empty = np.array([], dtype=np.int64)
         if with_node:
-            # (gpu, cpu, ssd, remote, swa_key, lock_node)
-            return empty, empty, empty, empty, -1, None
+            # (gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)
+            return empty, empty, empty, empty, -1, None, -1
         # (gpu, cpu, ssd, remote, swa_key)
         return empty, empty, empty, empty, -1
 
     def _swa_get_slots(self, request_id, sequence_meta, block_start_idx,
                        block_end_idx, full_hit_blocks):
-        """Resolve SWA-pool slots for a GET (load).
+        """Resolve SWA-pool slots for a GET (load), sourced across tiers.
 
-        Returns ``(gpu, cpu, ssd, remote, swa_key, lock_node)``. Matches the
-        node-mounted SWA within the full-KV hit (SWA subset of Full) on the CPU
-        tier, pins it (lock_for_load) so it survives until the SWA H2D reads it,
-        and returns the CPU SWA slot + the pinned node (released in the H2D
-        completion callback). Empty when SWA is disabled or there is no SWA hit.
-        """
+        Mirrors full-KV multi-tier staging: the trailing SWA window (page
+        granular, one slot) is sourced from the highest-priority tier that holds
+        it (CPU > SSD > REMOTE), matching full-KV's loader preference.
+
+        * CPU source: the matched CPU SWA slot feeds the SWA H2D directly (no
+          staging), and the CPU node is pinned (released on H2D completion).
+        * SSD/REMOTE source: there is no CPU-resident window, so a TRANSIENT CPU
+          SWA staging slot is allocated as the DISK2H/REMOTE2H destination and
+          the SWA H2D source (mirrors full-KV's fragment23 CPU staging blocks).
+          The source-tier node is pinned; the staging slot is freed on H2D
+          completion (it is unmounted — not a cached entry).
+
+        Returns ``(gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)``.
+        ``cpu`` is always the SWA H2D source (matched CPU slot OR staging slot);
+        ``ssd``/``remote`` are non-empty only for a staged source; ``staging_slot``
+        is the transient CPU slot to free on H2D completion (-1 when CPU-sourced).
+        Empty when SWA is disabled or no tier holds the window."""
         if not self.swa_cache.enabled or full_hit_blocks <= 0:
             return self._empty_swa_slots(with_node=True)
         cpu_engine = self.cpu_cache_engine
         if cpu_engine is None or not getattr(cpu_engine, "swa_enabled", False):
             return self._empty_swa_slots(with_node=True)
-        # match_swa returns (swa_hit_blocks, cpu_slot, swa_key) and, with
-        # lock_for_load=True, pins the matched CPU SWA node. We also need the node
-        # handle to release the pin later, so use the lower-level match to grab it.
-        swa_hit, cpu_slot, swa_key, lock_node = \
-            cpu_engine.match_swa_locked(sequence_meta, upper_bound_blocks=full_hit_blocks)
-        if swa_hit <= 0 or cpu_slot < 0:
-            return self._empty_swa_slots(with_node=True)
-        cpu = np.array([cpu_slot], dtype=np.int64)
         gpu = self._SWA_GPU_PLACEHOLDER.copy()
         empty = np.array([], dtype=np.int64)
-        # SSD/REMOTE SWA staging is a later tier; CPU-resident SWA needs no stage.
-        return gpu, cpu, empty, empty, swa_key, lock_node
+
+        # 1) CPU tier first (preferred, no staging). match_swa_locked pins the
+        #    matched CPU SWA node; the H2D completion callback releases the pin.
+        swa_hit, cpu_slot, swa_key, lock_node = \
+            cpu_engine.match_swa_locked(sequence_meta, upper_bound_blocks=full_hit_blocks)
+        if swa_hit > 0 and cpu_slot >= 0:
+            cpu = np.array([cpu_slot], dtype=np.int64)
+            return gpu, cpu, empty, empty, swa_key, lock_node, -1
+
+        # 2) Fall back to SSD then REMOTE: source tier stages into a transient
+        #    CPU SWA slot (DISK2H/REMOTE2H -> CPU) that the SWA H2D then reads.
+        for device_type in (DeviceType.SSD, DeviceType.REMOTE):
+            engine = self.cache_engines.get(device_type)
+            if engine is None or not getattr(engine, "swa_enabled", False):
+                continue
+            tier_hit, tier_slot, tier_key, tier_node = \
+                engine.match_swa_locked(sequence_meta, upper_bound_blocks=full_hit_blocks)
+            if tier_hit <= 0 or tier_slot < 0:
+                continue
+            # Transient CPU staging slot (unmounted; freed on H2D completion).
+            staging_slot = cpu_engine.swa_alloc_slot()
+            if staging_slot < 0:
+                # No CPU room to stage: release the just-taken source pin and
+                # skip SWA reuse for this get (full-KV load is unaffected).
+                if tier_node is not None and getattr(tier_node, "swa_lock_ref", 0) > 0:
+                    tier_node.dec_swa_lock_ref()
+                cpu_engine._drain_swa_slots()
+                return self._empty_swa_slots(with_node=True)
+            cpu = np.array([staging_slot], dtype=np.int64)
+            tier = np.array([tier_slot], dtype=np.int64)
+            ssd = tier if device_type == DeviceType.SSD else empty
+            remote = tier if device_type == DeviceType.REMOTE else empty
+            return gpu, cpu, ssd, remote, tier_key, tier_node, staging_slot
+
+        return self._empty_swa_slots(with_node=True)
 
     def _swa_put_slots(self, request_id, sequence_meta, block_start_idx,
-                       block_end_idx, cpu_store_node):
-        """Resolve SWA-pool slots for a PUT (store).
+                       block_end_idx, node_to_unlock):
+        """Resolve SWA-pool slots for a PUT (store), across all stored tiers.
 
-        Allocates a fresh SWA host-pool slot (evicting SWA-LRU when full) and
-        mounts it on the stored tail node (set_swa) so a future GET matches it.
-        Returns ``(gpu_placeholder, cpu=[slot], ssd, remote, swa_key)``; empty
-        when SWA is disabled, there is no stored node, or the pool is full and
-        every entry is locked (full-KV store is unaffected)."""
+        Mirrors full-KV write-through: the SWA D2H lands the window in the CPU
+        SWA pool, and — for every tier full-KV ALSO stored to (CPU/SSD/REMOTE,
+        i.e. present in ``node_to_unlock``) — allocate that tier's SWA slot and
+        mount it on that tier's store node (set_swa). build_put_chain then emits
+        the SWA H2DISK / H2REMOTE write-through ops (CPU SWA slot -> tier slot),
+        fire-and-forget, exactly like the full-KV H2DISK/H2REMOTE. Gating on
+        ``node_to_unlock`` keeps SWA a subset of Full PER TIER: SWA is written to
+        a tier iff full-KV was.
+
+        Returns ``(gpu_placeholder, cpu=[slot], ssd, remote, swa_key)``. The CPU
+        slot is required (the D2H target); ssd/remote are non-empty only when
+        that tier both stored full-KV and has an SWA host pool. All empty when
+        SWA is disabled, there is no CPU store node, or the CPU pool is full and
+        fully locked (full-KV store is unaffected)."""
+        empty = np.array([], dtype=np.int64)
+        cpu_store_node = (node_to_unlock[DeviceType.CPU][0]
+                          if node_to_unlock and DeviceType.CPU in node_to_unlock
+                          else None)
         if not self.swa_cache.enabled or cpu_store_node is None:
             return self._empty_swa_slots()
         cpu_engine = self.cpu_cache_engine
@@ -2125,19 +2166,51 @@ class GlobalCacheEngine:
         cpu_engine._drain_swa_slots()
         cpu = np.array([slot], dtype=np.int64)
         gpu = self._SWA_GPU_PLACEHOLDER.copy()
-        empty = np.array([], dtype=np.int64)
-        return gpu, cpu, empty, empty, slot
 
-    def _swa_release_load_lock(self, node) -> None:
-        """Release the load-time SWA pin taken by _swa_get_slots (H2D done).
+        # Write-through to a lower tier iff full-KV stored there AND that tier
+        # has an SWA host pool. One slot per tier (page-granular window). A tier
+        # whose SWA pool is full-and-locked simply skips write-through (its slot
+        # stays empty) — the CPU SWA store is unaffected.
+        def _tier_slot(device_type):
+            if device_type not in node_to_unlock:
+                return empty
+            engine = self.cache_engines.get(device_type)
+            if engine is None or not getattr(engine, "swa_enabled", False):
+                return empty
+            tier_slot = engine.swa_alloc_slot()
+            if tier_slot < 0:
+                return empty
+            engine.set_swa(node_to_unlock[device_type][0], tier_slot)
+            engine._drain_swa_slots()
+            return np.array([tier_slot], dtype=np.int64)
 
-        Uses the plain SWA lock dec (dec_swa_lock_ref), NOT dec_swa_lock_only:
-        the loaded SWA window stays cached for future reuse; we only drop the
-        eviction pin. No-op if the node lost its SWA meanwhile."""
+        ssd = _tier_slot(DeviceType.SSD)
+        remote = _tier_slot(DeviceType.REMOTE)
+        return gpu, cpu, ssd, remote, slot
+
+
+    def _swa_release_load_lock(self, node, staging_slot: int = -1) -> None:
+        """SWA H2D completion callback: release the source pin and free any
+        transient CPU staging slot.
+
+        For a CPU-sourced load, ``node`` is the matched CPU SWA node and its pin
+        is dropped with the plain dec (dec_swa_lock_ref, NOT dec_swa_lock_only):
+        the loaded window stays cached for future reuse. For a staged
+        (SSD/REMOTE) source, ``node`` is the source-tier node (same pin release)
+        and ``staging_slot`` is the transient CPU SWA slot used as the DISK2H/
+        REMOTE2H destination — it is unmounted (not a cached entry), so free it
+        back to the CPU SWA pool. No-op on parts that are absent."""
         try:
             if node is not None and getattr(node, "swa_lock_ref", 0) > 0:
                 node.dec_swa_lock_ref()
         except Exception:  # noqa: BLE001 — never let a callback crash the loop
+            pass
+        try:
+            if staging_slot is not None and staging_slot >= 0:
+                cpu_engine = self.cpu_cache_engine
+                if cpu_engine is not None and cpu_engine.swa_pool is not None:
+                    cpu_engine.swa_pool.free(int(staging_slot))
+        except Exception:  # noqa: BLE001
             pass
 
     @nvtx.annotate("Match Prefix", color="yellow")

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -30,7 +30,7 @@ from flexkv.cache.redis_meta import RedisMeta, dist_available
 from flexkv.cache.mempool import Mempool
 from flexkv.cache.radixtree import RadixTreeIndex, RadixNode, MatchResult
 from flexkv.cache.transfer_pattern import add_virtual_op_for_multiple_finished_ops
-from flexkv.cache.swa_cache_engine import SWACacheManager, SWAMatchResult
+from flexkv.cache.swa_cache_engine import SWACacheManager
 from flexkv.common.block import SequenceMeta
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.transfer import (
@@ -297,8 +297,8 @@ class CacheEngineAccel:
             physical_blocks=phys,
             block_node_ids=bnids_np,
             matched_pos="remote" if self.device_type == DeviceType.REMOTE else "local",
-            # SWA node-mount: pass through the SWA hit found in the SAME forward
-            # pass so swa_align can reuse it (no second match_prefix walk).
+            # SWA node-mount: carry the SWA hit found on the SAME forward pass so
+            # the SWA-aware get can reuse it (no second match_prefix walk).
             last_swa_node=getattr(match_result, "last_swa_node", None),
             swa_hit_blocks=int(getattr(match_result, "swa_hit_blocks", 0) or 0),
         )
@@ -764,7 +764,7 @@ class GlobalCacheEngine:
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
             # Initialize the node-mounted SWA host pool on the CPU engine when SWA
             # is enabled (DSv4). Without this the SWA pool is never constructed and
-            # get_match_swa finds no SWA. Guarded by hasattr because the non-accel
+            # a SWA-aware get finds no SWA. Guarded by hasattr because the non-accel
             # CacheEngine fallback (Python RadixTreeIndex) also supports it.
             swa_config = getattr(cache_config, "swa", None)
             if swa_config is not None and getattr(swa_config, "enabled", False):
@@ -941,11 +941,10 @@ class GlobalCacheEngine:
 
         block_start_idx, block_end_idx = self._get_block_range(token_mask)
         # block_end_idx is the block just past the LAST True in token_mask. On the
-        # plain get() path the caller marks every non-resident token up to the
-        # aligned end, so this equals aligned_length // tokens_per_block. The
-        # SWA-aware caller (kvtask.get_match_swa) deliberately truncates the mask
-        # to usable = min(full_hit, swa_hit), leaving trailing False when the full
-        # hit runs past the reusable SWA window — a legitimate short match. So the
+        # plain path the caller marks every non-resident token up to the aligned
+        # end, so this equals aligned_length // tokens_per_block. On the SWA-aware
+        # path (swa_aware=True) _get_impl_* clamps the window to usable = min(full,
+        # swa) after matching, which can end before the aligned length. So the
         # invariant is <= (can never exceed the aligned length), not ==. Nothing
         # below uses aligned_length; all downstream sizing keys off block_end_idx.
         assert block_end_idx <= aligned_length // self.tokens_per_block
@@ -2033,144 +2032,6 @@ class GlobalCacheEngine:
                     ssd_matched_result = self.ssd_cache_engine.match_all(sequence_meta, gpu_matched_blocks)
 
         return cpu_matched_result, ssd_matched_result
-
-    # ===== SWA control plane (delegated to SWACacheManager) ===================
-    # The multi-tier SWA match and the SWA peer-op graph construction live in
-    # flexkv/cache/swa_cache_engine.py (self.swa_cache). This thin delegate keeps
-    # the call sites (kvtask.get_match_swa) reading the same as the full-KV path.
-
-    def match_swa_prefix(self,
-                         sequence_meta: SequenceMeta,
-                         max_full_hit_blocks: int,
-                         lock_for_load: bool = False,
-                         cpu_match_result=None,
-                         ssd_match_result=None,
-                         remote_match_result=None) -> SWAMatchResult:
-        """Multi-tier SWA prefix match (delegates to SWACacheManager.match_prefix).
-
-        Per-tier ``*_match_result`` (from the SAME forward pass that produced the
-        full hit) let the SWA match REUSE that pass instead of re-walking. Every
-        tier is clamped to the single ``max_full_hit_blocks`` upper bound.
-        """
-        return self.swa_cache.match_prefix(
-            sequence_meta,
-            max_full_hit_blocks=max_full_hit_blocks,
-            lock_for_load=lock_for_load,
-            cpu_match_result=cpu_match_result,
-            ssd_match_result=ssd_match_result,
-            remote_match_result=remote_match_result,
-        )
-
-    def swa_align(self,
-                  token_ids: np.ndarray,
-                  full_mask: np.ndarray,
-                  namespace: Optional[List[str]] = None,
-                  cpu_only: bool = False,
-                  lock_for_load: bool = False) -> Tuple[int, int]:
-        """Match-only SWA alignment: return ``(full_hit_blocks, swa_hit_blocks)``
-        without allocating or building any transfer op.
-
-        Owns all SWA tier access (per-tier node-mounted SWA via
-        :meth:`match_swa_prefix`). Used by the SWA-only get path
-        (kvtask.get_match_swa when the GPU already holds the full prefix), where
-        there is no Full-KV transfer to ride and the SWA window must be looked up
-        directly. The main get path resolves the SWA hit inside a single match in
-        :meth:`get` and does not call this.
-
-        Args:
-            token_ids: the request's full token ids (token-length, unaligned).
-            full_mask: token_mask (1 = token not on the GPU full pool). The leading
-                run of 0s is the device-resident full prefix.
-            namespace: optional cache namespace (folded into the prefix hash).
-            cpu_only: restrict to the CPU tier (mirrors get_match's cpu_only).
-            lock_for_load: pin matched SWA entries against eviction until the load.
-
-        Returns:
-            ``full_hit_blocks``: the Full-KV prefix resident after this get (the
-                SWA upper bound, since SWA is a subset of Full).
-            ``swa_hit_blocks``: longest reusable trailing-SWA prefix within the
-                full hit (0 when no SWA). SWA is page-granular, so this bounds a
-                single-block window.
-        """
-        tokens_per_block = self.tokens_per_block
-        if full_mask is None:
-            full_mask = np.ones_like(token_ids, dtype=np.bool_)
-
-        aligned_length = (token_ids.shape[0] // tokens_per_block) * tokens_per_block
-        if aligned_length == 0:
-            return 0, 0
-        aligned_mask = full_mask.copy()
-        aligned_mask[aligned_length:] = False
-
-        # Device-resident full prefix = leading run of 0s in full_mask, plus the
-        # ready matched transfer span — exactly the prefix get() will make resident.
-        block_start_idx, block_end_idx = self._get_block_range(aligned_mask)
-        if not aligned_mask.any():
-            # SWA-only: full_mask all-0 means the GPU holds the entire aligned
-            # prefix, so there is no transfer span but the full hit is the whole
-            # resident prefix (the SWA upper bound). Set the window to the aligned
-            # length so the SWA match below is not disabled by an empty range.
-            num_aligned_blocks = aligned_length // tokens_per_block
-            block_start_idx = block_end_idx = num_aligned_blocks
-        sequence_meta = SequenceMeta(token_ids=token_ids[:aligned_length],
-                                     tokens_per_block=tokens_per_block,
-                                     namespace=namespace)
-
-        temp_cache_strategy = CPUONLY_CACHE_STRATEGY if cpu_only else DEFAULT_CACHE_STRATEGY
-
-        # --- ready Full-KV hit within [block_start, block_end) -----------------
-        # Mirrors the fragment accounting in _get_impl_local / _get_impl_global:
-        # per tier, the reusable span is the ready-matched blocks clamped to the
-        # query window; the full hit is the max across tiers. We only read lengths
-        # here (no take / insert / op build).
-        def _ready_span(match_result) -> int:
-            ready = getattr(match_result, "num_ready_matched_blocks", 0)
-            return max(0, min(int(ready), block_end_idx) - block_start_idx)
-
-        remote_mr = None
-        if not self.cache_config.enable_remote or temp_cache_strategy.ignore_remote:
-            if self.index_accel:
-                cpu_mr, ssd_mr = self.match_local_accel(
-                    sequence_meta, temp_cache_strategy, is_put=False,
-                    gpu_matched_blocks=block_start_idx)
-            else:
-                cpu_mr, ssd_mr = self.match_local(sequence_meta, temp_cache_strategy)
-            ready_span = max(_ready_span(cpu_mr), _ready_span(ssd_mr))
-        else:
-            if self.index_accel:
-                cpu_mr, ssd_mr, remote_mr = self.match_all_accel(sequence_meta)
-            else:
-                cpu_mr, ssd_mr, remote_mr = self.match_all(sequence_meta)
-            ready_span = max(_ready_span(cpu_mr), _ready_span(ssd_mr), _ready_span(remote_mr))
-
-        full_hit_blocks = block_start_idx + ready_span
-        if full_hit_blocks == 0:
-            return 0, 0
-
-        # --- SWA prefix match clamped to the full hit (SWA subset of Full) -----
-        # Node-mount: SWA state lives on the radix nodes, so a tier has SWA iff
-        # its engine has an SWA host pool (swa_enabled). match_swa_prefix reads
-        # the SWA hit from the same radix match_prefix.
-        cpu_engine = self.cpu_cache_engine
-        if cpu_engine is None or not getattr(cpu_engine, "swa_enabled", False):
-            return full_hit_blocks, 0
-
-        swa_match = self.match_swa_prefix(
-            sequence_meta, max_full_hit_blocks=full_hit_blocks,
-            lock_for_load=lock_for_load,
-            # Reuse the Full-KV matches computed above so no tier re-walks the tree.
-            cpu_match_result=cpu_mr,
-            ssd_match_result=ssd_mr,
-            remote_match_result=remote_mr)
-
-        # Best (longest) reusable SWA hit across tiers. Each tier is already
-        # clamped to its Full-KV hit inside match_swa_prefix (SWA subset of Full),
-        # so best <= full_hit_blocks always holds.
-        best_hit = swa_match.best_hit_blocks
-        assert best_hit <= full_hit_blocks, (
-            f"SWA hit {best_hit} exceeds Full-KV hit {full_hit_blocks} "
-            "(SWA-subset-of-Full violated)")
-        return full_hit_blocks, best_hit
 
     def _swa_hit_from_match_results(self, tier_match_results: Dict) -> int:
         """Best (max) SWA hit across tiers, read from already-computed Full-KV

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -862,9 +862,8 @@ class GlobalCacheEngine:
         self.start()
 
         # The trailing dict is the per-tier Full-KV match results (DeviceType ->
-        # MatchResult) from THIS get's single forward pass, so the SWA slot
-        # resolution can REUSE them (match_swa_from_result) instead of re-walking
-        # the tree — the Level 2 single-pass contract. Empty on a full miss.
+        # MatchResult), so SWA slot resolution can reuse them (no re-walk).
+        # Empty on a full miss.
         self._empty_get_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, Dict]] = \
             lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0, {})
         self._empty_put_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, int]] = \
@@ -988,16 +987,14 @@ class GlobalCacheEngine:
                     swa_aware=swa_aware,
                 )
 
-        # SWA peer-op (data plane): build the SWA load chain into THIS graph
-        # alongside the full-KV ops, then append its terminal SWA H2D op to
-        # finished_ops_ids so the VIRTUAL barrier waits for full AND SWA. The SWA
-        # ops carry is_swa=True (routed to the SWA worker) and use SWA-pool slot
-        # ids: the CPU slot is the node-mounted radix match (resolved here), the
-        # GPU slot is a placeholder bound LATE from the request's swa_slot_mapping
-        # (graph.set_swa_gpu_blocks in launch). build_get_chain returns None
-        # (no-op) unless enable_swa_transfer is on and the tier has a live SWA hit.
-        # num_full_hit = ready full-KV prefix (blocks) resident after this get; the
-        # SWA hit is clamped to it (SWA subset of Full).
+        # SWA peer-op: build the SWA load chain into the SAME graph as the full-KV
+        # ops and append its terminal SWA H2D to finished_ops_ids, so the VIRTUAL
+        # barrier waits for full AND SWA. SWA ops carry is_swa=True (routed to the
+        # SWA worker) and use SWA-pool slot ids: the CPU slot is the node-mounted
+        # radix match, the GPU slot is a placeholder bound late at launch
+        # (graph.set_swa_gpu_blocks). build_get_chain is a no-op unless SWA
+        # transfer is on and a tier has a live SWA hit. num_full_hit = the ready
+        # full-KV prefix resident after this get (the SWA hit's upper bound).
         num_full_hit = block_start_idx + num_gpu_blocks_to_transfer
         (swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots,
          swa_key, swa_lock_node, swa_staging_slot) = \
@@ -1096,8 +1093,8 @@ class GlobalCacheEngine:
             cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all_accel(sequence_meta)
         else:
             cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all(sequence_meta)
-        # SWA-aware: clamp Full-KV transfer to usable = min(full, swa) from THIS
-        # single pass (Level 2). See _get_impl_local for rationale.
+        # SWA-aware: clamp the Full-KV transfer to usable = min(full, swa) read
+        # from this same match. See _get_impl_local for rationale.
         if swa_aware:
             block_mask_end = self._clamp_end_to_swa(
                 block_mask_start, block_mask_end,
@@ -1270,8 +1267,8 @@ class GlobalCacheEngine:
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
 
         # NOTE: for now in build transfer graph, we assume that cpu works as a cache for ssd
-        # Trailing dict: per-tier Full-KV match results from THIS single pass, so
-        # SWA slot resolution reuses them (Level 2 single-pass) instead of re-walking.
+        # Trailing dict: per-tier Full-KV match results, so SWA slot resolution
+        # reuses them instead of re-walking the tree.
         return (
             transfer_graph, finished_ops_ids, node_to_unlock, {}, buffer_to_free,
             len(fragment123_gpu_blocks) if enable_gpu else 0,  # op_node_to_ready: {}
@@ -1313,11 +1310,11 @@ class GlobalCacheEngine:
         else:
             cpu_matched_result, ssd_matched_result = self.match_local(sequence_meta, temp_cache_strategy)
 
-        # SWA-aware: clamp the Full-KV transfer to usable = min(full, swa) from
-        # THIS single pass (Level 2). The SWA window slid out past `usable` has no
-        # reusable KV, so loading Full past it would feed stale SWA to attention.
-        # SWA hit is read from the same match results (no re-walk); block_mask_end
-        # is the sole knob — every fragment below slices [block_mask_start:end].
+        # SWA-aware: clamp the Full-KV transfer to usable = min(full, swa). The
+        # SWA window past `usable` has no reusable KV, so loading Full past it
+        # would feed stale KV to the SWA-layer attention. The SWA hit is read from
+        # this same match (no re-walk); block_mask_end is the sole knob — every
+        # fragment below slices [block_mask_start:block_mask_end].
         if swa_aware:
             block_mask_end = self._clamp_end_to_swa(
                 block_mask_start, block_mask_end,
@@ -1505,8 +1502,8 @@ class GlobalCacheEngine:
             node_to_unlock[DeviceType.SSD] = (ssd_node_to_unlock, ssd_node_to_unlock.size())
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
         nvtx.end_range(nvtx_range)
-        # Trailing dict: per-tier Full-KV match results from THIS single pass, so
-        # SWA slot resolution reuses them (Level 2 single-pass) instead of re-walking.
+        # Trailing dict: per-tier Full-KV match results, so SWA slot resolution
+        # reuses them instead of re-walking the tree.
         return (
             transfer_graph, finished_ops_ids, node_to_unlock, op_node_to_ready,
             buffer_to_free, len(fragment12_gpu_blocks) if enable_gpu else 0,
@@ -2070,35 +2067,30 @@ class GlobalCacheEngine:
                   namespace: Optional[List[str]] = None,
                   cpu_only: bool = False,
                   lock_for_load: bool = False) -> Tuple[int, int]:
-        """Match-only SWA alignment for a SWA-aware GET — owns ALL SWA tier access.
+        """Match-only SWA alignment: return ``(full_hit_blocks, swa_hit_blocks)``
+        without allocating or building any transfer op.
 
-        Returns ``(full_hit_blocks, swa_hit_blocks)`` WITHOUT
-        allocating or building any transfer op. The caller (kvtask.get_match_swa)
-        uses these to truncate the Full-KV transfer to ``usable = min(full, swa)``
-        BEFORE building the graph, so Full-KV is never loaded past the reusable SWA
-        prefix (loading full without the matching SWA window would feed stale SWA
-        KV to the SWA-layer attention).
-
-        Layering: this is the SWA peer of the Full-KV match inside :meth:`get`. It
-        reaches the per-tier node-mounted SWA / :meth:`match_swa_prefix`; kvtask never
-        does, exactly as it never touches the Full-KV radix tree.
+        Owns all SWA tier access (per-tier node-mounted SWA via
+        :meth:`match_swa_prefix`). Used by the SWA-only get path
+        (kvtask.get_match_swa when the GPU already holds the full prefix), where
+        there is no Full-KV transfer to ride and the SWA window must be looked up
+        directly. The main get path resolves the SWA hit inside a single match in
+        :meth:`get` and does not call this.
 
         Args:
             token_ids: the request's full token ids (token-length, unaligned).
-            full_mask: original token_mask (1 = token NOT on the GPU full pool).
-                The leading run of 0s is the device-resident full prefix.
+            full_mask: token_mask (1 = token not on the GPU full pool). The leading
+                run of 0s is the device-resident full prefix.
             namespace: optional cache namespace (folded into the prefix hash).
             cpu_only: restrict to the CPU tier (mirrors get_match's cpu_only).
             lock_for_load: pin matched SWA entries against eviction until the load.
-                Kept False until the SWA data plane can release the lock.
 
         Returns:
-            ``full_hit_blocks``: the Full-KV prefix that WILL be resident after this
-                get (device-resident prefix + ready matched transfer span); the SWA
-                upper bound (SWA must be a subset of Full).
-            ``swa_hit_blocks``: longest reusable trailing-SWA prefix within the full
-                hit (0 when no SWA / data plane not wired). SWA is page-granular, so
-                the trailing window this bounds is a single block (one swa_page).
+            ``full_hit_blocks``: the Full-KV prefix resident after this get (the
+                SWA upper bound, since SWA is a subset of Full).
+            ``swa_hit_blocks``: longest reusable trailing-SWA prefix within the
+                full hit (0 when no SWA). SWA is page-granular, so this bounds a
+                single-block window.
         """
         tokens_per_block = self.tokens_per_block
         if full_mask is None:
@@ -2114,12 +2106,10 @@ class GlobalCacheEngine:
         # ready matched transfer span — exactly the prefix get() will make resident.
         block_start_idx, block_end_idx = self._get_block_range(aligned_mask)
         if not aligned_mask.any():
-            # SWA-only / fully-resident case: full_mask all-0 means the GPU already
-            # holds the ENTIRE aligned prefix, so there is no transfer span but the
-            # full hit is the whole resident prefix (the SWA upper bound). Without
-            # this, _get_block_range collapses to (0, 0) and full_hit_blocks would
-            # be 0, hitting the early-return below and silently disabling the
-            # documented SWA-only path (see kvtask.get_match_swa).
+            # SWA-only: full_mask all-0 means the GPU holds the entire aligned
+            # prefix, so there is no transfer span but the full hit is the whole
+            # resident prefix (the SWA upper bound). Set the window to the aligned
+            # length so the SWA match below is not disabled by an empty range.
             num_aligned_blocks = aligned_length // tokens_per_block
             block_start_idx = block_end_idx = num_aligned_blocks
         sequence_meta = SequenceMeta(token_ids=token_ids[:aligned_length],
@@ -2168,19 +2158,14 @@ class GlobalCacheEngine:
         swa_match = self.match_swa_prefix(
             sequence_meta, max_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load,
-            # Reuse the Full-KV matches just computed above — the SWA hit rides the
-            # SAME forward pass, so no tier re-walks the tree.
+            # Reuse the Full-KV matches computed above so no tier re-walks the tree.
             cpu_match_result=cpu_mr,
             ssd_match_result=ssd_mr,
             remote_match_result=remote_mr)
 
-        # Return the best (longest) reusable SWA hit across tiers. This shapes the
-        # SWA transfer graph (kvtask truncates full to usable=min(full, this)),
-        # and the GET data plane (_swa_get_slots) now sources the window from the
-        # highest-priority tier that holds it (CPU > SSD > REMOTE, staging
-        # SSD/REMOTE -> CPU -> GPU), so any tier's hit is fetchable. best is
-        # already clamped per tier to that tier's Full-KV hit (SWA subset of Full)
-        # inside match_swa_prefix, so best <= full_hit_blocks always holds.
+        # Best (longest) reusable SWA hit across tiers. Each tier is already
+        # clamped to its Full-KV hit inside match_swa_prefix (SWA subset of Full),
+        # so best <= full_hit_blocks always holds.
         best_hit = swa_match.best_hit_blocks
         assert best_hit <= full_hit_blocks, (
             f"SWA hit {best_hit} exceeds Full-KV hit {full_hit_blocks} "
@@ -2188,18 +2173,13 @@ class GlobalCacheEngine:
         return full_hit_blocks, best_hit
 
     def _swa_hit_from_match_results(self, tier_match_results: Dict) -> int:
-        """Pure read of the best (max) SWA hit across tiers from ALREADY-computed
-        Full-KV match results — no tree walk, no promote, no pin.
+        """Best (max) SWA hit across tiers, read from already-computed Full-KV
+        match results — no tree walk, no promote, no pin.
 
-        Node-mount: each tier's match_prefix returned ``swa_hit_blocks`` on the
-        SAME forward pass that produced its Full-KV hit. The SWA hit only advances
-        on ready fully-matched nodes, so per tier it is already <= that tier's
-        Full-KV ready hit (SWA subset of Full). Used by _get_impl_* to clamp the
-        Full-KV transfer to ``usable = min(full, swa)`` BEFORE fragment sizing.
-
-        Returns 0 when SWA is disabled or no tier has a live SWA hit. This is a
-        read-only probe; the actual promote/pin happens later in _swa_get_slots
-        via match_swa_from_result (do NOT promote here — that would double-count).
+        Each tier's match_prefix returned ``swa_hit_blocks`` on the same pass that
+        produced its Full-KV hit, already <= that tier's Full-KV hit (SWA subset
+        of Full). Returns 0 when SWA is disabled or no tier has a live SWA hit.
+        Read-only: the promote/pin happens later in _swa_get_slots.
         """
         if not self.swa_cache.enabled or not tier_match_results:
             return 0
@@ -2212,17 +2192,15 @@ class GlobalCacheEngine:
 
     def _clamp_end_to_swa(self, block_mask_start: int, block_mask_end: int,
                           tier_match_results: Dict) -> int:
-        """Return block_mask_end clamped to usable = min(full_hit, swa_hit).
+        """Clamp block_mask_end to usable = min(full_hit, swa_hit).
 
-        All three are ABSOLUTE block counts from prefix block 0 (matching
-        kvtask.get_match_swa's old usable = min(full_hit_blocks, swa_hit_blocks),
-        both absolute). ``block_mask_end`` is the Full-KV query-window end (the
-        full hit upper bound); ``swa_hit`` is read from the same-pass match
-        results. When SWA is disabled or there is no SWA hit, ``usable`` collapses
-        to block_mask_start and the Full-KV transfer window is empty — the correct
-        behavior for a SWA-aware get with no reusable SWA window (loading Full
-        without its SWA window would feed stale SWA to attention). Never widens
-        (clamped to the incoming end) and never drops below block_mask_start."""
+        All three are absolute block counts from prefix block 0. ``block_mask_end``
+        is the Full-KV query-window end (the full hit); ``swa_hit`` comes from the
+        same-pass match results. When there is no SWA hit, usable collapses to
+        block_mask_start (empty Full-KV window) — loading Full past the reusable
+        SWA window would feed stale KV to the SWA-layer attention. Never widens the
+        window and never drops below block_mask_start.
+        """
         swa_hit = self._swa_hit_from_match_results(tier_match_results)
         usable = min(block_mask_end, swa_hit)
         return max(block_mask_start, usable)
@@ -2266,9 +2244,8 @@ class GlobalCacheEngine:
           completion (it is unmounted — not a cached entry).
 
         ``tier_match_results`` (DeviceType -> MatchResult), when provided, is the
-        Full-KV match from THIS get's single forward pass; each tier resolves its
-        SWA slot via ``match_swa_from_result`` (REUSE the pass, no re-walk) — the
-        Level 2 single-pass path. When None (plain callers / back-compat), each
+        Full-KV match already computed for this get; each tier resolves its SWA
+        slot via ``match_swa_from_result`` (reuse it, no re-walk). When None, each
         tier falls back to a fresh ``match_swa_locked`` probe.
 
         Returns ``(gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)``.
@@ -2285,8 +2262,8 @@ class GlobalCacheEngine:
         empty = np.array([], dtype=np.int64)
 
         def _match_locked(engine, device_type):
-            """Resolve (hit, slot, key, node) for a tier, pinned for load.
-            Reuse the single-pass match result when available, else re-walk."""
+            """Resolve (hit, slot, key, node) for a tier, pinned for load. Reuse
+            the given match result when available, else probe the tree."""
             mr = tier_match_results.get(device_type) if tier_match_results else None
             if mr is not None:
                 return engine.match_swa_from_result(

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -2029,7 +2029,30 @@ class GlobalCacheEngine:
             ssd_full_hit_blocks=full_hit_blocks,
             remote_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load)
-        return full_hit_blocks, swa_match.best_hit_blocks
+
+        # Tier-consistency (SWA subset of Full, AND graph shape must match the
+        # tier actually fetched). swa_align's return shapes the SWA transfer graph
+        # (kvtask truncates to usable=min(full, this)); but the GET data plane
+        # (_swa_get_slots) currently fetches the CPU tier ONLY. best_hit_blocks is
+        # the cross-tier MAX, so if SSD/REMOTE ever carry a LONGER SWA hit than
+        # CPU, returning best_hit_blocks would shape the graph for blocks the
+        # CPU-only fetch cannot fill -> src/dst block-count mismatch / stale-SWA
+        # read (silent corruption). Today SSD/REMOTE SWA default to 0 slots so
+        # best == cpu_hit and this is a no-op; clamp to the fetched (CPU) tier and
+        # warn once if a longer non-CPU hit is dropped, so enabling SSD/REMOTE SWA
+        # without extending the fetcher fails safe (lose a few SWA hits) instead
+        # of shaping an unfillable graph.
+        cpu_hit = swa_match.cpu_hit_blocks
+        best_hit = swa_match.best_hit_blocks
+        if best_hit > cpu_hit and not getattr(self, "_warned_swa_multitier", False):
+            self._warned_swa_multitier = True
+            flexkv_logger.warning(
+                "SWA multi-tier hit (best=%d blocks) exceeds the CPU tier "
+                "(cpu=%d); GET fetches CPU-only, clamping the SWA graph to the "
+                "CPU hit to avoid an unfillable transfer graph. Extend "
+                "_swa_get_slots to the winning tier before relying on SSD/REMOTE "
+                "SWA loads.", best_hit, cpu_hit)
+        return full_hit_blocks, cpu_hit
 
     # --- SWA slot sources for the get()/put() build chains --------------------
     # Resolve the per-tier SWA-pool slot ids for the current request so the SWA

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -861,8 +861,12 @@ class GlobalCacheEngine:
         #TODO move this to kvmanager.start()
         self.start()
 
-        self._empty_get_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]] = \
-            lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0)
+        # The trailing dict is the per-tier Full-KV match results (DeviceType ->
+        # MatchResult) from THIS get's single forward pass, so the SWA slot
+        # resolution can REUSE them (match_swa_from_result) instead of re-walking
+        # the tree — the Level 2 single-pass contract. Empty on a full miss.
+        self._empty_get_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, Dict]] = \
+            lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0, {})
         self._empty_put_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, int]] = \
             lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0, 0)
 
@@ -920,7 +924,8 @@ class GlobalCacheEngine:
             slot_mapping: np.ndarray,
             dp_client_id: int,
             temp_cache_strategy: CacheStrategy = DEFAULT_CACHE_STRATEGY,
-            namespace: Optional[List[str]] = None) \
+            namespace: Optional[List[str]] = None,
+            swa_aware: bool = False) \
                  -> Tuple[TransferOpGraph, np.ndarray, Callable, Dict, int]:
         self._check_input(token_ids, token_mask, slot_mapping)
 
@@ -955,7 +960,8 @@ class GlobalCacheEngine:
         if not self.cache_config.enable_remote or temp_cache_strategy.ignore_remote:
             # from this entrance, we will also handle the case of peer_cpu and peer_ssd
             (transfer_graph, finished_ops_ids, node_to_unlock,
-             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer) = \
+             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer,
+             tier_match_results) = \
                 self._get_impl_local(
                     request_id,
                     sequence_meta,
@@ -964,11 +970,13 @@ class GlobalCacheEngine:
                     gpu_block_ids,
                     temp_cache_strategy,
                     dp_client_id,
+                    swa_aware=swa_aware,
                 )
         else:
             #TODO pcfs will be supported later
             (transfer_graph, finished_ops_ids, node_to_unlock,
-             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer) = \
+             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer,
+             tier_match_results) = \
                 self._get_impl_global(
                     request_id,
                     sequence_meta,
@@ -977,6 +985,7 @@ class GlobalCacheEngine:
                     gpu_block_ids,
                     temp_cache_strategy,
                     dp_client_id,
+                    swa_aware=swa_aware,
                 )
 
         # SWA peer-op (data plane): build the SWA load chain into THIS graph
@@ -993,7 +1002,8 @@ class GlobalCacheEngine:
         (swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots,
          swa_key, swa_lock_node, swa_staging_slot) = \
             self._swa_get_slots(request_id, sequence_meta, block_start_idx,
-                                block_end_idx, num_full_hit)
+                                block_end_idx, num_full_hit,
+                                tier_match_results=tier_match_results)
         swa_h2d_id = self.swa_cache.build_get_chain(
             transfer_graph,
             gpu_slot_ids=swa_gpu_slots,
@@ -1062,7 +1072,8 @@ class GlobalCacheEngine:
             block_mask_end: int,
             gpu_block_ids: np.ndarray,
             temp_cache_strategy: CacheStrategy,
-            dp_client_id: int) \
+            dp_client_id: int,
+            swa_aware: bool = False) \
                  -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
         """
         transfer pattern:
@@ -1085,6 +1096,14 @@ class GlobalCacheEngine:
             cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all_accel(sequence_meta)
         else:
             cpu_matched_result, ssd_matched_result, remote_matched_result = self.match_all(sequence_meta)
+        # SWA-aware: clamp Full-KV transfer to usable = min(full, swa) from THIS
+        # single pass (Level 2). See _get_impl_local for rationale.
+        if swa_aware:
+            block_mask_end = self._clamp_end_to_swa(
+                block_mask_start, block_mask_end,
+                {DeviceType.CPU: cpu_matched_result,
+                 DeviceType.SSD: ssd_matched_result,
+                 DeviceType.REMOTE: remote_matched_result})
         cpu_matched_blocks = cpu_matched_result.physical_blocks[
             :cpu_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
         ssd_matched_blocks = ssd_matched_result.physical_blocks[
@@ -1251,9 +1270,14 @@ class GlobalCacheEngine:
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
 
         # NOTE: for now in build transfer graph, we assume that cpu works as a cache for ssd
+        # Trailing dict: per-tier Full-KV match results from THIS single pass, so
+        # SWA slot resolution reuses them (Level 2 single-pass) instead of re-walking.
         return (
             transfer_graph, finished_ops_ids, node_to_unlock, {}, buffer_to_free,
-            len(fragment123_gpu_blocks) if enable_gpu else 0  # op_node_to_ready: {}
+            len(fragment123_gpu_blocks) if enable_gpu else 0,  # op_node_to_ready: {}
+            {DeviceType.CPU: cpu_matched_result,
+             DeviceType.SSD: ssd_matched_result,
+             DeviceType.REMOTE: remote_matched_result},
         )
 
     def _get_impl_local(self,
@@ -1263,7 +1287,8 @@ class GlobalCacheEngine:
                         block_mask_end: int,
                         gpu_block_ids: np.ndarray,
                         temp_cache_strategy: CacheStrategy,
-                        dp_client_id: int) \
+                        dp_client_id: int,
+                        swa_aware: bool = False) \
                             -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
         """
         transfer pattern:
@@ -1288,6 +1313,16 @@ class GlobalCacheEngine:
         else:
             cpu_matched_result, ssd_matched_result = self.match_local(sequence_meta, temp_cache_strategy)
 
+        # SWA-aware: clamp the Full-KV transfer to usable = min(full, swa) from
+        # THIS single pass (Level 2). The SWA window slid out past `usable` has no
+        # reusable KV, so loading Full past it would feed stale SWA to attention.
+        # SWA hit is read from the same match results (no re-walk); block_mask_end
+        # is the sole knob — every fragment below slices [block_mask_start:end].
+        if swa_aware:
+            block_mask_end = self._clamp_end_to_swa(
+                block_mask_start, block_mask_end,
+                {DeviceType.CPU: cpu_matched_result,
+                 DeviceType.SSD: ssd_matched_result})
 
         # DEBUG: Log GET operation with hash info
         #if len(sequence_meta.block_hashes) > 0:
@@ -1470,9 +1505,13 @@ class GlobalCacheEngine:
             node_to_unlock[DeviceType.SSD] = (ssd_node_to_unlock, ssd_node_to_unlock.size())
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
         nvtx.end_range(nvtx_range)
+        # Trailing dict: per-tier Full-KV match results from THIS single pass, so
+        # SWA slot resolution reuses them (Level 2 single-pass) instead of re-walking.
         return (
             transfer_graph, finished_ops_ids, node_to_unlock, op_node_to_ready,
-            buffer_to_free, len(fragment12_gpu_blocks) if enable_gpu else 0
+            buffer_to_free, len(fragment12_gpu_blocks) if enable_gpu else 0,
+            {DeviceType.CPU: cpu_matched_result,
+             DeviceType.SSD: ssd_matched_result},
         )
 
     def put(self,
@@ -2153,6 +2192,46 @@ class GlobalCacheEngine:
             "(SWA-subset-of-Full violated)")
         return full_hit_blocks, best_hit
 
+    def _swa_hit_from_match_results(self, tier_match_results: Dict) -> int:
+        """Pure read of the best (max) SWA hit across tiers from ALREADY-computed
+        Full-KV match results — no tree walk, no promote, no pin.
+
+        Node-mount: each tier's match_prefix returned ``swa_hit_blocks`` on the
+        SAME forward pass that produced its Full-KV hit. The SWA hit only advances
+        on ready fully-matched nodes, so per tier it is already <= that tier's
+        Full-KV ready hit (SWA subset of Full). Used by _get_impl_* to clamp the
+        Full-KV transfer to ``usable = min(full, swa)`` BEFORE fragment sizing.
+
+        Returns 0 when SWA is disabled or no tier has a live SWA hit. This is a
+        read-only probe; the actual promote/pin happens later in _swa_get_slots
+        via match_swa_from_result (do NOT promote here — that would double-count).
+        """
+        if not self.swa_cache.enabled or not tier_match_results:
+            return 0
+        best = 0
+        for mr in tier_match_results.values():
+            hit = int(getattr(mr, "swa_hit_blocks", 0) or 0) if mr is not None else 0
+            if hit > best:
+                best = hit
+        return best
+
+    def _clamp_end_to_swa(self, block_mask_start: int, block_mask_end: int,
+                          tier_match_results: Dict) -> int:
+        """Return block_mask_end clamped to usable = min(full_hit, swa_hit).
+
+        All three are ABSOLUTE block counts from prefix block 0 (matching
+        kvtask.get_match_swa's old usable = min(full_hit_blocks, swa_hit_blocks),
+        both absolute). ``block_mask_end`` is the Full-KV query-window end (the
+        full hit upper bound); ``swa_hit`` is read from the same-pass match
+        results. When SWA is disabled or there is no SWA hit, ``usable`` collapses
+        to block_mask_start and the Full-KV transfer window is empty — the correct
+        behavior for a SWA-aware get with no reusable SWA window (loading Full
+        without its SWA window would feed stale SWA to attention). Never widens
+        (clamped to the incoming end) and never drops below block_mask_start."""
+        swa_hit = self._swa_hit_from_match_results(tier_match_results)
+        usable = min(block_mask_end, swa_hit)
+        return max(block_mask_start, usable)
+
     # --- SWA slot sources for the get()/put() build chains --------------------
     # Resolve the per-tier SWA-pool slot ids for the current request so the SWA
     # build chains can wire ops into the transfer graph. GET reads the matched
@@ -2176,7 +2255,7 @@ class GlobalCacheEngine:
         return empty, empty, empty, empty, -1
 
     def _swa_get_slots(self, request_id, sequence_meta, block_start_idx,
-                       block_end_idx, full_hit_blocks):
+                       block_end_idx, full_hit_blocks, tier_match_results=None):
         """Resolve SWA-pool slots for a GET (load), sourced across tiers.
 
         Mirrors full-KV multi-tier staging: the trailing SWA window (page
@@ -2191,6 +2270,12 @@ class GlobalCacheEngine:
           The source-tier node is pinned; the staging slot is freed on H2D
           completion (it is unmounted — not a cached entry).
 
+        ``tier_match_results`` (DeviceType -> MatchResult), when provided, is the
+        Full-KV match from THIS get's single forward pass; each tier resolves its
+        SWA slot via ``match_swa_from_result`` (REUSE the pass, no re-walk) — the
+        Level 2 single-pass path. When None (plain callers / back-compat), each
+        tier falls back to a fresh ``match_swa_locked`` probe.
+
         Returns ``(gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)``.
         ``cpu`` is always the SWA H2D source (matched CPU slot OR staging slot);
         ``ssd``/``remote`` are non-empty only for a staged source; ``staging_slot``
@@ -2204,10 +2289,21 @@ class GlobalCacheEngine:
         gpu = self._SWA_GPU_PLACEHOLDER.copy()
         empty = np.array([], dtype=np.int64)
 
-        # 1) CPU tier first (preferred, no staging). match_swa_locked pins the
-        #    matched CPU SWA node; the H2D completion callback releases the pin.
+        def _match_locked(engine, device_type):
+            """Resolve (hit, slot, key, node) for a tier, pinned for load.
+            Reuse the single-pass match result when available, else re-walk."""
+            mr = tier_match_results.get(device_type) if tier_match_results else None
+            if mr is not None:
+                return engine.match_swa_from_result(
+                    mr, sequence_meta, upper_bound_blocks=full_hit_blocks,
+                    lock_for_load=True)
+            return engine.match_swa_locked(
+                sequence_meta, upper_bound_blocks=full_hit_blocks)
+
+        # 1) CPU tier first (preferred, no staging). The matched CPU SWA node is
+        #    pinned; the H2D completion callback releases the pin.
         swa_hit, cpu_slot, swa_key, lock_node = \
-            cpu_engine.match_swa_locked(sequence_meta, upper_bound_blocks=full_hit_blocks)
+            _match_locked(cpu_engine, DeviceType.CPU)
         if swa_hit > 0 and cpu_slot >= 0:
             cpu = np.array([cpu_slot], dtype=np.int64)
             return gpu, cpu, empty, empty, swa_key, lock_node, -1
@@ -2219,7 +2315,7 @@ class GlobalCacheEngine:
             if engine is None or not getattr(engine, "swa_enabled", False):
                 continue
             tier_hit, tier_slot, tier_key, tier_node = \
-                engine.match_swa_locked(sequence_meta, upper_bound_blocks=full_hit_blocks)
+                _match_locked(engine, device_type)
             if tier_hit <= 0 or tier_slot < 0:
                 continue
             # Transient CPU staging slot (unmounted; freed on H2D completion).

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -423,6 +423,14 @@ class RadixTreeIndex:
                 last_node_matched_length = matched_length
                 prefix_blocks_num += matched_length
                 break
+        # Read-hit heat update: on a real match (update_cache_info=True), promote
+        # the matched SWA node to its SWA-LRU MRU — the SWA peer of the per-node
+        # Full-KV heat bump above, so a reused SWA copy survives eviction over a
+        # never-reused one. last_swa_node is the deepest fully-matched ready node
+        # with a live SWA slot (or None); promote_swa no-ops on root / no-SWA.
+        # A probe (update_cache_info=False) must NOT touch the SWA-LRU.
+        if update_cache_info and last_swa_node is not None:
+            self.promote_swa(last_swa_node)
         return MatchResult(num_matched_blocks=prefix_blocks_num,
                            num_ready_matched_blocks=ready_prefix_blocks_num,
                            last_ready_node=last_ready_node,

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -54,46 +54,11 @@ movement, kernels, SWA SSD/remote storage and completion callbacks are the data
 plane's responsibility.
 """
 
-from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
-from flexkv.common.block import SequenceMeta
 from flexkv.common.transfer import DeviceType, TransferOp, TransferOpGraph, TransferType
-
-
-@dataclass
-class SWAMatchResult:
-    """Per-tier SWA prefix-match result (control plane).
-
-    Each tier (CPU, SSD, REMOTE) is matched independently against its own
-    node-mounted SWA (on the radix tree) and clamped to that tier's Full-KV hit. SWA is page-granular:
-    one slot holds exactly one swa_page window, so the trailing SWA window is
-    always a single block (``window_size == tokens_per_block`` on DSv4) — there
-    is no separate window length to carry. Slots/keys are for the data-plane
-    transfer + set_ready/unlock bookkeeping (-1 when that tier missed).
-    """
-    cpu_hit_blocks: int = 0
-    ssd_hit_blocks: int = 0
-    remote_hit_blocks: int = 0
-    cpu_slot: int = -1
-    ssd_slot: int = -1
-    remote_slot: int = -1
-    cpu_key: int = -1
-    ssd_key: int = -1
-    remote_key: int = -1
-
-    @property
-    def best_hit_blocks(self) -> int:
-        """Longest reusable SWA prefix length (in blocks) across all tiers.
-
-        This is a length only — it does NOT pick a tier. The data-plane loader
-        decides which tier to source from (CPU > SSD > REMOTE) when building the
-        transfer; the current consumer (sizing return_mask_swa) needs only the
-        length.
-        """
-        return max(self.cpu_hit_blocks, self.ssd_hit_blocks, self.remote_hit_blocks)
 
 
 class SWACacheManager:
@@ -129,72 +94,6 @@ class SWACacheManager:
         cfg = getattr(self._gce, "cache_config", None)
         return bool(getattr(cfg, "enable_swa_transfer", False)) and \
             self._swa_enabled_tier(DeviceType.CPU)
-
-    # --- multi-tier match --------------------------------------------------
-
-    def match_prefix(self,
-                     sequence_meta: SequenceMeta,
-                     max_full_hit_blocks: int,
-                     lock_for_load: bool = False,
-                     cpu_match_result=None,
-                     ssd_match_result=None,
-                     remote_match_result=None) -> SWAMatchResult:
-        """Match the trailing-SWA prefix on each tier, clamped to the Full-KV hit.
-
-        Each tier's node-mounted SWA (on its radix tree) is matched independently
-        within the (already cross-tier max'd) Full-KV hit ``max_full_hit_blocks``
-        (SWA subset of Full). CPU is preferred; SSD then REMOTE are the fallbacks
-        whose load needs a staging chain (SWA DISK2H / REMOTE2H -> SWA H2D, all
-        is_swa=True).
-
-        When a tier's Full-KV ``*_match_result`` is supplied (from the SAME
-        forward pass that produced ``max_full_hit_blocks``), the SWA hit is
-        REUSED from it via ``match_swa_from_result`` — no second tree walk. When
-        omitted, it falls back to the standalone ``match_swa`` probe.
-
-        Args:
-            sequence_meta: the (page-aligned) query prefix.
-            max_full_hit_blocks: Full-KV hit length in blocks, the single upper
-                bound applied to every tier (the caller has already collapsed the
-                per-tier Full hits to their cross-tier max).
-            lock_for_load: pin the matched SWA entries against eviction until load.
-            cpu_match_result / ssd_match_result / remote_match_result: the tier's
-                Full-KV match to reuse (optional; carries last_swa_node/swa_hit_blocks).
-
-        Returns:
-            SWAMatchResult with per-tier hit lengths / slots / keys. SWA is
-            page-granular (one slot = one swa_page window = one block).
-        """
-        result = SWAMatchResult()
-        if not self._swa_enabled_tier(DeviceType.CPU):
-            return result
-        sequence_meta.gen_hashes()
-
-        def _match(engine, upper_bound, match_result):
-            """Reuse the Full-KV match when given, else probe. Returns
-            (hit, slot, key) — drops the node handle (callers that need the
-            pinned node use engine.match_swa_locked directly)."""
-            if match_result is not None:
-                hit, slot, key, _node = engine.match_swa_from_result(
-                    match_result, sequence_meta, upper_bound_blocks=upper_bound,
-                    lock_for_load=lock_for_load)
-                return hit, slot, key
-            return engine.match_swa(
-                sequence_meta, upper_bound_blocks=upper_bound,
-                lock_for_load=lock_for_load)
-
-        if max_full_hit_blocks > 0:
-            result.cpu_hit_blocks, result.cpu_slot, result.cpu_key = \
-                _match(self._engine(DeviceType.CPU), max_full_hit_blocks, cpu_match_result)
-
-            if self._swa_enabled_tier(DeviceType.SSD):
-                result.ssd_hit_blocks, result.ssd_slot, result.ssd_key = \
-                    _match(self._engine(DeviceType.SSD), max_full_hit_blocks, ssd_match_result)
-
-            if self._swa_enabled_tier(DeviceType.REMOTE):
-                result.remote_hit_blocks, result.remote_slot, result.remote_key = \
-                    _match(self._engine(DeviceType.REMOTE), max_full_hit_blocks, remote_match_result)
-        return result
 
     # --- peer-op graph construction (gated) --------------------------------
 
@@ -310,24 +209,3 @@ class SWACacheManager:
             if h2remote_id is not None:
                 graph.add_dependency(h2remote_id, d2h_id)
         return d2h_id
-
-    def build_swa_only_graph(self,
-                             transfer_type: TransferType,
-                             src_slot_ids: np.ndarray,
-                             dst_slot_ids: np.ndarray,
-                             swa_key: int = -1,
-                             dp_client_id: int = 0) -> Tuple[TransferOpGraph, int]:
-        """Build a graph containing ONLY an SWA op (the SWA-only form).
-
-        Returns (graph, swa_op_id); swa_op_id is -1 (empty graph) when SWA
-        transfer is disabled or the slots are empty. This is the form the
-        derivation model could not express (no full op to derive from), e.g. the
-        GPU already holds the full prefix and only the trailing SWA window slid
-        out and must be reloaded.
-        """
-        graph = TransferOpGraph()
-        op_id = self.build_swa_op(
-            graph, transfer_type, src_slot_ids, dst_slot_ids,
-            swa_key=swa_key, dp_client_id=dp_client_id,
-        )
-        return graph, (op_id if op_id is not None else -1)

--- a/flexkv/common/type.py
+++ b/flexkv/common/type.py
@@ -16,8 +16,8 @@ class MatchResultAccel:
     matched_node_ids: Optional[np.ndarray] = None #TODO id or ids? should we allow one req match results on multiple nodes?
     insert_to_local_cpu_index: bool = True
     # ===== SWA (node-mounted) — passed through from CMatchResult so the SWA
-    # control plane can reuse the SAME forward match instead of re-walking the
-    # tree (see GlobalCacheEngine.swa_align / match_swa_from_result). The deepest
+    # slot resolution can reuse the SAME forward match instead of re-walking the
+    # tree (see CacheEngineAccel.match_swa_from_result). The deepest
     # fully-matched ready node carrying a live SWA slot, and the ready-prefix
     # block count ending at it. None / 0 when no SWA on the matched path.
     last_swa_node: Optional['CRadixNode'] = None

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -501,8 +501,8 @@ class FlexKVConfig:
         # sliding_window (128). The per-token byte size is hard-asserted to
         # 584 (qk_nope_head_dim fp8 448 + qk_rope_head_dim bf16 128 + scale 8)
         # in DeepSeekV4SingleKVPool. Without this config, cache_config.swa
-        # stays None -> the cache engine never builds an SWA pool -> get_match_swa
-        # finds no SWA, so SWA KV is never matched/reused for this all-SWA model.
+        # stays None -> the cache engine never builds an SWA pool -> a SWA-aware
+        # get finds no SWA, so SWA KV is never matched/reused for this all-SWA model.
         is_dsv4 = bool(getattr(sglang_config, "is_deepseek_v4_arch", False))
         if is_dsv4 and self.cache_config.swa is None:
             swa_window = 256  # physical swa_page_size, asserted == 256 by sglang

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -209,39 +209,31 @@ class KVManager:
     def get_match_swa(self,
                       token_ids: Union[torch.Tensor, np.ndarray],
                       full_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                      swa_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
                       cpu_only: bool = False,
                       namespace: Optional[List[str]] = None,
                       update_state_for_load: bool = True,
                       ) -> Tuple[int, np.ndarray, np.ndarray]:
-        """Dual-mask SWA-aware match — deployment-dispatch wrapper.
+        """SWA-aware match — deployment-dispatch wrapper for get_match_swa.
 
-        Mirrors :meth:`get_match`'s wrapper exactly: convert tensors to numpy and
-        dispatch on ``server_client_mode``. ``full_mask`` is the original
-        token_mask (1 = token not on GPU full pool, needs transfer); ``swa_mask``
-        marks tokens missing on the GPU SWA pool.  Returns
+        Mirrors :meth:`get_match`'s wrapper: convert tensors to numpy and dispatch
+        on ``server_client_mode``. ``full_mask`` (1 = token not on GPU full pool,
+        needs transfer) drives the match. Returns
         ``(task_id, return_mask_full, return_mask_swa)``; the matching itself lives
         in :meth:`KVTaskEngine.get_match_swa`.
 
-        Both deployment forms are supported (this is the SWA analogue of
-        ``get_match``'s ``if server_client_mode`` branch): in-process calls
-        ``kv_task_engine.get_match_swa``; server mode forwards over the SWA RPC
-        (``dp_client.get_match_swa`` → ``GetMatchSwaRequest`` →
-        ``_handle_get_match_swa_request``).  If the RPC fails, it falls back to a
-        no-hit reply (matching ``get_match``'s None-on-error tolerance) rather than
-        crashing the scheduler.
+        In-process mode calls ``kv_task_engine.get_match_swa`` directly; server
+        mode forwards over the SWA RPC (``dp_client.get_match_swa`` →
+        ``GetMatchSwaRequest`` → ``_handle_get_match_swa_request``). If the RPC
+        fails it degrades to a no-hit reply rather than crashing the scheduler.
         """
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
         if isinstance(full_mask, torch.Tensor):
             full_mask = full_mask.numpy()
-        if isinstance(swa_mask, torch.Tensor):
-            swa_mask = swa_mask.numpy()
         if self.server_client_mode:
             result = self.dp_client.get_match_swa(
                 token_ids,
                 full_mask,
-                swa_mask,
                 cpu_only=cpu_only,
                 namespace=namespace,
                 update_state_for_load=update_state_for_load,
@@ -255,7 +247,6 @@ class KVManager:
         return self.kv_task_engine.get_match_swa(
             token_ids=token_ids,
             full_mask=full_mask,
-            swa_mask=swa_mask,
             cpu_only=cpu_only,
             namespace=namespace,
             update_state_for_load=update_state_for_load,

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -187,7 +187,15 @@ class KVManager:
                   token_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
                   cpu_only: bool = False,
                   namespace: Optional[List[str]] = None,
+                  swa_aware: bool = False,
                   ) -> Tuple[int, np.ndarray]:
+        """Match a prefix and build the load graph; return (task_id, mask).
+
+        ``swa_aware=True`` clamps the Full-KV transfer to the reusable SWA window
+        (from the same single match); the SWA window is the trailing block of the
+        returned mask, which the caller reads directly. ``swa_aware=False``
+        (default) is the plain path.
+        """
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
         if isinstance(token_mask, torch.Tensor):
@@ -196,61 +204,17 @@ class KVManager:
             task_id, mask = self.dp_client.get_match(token_ids,
                                                      token_mask,
                                                      cpu_only=cpu_only,
-                                                     namespace=namespace)
+                                                     namespace=namespace,
+                                                     swa_aware=swa_aware)
         else:
             task_id, mask = self.kv_task_engine.get_match(
                 token_ids=token_ids,
                 token_mask=token_mask,
                 cpu_only=cpu_only,
                 namespace=namespace,
+                swa_aware=swa_aware,
             )
         return task_id, mask
-
-    def get_match_swa(self,
-                      token_ids: Union[torch.Tensor, np.ndarray],
-                      full_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
-                      cpu_only: bool = False,
-                      namespace: Optional[List[str]] = None,
-                      update_state_for_load: bool = True,
-                      ) -> Tuple[int, np.ndarray, np.ndarray]:
-        """SWA-aware match — deployment-dispatch wrapper for get_match_swa.
-
-        Mirrors :meth:`get_match`'s wrapper: convert tensors to numpy and dispatch
-        on ``server_client_mode``. ``full_mask`` (1 = token not on GPU full pool,
-        needs transfer) drives the match. Returns
-        ``(task_id, return_mask_full, return_mask_swa)``; the matching itself lives
-        in :meth:`KVTaskEngine.get_match_swa`.
-
-        In-process mode calls ``kv_task_engine.get_match_swa`` directly; server
-        mode forwards over the SWA RPC (``dp_client.get_match_swa`` →
-        ``GetMatchSwaRequest`` → ``_handle_get_match_swa_request``). If the RPC
-        fails it degrades to a no-hit reply rather than crashing the scheduler.
-        """
-        if isinstance(token_ids, torch.Tensor):
-            token_ids = token_ids.numpy()
-        if isinstance(full_mask, torch.Tensor):
-            full_mask = full_mask.numpy()
-        if self.server_client_mode:
-            result = self.dp_client.get_match_swa(
-                token_ids,
-                full_mask,
-                cpu_only=cpu_only,
-                namespace=namespace,
-                update_state_for_load=update_state_for_load,
-            )
-            if result is None:
-                # RPC failed on the server; degrade to a no-hit reply so the
-                # caller never unpacks None (same tolerance as get_match).
-                empty = np.zeros_like(token_ids, dtype=np.bool_)
-                return -1, empty, empty
-            return result
-        return self.kv_task_engine.get_match_swa(
-            token_ids=token_ids,
-            full_mask=full_mask,
-            cpu_only=cpu_only,
-            namespace=namespace,
-            update_state_for_load=update_state_for_load,
-        )
 
     def put_async(self,
                   token_ids: Union[torch.Tensor, np.ndarray],
@@ -394,7 +358,7 @@ class KVManager:
     # ===== SWA (Sliding Window Attention) =====
     #
     # SWA is NODE-MOUNTED on the Full-KV radix tree and matched via
-    # ``get_match_swa`` (see above); SWA bytes move through the FlexKV transfer
+    # ``get_match(swa_aware=True)``; SWA bytes move through the FlexKV transfer
     # engine (data plane). The legacy standalone-index / blob API (SWAIndex,
     # swa_put / swa_get / swa_available + node_swa_ops + SWAProductionManager)
     # has been removed. See deployments/swa_design/08_节点挂载SWA架构.md.

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -712,46 +712,30 @@ class KVTaskEngine(KVTaskManager):
     def get_match_swa(self,
                       token_ids: np.ndarray,
                       full_mask: Optional[np.ndarray] = None,
-                      swa_mask: Optional[np.ndarray] = None,
                       dp_client_id: int = 0,
                       cpu_only: bool = False,
                       task_id: int = -1,
                       namespace: Optional[List[str]] = None,
                       update_state_for_load: bool = True,
                       ) -> Tuple[int, np.ndarray, np.ndarray]:
-        """Dual-mask SWA-aware match — the SWA counterpart to :meth:`get_match`.
+        """SWA-aware match: match Full-KV and its trailing SWA window together.
 
-        Unlike the single-mask :meth:`get_match`, the Full-KV transfer is bounded
-        by the SWA-reusable prefix: it computes ``usable = min(full_hit, swa_hit)``
-        FIRST (match-only, no allocation), then builds the transfer graph truncated
-        to ``usable``. This is mandatory — loading Full-KV past the reusable SWA
-        prefix would (a) waste H2D bandwidth on blocks the caller will recompute,
-        and (b) feed stale / unrestored SWA KV to the SWA-layer attention. Because
-        the graph is built once at ``usable``, there is no src/dst block-count
-        mismatch (the failure the old connector avoided via cancel+reissue).
+        Bounds the Full-KV transfer to ``usable = min(full_hit, swa_hit)``: past
+        the reusable SWA window the Full-KV bytes would feed stale KV to the
+        SWA-layer attention, so they are excluded. A single radix match yields
+        both the Full-KV hit and the node-mounted SWA hit, and the graph is built
+        clamped to ``usable`` in one pass (no src/dst count mismatch).
 
-        ``full_mask`` (1 = token NOT on GPU full pool, needs transfer) drives the
-        Full-KV match; ``swa_mask`` (1 = token NOT on GPU SWA pool) is reserved for
-        the future SWA H2D restore and not yet consumed.
-
-        When the GPU already holds the full prefix (``full_mask`` all-0), the
-        Full-KV match is empty and ``usable`` reduces to the SWA hit — the
-        "SWA-only" form — handled by the same code path.
-
-        Level 2 (single pass): the Full-KV match inside ``get(swa_aware=True)``
-        rides ONE forward pass that also yields the node-mounted SWA hit, and
-        clamps the Full-KV transfer to ``usable = min(full, swa)`` in-place. There
-        is no separate ``swa_align`` match — kvtask passes the ORIGINAL mask and
-        the engine owns the single match + clamp. ``return_mask_full`` therefore
-        already ends at ``usable``; the SWA window is its trailing page-block.
+        ``full_mask`` (1 = token not on the GPU full pool, needs transfer) drives
+        the match. When it is all-0 the GPU already holds the full prefix and only
+        the trailing SWA window needs reloading (the SWA-only form).
 
         Returns ``(task_id, return_mask_full, return_mask_swa)``; both masks are
-        token-length, True where CPU can supply that token.  The single-mask
-        :meth:`get_match` is left untouched.
+        token-length, True where CPU can supply that token. ``return_mask_swa``
+        marks the single trailing SWA page-block at the SWA hit.
         """
         nvtx.push_range(f"get match swa: task_id={task_id}", color=get_nvtx_default_color())
-        # Flush pending D2H completions so set_ready callbacks run before we check
-        # the radix tree — same rationale as get_match.
+        # Flush pending D2H completions so set_ready callbacks see the latest tree.
         self._update_tasks(timeout=0)
         if full_mask is None:
             full_mask = np.ones_like(token_ids, dtype=np.bool_)
@@ -759,12 +743,9 @@ class KVTaskEngine(KVTaskManager):
         tokens_per_block = self.cache_engine.tokens_per_block
         num_tokens = token_ids.shape[0]
 
-        # --- SWA-only branch: GPU already holds the full prefix (full_mask all-0)
-        # There is NO Full-KV match to ride, so this path resolves the SWA hit via
-        # a single swa_align probe and reports the trailing window. get() would
-        # early-return an empty graph on an all-0 mask, so the fold below cannot
-        # derive the window from return_mask_full here — this is the one branch
-        # that keeps swa_align (a single match, not a redundant second one).
+        # SWA-only: the GPU already holds the full prefix (full_mask all-0), so
+        # only the trailing SWA window needs reloading. There is no Full-KV
+        # transfer to build, so match the SWA hit directly and report its window.
         if not full_mask.any():
             _full_hit, swa_hit_blocks = self.cache_engine.swa_align(
                 token_ids, full_mask, namespace=namespace,
@@ -786,11 +767,10 @@ class KVTaskEngine(KVTaskManager):
             nvtx.pop_range()
             return result_task_id, return_mask_full, return_mask_swa
 
-        # --- Single pass: build the (SWA-clamped) transfer graph directly -----
-        # get(swa_aware=True) matches ONCE, reads the SWA hit off that same pass,
-        # clamps Full-KV to usable = min(full, swa), and builds the graph. No
-        # standalone swa_align match. The ORIGINAL mask goes in; the engine does
-        # the truncation, so return_mask_full already ends at usable.
+        # Build the SWA-clamped Full-KV graph. Passing swa_aware=True makes the
+        # engine match once, read the SWA hit off that same pass, and clamp the
+        # Full-KV transfer to usable = min(full, swa). return_mask_full ends at
+        # usable.
         fake_slot_mapping = np.zeros_like(token_ids[full_mask])
         result_task_id, return_mask_full = self._get_match_impl(
             token_ids, fake_slot_mapping, is_fake_slot_mapping=True,
@@ -798,18 +778,14 @@ class KVTaskEngine(KVTaskManager):
             cpu_only=cpu_only, task_id=task_id, namespace=namespace,
             swa_aware=True)
 
-        # --- return_mask_swa: the trailing SWA window at the SWA hit -----------
-        # SWA is page-granular: one slot = one swa_page window = exactly one block
-        # (window_size == tokens_per_block). usable == swa_hit (Full clamped to
-        # SWA), so the reusable SWA window is the LAST True page-block of
-        # return_mask_full. Derived from the clamped mask — no extra match.
+        # The SWA window is page-granular (one block). Since Full-KV is clamped to
+        # the SWA hit, it is the last block of return_mask_full.
         return_mask_swa = np.zeros(num_tokens, dtype=np.bool_)
         usable_blocks = int(return_mask_full.sum()) // tokens_per_block
         if usable_blocks > 0:
             return_mask_swa[(usable_blocks - 1) * tokens_per_block:
                             usable_blocks * tokens_per_block] = True
 
-        # trace get match swa request (mirrors get_match's GET_MATCH trace)
         self.tracer.trace_request(
             request_type="GET_MATCH_SWA",
             request_id=result_task_id,

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -198,6 +198,7 @@ class KVTaskManager:
                         is_fake_slot_mapping: bool = False,
                         temp_cache_strategy=DEFAULT_CACHE_STRATEGY,
                         namespace: Optional[List[str]] = None,
+                        swa_aware: bool = False,
                         ) -> None:
         if task_id in self.tasks:
             raise ValueError(f"Task ID {task_id} already exists")
@@ -208,7 +209,8 @@ class KVTaskManager:
             slot_mapping=slot_mapping,
             dp_client_id=dp_client_id,
             temp_cache_strategy=temp_cache_strategy,
-            namespace=namespace)
+            namespace=namespace,
+            swa_aware=swa_aware)
         self.tasks[task_id] = KVTask(
             task_id=task_id,
             task_type=TaskType.GET,
@@ -684,7 +686,8 @@ class KVTaskEngine(KVTaskManager):
                   token_mask: Optional[np.ndarray] = None,
                   cpu_only: bool = False,
                   task_id: int = -1,
-                  namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
+                  namespace: Optional[List[str]] = None,
+                  swa_aware: bool = False) -> Tuple[int, np.ndarray]:
         if token_mask is None:
             token_mask = np.ones_like(token_ids)
         if task_id == -1:
@@ -700,7 +703,8 @@ class KVTaskEngine(KVTaskManager):
                              token_mask=token_mask,
                              is_fake_slot_mapping=is_fake_slot_mapping,
                              temp_cache_strategy=temp_cache_strategy,
-                             namespace=namespace)
+                             namespace=namespace,
+                             swa_aware=swa_aware)
         self._process_empty_graph(task_id)
         nvtx.pop_range()
         return task_id, self.tasks[task_id].return_mask
@@ -732,12 +736,14 @@ class KVTaskEngine(KVTaskManager):
 
         When the GPU already holds the full prefix (``full_mask`` all-0), the
         Full-KV match is empty and ``usable`` reduces to the SWA hit — the
-        "SWA-only" form — handled by the same code path (the truncated mask stays
-        all-0, so ``_get_match_impl`` builds an empty Full-KV graph).
+        "SWA-only" form — handled by the same code path.
 
-        The match itself (full hit, SWA hit, window) is computed by
-        :meth:`GlobalCacheEngine.swa_align`, which owns ALL SWA tier access — this
-        layer never touches the SWA radix state directly.
+        Level 2 (single pass): the Full-KV match inside ``get(swa_aware=True)``
+        rides ONE forward pass that also yields the node-mounted SWA hit, and
+        clamps the Full-KV transfer to ``usable = min(full, swa)`` in-place. There
+        is no separate ``swa_align`` match — kvtask passes the ORIGINAL mask and
+        the engine owns the single match + clamp. ``return_mask_full`` therefore
+        already ends at ``usable``; the SWA window is its trailing page-block.
 
         Returns ``(task_id, return_mask_full, return_mask_swa)``; both masks are
         token-length, True where CPU can supply that token.  The single-mask
@@ -753,36 +759,55 @@ class KVTaskEngine(KVTaskManager):
         tokens_per_block = self.cache_engine.tokens_per_block
         num_tokens = token_ids.shape[0]
 
-        # --- ① Align first (match-only): full hit, SWA hit -------------------
-        # All tier access (node-mounted SWA / match_swa_prefix) lives in the cache
-        # engine; kvtask stays at the task-lifecycle layer. lock_for_load stays
-        # False until the SWA data plane can release the lock.
-        full_hit_blocks, swa_hit_blocks = self.cache_engine.swa_align(
-            token_ids, full_mask, namespace=namespace,
-            cpu_only=cpu_only, lock_for_load=False)
-        # SWA must be a subset of Full, so this is just swa_hit_blocks — but the
-        # min() makes the SWA-bound explicit and is robust if that ever loosens.
-        usable_blocks = min(full_hit_blocks, swa_hit_blocks)
+        # --- SWA-only branch: GPU already holds the full prefix (full_mask all-0)
+        # There is NO Full-KV match to ride, so this path resolves the SWA hit via
+        # a single swa_align probe and reports the trailing window. get() would
+        # early-return an empty graph on an all-0 mask, so the fold below cannot
+        # derive the window from return_mask_full here — this is the one branch
+        # that keeps swa_align (a single match, not a redundant second one).
+        if not full_mask.any():
+            _full_hit, swa_hit_blocks = self.cache_engine.swa_align(
+                token_ids, full_mask, namespace=namespace,
+                cpu_only=cpu_only, lock_for_load=False)
+            fake_slot_mapping = np.zeros_like(token_ids[full_mask])  # empty
+            result_task_id, return_mask_full = self._get_match_impl(
+                token_ids, fake_slot_mapping, is_fake_slot_mapping=True,
+                token_mask=full_mask, dp_client_id=dp_client_id,
+                cpu_only=cpu_only, task_id=task_id, namespace=namespace,
+                swa_aware=True)
+            return_mask_swa = np.zeros(num_tokens, dtype=np.bool_)
+            if swa_hit_blocks > 0:
+                return_mask_swa[(swa_hit_blocks - 1) * tokens_per_block:
+                                swa_hit_blocks * tokens_per_block] = True
+            self.tracer.trace_request(
+                request_type="GET_MATCH_SWA", request_id=result_task_id,
+                token_ids=token_ids, slot_mapping=fake_slot_mapping,
+                token_mask=full_mask, dp_client_id=dp_client_id)
+            nvtx.pop_range()
+            return result_task_id, return_mask_full, return_mask_swa
 
-        # --- ② Truncate full_mask to usable, THEN build the transfer graph ----
-        # Past usable, the Full-KV bytes have no reusable SWA window, so they are
-        # excluded from transfer. The graph is built once at this length.
-        truncated_full_mask = full_mask.copy()
-        truncated_full_mask[usable_blocks * tokens_per_block:] = False
-        fake_slot_mapping = np.zeros_like(token_ids[truncated_full_mask])
+        # --- Single pass: build the (SWA-clamped) transfer graph directly -----
+        # get(swa_aware=True) matches ONCE, reads the SWA hit off that same pass,
+        # clamps Full-KV to usable = min(full, swa), and builds the graph. No
+        # standalone swa_align match. The ORIGINAL mask goes in; the engine does
+        # the truncation, so return_mask_full already ends at usable.
+        fake_slot_mapping = np.zeros_like(token_ids[full_mask])
         result_task_id, return_mask_full = self._get_match_impl(
             token_ids, fake_slot_mapping, is_fake_slot_mapping=True,
-            token_mask=truncated_full_mask, dp_client_id=dp_client_id,
-            cpu_only=cpu_only, task_id=task_id, namespace=namespace)
+            token_mask=full_mask, dp_client_id=dp_client_id,
+            cpu_only=cpu_only, task_id=task_id, namespace=namespace,
+            swa_aware=True)
 
-        # --- ③ return_mask_swa: the trailing SWA window at the SWA hit ---------
-        # SWA is page-granular: one slot = one swa_page window = exactly one
-        # block (window_size == tokens_per_block), so the trailing window is the
-        # single block ending at swa_hit_blocks.
+        # --- return_mask_swa: the trailing SWA window at the SWA hit -----------
+        # SWA is page-granular: one slot = one swa_page window = exactly one block
+        # (window_size == tokens_per_block). usable == swa_hit (Full clamped to
+        # SWA), so the reusable SWA window is the LAST True page-block of
+        # return_mask_full. Derived from the clamped mask — no extra match.
         return_mask_swa = np.zeros(num_tokens, dtype=np.bool_)
-        if swa_hit_blocks > 0:
-            return_mask_swa[(swa_hit_blocks - 1) * tokens_per_block:
-                            swa_hit_blocks * tokens_per_block] = True
+        usable_blocks = int(return_mask_full.sum()) // tokens_per_block
+        if usable_blocks > 0:
+            return_mask_swa[(usable_blocks - 1) * tokens_per_block:
+                            usable_blocks * tokens_per_block] = True
 
         # trace get match swa request (mirrors get_match's GET_MATCH trace)
         self.tracer.trace_request(
@@ -790,7 +815,7 @@ class KVTaskEngine(KVTaskManager):
             request_id=result_task_id,
             token_ids=token_ids,
             slot_mapping=fake_slot_mapping,
-            token_mask=truncated_full_mask,
+            token_mask=full_mask,
             dp_client_id=dp_client_id
         )
         nvtx.pop_range()

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -647,7 +647,18 @@ class KVTaskEngine(KVTaskManager):
                   token_mask: Optional[np.ndarray] = None,
                   cpu_only: bool = False,
                   task_id: int = -1,
-                  namespace: Optional[List[str]] = None) -> Tuple[int, np.ndarray]:
+                  namespace: Optional[List[str]] = None,
+                  swa_aware: bool = False) -> Tuple[int, np.ndarray]:
+        """Match a prefix and build the load graph; return (task_id, return_mask).
+
+        With ``swa_aware=True`` the Full-KV transfer is clamped to the reusable
+        SWA window (``usable = min(full_hit, swa_hit)``) from the same single radix
+        match: past that window the Full-KV bytes would feed stale KV to the
+        SWA-layer attention. The SWA window is the trailing block of the returned
+        mask (page-granular), which the caller reads directly — there is no
+        separate SWA mask. ``swa_aware=False`` (default) is the plain path,
+        untouched.
+        """
         nvtx.push_range(f"get match: task_id={task_id}", color=get_nvtx_default_color())
         # self._sync_prefetch(token_ids, namespace)
         # Flush pending D2H completions so set_ready callbacks run before
@@ -665,7 +676,8 @@ class KVTaskEngine(KVTaskManager):
                                                            dp_client_id=dp_client_id,
                                                            cpu_only=cpu_only,
                                                            task_id=task_id,
-                                                           namespace=namespace)
+                                                           namespace=namespace,
+                                                           swa_aware=swa_aware)
         # trace get match request
         self.tracer.trace_request(
             request_type="GET_MATCH",
@@ -708,94 +720,6 @@ class KVTaskEngine(KVTaskManager):
         self._process_empty_graph(task_id)
         nvtx.pop_range()
         return task_id, self.tasks[task_id].return_mask
-
-    def get_match_swa(self,
-                      token_ids: np.ndarray,
-                      full_mask: Optional[np.ndarray] = None,
-                      dp_client_id: int = 0,
-                      cpu_only: bool = False,
-                      task_id: int = -1,
-                      namespace: Optional[List[str]] = None,
-                      update_state_for_load: bool = True,
-                      ) -> Tuple[int, np.ndarray, np.ndarray]:
-        """SWA-aware match: match Full-KV and its trailing SWA window together.
-
-        Bounds the Full-KV transfer to ``usable = min(full_hit, swa_hit)``: past
-        the reusable SWA window the Full-KV bytes would feed stale KV to the
-        SWA-layer attention, so they are excluded. A single radix match yields
-        both the Full-KV hit and the node-mounted SWA hit, and the graph is built
-        clamped to ``usable`` in one pass (no src/dst count mismatch).
-
-        ``full_mask`` (1 = token not on the GPU full pool, needs transfer) drives
-        the match. When it is all-0 the GPU already holds the full prefix and only
-        the trailing SWA window needs reloading (the SWA-only form).
-
-        Returns ``(task_id, return_mask_full, return_mask_swa)``; both masks are
-        token-length, True where CPU can supply that token. ``return_mask_swa``
-        marks the single trailing SWA page-block at the SWA hit.
-        """
-        nvtx.push_range(f"get match swa: task_id={task_id}", color=get_nvtx_default_color())
-        # Flush pending D2H completions so set_ready callbacks see the latest tree.
-        self._update_tasks(timeout=0)
-        if full_mask is None:
-            full_mask = np.ones_like(token_ids, dtype=np.bool_)
-
-        tokens_per_block = self.cache_engine.tokens_per_block
-        num_tokens = token_ids.shape[0]
-
-        # SWA-only: the GPU already holds the full prefix (full_mask all-0), so
-        # only the trailing SWA window needs reloading. There is no Full-KV
-        # transfer to build, so match the SWA hit directly and report its window.
-        if not full_mask.any():
-            _full_hit, swa_hit_blocks = self.cache_engine.swa_align(
-                token_ids, full_mask, namespace=namespace,
-                cpu_only=cpu_only, lock_for_load=False)
-            fake_slot_mapping = np.zeros_like(token_ids[full_mask])  # empty
-            result_task_id, return_mask_full = self._get_match_impl(
-                token_ids, fake_slot_mapping, is_fake_slot_mapping=True,
-                token_mask=full_mask, dp_client_id=dp_client_id,
-                cpu_only=cpu_only, task_id=task_id, namespace=namespace,
-                swa_aware=True)
-            return_mask_swa = np.zeros(num_tokens, dtype=np.bool_)
-            if swa_hit_blocks > 0:
-                return_mask_swa[(swa_hit_blocks - 1) * tokens_per_block:
-                                swa_hit_blocks * tokens_per_block] = True
-            self.tracer.trace_request(
-                request_type="GET_MATCH_SWA", request_id=result_task_id,
-                token_ids=token_ids, slot_mapping=fake_slot_mapping,
-                token_mask=full_mask, dp_client_id=dp_client_id)
-            nvtx.pop_range()
-            return result_task_id, return_mask_full, return_mask_swa
-
-        # Build the SWA-clamped Full-KV graph. Passing swa_aware=True makes the
-        # engine match once, read the SWA hit off that same pass, and clamp the
-        # Full-KV transfer to usable = min(full, swa). return_mask_full ends at
-        # usable.
-        fake_slot_mapping = np.zeros_like(token_ids[full_mask])
-        result_task_id, return_mask_full = self._get_match_impl(
-            token_ids, fake_slot_mapping, is_fake_slot_mapping=True,
-            token_mask=full_mask, dp_client_id=dp_client_id,
-            cpu_only=cpu_only, task_id=task_id, namespace=namespace,
-            swa_aware=True)
-
-        # The SWA window is page-granular (one block). Since Full-KV is clamped to
-        # the SWA hit, it is the last block of return_mask_full.
-        return_mask_swa = np.zeros(num_tokens, dtype=np.bool_)
-        usable_blocks = int(return_mask_full.sum()) // tokens_per_block
-        if usable_blocks > 0:
-            return_mask_swa[(usable_blocks - 1) * tokens_per_block:
-                            usable_blocks * tokens_per_block] = True
-
-        self.tracer.trace_request(
-            request_type="GET_MATCH_SWA",
-            request_id=result_task_id,
-            token_ids=token_ids,
-            slot_mapping=fake_slot_mapping,
-            token_mask=full_mask,
-            dp_client_id=dp_client_id
-        )
-        nvtx.pop_range()
-        return result_task_id, return_mask_full, return_mask_swa
 
     def put_match(self,
                   token_ids: np.ndarray,

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -192,20 +192,18 @@ class KVDPClient:
         self,
         token_ids: np.ndarray,
         full_mask: Optional[np.ndarray],
-        swa_mask: Optional[np.ndarray] = None,
         cpu_only: bool = False,
         namespace: Optional[List[str]] = None,
         update_state_for_load: bool = True,
     ) -> Optional[Tuple[int, np.ndarray, np.ndarray]]:
-        """SWA-aware dual-mask match RPC — the server-mode counterpart to
-        :meth:`get_match`. Returns ``(task_id, return_mask_full, return_mask_swa)``
-        or None on server error (mirrors get_match's None-on-error contract so the
-        connector can fall back to single-mask get_match)."""
+        """SWA-aware match RPC — the server-mode counterpart to :meth:`get_match`.
+        Returns ``(task_id, return_mask_full, return_mask_swa)`` or None on server
+        error (mirrors get_match's None-on-error contract so the connector can fall
+        back to single-mask get_match)."""
         req = GetMatchSwaRequest(
             dp_client_id=self.dp_client_id,
             token_ids=token_ids,
             full_mask=full_mask if full_mask is not None else None,
-            swa_mask=swa_mask if swa_mask is not None else None,
             cpu_only=cpu_only,
             task_id=self._get_task_id(),
             namespace=namespace,

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -23,7 +23,6 @@ from flexkv.server.request import (
     GetRequest,
     PutMatchRequest,
     GetMatchRequest,
-    GetMatchSwaRequest,
     LaunchTaskRequest,
     CancelTaskRequest,
     WaitRequest,
@@ -171,6 +170,7 @@ class KVDPClient:
         token_mask: Optional[np.ndarray],
         cpu_only: bool = False,
         namespace: Optional[List[str]] = None,
+        swa_aware: bool = False,
     ) -> Optional[Tuple[int, np.ndarray]]:
         req = GetMatchRequest(
             dp_client_id=self.dp_client_id,
@@ -179,6 +179,7 @@ class KVDPClient:
             cpu_only=cpu_only,
             task_id=self._get_task_id(),
             namespace=namespace,
+            swa_aware=swa_aware,
         )
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
@@ -186,35 +187,6 @@ class KVDPClient:
             return req.task_id, response.mask
         else:
             flexkv_logger.error(f"get_match failed, error_msg: {response.error_msg}")
-            return None
-
-    def get_match_swa(
-        self,
-        token_ids: np.ndarray,
-        full_mask: Optional[np.ndarray],
-        cpu_only: bool = False,
-        namespace: Optional[List[str]] = None,
-        update_state_for_load: bool = True,
-    ) -> Optional[Tuple[int, np.ndarray, np.ndarray]]:
-        """SWA-aware match RPC — the server-mode counterpart to :meth:`get_match`.
-        Returns ``(task_id, return_mask_full, return_mask_swa)`` or None on server
-        error (mirrors get_match's None-on-error contract so the connector can fall
-        back to single-mask get_match)."""
-        req = GetMatchSwaRequest(
-            dp_client_id=self.dp_client_id,
-            token_ids=token_ids,
-            full_mask=full_mask if full_mask is not None else None,
-            cpu_only=cpu_only,
-            task_id=self._get_task_id(),
-            namespace=namespace,
-            update_state_for_load=update_state_for_load,
-        )
-        self.send_to_server.send_pyobj(req)
-        response: Response = self.recv_from_server.recv_pyobj()
-        if response.error_msg is None:
-            return req.task_id, response.mask, response.mask_swa
-        else:
-            flexkv_logger.error(f"get_match_swa failed, error_msg: {response.error_msg}")
             return None
 
     def launch_tasks(

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -88,15 +88,12 @@ class GetMatchRequest:
 
 @dataclass
 class GetMatchSwaRequest:
-    # SWA-aware dual-mask match (DSv4). Mirrors GetMatchRequest but carries the
-    # two masks of get_match_swa: ``full_mask`` (== the single-mask token_mask,
-    # drives the Full-KV match) and ``swa_mask`` (reserved for the future SWA H2D
-    # restore, currently unconsumed). The reply uses Response.mask for
+    # SWA-aware match (DSv4). Mirrors GetMatchRequest; ``full_mask`` (== the
+    # single-mask token_mask) drives the match. The reply uses Response.mask for
     # return_mask_full and Response.mask_swa for return_mask_swa.
     dp_client_id: int
     token_ids: np.ndarray
     full_mask: Optional[np.ndarray]
-    swa_mask: Optional[np.ndarray]
     cpu_only: bool = False
     task_id: int = -1
     namespace: Optional[List[str]] = None

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -84,20 +84,9 @@ class GetMatchRequest:
     cpu_only: bool = False
     task_id: int = -1
     namespace: Optional[List[str]] = None
-
-
-@dataclass
-class GetMatchSwaRequest:
-    # SWA-aware match (DSv4). Mirrors GetMatchRequest; ``full_mask`` (== the
-    # single-mask token_mask) drives the match. The reply uses Response.mask for
-    # return_mask_full and Response.mask_swa for return_mask_swa.
-    dp_client_id: int
-    token_ids: np.ndarray
-    full_mask: Optional[np.ndarray]
-    cpu_only: bool = False
-    task_id: int = -1
-    namespace: Optional[List[str]] = None
-    update_state_for_load: bool = True
+    # SWA-aware match: clamp the Full-KV transfer to the reusable SWA window; the
+    # SWA window is the trailing block of the returned mask.
+    swa_aware: bool = False
 
 
 @dataclass
@@ -140,11 +129,6 @@ class Response:
     status: Optional[Dict[int, KVResponseStatus]] = None
     is_ready: bool = False
     error_msg: Optional[str] = None
-    # SWA dual-mask reply: ``mask`` carries return_mask_full, ``mask_swa`` carries
-    # return_mask_swa (the trailing reusable SWA window). Only set by the
-    # get_match_swa handler; None for every other request so existing handlers
-    # stay backward-compatible.
-    mask_swa: Optional[np.ndarray] = None
 
     @property
     def success(self) -> bool:

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -430,7 +430,7 @@ class KVServer:
         result_zmq.send_pyobj(response)
 
     def _handle_get_match_swa_request(self, req: GetMatchSwaRequest) -> None:
-        """Handle SWA-aware dual-mask GetMatch request (DSv4 server mode).
+        """Handle SWA-aware GetMatch request (DSv4 server mode).
 
         Mirrors :meth:`_handle_get_match_request`: runs the same in-process
         get_match_swa and replies with return_mask_full in ``mask`` and
@@ -439,7 +439,6 @@ class KVServer:
         req_id, mask_full, mask_swa = self.kv_task_engine.get_match_swa(
             token_ids=req.token_ids,
             full_mask=req.full_mask,
-            swa_mask=req.swa_mask,
             dp_client_id=req.dp_client_id,
             cpu_only=req.cpu_only,
             task_id=req.task_id,

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -29,7 +29,6 @@ from flexkv.server.request import (
     GetRequest,
     PutMatchRequest,
     GetMatchRequest,
-    GetMatchSwaRequest,
     LaunchTaskRequest,
     CancelTaskRequest,
     WaitRequest,
@@ -198,7 +197,6 @@ class KVServer:
             GetRequest: self._handle_get_request,
             PutRequest: self._handle_put_request,
             GetMatchRequest: self._handle_get_match_request,
-            GetMatchSwaRequest: self._handle_get_match_swa_request,
             PutMatchRequest: self._handle_put_match_request,
             PrefetchRequest: self._handle_prefetch_request,
             WaitRequest: self._handle_wait_request,
@@ -423,30 +421,10 @@ class KVServer:
             cpu_only=req.cpu_only,
             task_id=req.task_id,
             namespace=req.namespace,
+            swa_aware=req.swa_aware,
         )
         response = Response(dp_client_id=req.dp_client_id,
                             task_id=req_id, mask=mask)
-        result_zmq = self.client_manager.get_zmq(req.dp_client_id)
-        result_zmq.send_pyobj(response)
-
-    def _handle_get_match_swa_request(self, req: GetMatchSwaRequest) -> None:
-        """Handle SWA-aware GetMatch request (DSv4 server mode).
-
-        Mirrors :meth:`_handle_get_match_request`: runs the same in-process
-        get_match_swa and replies with return_mask_full in ``mask`` and
-        return_mask_swa in ``mask_swa``.
-        """
-        req_id, mask_full, mask_swa = self.kv_task_engine.get_match_swa(
-            token_ids=req.token_ids,
-            full_mask=req.full_mask,
-            dp_client_id=req.dp_client_id,
-            cpu_only=req.cpu_only,
-            task_id=req.task_id,
-            namespace=req.namespace,
-            update_state_for_load=req.update_state_for_load,
-        )
-        response = Response(dp_client_id=req.dp_client_id,
-                            task_id=req_id, mask=mask_full, mask_swa=mask_swa)
         result_zmq = self.client_manager.get_zmq(req.dp_client_id)
         result_zmq.send_pyobj(response)
 

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -83,13 +83,13 @@ def test_shed_heavy_resources_keeps_status():
     assert t.return_mask is not None
 
 
-# --- M15/M16: get_match_swa's core arithmetic (pure, mirrors kvtask logic) --- #
+# --- M15/M16: SWA-aware get's core arithmetic (pure, mirrors kvtask logic) --- #
 
 def _usable_and_swa_mask(full_hit, swa_hit, num_tokens, tpb):
-    """Replicate the arithmetic in KVTaskEngine.get_match_swa (② + ③) so the
-    contract is pinned without standing up a KVTaskEngine (which needs a GPU
-    TransferManager subprocess). usable=min(full,swa) truncates the full_mask
-    BEFORE the graph is built; return_mask_swa marks the trailing SWA window."""
+    """Replicate the SWA-aware get arithmetic so the contract is pinned without
+    standing up a KVTaskEngine (which needs a GPU TransferManager subprocess).
+    usable=min(full,swa) clamps the full transfer; the trailing SWA window is
+    the last block of the clamped hit."""
     usable = min(full_hit, swa_hit)
     full_mask = np.ones(num_tokens, dtype=np.bool_)
     truncated = full_mask.copy()

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -83,6 +83,54 @@ def test_shed_heavy_resources_keeps_status():
     assert t.return_mask is not None
 
 
+# --- M15/M16: get_match_swa's core arithmetic (pure, mirrors kvtask logic) --- #
+
+def _usable_and_swa_mask(full_hit, swa_hit, num_tokens, tpb):
+    """Replicate the arithmetic in KVTaskEngine.get_match_swa (② + ③) so the
+    contract is pinned without standing up a KVTaskEngine (which needs a GPU
+    TransferManager subprocess). usable=min(full,swa) truncates the full_mask
+    BEFORE the graph is built; return_mask_swa marks the trailing SWA window."""
+    usable = min(full_hit, swa_hit)
+    full_mask = np.ones(num_tokens, dtype=np.bool_)
+    truncated = full_mask.copy()
+    truncated[usable * tpb:] = False
+    swa_mask = np.zeros(num_tokens, dtype=np.bool_)
+    if swa_hit > 0:
+        swa_mask[(swa_hit - 1) * tpb: swa_hit * tpb] = True
+    return usable, truncated, swa_mask
+
+
+@pytest.mark.parametrize("full_hit,swa_hit,exp_usable", [
+    (10, 6, 6),   # M15.1: SWA shorter than full -> clamp full to SWA
+    (6, 6, 6),    # M15.4: SWA covers whole full hit -> no truncation loss
+    (10, 0, 0),   # M15.3: no SWA hit -> usable 0 -> empty full graph
+])
+def test_get_match_swa_usable_is_min(full_hit, swa_hit, exp_usable):
+    tpb, num_tokens = 16, 10 * 16
+    usable, truncated, _ = _usable_and_swa_mask(full_hit, swa_hit, num_tokens, tpb)
+    assert usable == exp_usable
+    # The full transfer is shaped to exactly `usable` blocks (truncate-before-build).
+    assert int(truncated.sum()) == exp_usable * tpb
+
+
+@pytest.mark.parametrize("swa_hit", [1, 3, 6])
+def test_get_match_swa_trailing_window_is_one_block(swa_hit):
+    """M16.1: SWA is page-granular (window == tokens_per_block), so return_mask_swa
+    marks exactly ONE block, ending at swa_hit."""
+    tpb, num_tokens = 16, 6 * 16
+    _, _, swa_mask = _usable_and_swa_mask(6, swa_hit, num_tokens, tpb)
+    assert int(swa_mask.sum()) == tpb                       # exactly one block
+    assert swa_mask[(swa_hit - 1) * tpb: swa_hit * tpb].all()  # the trailing one
+
+
+def test_get_match_swa_no_hit_empty_window_no_underflow():
+    """M16.2: swa_hit=0 -> return_mask_swa all-zero, and the (swa_hit-1) index is
+    never evaluated (no negative-index wraparound marking the last block)."""
+    tpb, num_tokens = 16, 6 * 16
+    _, _, swa_mask = _usable_and_swa_mask(6, 0, num_tokens, tpb)
+    assert not swa_mask.any()
+
+
 # --------------------------------------------------------------------------- #
 # 2. SWA load-lock lifecycle on the engine (needs c_ext)                       #
 # --------------------------------------------------------------------------- #

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -8,9 +8,9 @@ Enters from the top (GlobalCacheEngine), NOT the data plane, using the REAL
 into a Full+SWA transfer graph + masks against the node-mounted radix tree:
 
     put()       -> full-KV D2H graph + SWA peer D2H (alloc slot + set_swa)
-    swa_align() -> full_hit, swa_hit, usable = min(full, swa)
-    get()       -> full-KV H2D graph + SWA peer H2D (matched slot), joined by
-                   the VIRTUAL barrier; the matched CPU SWA node is pinned for
+    get(swa_aware=True) -> full-KV H2D clamped to usable=min(full,swa) + SWA peer
+                   H2D (matched slot), joined by the VIRTUAL barrier; the matched
+                   CPU SWA node is pinned for
                    load and released by the H2D completion callback.
 
 The launch-time bind path mirrors what the connector triggers via
@@ -114,7 +114,7 @@ def _seed_swa_hit(eng, tok):
 
 
 # =========================================================================== #
-# 1. control-plane graph build (put / swa_align / get)                        #
+# 1. control-plane graph build (put / get)                                    #
 # =========================================================================== #
 
 def test_put_builds_full_plus_swa_store_chain():
@@ -140,22 +140,6 @@ def test_put_builds_full_plus_swa_store_chain():
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
     hit, slot, key = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
     assert hit == 4 and slot >= 0
-
-
-def test_swa_align_clamps_full_to_swa_hit():
-    eng = GlobalCacheEngine(_cache_config(True), _model_config())
-    tok = _tokens(4, base=2)
-    mask = np.ones_like(tok, dtype=np.int64)
-    slot_mapping = np.arange(tok.shape[0], dtype=np.int64)
-
-    _g, _rm, cb, op_cb, _e = eng.put(1, tok, mask, slot_mapping, dp_client_id=0)
-    _complete(op_cb, cb)
-
-    # swa_align: full_hit=4, swa_hit=4 (SWA on the stored tail), usable=min=4.
-    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
-    assert full_hit == 4, f"full_hit={full_hit}"
-    assert swa_hit == 4, f"swa_hit={swa_hit}"
-    assert min(full_hit, swa_hit) == 4
 
 
 def test_get_builds_full_plus_swa_load_chain():
@@ -363,26 +347,6 @@ def test_get_prefers_cpu_when_both_tiers_have_swa():
     assert "H2D" in kinds, kinds
     assert "DISK2H" not in kinds, f"CPU-resident SWA must not stage from SSD: {kinds}"
     _complete(gop, gcb)
-
-
-def test_swa_align_uses_best_across_tiers():
-    """Supersedes the #196 CPU-clamp guard: now that GET fetches all tiers,
-    swa_align must return the best (longest) reusable SWA hit across tiers, not
-    clamp to CPU. Here SSD holds a window CPU lost -> swa_align must still report
-    it (best == ssd_hit), so the graph is shaped to reuse it."""
-    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
-    tok = _tokens(4, base=24)
-    mask = np.ones_like(tok, dtype=np.int64)
-    sm = np.arange(tok.shape[0], dtype=np.int64)
-    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
-    _complete(pop, pcb)
-    eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
-
-    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
-    assert full_hit == 4
-    assert swa_hit == 4, (
-        f"swa_align must report the SSD SWA hit (best across tiers), got {swa_hit} "
-        f"(the #196 CPU clamp would return 0 here)")
 
 
 if __name__ == "__main__":

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -64,6 +64,26 @@ def _cache_config(enable_swa_transfer: bool = True):
     return cc
 
 
+def _cache_config_ssd(enable_swa_transfer: bool = True):
+    """CPU + SSD tiers, both with an SWA host pool. The SSD cache engine is an
+    in-memory radix+mempool+swa_pool (no real SSD files at construction — files
+    are only touched by the data-plane worker at transfer time), so multi-tier
+    SWA orchestration (_swa_put_slots / _swa_get_slots) is testable at smoke
+    level without disk I/O."""
+    cc = CacheConfig(
+        tokens_per_block=TPB,
+        enable_cpu=True, enable_ssd=True, enable_remote=False,
+        num_cpu_blocks=4096, num_ssd_blocks=4096,
+        ssd_cache_dir="./ssd_cache_swa_test",
+    )
+    cc.swa = SWAPoolConfig(
+        enabled=True, num_slots=256, num_ssd_slots=256, window_size=TPB,
+        num_swa_layers=1, bytes_per_token_per_layer=64,
+    )
+    cc.enable_swa_transfer = enable_swa_transfer
+    return cc
+
+
 def _swa_ops(graph):
     return [op for op in graph._op_map.values() if getattr(op, "is_swa", False)]
 
@@ -136,46 +156,6 @@ def test_swa_align_clamps_full_to_swa_hit():
     assert full_hit == 4, f"full_hit={full_hit}"
     assert swa_hit == 4, f"swa_hit={swa_hit}"
     assert min(full_hit, swa_hit) == 4
-
-
-def test_swa_align_hit_equals_fetched_cpu_tier(monkeypatch):
-    """#9 tier-consistency guard: swa_align's returned SWA hit shapes the transfer
-    graph, but the GET data plane (_swa_get_slots) fetches the CPU tier ONLY.
-    match_swa_prefix reports best_hit_blocks = cross-tier MAX. If a non-CPU tier
-    ever reports a LONGER hit than CPU, returning best would shape a graph the
-    CPU-only fetch cannot fill (src/dst mismatch / stale SWA). swa_align must
-    clamp its return to the CPU (fetched) tier. We fake a longer SSD hit and
-    assert the returned hit stays at the CPU tier's value."""
-    eng = GlobalCacheEngine(_cache_config(True), _model_config())
-    tok = _tokens(4, base=7)
-    mask = np.ones_like(tok, dtype=np.int64)
-    slot_mapping = np.arange(tok.shape[0], dtype=np.int64)
-    _g, _rm, cb, op_cb, _e = eng.put(1, tok, mask, slot_mapping, dp_client_id=0)
-    _complete(op_cb, cb)
-
-    # CPU-only truth: best == cpu == 4.
-    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
-    assert swa_hit == 4
-
-    # Simulate a future SSD/REMOTE tier reporting a LONGER SWA hit than CPU.
-    real_match = eng.match_swa_prefix
-
-    def _fake_match(sequence_meta, cpu_full_hit_blocks, ssd_full_hit_blocks=0,
-                    remote_full_hit_blocks=0, lock_for_load=False):
-        r = real_match(sequence_meta, cpu_full_hit_blocks=cpu_full_hit_blocks,
-                       ssd_full_hit_blocks=ssd_full_hit_blocks,
-                       remote_full_hit_blocks=remote_full_hit_blocks,
-                       lock_for_load=lock_for_load)
-        r.ssd_hit_blocks = r.cpu_hit_blocks + 2  # SSD claims a longer hit
-        r.ssd_slot = 999
-        return r
-
-    monkeypatch.setattr(eng, "match_swa_prefix", _fake_match)
-    full_hit2, swa_hit2 = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
-    # Must clamp to the fetched CPU tier (4), NOT the cross-tier max (6).
-    assert swa_hit2 == 4, (
-        f"swa_align returned {swa_hit2} (cross-tier best) but GET fetches CPU-only "
-        f"(cpu_hit=4); graph would be shaped for blocks the fetch cannot fill")
 
 
 def test_get_builds_full_plus_swa_load_chain():
@@ -303,6 +283,106 @@ def test_no_swa_slot_mapping_leaves_placeholder():
     graph.set_gpu_blocks(np.arange(50, 50 + len(tok) // TPB, dtype=np.int64))
     assert swa_d2h.src_block_ids.tolist() == before  # untouched by full-KV bind
     _complete(op_cb, cb)
+
+
+# =========================================================================== #
+# 3. multi-tier SWA orchestration (CPU + SSD): write-through + get staging     #
+#    These exercise _swa_put_slots / _swa_get_slots across tiers (the layer    #
+#    that was CPU-only). Written TDD-first: they FAIL against CPU-only code.    #
+# =========================================================================== #
+
+def test_put_writethrough_ssd_builds_swa_h2disk():
+    """PUT with an SSD tier: SWA store must write through to SSD, mirroring the
+    full-KV H2DISK. The SWA graph should carry a SWA D2H (GPU->CPU) AND a SWA
+    H2DISK (CPU->SSD) that depends on the D2H (fire-and-forget), and an SSD SWA
+    slot must be allocated + mounted on the SSD store node."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    tok = _tokens(4, base=21)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+
+    graph, _rm, cb, op_cb, _e = eng.put(1, tok, mask, sm, dp_client_id=0)
+    swa = _swa_ops(graph)
+    kinds = sorted(o.transfer_type.name for o in swa)
+    assert "D2H" in kinds, f"SWA D2H missing: {kinds}"
+    assert "H2DISK" in kinds, f"SWA write-through H2DISK missing (CPU-only bug): {kinds}"
+    swa_d2h = [o for o in swa if o.transfer_type == TransferType.D2H][0]
+    swa_h2disk = [o for o in swa if o.transfer_type == TransferType.H2DISK][0]
+    assert swa_d2h.op_id in swa_h2disk.predecessors, "H2DISK must depend on SWA D2H"
+    # an SSD SWA slot was allocated (mounted on the SSD store node)
+    assert eng.ssd_cache_engine.swa_pool.num_used == 1
+    _complete(op_cb, cb)
+
+
+def test_get_ssd_staging_when_only_ssd_has_swa():
+    """GET where the SWA window lives ONLY on SSD (CPU SWA evicted): the load
+    must stage SSD->CPU (SWA DISK2H) then CPU->GPU (SWA H2D), mirroring full-KV
+    fragment2. CPU-only code returns no SSD slot -> no DISK2H -> FAIL."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    tok = _tokens(4, base=22)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    # store to both tiers, complete, then drop the CPU SWA slot so only SSD holds it
+    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
+    _complete(pop, pcb)
+    # evict the CPU SWA (SWA-only eviction) so the CPU tier no longer matches it
+    eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
+
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
+    cpu_hit, _s, _k = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    assert cpu_hit == 0, "precondition: CPU SWA must be gone"
+    ssd_hit, _s2, _k2 = eng.ssd_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    assert ssd_hit > 0, "precondition: SSD SWA must still hold the window"
+
+    graph, _rm2, gcb, gop, _ge = eng.get(
+        request_id=2, token_ids=tok, token_mask=mask, slot_mapping=sm, dp_client_id=0)
+    swa = _swa_ops(graph)
+    kinds = sorted(o.transfer_type.name for o in swa)
+    assert "H2D" in kinds and "DISK2H" in kinds, (
+        f"SSD staging chain missing (CPU-only bug): {kinds}")
+    swa_h2d = [o for o in swa if o.transfer_type == TransferType.H2D][0]
+    swa_disk2h = [o for o in swa if o.transfer_type == TransferType.DISK2H][0]
+    assert swa_disk2h.op_id in swa_h2d.predecessors, "H2D must depend on SSD DISK2H"
+    _complete(gop, gcb)
+
+
+def test_get_prefers_cpu_when_both_tiers_have_swa():
+    """Tier priority CPU>SSD: when CPU still holds the SWA window, GET sources
+    from CPU (plain H2D, no staging) even though SSD also has it."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    tok = _tokens(4, base=23)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
+    _complete(pop, pcb)
+
+    graph, _rm2, gcb, gop, _ge = eng.get(
+        request_id=2, token_ids=tok, token_mask=mask, slot_mapping=sm, dp_client_id=0)
+    swa = _swa_ops(graph)
+    kinds = sorted(o.transfer_type.name for o in swa)
+    assert "H2D" in kinds, kinds
+    assert "DISK2H" not in kinds, f"CPU-resident SWA must not stage from SSD: {kinds}"
+    _complete(gop, gcb)
+
+
+def test_swa_align_uses_best_across_tiers():
+    """Supersedes the #196 CPU-clamp guard: now that GET fetches all tiers,
+    swa_align must return the best (longest) reusable SWA hit across tiers, not
+    clamp to CPU. Here SSD holds a window CPU lost -> swa_align must still report
+    it (best == ssd_hit), so the graph is shaped to reuse it."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    tok = _tokens(4, base=24)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
+    _complete(pop, pcb)
+    eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
+
+    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
+    assert full_hit == 4
+    assert swa_hit == 4, (
+        f"swa_align must report the SSD SWA hit (best across tiers), got {swa_hit} "
+        f"(the #196 CPU clamp would return 0 here)")
 
 
 if __name__ == "__main__":

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -349,6 +349,41 @@ def test_get_prefers_cpu_when_both_tiers_have_swa():
     _complete(gop, gcb)
 
 
+def test_multitier_match_promotes_swa_in_each_tier():
+    """Multi-tier heat parity: one full-KV match promotes the matched SWA copy in
+    EVERY tier that holds it (CPU AND SSD), so a reused prefix survives SWA
+    eviction over a never-reused one independently per tier — mirroring how
+    full-KV match_prefix(update_cache_info=True) bumps each tier's heat.
+
+    Store A then B (distinct prefixes) to both tiers with SWA -> per-tier SWA-LRU
+    order tail->head = A, B. A real multi-tier match of A must promote A to MRU in
+    BOTH tiers, so a single SWA eviction per tier drops B and keeps A."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    tok_a = _tokens(4, base=40)
+    tok_b = _tokens(4, base=41)
+    for i, tok in enumerate((tok_a, tok_b)):
+        m = np.ones_like(tok, dtype=np.int64)
+        sm = np.arange(tok.shape[0], dtype=np.int64)
+        _pg, _rm, pcb, pop, _pe = eng.put(i + 1, tok, m, sm, dp_client_id=0)
+        _complete(pop, pcb)
+
+    # A real match of A on each tier (match() -> match_prefix(update_cache_info=True)).
+    seq_a = SequenceMeta(token_ids=tok_a, tokens_per_block=TPB); seq_a.gen_hashes()
+    eng.cpu_cache_engine.match(seq_a)
+    eng.ssd_cache_engine.match(seq_a)
+
+    # Evict one SWA slot per tier: B (never reused) must go, A (reused) survives.
+    eng.cpu_cache_engine._evict_swa(1)
+    eng.ssd_cache_engine._evict_swa(1)
+
+    seq_b = SequenceMeta(token_ids=tok_b, tokens_per_block=TPB); seq_b.gen_hashes()
+    for name, engine in (("cpu", eng.cpu_cache_engine), ("ssd", eng.ssd_cache_engine)):
+        a_hit, _sa, _ka = engine.match_swa(seq_a, upper_bound_blocks=4)
+        b_hit, _sb, _kb = engine.match_swa(seq_b, upper_bound_blocks=4)
+        assert a_hit == 4, f"{name}: reused SWA A was evicted (tier not promoted)"
+        assert b_hit == 0, f"{name}: never-reused SWA B should have been evicted"
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -138,6 +138,46 @@ def test_swa_align_clamps_full_to_swa_hit():
     assert min(full_hit, swa_hit) == 4
 
 
+def test_swa_align_hit_equals_fetched_cpu_tier(monkeypatch):
+    """#9 tier-consistency guard: swa_align's returned SWA hit shapes the transfer
+    graph, but the GET data plane (_swa_get_slots) fetches the CPU tier ONLY.
+    match_swa_prefix reports best_hit_blocks = cross-tier MAX. If a non-CPU tier
+    ever reports a LONGER hit than CPU, returning best would shape a graph the
+    CPU-only fetch cannot fill (src/dst mismatch / stale SWA). swa_align must
+    clamp its return to the CPU (fetched) tier. We fake a longer SSD hit and
+    assert the returned hit stays at the CPU tier's value."""
+    eng = GlobalCacheEngine(_cache_config(True), _model_config())
+    tok = _tokens(4, base=7)
+    mask = np.ones_like(tok, dtype=np.int64)
+    slot_mapping = np.arange(tok.shape[0], dtype=np.int64)
+    _g, _rm, cb, op_cb, _e = eng.put(1, tok, mask, slot_mapping, dp_client_id=0)
+    _complete(op_cb, cb)
+
+    # CPU-only truth: best == cpu == 4.
+    full_hit, swa_hit = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
+    assert swa_hit == 4
+
+    # Simulate a future SSD/REMOTE tier reporting a LONGER SWA hit than CPU.
+    real_match = eng.match_swa_prefix
+
+    def _fake_match(sequence_meta, cpu_full_hit_blocks, ssd_full_hit_blocks=0,
+                    remote_full_hit_blocks=0, lock_for_load=False):
+        r = real_match(sequence_meta, cpu_full_hit_blocks=cpu_full_hit_blocks,
+                       ssd_full_hit_blocks=ssd_full_hit_blocks,
+                       remote_full_hit_blocks=remote_full_hit_blocks,
+                       lock_for_load=lock_for_load)
+        r.ssd_hit_blocks = r.cpu_hit_blocks + 2  # SSD claims a longer hit
+        r.ssd_slot = 999
+        return r
+
+    monkeypatch.setattr(eng, "match_swa_prefix", _fake_match)
+    full_hit2, swa_hit2 = eng.swa_align(tok, np.ones_like(tok, dtype=np.bool_))
+    # Must clamp to the fetched CPU tier (4), NOT the cross-tier max (6).
+    assert swa_hit2 == 4, (
+        f"swa_align returned {swa_hit2} (cross-tier best) but GET fetches CPU-only "
+        f"(cpu_hit=4); graph would be shaped for blocks the fetch cannot fill")
+
+
 def test_get_builds_full_plus_swa_load_chain():
     eng = GlobalCacheEngine(_cache_config(True), _model_config())
     tok = _tokens(4, base=3)

--- a/tests/test_swa_control_plane_e2e.py
+++ b/tests/test_swa_control_plane_e2e.py
@@ -12,7 +12,7 @@ match, plus the size-1 GPU placeholder), the GPU sides are bound LATE via
 ``TransferEngine`` with GPU pools. We then assert a byte-exact main-KV + SWA
 GPU->CPU->GPU roundtrip.
 
-Flow (mirrors KVManager get_match_swa + launch, minus the tp_client subprocess):
+Flow (mirrors KVManager get_match(swa_aware=True) + launch, minus the tp_client subprocess):
   PUT : engine.put() -> graph {full D2H, SWA D2H} -> bind GPU slots -> submit
         -> full+SWA bytes land in the shared CPU pool + SWA host pool
   GET : engine.get() -> graph {full H2D, SWA H2D} -> bind GPU slots -> submit

--- a/tests/test_swa_level2_single_pass.py
+++ b/tests/test_swa_level2_single_pass.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Level 2 — SWA light-attach to the full-KV path (single-pass match).
+
+Node-mount makes ``radix.match_prefix`` return the full prefix AND the deepest
+in-range SWA node in ONE forward pass. Level 2 removes the redundant standalone
+match that ``swa_align`` used to run: a SWA-aware GET must resolve
+``usable = min(full_hit, swa_hit)`` and build the (clamped) graph from a SINGLE
+per-tier match, not two.
+
+These tests pin the Level 2 contract at the GlobalCacheEngine layer (no GPU /
+KVTaskEngine needed — the match redundancy lives entirely in the engine):
+
+  RED (the point of Level 2):
+    * a SWA-aware get triggers exactly ONE round of per-tier full-KV matching
+      (today's swa_align + get() path does TWO — this is what we remove).
+  Behavior-equivalence (must stay green after the fold):
+    * the full-KV transfer is still clamped to usable = min(full, swa).
+  Guardrail (must stay green — plain path untouched):
+    * a NON-SWA get on an SWA-enabled cache is never clamped and matches once.
+
+Requires flexkv.c_ext (production CacheEngineAccel / CRadixTreeIndex).
+"""
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("flexkv.c_ext")
+
+from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
+from flexkv.common.debug import flexkv_logger
+
+flexkv_logger.set_level("OFF")
+
+pytestmark = pytest.mark.smoke
+
+TPB = 16
+
+
+def _model_config():
+    return ModelConfig(
+        num_layers=4, num_kv_heads=1, head_size=128,
+        use_mla=True, dtype=torch.bfloat16, tp_size=1, dp_size=1,
+    )
+
+
+def _cache_config():
+    cc = CacheConfig(
+        tokens_per_block=TPB,
+        enable_cpu=True, enable_ssd=False, enable_remote=False,
+        num_cpu_blocks=4096,
+    )
+    cc.swa = SWAPoolConfig(
+        enabled=True, num_slots=256, window_size=TPB,
+        num_swa_layers=1, bytes_per_token_per_layer=64,
+    )
+    cc.enable_swa_transfer = True
+    return cc
+
+
+def _tokens(n_blocks, base):
+    rs = np.random.RandomState(base)
+    return rs.randint(0, 30000, size=n_blocks * TPB, dtype=np.int64)
+
+
+def _complete(op_cb, cb):
+    for c in op_cb.values():
+        c()
+    cb()
+
+
+def _put(eng, tok, req=1):
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    _g, _rm, cb, op_cb, _e = eng.put(req, tok, mask, sm, dp_client_id=0)
+    _complete(op_cb, cb)
+
+
+class _MatchCounter:
+    """Wrap the engine's per-tier match entry points and count invocations.
+
+    CPU-only config routes through ``match_local_accel``; we also wrap
+    ``match_all_accel`` so the same counter works if a tier config changes.
+    Each call = one round of per-tier radix matching.
+    """
+
+    def __init__(self, eng):
+        self.eng = eng
+        self.n = 0
+        self._orig_local = eng.match_local_accel
+        self._orig_all = eng.match_all_accel
+
+    def __enter__(self):
+        def local(*a, **k):
+            self.n += 1
+            return self._orig_local(*a, **k)
+
+        def allm(*a, **k):
+            self.n += 1
+            return self._orig_all(*a, **k)
+
+        self.eng.match_local_accel = local
+        self.eng.match_all_accel = allm
+        return self
+
+    def __exit__(self, *exc):
+        self.eng.match_local_accel = self._orig_local
+        self.eng.match_all_accel = self._orig_all
+        return False
+
+
+# =========================================================================== #
+# RED — the redundant-match removal (Level 2 core)                            #
+# =========================================================================== #
+
+def test_swa_aware_get_matches_once():
+    """A single SWA-aware GET must trigger exactly ONE round of full-KV matching.
+
+    Today the get_match_swa path does two rounds: swa_align() runs a full
+    per-tier match to compute usable, then get() -> _get_impl_* runs the SAME
+    match again to build the graph. Level 2 folds usable computation into
+    _get_impl_*; get(swa_aware=True) must own the single match.
+
+    RED until Level 2 lands: get() has no swa_aware parameter (TypeError), and
+    even routed through it the current code would match once in get() while
+    swa_align matched separately.
+    """
+    eng = GlobalCacheEngine(_cache_config(), _model_config())
+    tok = _tokens(4, base=31)
+    _put(eng, tok)
+
+    with _MatchCounter(eng) as mc:
+        eng.get(request_id=2, token_ids=tok,
+                token_mask=np.ones_like(tok, dtype=np.int64),
+                slot_mapping=np.arange(tok.shape[0], dtype=np.int64),
+                dp_client_id=0, swa_aware=True)
+    assert mc.n == 1, (
+        f"SWA-aware get matched {mc.n} rounds; Level 2 requires exactly 1 "
+        "(no separate swa_align pass)")
+
+
+def test_swa_aware_get_clamps_full_to_usable():
+    """The folded path must still clamp the full-KV transfer to usable =
+    min(full_hit, swa_hit) — the behavior swa_align+truncate used to provide.
+
+    With SWA on the full stored tail, full_hit == swa_hit == 4, so return_mask
+    covers all 4 blocks. This pins that the fold does not over- or under-clamp.
+    """
+    eng = GlobalCacheEngine(_cache_config(), _model_config())
+    tok = _tokens(4, base=32)
+    _put(eng, tok)
+
+    graph, return_mask, cb, op_cb, end_id = eng.get(
+        request_id=2, token_ids=tok,
+        token_mask=np.ones_like(tok, dtype=np.int64),
+        slot_mapping=np.arange(tok.shape[0], dtype=np.int64),
+        dp_client_id=0, swa_aware=True)
+    # usable = min(4, 4) = 4 -> all 4 blocks resident, SWA H2D present.
+    assert int(return_mask.sum()) == 4 * TPB
+    swa = [o for o in graph._op_map.values() if getattr(o, "is_swa", False)]
+    assert len(swa) == 1, "SWA H2D must still attach to the same graph"
+    _complete(op_cb, cb)
+
+
+# =========================================================================== #
+# Guardrail — the plain (non-SWA) path must be untouched                      #
+# =========================================================================== #
+
+def test_plain_get_on_swa_cache_matches_once_and_unclamped():
+    """A plain get() (swa_aware defaults False) on an SWA-enabled cache must
+    match exactly once and must NOT be clamped by any SWA window. This is the
+    critical guardrail: Level 2 touches the shared _get_impl_* hot path."""
+    eng = GlobalCacheEngine(_cache_config(), _model_config())
+    tok = _tokens(4, base=33)
+    _put(eng, tok)
+
+    with _MatchCounter(eng) as mc:
+        graph, return_mask, cb, op_cb, end_id = eng.get(
+            request_id=2, token_ids=tok,
+            token_mask=np.ones_like(tok, dtype=np.int64),
+            slot_mapping=np.arange(tok.shape[0], dtype=np.int64),
+            dp_client_id=0)
+    assert mc.n == 1, f"plain get matched {mc.n} rounds; must be 1"
+    # full 4-block hit, unclamped by SWA.
+    assert int(return_mask.sum()) == 4 * TPB
+    _complete(op_cb, cb)
+
+
+# =========================================================================== #
+# kvtask dispatch — get_match_swa's main path drops swa_align (single pass)   #
+# =========================================================================== #
+
+def test_get_match_swa_main_path_no_swa_align():
+    """KVTaskEngine.get_match_swa on the main path (mask has 1s) must NOT call
+    swa_align (the removed redundant match) and must drive exactly ONE
+    _get_match_impl with swa_aware=True. Exercised via the real unbound method on
+    a fake self — no GPU/TransferManager subprocess, mirroring the pure-logic
+    tests in test_kvtask_lifecycle.py."""
+    import types
+    from flexkv.kvtask import KVTaskEngine
+
+    calls = {"swa_align": 0, "get_match_impl": [], "update": 0, "trace": 0}
+    tok = np.arange(4 * TPB, dtype=np.int64)
+
+    class _FakeCacheEngine:
+        tokens_per_block = TPB
+        def swa_align(self, *a, **k):
+            calls["swa_align"] += 1
+            return 4, 4
+
+    def _fake_get_match_impl(token_ids, slot_mapping, **kw):
+        calls["get_match_impl"].append(kw.get("swa_aware"))
+        # emulate a clamped return_mask_full covering all 4 blocks (usable=4)
+        rm = np.zeros(token_ids.shape[0], dtype=np.bool_)
+        rm[:4 * TPB] = True
+        return 7, rm
+
+    fake = types.SimpleNamespace(
+        cache_engine=_FakeCacheEngine(),
+        _update_tasks=lambda timeout=0: calls.__setitem__("update", calls["update"] + 1),
+        _get_match_impl=_fake_get_match_impl,
+        tracer=types.SimpleNamespace(
+            trace_request=lambda **k: calls.__setitem__("trace", calls["trace"] + 1)),
+    )
+    full_mask = np.ones(4 * TPB, dtype=np.bool_)
+
+    tid, rm_full, rm_swa = KVTaskEngine.get_match_swa(
+        fake, tok, full_mask=full_mask, dp_client_id=0)
+
+    assert calls["swa_align"] == 0, "main path must NOT call swa_align (Level 2)"
+    assert calls["get_match_impl"] == [True], \
+        "must drive exactly one _get_match_impl with swa_aware=True"
+    assert tid == 7
+    assert int(rm_full.sum()) == 4 * TPB
+    # SWA window = trailing single block of the clamped full hit.
+    assert int(rm_swa.sum()) == TPB
+    assert rm_swa[3 * TPB:4 * TPB].all()
+
+
+def test_get_match_swa_only_path_keeps_single_swa_align():
+    """The SWA-only branch (full_mask all-0: GPU already holds full prefix) keeps
+    ONE swa_align probe — there is no Full-KV match to ride, so this single match
+    is necessary, not redundant. It must still report the trailing SWA window."""
+    import types
+    from flexkv.kvtask import KVTaskEngine
+
+    calls = {"swa_align": 0, "get_match_impl": 0}
+    tok = np.arange(4 * TPB, dtype=np.int64)
+
+    class _FakeCacheEngine:
+        tokens_per_block = TPB
+        def swa_align(self, *a, **k):
+            calls["swa_align"] += 1
+            return 4, 4   # full_hit=4 (resident), swa_hit=4
+
+    def _fake_get_match_impl(token_ids, slot_mapping, **kw):
+        calls["get_match_impl"] += 1
+        return 9, np.zeros(token_ids.shape[0], dtype=np.bool_)  # empty full graph
+
+    fake = types.SimpleNamespace(
+        cache_engine=_FakeCacheEngine(),
+        _update_tasks=lambda timeout=0: None,
+        _get_match_impl=_fake_get_match_impl,
+        tracer=types.SimpleNamespace(trace_request=lambda **k: None),
+    )
+    full_mask = np.zeros(4 * TPB, dtype=np.bool_)   # all-0: SWA-only
+
+    tid, rm_full, rm_swa = KVTaskEngine.get_match_swa(
+        fake, tok, full_mask=full_mask, dp_client_id=0)
+
+    assert calls["swa_align"] == 1, "SWA-only path resolves via one swa_align"
+    assert tid == 9
+    assert int(rm_full.sum()) == 0, "no Full-KV transfer when GPU holds full prefix"
+    # SWA window still reported (trailing block at swa_hit=4).
+    assert int(rm_swa.sum()) == TPB
+    assert rm_swa[3 * TPB:4 * TPB].all()

--- a/tests/test_swa_level2_single_pass.py
+++ b/tests/test_swa_level2_single_pass.py
@@ -1,23 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Level 2 — SWA light-attach to the full-KV path (single-pass match).
+"""SWA single-pass match: SWA rides the full-KV match, no redundant second pass.
 
 Node-mount makes ``radix.match_prefix`` return the full prefix AND the deepest
-in-range SWA node in ONE forward pass. Level 2 removes the redundant standalone
-match that ``swa_align`` used to run: a SWA-aware GET must resolve
-``usable = min(full_hit, swa_hit)`` and build the (clamped) graph from a SINGLE
-per-tier match, not two.
+in-range SWA node in one forward pass. A SWA-aware GET therefore resolves
+``usable = min(full_hit, swa_hit)`` and builds the (clamped) graph from a SINGLE
+per-tier match.
 
-These tests pin the Level 2 contract at the GlobalCacheEngine layer (no GPU /
-KVTaskEngine needed — the match redundancy lives entirely in the engine):
+These tests pin that contract at the GlobalCacheEngine layer (no GPU /
+KVTaskEngine needed):
 
-  RED (the point of Level 2):
-    * a SWA-aware get triggers exactly ONE round of per-tier full-KV matching
-      (today's swa_align + get() path does TWO — this is what we remove).
-  Behavior-equivalence (must stay green after the fold):
-    * the full-KV transfer is still clamped to usable = min(full, swa).
-  Guardrail (must stay green — plain path untouched):
-    * a NON-SWA get on an SWA-enabled cache is never clamped and matches once.
+  * a SWA-aware get triggers exactly ONE round of per-tier full-KV matching;
+  * the full-KV transfer is clamped to usable = min(full, swa);
+  * a plain (non-SWA) get on an SWA-enabled cache is never clamped and matches once.
 
 Requires flexkv.c_ext (production CacheEngineAccel / CRadixTreeIndex).
 """
@@ -112,20 +107,14 @@ class _MatchCounter:
 
 
 # =========================================================================== #
-# RED — the redundant-match removal (Level 2 core)                            #
+# single-pass match                                                           #
 # =========================================================================== #
 
 def test_swa_aware_get_matches_once():
-    """A single SWA-aware GET must trigger exactly ONE round of full-KV matching.
+    """A SWA-aware GET triggers exactly ONE round of per-tier full-KV matching.
 
-    Today the get_match_swa path does two rounds: swa_align() runs a full
-    per-tier match to compute usable, then get() -> _get_impl_* runs the SAME
-    match again to build the graph. Level 2 folds usable computation into
-    _get_impl_*; get(swa_aware=True) must own the single match.
-
-    RED until Level 2 lands: get() has no swa_aware parameter (TypeError), and
-    even routed through it the current code would match once in get() while
-    swa_align matched separately.
+    get(swa_aware=True) matches once, reads the SWA hit off that same match, and
+    builds the clamped graph — no separate match pass.
     """
     eng = GlobalCacheEngine(_cache_config(), _model_config())
     tok = _tokens(4, base=31)
@@ -137,8 +126,7 @@ def test_swa_aware_get_matches_once():
                 slot_mapping=np.arange(tok.shape[0], dtype=np.int64),
                 dp_client_id=0, swa_aware=True)
     assert mc.n == 1, (
-        f"SWA-aware get matched {mc.n} rounds; Level 2 requires exactly 1 "
-        "(no separate swa_align pass)")
+        f"SWA-aware get matched {mc.n} rounds; must be exactly 1")
 
 
 def test_swa_aware_get_clamps_full_to_usable():
@@ -169,9 +157,9 @@ def test_swa_aware_get_clamps_full_to_usable():
 # =========================================================================== #
 
 def test_plain_get_on_swa_cache_matches_once_and_unclamped():
-    """A plain get() (swa_aware defaults False) on an SWA-enabled cache must
-    match exactly once and must NOT be clamped by any SWA window. This is the
-    critical guardrail: Level 2 touches the shared _get_impl_* hot path."""
+    """A plain get() (swa_aware defaults False) on an SWA-enabled cache matches
+    exactly once and is NOT clamped by any SWA window — the shared _get_impl_*
+    hot path is unaffected for non-SWA callers."""
     eng = GlobalCacheEngine(_cache_config(), _model_config())
     tok = _tokens(4, base=33)
     _put(eng, tok)
@@ -189,15 +177,14 @@ def test_plain_get_on_swa_cache_matches_once_and_unclamped():
 
 
 # =========================================================================== #
-# kvtask dispatch — get_match_swa's main path drops swa_align (single pass)   #
+# kvtask dispatch — get_match_swa main path resolves in a single match        #
 # =========================================================================== #
 
 def test_get_match_swa_main_path_no_swa_align():
     """KVTaskEngine.get_match_swa on the main path (mask has 1s) must NOT call
-    swa_align (the removed redundant match) and must drive exactly ONE
-    _get_match_impl with swa_aware=True. Exercised via the real unbound method on
-    a fake self — no GPU/TransferManager subprocess, mirroring the pure-logic
-    tests in test_kvtask_lifecycle.py."""
+    swa_align and must drive exactly ONE _get_match_impl with swa_aware=True.
+    Exercised via the real unbound method on a fake self — no GPU subprocess,
+    mirroring the pure-logic tests in test_kvtask_lifecycle.py."""
     import types
     from flexkv.kvtask import KVTaskEngine
 
@@ -229,7 +216,7 @@ def test_get_match_swa_main_path_no_swa_align():
     tid, rm_full, rm_swa = KVTaskEngine.get_match_swa(
         fake, tok, full_mask=full_mask, dp_client_id=0)
 
-    assert calls["swa_align"] == 0, "main path must NOT call swa_align (Level 2)"
+    assert calls["swa_align"] == 0, "main path must NOT call swa_align"
     assert calls["get_match_impl"] == [True], \
         "must drive exactly one _get_match_impl with swa_aware=True"
     assert tid == 7

--- a/tests/test_swa_level2_single_pass.py
+++ b/tests/test_swa_level2_single_pass.py
@@ -130,11 +130,11 @@ def test_swa_aware_get_matches_once():
 
 
 def test_swa_aware_get_clamps_full_to_usable():
-    """The folded path must still clamp the full-KV transfer to usable =
-    min(full_hit, swa_hit) — the behavior swa_align+truncate used to provide.
+    """The SWA-aware path clamps the full-KV transfer to usable = min(full_hit,
+    swa_hit).
 
     With SWA on the full stored tail, full_hit == swa_hit == 4, so return_mask
-    covers all 4 blocks. This pins that the fold does not over- or under-clamp.
+    covers all 4 blocks. This pins that the clamp does not over- or under-clamp.
     """
     eng = GlobalCacheEngine(_cache_config(), _model_config())
     tok = _tokens(4, base=32)
@@ -177,89 +177,38 @@ def test_plain_get_on_swa_cache_matches_once_and_unclamped():
 
 
 # =========================================================================== #
-# kvtask dispatch — get_match_swa main path resolves in a single match        #
+# kvtask dispatch — get_match threads swa_aware into the single match         #
 # =========================================================================== #
 
-def test_get_match_swa_main_path_no_swa_align():
-    """KVTaskEngine.get_match_swa on the main path (mask has 1s) must NOT call
-    swa_align and must drive exactly ONE _get_match_impl with swa_aware=True.
-    Exercised via the real unbound method on a fake self — no GPU subprocess,
-    mirroring the pure-logic tests in test_kvtask_lifecycle.py."""
+def test_get_match_threads_swa_aware():
+    """KVTaskEngine.get_match(swa_aware=True) drives exactly ONE _get_match_impl
+    with swa_aware=True. Exercised via the real unbound method on a fake self —
+    no GPU subprocess, mirroring the pure-logic tests in test_kvtask_lifecycle.py."""
     import types
     from flexkv.kvtask import KVTaskEngine
 
-    calls = {"swa_align": 0, "get_match_impl": [], "update": 0, "trace": 0}
+    calls = {"swa_aware": [], "task": None}
     tok = np.arange(4 * TPB, dtype=np.int64)
 
-    class _FakeCacheEngine:
-        tokens_per_block = TPB
-        def swa_align(self, *a, **k):
-            calls["swa_align"] += 1
-            return 4, 4
-
     def _fake_get_match_impl(token_ids, slot_mapping, **kw):
-        calls["get_match_impl"].append(kw.get("swa_aware"))
-        # emulate a clamped return_mask_full covering all 4 blocks (usable=4)
+        calls["swa_aware"].append(kw.get("swa_aware"))
         rm = np.zeros(token_ids.shape[0], dtype=np.bool_)
         rm[:4 * TPB] = True
         return 7, rm
 
     fake = types.SimpleNamespace(
-        cache_engine=_FakeCacheEngine(),
-        _update_tasks=lambda timeout=0: calls.__setitem__("update", calls["update"] + 1),
-        _get_match_impl=_fake_get_match_impl,
-        tracer=types.SimpleNamespace(
-            trace_request=lambda **k: calls.__setitem__("trace", calls["trace"] + 1)),
-    )
-    full_mask = np.ones(4 * TPB, dtype=np.bool_)
-
-    tid, rm_full, rm_swa = KVTaskEngine.get_match_swa(
-        fake, tok, full_mask=full_mask, dp_client_id=0)
-
-    assert calls["swa_align"] == 0, "main path must NOT call swa_align"
-    assert calls["get_match_impl"] == [True], \
-        "must drive exactly one _get_match_impl with swa_aware=True"
-    assert tid == 7
-    assert int(rm_full.sum()) == 4 * TPB
-    # SWA window = trailing single block of the clamped full hit.
-    assert int(rm_swa.sum()) == TPB
-    assert rm_swa[3 * TPB:4 * TPB].all()
-
-
-def test_get_match_swa_only_path_keeps_single_swa_align():
-    """The SWA-only branch (full_mask all-0: GPU already holds full prefix) keeps
-    ONE swa_align probe — there is no Full-KV match to ride, so this single match
-    is necessary, not redundant. It must still report the trailing SWA window."""
-    import types
-    from flexkv.kvtask import KVTaskEngine
-
-    calls = {"swa_align": 0, "get_match_impl": 0}
-    tok = np.arange(4 * TPB, dtype=np.int64)
-
-    class _FakeCacheEngine:
-        tokens_per_block = TPB
-        def swa_align(self, *a, **k):
-            calls["swa_align"] += 1
-            return 4, 4   # full_hit=4 (resident), swa_hit=4
-
-    def _fake_get_match_impl(token_ids, slot_mapping, **kw):
-        calls["get_match_impl"] += 1
-        return 9, np.zeros(token_ids.shape[0], dtype=np.bool_)  # empty full graph
-
-    fake = types.SimpleNamespace(
-        cache_engine=_FakeCacheEngine(),
+        cache_engine=types.SimpleNamespace(tokens_per_block=TPB),
         _update_tasks=lambda timeout=0: None,
         _get_match_impl=_fake_get_match_impl,
         tracer=types.SimpleNamespace(trace_request=lambda **k: None),
     )
-    full_mask = np.zeros(4 * TPB, dtype=np.bool_)   # all-0: SWA-only
+    full_mask = np.ones(4 * TPB, dtype=np.bool_)
 
-    tid, rm_full, rm_swa = KVTaskEngine.get_match_swa(
-        fake, tok, full_mask=full_mask, dp_client_id=0)
+    tid, mask = KVTaskEngine.get_match(
+        fake, tok, token_mask=full_mask, dp_client_id=0, swa_aware=True)
 
-    assert calls["swa_align"] == 1, "SWA-only path resolves via one swa_align"
-    assert tid == 9
-    assert int(rm_full.sum()) == 0, "no Full-KV transfer when GPU holds full prefix"
-    # SWA window still reported (trailing block at swa_hit=4).
-    assert int(rm_swa.sum()) == TPB
-    assert rm_swa[3 * TPB:4 * TPB].all()
+    assert calls["swa_aware"] == [True], \
+        "must drive exactly one _get_match_impl with swa_aware=True"
+    assert tid == 7
+    assert int(mask.sum()) == 4 * TPB
+

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -146,11 +146,11 @@ def test_py_evict_swa_leaf_with_full_lock_keeps_full():
 
 
 def test_py_match_probe_does_not_promote_swa_lru():
-    """M1.5 (regression guard): a match-only PROBE (update_cache_info=False, the
-    engine's swa_align path) must NOT reorder the SWA-LRU. A probe may never lead
-    to actual reuse (usable=min(full,swa) can truncate it to 0), so promoting on a
-    probe would pollute eviction. Passes today; must keep passing after the
-    reuse-promotion fix (which should gate on update_cache_info=True only)."""
+    """M1.5 (regression guard): a match-only PROBE (update_cache_info=False) must
+    NOT reorder the SWA-LRU. A probe may never lead to actual reuse
+    (usable=min(full,swa) can clamp it to 0), so promoting on a probe would
+    pollute eviction. Passes today; must keep passing after the reuse-promotion
+    fix (which should gate on update_cache_info=True only)."""
     idx = RadixTreeIndex(tokens_per_block=TPB)
     a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
     idx.set_swa(a, slot=10)

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -162,26 +162,16 @@ def test_py_match_probe_does_not_promote_swa_lru():
     assert idx._swa_lru_get_lru_unlocked() is a
 
 
-@pytest.mark.xfail(reason="LRU-on-match promotion not yet wired (colleague's fix "
-                          "target): match/reuse of an SWA node does not promote "
-                          "it on the SWA-LRU, so a reused entry can be evicted "
-                          "before a never-reused one. Acceptance test for M6.6.",
-                   strict=False)
 def test_py_reuse_promotes_swa_over_never_reused():
-    """M6.6 (acceptance, xfail): the SWA-LRU reuse contract, separate from any
-    correctness invariant — no leak/corruption occurs either way, only hit-rate.
+    """M6.6: the SWA-LRU reuse contract — a real match promotes the reused SWA
+    node to MRU, so a never-reused node becomes the eviction victim instead.
 
     A (older) and B (newer) each hold an SWA slot; SWA-LRU order tail->head = A,B.
     We then REUSE A via a real match (update_cache_info=True — the actual-reuse
     path, mirroring how full-KV match already bumps its own last_access_time). A
     correct SWA-LRU promotes the reused node to MRU, making B (never reused) the
     true LRU victim. On the next single-slot SWA eviction, B must go and A must
-    survive.
-
-    Currently match does NOT promote the SWA-LRU, so A stays at the LRU tail and
-    is wrongly evicted — this test fails until the promotion is wired. The whole
-    'evict interior/public-prefix SWA first' policy actively works against a hot
-    reused prefix without this promotion (see 场景与覆盖矩阵 §I.1)."""
+    survive."""
     idx = RadixTreeIndex(tokens_per_block=TPB)
     a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
     idx.set_swa(a, slot=10)
@@ -423,6 +413,46 @@ def test_cpp_match_reports_last_swa_node():
     assert mr.last_swa_node is not None
     assert mr.last_swa_node.swa_host_slot == 100
     assert mr.swa_hit_blocks == 4
+
+
+@cext
+def test_cpp_reuse_promotes_swa_over_never_reused():
+    """C++ peer of test_py_reuse_promotes_swa_over_never_reused: a real match
+    (update_cache_info=True) promotes the reused SWA node to MRU, so the
+    never-reused node is evicted instead. Observed via evict_swa (the SWA-LRU is
+    not directly bound to Python)."""
+    t = _tree()
+    a = _insert(t, [1, 2, 3, 4], 0)
+    t.set_swa(a, 10)
+    b = _insert(t, [5, 6, 7, 8], 4)
+    t.set_swa(b, 11)
+    # SWA-LRU order (LRU tail -> MRU head): A, B. Reuse A with a REAL match.
+    mr = t.match_prefix(_hashes([1, 2, 3, 4]), 2, True)
+    assert mr.last_swa_node is not None and mr.last_swa_node.swa_host_slot == 10
+    # Evict one SWA slot: B (never reused) must go, A (just reused) survives.
+    _evf, nfreed = _evict_swa(t, 1)
+    assert nfreed == 1
+    assert a.has_swa(), "reused SWA A was evicted (C++ match did not promote)"
+    assert not b.has_swa()
+
+
+@cext
+def test_cpp_match_probe_does_not_promote_swa_lru():
+    """C++ peer of test_py_match_probe_does_not_promote_swa_lru: a probe
+    (update_cache_info=False) must NOT reorder the SWA-LRU, so the older node A
+    stays the eviction victim even after being probed."""
+    t = _tree()
+    a = _insert(t, [1, 2, 3, 4], 0)
+    t.set_swa(a, 10)
+    b = _insert(t, [5, 6, 7, 8], 4)
+    t.set_swa(b, 11)
+    # Probe A without cache-info update — must not promote it.
+    t.match_prefix(_hashes([1, 2, 3, 4]), 2, False)
+    # A is still the LRU victim: evicting one drops A, keeps B.
+    _evf, nfreed = _evict_swa(t, 1)
+    assert nfreed == 1
+    assert not a.has_swa(), "probe wrongly promoted A (should stay LRU victim)"
+    assert b.has_swa()
 
 
 @cext

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -145,6 +145,57 @@ def test_py_evict_swa_leaf_with_full_lock_keeps_full():
     assert not idx.is_empty()
 
 
+def test_py_match_probe_does_not_promote_swa_lru():
+    """M1.5 (regression guard): a match-only PROBE (update_cache_info=False, the
+    engine's swa_align path) must NOT reorder the SWA-LRU. A probe may never lead
+    to actual reuse (usable=min(full,swa) can truncate it to 0), so promoting on a
+    probe would pollute eviction. Passes today; must keep passing after the
+    reuse-promotion fix (which should gate on update_cache_info=True only)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.set_swa(a, slot=10)
+    b = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    idx.set_swa(b, slot=11)
+    # SWA-LRU order (LRU tail -> MRU head): A, B. Probe A without cache-info update.
+    idx.match_prefix(_seq([1, 2, 3, 4]), update_cache_info=False)
+    # A must still be the LRU victim — the probe did not promote it.
+    assert idx._swa_lru_get_lru_unlocked() is a
+
+
+@pytest.mark.xfail(reason="LRU-on-match promotion not yet wired (colleague's fix "
+                          "target): match/reuse of an SWA node does not promote "
+                          "it on the SWA-LRU, so a reused entry can be evicted "
+                          "before a never-reused one. Acceptance test for M6.6.",
+                   strict=False)
+def test_py_reuse_promotes_swa_over_never_reused():
+    """M6.6 (acceptance, xfail): the SWA-LRU reuse contract, separate from any
+    correctness invariant — no leak/corruption occurs either way, only hit-rate.
+
+    A (older) and B (newer) each hold an SWA slot; SWA-LRU order tail->head = A,B.
+    We then REUSE A via a real match (update_cache_info=True — the actual-reuse
+    path, mirroring how full-KV match already bumps its own last_access_time). A
+    correct SWA-LRU promotes the reused node to MRU, making B (never reused) the
+    true LRU victim. On the next single-slot SWA eviction, B must go and A must
+    survive.
+
+    Currently match does NOT promote the SWA-LRU, so A stays at the LRU tail and
+    is wrongly evicted — this test fails until the promotion is wired. The whole
+    'evict interior/public-prefix SWA first' policy actively works against a hot
+    reused prefix without this promotion (see 场景与覆盖矩阵 §I.1)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    a = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.set_swa(a, slot=10)
+    b = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    idx.set_swa(b, slot=11)
+    # Reuse A (real match, not a probe).
+    mr = idx.match_prefix(_seq([1, 2, 3, 4]), update_cache_info=True)
+    assert mr.last_swa_node is a  # A was indeed matched/reused
+    # Evict one SWA slot: must drop the never-reused B, not the just-reused A.
+    idx.evict_swa(1)
+    assert a.has_swa(), "reused SWA A was evicted (SWA-LRU not promoted on match)"
+    assert not b.has_swa()
+
+
 def test_py_dual_lock_invariant():
     """I3: full_lock_ref (lock_cnt) >= swa_lock_ref, with paired inc/dec."""
     idx = RadixTreeIndex(tokens_per_block=TPB)

--- a/tests/test_swa_peer_op.py
+++ b/tests/test_swa_peer_op.py
@@ -33,7 +33,7 @@ from flexkv.common.transfer import (
     TransferOpGraph, TransferOp, TransferType, DeviceType,
 )
 from flexkv.cache.transfer_pattern import add_virtual_op_for_multiple_finished_ops
-from flexkv.cache.swa_cache_engine import SWACacheManager, SWAMatchResult
+from flexkv.cache.swa_cache_engine import SWACacheManager
 
 pytestmark = pytest.mark.unit
 
@@ -185,17 +185,6 @@ def test_get_full_plus_swa_ssd_and_remote_staging():
     assert all(g._op_map[p].is_swa for p in swa_h2d.predecessors)
 
 
-def test_get_swa_only():
-    """GPU has full, only the trailing SWA window slid out: SWA-only graph."""
-    mgr = _mgr(enabled=True)
-    g, swa_id = mgr.build_swa_only_graph(TransferType.H2D, SWA_CPU, SWA_GPU, swa_key=9)
-    g, end = add_virtual_op_for_multiple_finished_ops(g, [swa_id], 0)
-    _print_scenario("GET SWA-only", g, end)
-    assert len(_full_ops(g)) == 0
-    assert len(_swa_ops(g)) == 1
-    assert end == swa_id            # sole op, no VIRTUAL needed
-
-
 # ============================================================================
 # PUT scenarios (store) — write-through fire-and-forget
 # ============================================================================
@@ -276,106 +265,3 @@ def test_set_gpu_blocks_does_not_touch_swa_slots():
     # full H2D dst rebound to the new gpu blocks; SWA H2D dst still SWA_GPU
     assert g._op_map[full.op_id].dst_block_ids.tolist() == [900, 901]
     np.testing.assert_array_equal(g._op_map[swa_id].dst_block_ids, SWA_GPU)
-
-
-# ============================================================================
-# multi-tier match (SWAMatchResult)
-# ============================================================================
-
-class _FakeSWANode:
-    """A fake node-mounted SWA source: reports a fixed (hit, slot, key)."""
-    def __init__(self, hit_blocks, slot, key):
-        self._hit, self._slot, self._key = hit_blocks, slot, key
-
-    def match(self, block_hashes, upper_bound_blocks, lock_for_load=False):
-        hit = min(self._hit, int(upper_bound_blocks))
-        return (hit, self._slot, self._key) if hit > 0 else (0, -1, -1)
-
-
-def _engine_for(idx):
-    return SimpleNamespace(
-        swa_enabled=True,
-        match_swa=lambda seq, upper_bound_blocks, lock_for_load=False:
-            idx.match(None, upper_bound_blocks, lock_for_load),
-    )
-
-
-def _mgr_tiers(cpu=None, ssd=None, remote=None):
-    engines = {}
-    if cpu is not None:
-        engines[DeviceType.CPU] = _engine_for(cpu)
-    if ssd is not None:
-        engines[DeviceType.SSD] = _engine_for(ssd)
-    if remote is not None:
-        engines[DeviceType.REMOTE] = _engine_for(remote)
-    gce = SimpleNamespace(cache_engines=engines,
-                          cache_config=SimpleNamespace(enable_swa_transfer=True))
-    return SWACacheManager(gce)
-
-
-class _Seq:
-    def gen_hashes(self):
-        pass
-
-
-def test_match_cpu_preferred_then_ssd_then_remote():
-    mgr = _mgr_tiers(cpu=_FakeSWANode(0, -1, -1),
-                     ssd=_FakeSWANode(2, 22, 222),
-                     remote=_FakeSWANode(5, 33, 333))
-    r = mgr.match_prefix(_Seq(), 6)
-    assert r.cpu_hit_blocks == 0
-    assert r.ssd_hit_blocks == 2 and r.ssd_slot == 22
-    assert r.remote_hit_blocks == 5 and r.remote_slot == 33
-    assert r.best_hit_blocks == 5
-
-
-def test_match_clamp_to_full_hit():
-    """Every tier's SWA hit is clamped to the single ``max_full_hit_blocks``
-    upper bound (SWA subset of Full)."""
-    mgr = _mgr_tiers(cpu=_FakeSWANode(0, -1, -1),
-                     ssd=_FakeSWANode(9, 22, 222),
-                     remote=_FakeSWANode(9, 33, 333))
-    r = mgr.match_prefix(_Seq(), max_full_hit_blocks=3)
-    assert r.ssd_hit_blocks == 3 and r.remote_hit_blocks == 3
-
-
-def test_match_no_cpu_index_empty():
-    gce = SimpleNamespace(cache_engines={}, cache_config=SimpleNamespace(enable_swa_transfer=True))
-    r = SWACacheManager(gce).match_prefix(_Seq(), 4)
-    assert r.best_hit_blocks == 0 and r.cpu_slot == -1
-
-
-def test_match_propagates_per_tier_keys():
-    """Per-tier hit/slot/key propagate so the data plane can drive
-    set_ready/unlock for each tier; best_hit_blocks is the cross-tier max."""
-    mgr = _mgr_tiers(cpu=_FakeSWANode(1, 10, 100),
-                     ssd=_FakeSWANode(2, 22, 222),
-                     remote=_FakeSWANode(5, 33, 333))
-    r = mgr.match_prefix(_Seq(), 6)
-    assert r.cpu_hit_blocks == 1 and r.cpu_slot == 10 and r.cpu_key == 100
-    assert r.ssd_key == 222 and r.remote_key == 333
-    assert r.best_hit_blocks == 5        # cross-tier max (REMOTE here)
-
-
-def test_match_forwards_upper_bound_and_lock_per_tier():
-    """Each tier's match_swa is called with the single ``max_full_hit_blocks``
-    upper bound (SWA subset of Full) and the caller's lock_for_load is forwarded."""
-    calls = {}
-
-    def _engine(tier):
-        def _match(seq, upper_bound_blocks, lock_for_load=False):
-            calls[tier] = (upper_bound_blocks, lock_for_load)
-            return (1, 0, 0)
-        return SimpleNamespace(swa_enabled=True,
-                               match_swa=_match)
-
-    engines = {DeviceType.CPU: _engine("cpu"),
-               DeviceType.SSD: _engine("ssd"),
-               DeviceType.REMOTE: _engine("remote")}
-    gce = SimpleNamespace(cache_engines=engines,
-                          cache_config=SimpleNamespace(enable_swa_transfer=True))
-    SWACacheManager(gce).match_prefix(_Seq(), max_full_hit_blocks=5,
-                                      lock_for_load=True)
-    assert calls["cpu"] == (5, True)
-    assert calls["ssd"] == (5, True)
-    assert calls["remote"] == (5, True)

--- a/tests/test_swa_ssd_staging_e2e.py
+++ b/tests/test_swa_ssd_staging_e2e.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end SWA SSD-staging byte-exact test (multi-tier), entered from the
+ENGINE control-plane API with real byte movement — NO stubs.
+
+Proves the SSD SWA tier round-trip that the CPU-only e2e (test_swa_control_plane_e2e.py)
+does not cover:
+
+  PUT : engine.put() -> graph {full D2H, SWA D2H, SWA H2DISK write-through}
+        -> the SWA window lands in BOTH the CPU SWA host pool AND the SSD SWA
+           files (write-through).
+  EVICT: drop the CPU SWA slot (SWA-only eviction) so the window survives ONLY
+         on SSD — forcing the GET to stage from SSD.
+  GET : engine.get() -> graph {full H2D, SWA DISK2H (SSD->CPU staging) -> SWA H2D
+        (CPU->GPU)} -> bytes restored to a fresh GPU SWA slot -> byte-exact.
+
+This exercises the multi-tier _swa_put_slots (write-through) and _swa_get_slots
+(SSD->CPU transient staging slot + H2D), plus the transient staging slot free on
+H2D completion.
+
+Run INSIDE the container on a free GPU:
+    CUDA_VISIBLE_DEVICES=0 python3 tests/test_swa_ssd_staging_e2e.py
+"""
+import os
+import shutil
+import sys
+import time
+
+import numpy as np
+import pytest
+import torch
+
+from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
+from flexkv.common.memory_handle import TensorSharedHandle
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.common.transfer import DeviceType, WorkerKey
+from flexkv.storage.storage_engine import StorageEngine
+from flexkv.transfer.transfer_engine import TransferEngine
+
+NUM_LAYERS = 4
+NUM_BLOCKS_GPU = 64
+NUM_BLOCKS_CPU = 64
+NUM_BLOCKS_SSD = 128
+TOKENS_PER_BLOCK = 16
+BYTES_PER_TOKEN_PER_LAYER = 64
+DEVICE_ID = 0
+NUM_SWA_SLOTS = 32
+NUM_SWA_SSD_SLOTS = 32
+SWA_GPU_SLOT = 9
+SSD_CACHE_DIR = "./_swa_ssd_e2e_cache"
+
+
+def make_gpu_pool(num_blocks):
+    return torch.zeros((NUM_LAYERS, num_blocks, TOKENS_PER_BLOCK,
+                        BYTES_PER_TOKEN_PER_LAYER), dtype=torch.uint8,
+                       device=f"cuda:{DEVICE_ID}")
+
+
+def seed_block(pool, block, salt):
+    for layer in range(NUM_LAYERS):
+        plane = torch.zeros((TOKENS_PER_BLOCK, BYTES_PER_TOKEN_PER_LAYER),
+                            dtype=torch.uint8)
+        for tok in range(TOKENS_PER_BLOCK):
+            for b in range(BYTES_PER_TOKEN_PER_LAYER):
+                plane[tok, b] = ((layer * 31 + tok + salt) ^ b) & 0xFF
+        pool[layer, block].copy_(plane.to(pool.device))
+
+
+def block_bytes(pool, block):
+    chunks = [pool[layer, block].contiguous().view(-1).cpu().clone()
+              for layer in range(NUM_LAYERS)]
+    return torch.cat(chunks).numpy().tobytes()
+
+
+def make_layout(num_blocks):
+    return KVCacheLayout(type=KVCacheLayoutType.LAYERFIRST, num_layer=NUM_LAYERS,
+                         num_block=num_blocks, tokens_per_block=TOKENS_PER_BLOCK,
+                         num_head=1, head_size=BYTES_PER_TOKEN_PER_LAYER, is_mla=True)
+
+
+def wait_for_op(te, op_ids, timeout_s=30.0):
+    pending = set(op_ids)
+    deadline = time.monotonic() + timeout_s
+    while pending and time.monotonic() < deadline:
+        for c in te.get_completed_graphs_and_ops(timeout=1.0):
+            pending.discard(c.op_id)
+    if pending:
+        raise TimeoutError(f"Ops {pending} did not complete in {timeout_s}s")
+
+
+def _run_graph(te, graph, op_cb, cb, full_gpu_blocks, swa_gpu_slot, reported_op_ids):
+    graph.set_gpu_blocks(np.asarray(full_gpu_blocks, dtype=np.int64))
+    if graph._swa_gpu_transfer_op_id:
+        graph.set_swa_gpu_blocks(np.asarray([swa_gpu_slot], dtype=np.int64))
+    te.submit_transfer_graph(graph)
+    wait_for_op(te, reported_op_ids)
+    torch.cuda.synchronize()
+    for op_id, c in op_cb.items():
+        c()
+    cb()
+
+
+def main() -> int:
+    if not torch.cuda.is_available():
+        print("[verify] CUDA not available", flush=True)
+        return 2
+    torch.cuda.set_device(DEVICE_ID)
+    if os.path.isdir(SSD_CACHE_DIR):
+        shutil.rmtree(SSD_CACHE_DIR)
+    os.makedirs(SSD_CACHE_DIR, exist_ok=True)
+    print(f"[verify] device cuda:{DEVICE_ID}, ssd_dir={SSD_CACHE_DIR}", flush=True)
+
+    model_config = ModelConfig(num_layers=NUM_LAYERS, num_kv_heads=1,
+                               head_size=BYTES_PER_TOKEN_PER_LAYER, use_mla=True,
+                               dtype=torch.uint8, tp_size=1, pp_size=1, dp_size=1,
+                               cp_size=1)
+    cache_config = CacheConfig(
+        tokens_per_block=TOKENS_PER_BLOCK, enable_cpu=True, enable_ssd=True,
+        enable_remote=False, num_cpu_blocks=NUM_BLOCKS_CPU,
+        num_ssd_blocks=NUM_BLOCKS_SSD, ssd_cache_dir=SSD_CACHE_DIR,
+        swa=SWAPoolConfig(enabled=True, num_slots=NUM_SWA_SLOTS,
+                          num_ssd_slots=NUM_SWA_SSD_SLOTS,
+                          window_size=TOKENS_PER_BLOCK, num_swa_layers=NUM_LAYERS,
+                          bytes_per_token_per_layer=BYTES_PER_TOKEN_PER_LAYER,
+                          pin_memory=True))
+    cache_config.enable_swa_transfer = True
+
+    mk_pool = make_gpu_pool(NUM_BLOCKS_GPU)
+    sw_pool = make_gpu_pool(NUM_SWA_SLOTS)
+    PUT_FULL_GPU, GET_FULL_GPU = 0, 3
+    seed_block(mk_pool, PUT_FULL_GPU, salt=0xA1)
+    seed_block(sw_pool, SWA_GPU_SLOT, salt=0xB2)
+    expected_sw = block_bytes(sw_pool, SWA_GPU_SLOT)
+
+    mk_handles = [TensorSharedHandle(mk_pool[l].contiguous(), DEVICE_ID)
+                  for l in range(NUM_LAYERS)]
+    sw_handles = [TensorSharedHandle(sw_pool[l].contiguous(), DEVICE_ID)
+                  for l in range(NUM_LAYERS)]
+
+    se = StorageEngine(model_config, cache_config, num_layers_per_pp_stage=NUM_LAYERS)
+    assert se.has_storage_handle(DeviceType.CPU, device_id=0, is_swa=True), "SWA CPU pool missing"
+    assert se.has_storage_handle(DeviceType.SSD, device_id=0, is_swa=True), "SWA SSD pool missing"
+    gpu_layout = make_layout(NUM_BLOCKS_GPU)
+    swa_gpu_layout = make_layout(NUM_SWA_SLOTS)
+    se.register_gpu_blocks(mk_handles, gpu_layout, device_id=DEVICE_ID, dtype=torch.uint8)
+    se.register_swa_gpu_blocks(sw_handles, swa_gpu_layout, device_id=DEVICE_ID, dtype=torch.uint8)
+
+    worker_key = WorkerKey(dp_client_id=0, pp_rank=0)
+    te = TransferEngine(
+        gpu_handles={worker_key: [se.get_storage_handle(DeviceType.GPU, device_id=DEVICE_ID)]},
+        model_config=model_config, cache_config=cache_config,
+        cpu_handle=se.get_storage_handle(DeviceType.CPU),
+        ssd_handle=se.get_storage_handle(DeviceType.SSD),
+        swa_gpu_handles={worker_key: [se.get_swa_storage_handle(DEVICE_ID)]},
+        swa_cpu_handle=se.get_storage_handle(DeviceType.CPU, device_id=0, is_swa=True),
+        swa_ssd_handle=se.get_storage_handle(DeviceType.SSD, device_id=0, is_swa=True),
+    )
+    te.start()
+    print("[verify] TransferEngine started (main-KV + SWA CPU/SSD workers)", flush=True)
+
+    engine = GlobalCacheEngine(cache_config, model_config)
+    assert engine.ssd_cache_engine is not None and engine.ssd_cache_engine.swa_enabled, \
+        "engine SSD SWA tier not enabled"
+
+    tok = np.arange(1, TOKENS_PER_BLOCK + 1, dtype=np.int64)
+    put_slot_mapping = np.arange(PUT_FULL_GPU * TOKENS_PER_BLOCK,
+                                 (PUT_FULL_GPU + 1) * TOKENS_PER_BLOCK, dtype=np.int64)
+    mask = np.ones_like(tok, dtype=np.int64)
+
+    # ===== PUT: full D2H + SWA D2H + SWA H2DISK write-through ====================
+    put_graph, _rm, put_cb, put_op_cb, put_end = engine.put(
+        request_id=1, token_ids=tok, token_mask=mask,
+        slot_mapping=put_slot_mapping, dp_client_id=0)
+    swa_put_ops = [o for o in put_graph._op_map.values() if getattr(o, "is_swa", False)]
+    kinds = sorted(o.transfer_type.name for o in swa_put_ops)
+    assert "D2H" in kinds and "H2DISK" in kinds, f"expected SWA D2H + H2DISK, got {kinds}"
+    assert engine.ssd_cache_engine.swa_pool.num_used == 1, "SSD SWA slot not allocated on put"
+    reported = {put_end} | {o.op_id for o in swa_put_ops if o.transfer_type.name == "D2H"}
+    print(f"[verify] PUT graph: SWA ops={kinds} (write-through to SSD)", flush=True)
+    _run_graph(te, put_graph, put_op_cb, put_cb,
+               full_gpu_blocks=[PUT_FULL_GPU], swa_gpu_slot=SWA_GPU_SLOT,
+               reported_op_ids=reported)
+    print("[verify] PUT done (SWA in CPU pool + SSD files)", flush=True)
+
+    # ===== EVICT the CPU SWA so the window survives only on SSD =================
+    n_cpu = engine.cpu_cache_engine.swa_pool.num_used
+    engine.cpu_cache_engine._evict_swa(n_cpu)
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK); seq.gen_hashes()
+    cpu_hit, _s, _k = engine.cpu_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    ssd_hit, _s2, _k2 = engine.ssd_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    assert cpu_hit == 0 and ssd_hit > 0, f"precondition failed: cpu_hit={cpu_hit} ssd_hit={ssd_hit}"
+    print(f"[verify] evicted CPU SWA (cpu_hit=0, ssd_hit={ssd_hit}); GET must stage from SSD", flush=True)
+
+    # zero the GPU SWA pool so GET must restore from SSD->CPU->GPU
+    sw_pool.zero_(); mk_pool.zero_(); torch.cuda.synchronize()
+
+    # ===== GET: SWA DISK2H (SSD->CPU staging) -> SWA H2D (CPU->GPU) =============
+    get_slot_mapping = np.arange(GET_FULL_GPU * TOKENS_PER_BLOCK,
+                                 (GET_FULL_GPU + 1) * TOKENS_PER_BLOCK, dtype=np.int64)
+    get_graph, _rm2, get_cb, get_op_cb, get_end = engine.get(
+        request_id=2, token_ids=tok, token_mask=np.ones_like(tok, dtype=np.int64),
+        slot_mapping=get_slot_mapping, dp_client_id=0)
+    swa_get_ops = [o for o in get_graph._op_map.values() if getattr(o, "is_swa", False)]
+    gkinds = sorted(o.transfer_type.name for o in swa_get_ops)
+    assert "DISK2H" in gkinds and "H2D" in gkinds, f"expected SWA DISK2H+H2D staging, got {gkinds}"
+    swa_h2d = [o for o in swa_get_ops if o.transfer_type.name == "H2D"][0]
+    swa_disk2h = [o for o in swa_get_ops if o.transfer_type.name == "DISK2H"][0]
+    assert swa_disk2h.op_id in swa_h2d.predecessors, "SWA H2D must depend on SSD DISK2H"
+    barrier = get_graph._op_map[get_end]
+    reported2 = {swa_h2d.op_id} | set(barrier.predecessors)
+    print(f"[verify] GET graph: SWA ops={gkinds} (SSD staging chain)", flush=True)
+    _run_graph(te, get_graph, get_op_cb, get_cb,
+               full_gpu_blocks=[GET_FULL_GPU], swa_gpu_slot=SWA_GPU_SLOT,
+               reported_op_ids=reported2)
+    print("[verify] GET done (SWA restored via SSD->CPU->GPU)", flush=True)
+
+    # ===== byte-exact compare ==================================================
+    actual_sw = block_bytes(sw_pool, SWA_GPU_SLOT)
+    failed = actual_sw != expected_sw
+    if failed:
+        print("[verify] FAIL SWA byte mismatch after SSD staging", flush=True)
+    else:
+        print(f"[verify] OK    SWA: {len(expected_sw)} bytes match "
+              f"GPU->CPU/SSD->(evict CPU)->DISK2H->H2D->GPU", flush=True)
+
+    # transient CPU staging slot must be freed on H2D completion (no leak).
+    staging_used = engine.cpu_cache_engine.swa_pool.num_used
+    if staging_used != 0:
+        print(f"[verify] FAIL transient CPU staging slot leaked (num_used={staging_used})", flush=True)
+        failed = True
+    else:
+        print("[verify] OK    transient CPU staging slot freed (no leak)", flush=True)
+
+    te.shutdown()
+    if os.path.isdir(SSD_CACHE_DIR):
+        shutil.rmtree(SSD_CACHE_DIR)
+    if failed:
+        return 4
+    print("[verify] PASS: SSD SWA staging byte-exact, transient slot freed", flush=True)
+    return 0
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SWA SSD staging e2e needs a GPU")
+def test_swa_ssd_staging_e2e_byte_exact():
+    """pytest entry: SSD SWA write-through + staged GET byte-exact roundtrip."""
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Builds on node-mounted SWA with four changes, plus merges PRs #195/#201:

1. **Multi-tier SSD/REMOTE SWA** — write-through on PUT (SWA `H2DISK`/`H2REMOTE` ride the full-KV store) and staged load on GET (SSD/REMOTE-sourced SWA stages through a transient CPU slot: `DISK2H`/`REMOTE2H` → CPU → GPU).
2. **Single-pass fold** — the SWA-aware GET matches the radix tree once, not twice.
3. **Drop unused `swa_mask`** — remove a reserved-but-unwired RPC parameter.
4. **Collapse `get_match_swa` into `get_match(swa_aware=...)`** — unify the SWA-aware and plain match into one method and delete the code that only served the SWA-only special case.

Merged `dpskv4_refactor`: `swa_fix` (`promote_swa` read-hit LRU refresh + `match_swa_from_result` single-pass reuse) and #201 (`SWAHostPool` reduced to a pure slot-id allocator).

## Single-pass fold: why one match suffices

Node-mount makes `radix.match_prefix` return the full prefix AND the deepest in-range SWA node (`last_swa_node` / `swa_hit_blocks`) in one forward pass. The SWA-aware GET previously matched **twice**; this removes the first pass.

- `_get_impl_local/global` take `swa_aware`; after the single match they clamp `block_mask_end` to `usable = min(full, swa)` via `_clamp_end_to_swa` (SWA hit read from the same match, no re-walk). `block_mask_end` is the only knob — every fragment slices `[start:end]`.
- `_get_impl_*` return the per-tier match results; `_swa_get_slots` reuses them via `match_swa_from_result` (reuse + promote + pin) instead of a fresh `match_swa_locked`.

## Collapse into `get_match`

After the fold, `get_match_swa` differed from `get_match` only by `swa_aware=True` and a derived second mask. Since the reusable SWA window is always the trailing block of the clamped full mask, the caller derives it itself — so the whole method, its RPC, and the second return value are removed:

- `get_match` gains `swa_aware=False`, threaded through `_get_match_impl` → `create_get_task` → `get()`. Returns the usual `(task_id, mask)`.
- **Deleted end-to-end:** `get_match_swa` (KVTaskEngine + KVManager + client), `GetMatchSwaRequest`, `_handle_get_match_swa_request`, `Response.mask_swa`.
- The **SWA-only** case (full_mask all-0: GPU already holds the full prefix) is handled by the connector rolling the Full-KV window back one block, so the trailing block is fetched from CPU with full+swa resolved on the same node — the ordinary `swa_aware` path. This removed the only caller of `swa_align`.
- **Deleted now-dead code:** `swa_align`, `match_swa_prefix` (wrapper), `SWACacheManager.match_prefix`, the `SWAMatchResult` dataclass, and `build_swa_only_graph`. Kept `_swa_hit_from_match_results` / `_clamp_end_to_swa` (the live clamp) and the per-tier `match_swa` / `match_swa_from_result` primitives.

Net: **+78 / −718 lines** across the collapse commit.

## Guardrail

A plain `get()` / `get_match` (`swa_aware=False`, the default) short-circuits the SWA section, so the shared `_get_impl_*` hot path is byte-identical for non-SWA callers.

## RPC contract change

`GetMatchSwaRequest` is removed and `GetMatchRequest` gains `swa_aware`. The sglang connector (separate repo) must call `get_match(swa_aware=True)`, stop using `get_match_swa` / `mask_swa`, and roll the Full-KV window back one block for the SWA-only case.

## SWA-LRU promotion on match

Full-KV `match_prefix(update_cache_info=True)` bumps each tier's per-node heat even when no data is transferred from that tier. SWA promotion previously happened only in `_swa_get_slots` after the transfer source was chosen, so SSD/Remote SWA copies holding the same hot data — but not selected as the source — were never promoted and could be evicted before never-reused entries.

`match_prefix` now promotes the final `last_swa_node` to its SWA-LRU MRU when `update_cache_info=True`, right before returning — the SWA peer of the per-node Full-KV `update_time()` bump. Strictly gated: a probe (`update_cache_info=False`) never touches the SWA-LRU. `last_swa_node` is the deepest fully-matched ready node with a live SWA slot by construction, so partial matches and tombstones are never promoted. Applied identically to Python `RadixTreeIndex` and C++ `CRadixTreeIndex`. Because `match_all`/`match_local` call `match()` per tier, each tier's SWA copy is promoted in its own SWA-LRU (multi-tier parity).

The explicit `promote_swa()` in `match_swa` / `match_swa_locked` / `match_swa_from_result` is kept: those standalone probes pass `update_cache_info=False` (must not bump Full-KV heat) yet represent a real reuse, so they need their own promote — idempotent with the new in-match promote.

Tests: `test_py_reuse_promotes_swa_over_never_reused` (xfail removed, now passes); `test_py_match_probe_does_not_promote_swa_lru` (unchanged); added C++ peers `test_cpp_reuse_promotes_swa_over_never_reused` / `test_cpp_match_probe_does_not_promote_swa_lru`; added `test_multitier_match_promotes_swa_in_each_tier`.

## Verification

Verified on the remote test host (container `dsv4-liuxing-2node`) at HEAD `df2caaf`:

- Full SWA + kvtask suite: **88 passed / 1 skipped **, no regression (includes multi-tier byte-exact SSD-staging e2e and control-plane e2e). The count reflects deleting the tests for now-removed code (`test_swa_align_*`, `test_get_swa_only`, the multi-tier `match_prefix` suite, the `get_match_swa` dispatch tests).
- Non-SWA regression (`test_cache_engine`, `test_namespace_isolation`): **161 passed** — the shared `get_match` / RPC path is unaffected.
- Import check: `GetMatchSwaRequest`, `get_match_swa`, `swa_align`, `SWACacheManager.match_prefix`, `SWAMatchResult`, `build_swa_only_graph`, `Response.mask_swa` all gone; `swa_aware` present on `get_match` / `GetMatchRequest`; all modules import cleanly.

