### PR TITLE
Fix: removed the redundant slot_size dimension from SWAHostPool

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -2002,9 +2002,7 @@ class GlobalCacheEngine:
 
     def match_swa_prefix(self,
                          sequence_meta: SequenceMeta,
-                         cpu_full_hit_blocks: int,
-                         ssd_full_hit_blocks: int = 0,
-                         remote_full_hit_blocks: int = 0,
+                         max_full_hit_blocks: int,
                          lock_for_load: bool = False,
                          cpu_match_result=None,
                          ssd_match_result=None,
@@ -2012,13 +2010,12 @@ class GlobalCacheEngine:
         """Multi-tier SWA prefix match (delegates to SWACacheManager.match_prefix).
 
         Per-tier ``*_match_result`` (from the SAME forward pass that produced the
-        full hits) let the SWA match REUSE that pass instead of re-walking.
+        full hit) let the SWA match REUSE that pass instead of re-walking. Every
+        tier is clamped to the single ``max_full_hit_blocks`` upper bound.
         """
         return self.swa_cache.match_prefix(
             sequence_meta,
-            cpu_full_hit_blocks=cpu_full_hit_blocks,
-            ssd_full_hit_blocks=ssd_full_hit_blocks,
-            remote_full_hit_blocks=remote_full_hit_blocks,
+            max_full_hit_blocks=max_full_hit_blocks,
             lock_for_load=lock_for_load,
             cpu_match_result=cpu_match_result,
             ssd_match_result=ssd_match_result,
@@ -2127,9 +2124,7 @@ class GlobalCacheEngine:
             return full_hit_blocks, 0
 
         swa_match = self.match_swa_prefix(
-            sequence_meta, cpu_full_hit_blocks=full_hit_blocks,
-            ssd_full_hit_blocks=full_hit_blocks,
-            remote_full_hit_blocks=full_hit_blocks,
+            sequence_meta, max_full_hit_blocks=full_hit_blocks,
             lock_for_load=lock_for_load,
             # Reuse the Full-KV matches just computed above — the SWA hit rides the
             # SAME forward pass, so no tier re-walks the tree.

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -134,30 +134,29 @@ class SWACacheManager:
 
     def match_prefix(self,
                      sequence_meta: SequenceMeta,
-                     cpu_full_hit_blocks: int,
-                     ssd_full_hit_blocks: int = 0,
-                     remote_full_hit_blocks: int = 0,
+                     max_full_hit_blocks: int,
                      lock_for_load: bool = False,
                      cpu_match_result=None,
                      ssd_match_result=None,
                      remote_match_result=None) -> SWAMatchResult:
-        """Match the trailing-SWA prefix on each tier, clamped to its Full-KV hit.
+        """Match the trailing-SWA prefix on each tier, clamped to the Full-KV hit.
 
         Each tier's node-mounted SWA (on its radix tree) is matched independently
-        within that tier's Full-KV hit (SWA subset of Full).
-        CPU is preferred; SSD then REMOTE are the fallbacks whose load needs a
-        staging chain (SWA DISK2H / REMOTE2H -> SWA H2D, all is_swa=True).
+        within the (already cross-tier max'd) Full-KV hit ``max_full_hit_blocks``
+        (SWA subset of Full). CPU is preferred; SSD then REMOTE are the fallbacks
+        whose load needs a staging chain (SWA DISK2H / REMOTE2H -> SWA H2D, all
+        is_swa=True).
 
         When a tier's Full-KV ``*_match_result`` is supplied (from the SAME
-        forward pass that produced its ``*_full_hit_blocks``), the SWA hit is
+        forward pass that produced ``max_full_hit_blocks``), the SWA hit is
         REUSED from it via ``match_swa_from_result`` — no second tree walk. When
         omitted, it falls back to the standalone ``match_swa`` probe.
 
         Args:
             sequence_meta: the (page-aligned) query prefix.
-            cpu_full_hit_blocks: Full-KV CPU hit length in blocks (CPU upper bound).
-            ssd_full_hit_blocks: Full-KV SSD hit length in blocks (SSD upper bound).
-            remote_full_hit_blocks: Full-KV REMOTE hit length in blocks (upper bound).
+            max_full_hit_blocks: Full-KV hit length in blocks, the single upper
+                bound applied to every tier (the caller has already collapsed the
+                per-tier Full hits to their cross-tier max).
             lock_for_load: pin the matched SWA entries against eviction until load.
             cpu_match_result / ssd_match_result / remote_match_result: the tier's
                 Full-KV match to reuse (optional; carries last_swa_node/swa_hit_blocks).
@@ -184,17 +183,17 @@ class SWACacheManager:
                 sequence_meta, upper_bound_blocks=upper_bound,
                 lock_for_load=lock_for_load)
 
-        if cpu_full_hit_blocks > 0:
+        if max_full_hit_blocks > 0:
             result.cpu_hit_blocks, result.cpu_slot, result.cpu_key = \
-                _match(self._engine(DeviceType.CPU), cpu_full_hit_blocks, cpu_match_result)
+                _match(self._engine(DeviceType.CPU), max_full_hit_blocks, cpu_match_result)
 
-        if self._swa_enabled_tier(DeviceType.SSD) and ssd_full_hit_blocks > 0:
-            result.ssd_hit_blocks, result.ssd_slot, result.ssd_key = \
-                _match(self._engine(DeviceType.SSD), ssd_full_hit_blocks, ssd_match_result)
+            if self._swa_enabled_tier(DeviceType.SSD):
+                result.ssd_hit_blocks, result.ssd_slot, result.ssd_key = \
+                    _match(self._engine(DeviceType.SSD), max_full_hit_blocks, ssd_match_result)
 
-        if self._swa_enabled_tier(DeviceType.REMOTE) and remote_full_hit_blocks > 0:
-            result.remote_hit_blocks, result.remote_slot, result.remote_key = \
-                _match(self._engine(DeviceType.REMOTE), remote_full_hit_blocks, remote_match_result)
+            if self._swa_enabled_tier(DeviceType.REMOTE):
+                result.remote_hit_blocks, result.remote_slot, result.remote_key = \
+                    _match(self._engine(DeviceType.REMOTE), max_full_hit_blocks, remote_match_result)
         return result
 
     # --- peer-op graph construction (gated) --------------------------------

--- a/flexkv/swa/swa_host_pool.py
+++ b/flexkv/swa/swa_host_pool.py
@@ -1,46 +1,28 @@
-"""SWA Host Pool — CPU-side pinned memory for SWA page storage.
+"""SWA Host Pool — CPU-side slot-id allocator for SWA pages.
 
-SWA is managed at PAGE granularity: each slot stores exactly one swa_page of
+SWA is managed at PAGE granularity: each slot denotes exactly one swa_page of
 window KV = swa_page_size tokens x num_swa_layers layers x bytes_per_token_per_layer
 (``window_size`` in SWAPoolConfig carries the physical swa_page_size). All SWA
-IO addresses a whole slot (= one page) at a time. Slot allocation uses a simple
-free-list (stack). When the pool is full, the caller (cache engine) triggers SWA-LRU
-eviction before retrying.
+IO addresses a whole slot (= one page) at a time.
+
+This pool is purely a slot-id allocator / free-list (stack): it hands out and
+reclaims integer slot ids and keeps the used/free accounting. It does NOT hold
+the SWA KV bytes — those live in the ``StorageEngine`` buffer allocated with
+``is_swa=True`` (sized from the SAME SWAPoolConfig geometry) and are read/written
+by the transfer worker via the storage handle, addressed by slot id. When the
+pool is full, the caller (cache engine) triggers SWA-LRU eviction before retrying.
 """
-import time
-from typing import Optional, Union
-
-import numpy as np
-
-try:
-    import torch
-    _TORCH_AVAILABLE = True
-except ImportError:
-    _TORCH_AVAILABLE = False
+from typing import Optional
 
 from flexkv.common.config import SWAPoolConfig
 
 
 class SWAHostPool:
-    """Fixed-size CPU buffer pool for SWA page snapshots."""
+    """Fixed-size SWA slot-id allocator (free-list); holds no KV bytes."""
 
     def __init__(self, config: SWAPoolConfig):
         self._config = config
-        self._slot_size = config.slot_size_bytes
         self._num_slots = config.num_slots
-
-        # Allocate buffer
-        if _TORCH_AVAILABLE:
-            use_pin = config.pin_memory and torch.cuda.is_available()
-            self._buffer = torch.zeros(
-                (self._num_slots, self._slot_size),
-                dtype=torch.uint8,
-                pin_memory=use_pin,
-            )
-            self._use_torch = True
-        else:
-            self._buffer = np.zeros((self._num_slots, self._slot_size), dtype=np.uint8)
-            self._use_torch = False
 
         # Free-list (stack-based)
         self._free_slots = list(range(self._num_slots - 1, -1, -1))
@@ -66,52 +48,7 @@ class SWAHostPool:
         """
         self._free_slots = list(range(self._num_slots - 1, -1, -1))
 
-    # --- Data Access -------------------------------------------------------
-
-    def write(self, slot_id: int, data: Union['torch.Tensor', np.ndarray, bytes]) -> None:
-        """Write SWA data into a slot."""
-        if isinstance(data, bytes):
-            # np.frombuffer on bytes yields a read-only array; copy so the
-            # resulting tensor is writable and torch.from_numpy stays quiet.
-            arr = np.frombuffer(data, dtype=np.uint8).copy()
-        elif _TORCH_AVAILABLE and isinstance(data, torch.Tensor):
-            arr = data.detach().cpu().view(-1).to(torch.uint8)
-        else:
-            arr = np.asarray(data, dtype=np.uint8).ravel()
-
-        n = min(len(arr), self._slot_size)
-        if self._use_torch:
-            if isinstance(arr, np.ndarray):
-                self._buffer[slot_id, :n] = torch.from_numpy(arr[:n])
-            else:
-                self._buffer[slot_id, :n] = arr[:n]
-        else:
-            if _TORCH_AVAILABLE and isinstance(arr, torch.Tensor):
-                self._buffer[slot_id, :n] = arr[:n].numpy()
-            else:
-                self._buffer[slot_id, :n] = arr[:n]
-
-    def read(self, slot_id: int) -> Union['torch.Tensor', np.ndarray]:
-        """Read SWA data from a slot (returns a view, zero-copy)."""
-        return self._buffer[slot_id]
-
-    def read_copy(self, slot_id: int) -> Union['torch.Tensor', np.ndarray]:
-        """Read SWA data from a slot (returns a copy)."""
-        if self._use_torch:
-            return self._buffer[slot_id].clone()
-        else:
-            return self._buffer[slot_id].copy()
-
     # --- Properties --------------------------------------------------------
-
-    @property
-    def buffer(self):
-        """The backing slot buffer ``[num_slots, slot_size_bytes]`` (uint8).
-
-        Pinned torch tensor when CUDA is available, else a numpy array. The SWA
-        transfer worker (data plane) shares this and addresses bytes by slot row.
-        """
-        return self._buffer
 
     @property
     def num_free(self) -> int:
@@ -127,7 +64,12 @@ class SWAHostPool:
 
     @property
     def slot_size_bytes(self) -> int:
-        return self._slot_size
+        """Bytes per slot (= one swa_page), forwarded from the config.
+
+        The bytes themselves live in the StorageEngine ``is_swa=True`` buffer,
+        not here; this is exposed only so callers can size that buffer / slot.
+        """
+        return self._config.slot_size_bytes
 
     @property
     def config(self) -> SWAPoolConfig:

--- a/tests/test_swa_host_pool.py
+++ b/tests/test_swa_host_pool.py
@@ -1,5 +1,4 @@
-"""Tests for SWA Host Pool — CPU pinned memory slot allocation."""
-import numpy as np
+"""Tests for SWA Host Pool — CPU-side SWA slot-id allocation (free-list)."""
 import pytest
 
 from flexkv.common.config import SWAPoolConfig
@@ -59,32 +58,16 @@ class TestSWAHostPoolAllocation:
         new_slot = pool.allocate()
         assert new_slot is not None
 
+    def test_reset_rearms_all_slots(self, pool):
+        for _ in range(5):
+            pool.allocate()
+        assert pool.num_used == 5
+        pool.reset()
+        assert pool.num_free == 8
+        assert pool.num_used == 0
 
-class TestSWAHostPoolIO:
-    def test_write_read_numpy(self, pool, small_config):
-        slot = pool.allocate()
-        data = np.arange(small_config.slot_size_bytes, dtype=np.uint8)
-        pool.write(slot, data)
-        result = pool.read(slot)
-        np.testing.assert_array_equal(np.asarray(result)[:len(data)], data)
-
-    def test_write_read_bytes(self, pool, small_config):
-        slot = pool.allocate()
-        data = bytes(range(min(256, small_config.slot_size_bytes)))
-        pool.write(slot, data)
-        result = np.asarray(pool.read(slot))
-        np.testing.assert_array_equal(result[:len(data)], np.frombuffer(data, dtype=np.uint8))
-
-    def test_slot_size(self, pool, small_config):
-        expected = 4 * 2 * 8  # window_size * layers * bytes
-        assert pool.slot_size_bytes == expected
-
-    def test_read_copy_independence(self, pool, small_config):
-        slot = pool.allocate()
-        data = np.ones(small_config.slot_size_bytes, dtype=np.uint8) * 42
-        pool.write(slot, data)
-        copy1 = pool.read_copy(slot)
-        copy2 = pool.read_copy(slot)
-        # Modify copy1, copy2 should be unaffected
-        np.asarray(copy1)[0] = 99
-        assert np.asarray(copy2)[0] == 42
+    def test_slot_size_bytes_forwarded_from_config(self, pool, small_config):
+        # slot_size_bytes is a pure forward of the config geometry; the pool
+        # holds no bytes (those live in the StorageEngine is_swa buffer).
+        expected = 4 * 2 * 8  # window_size * layers * bytes_per_token_per_layer
+        assert pool.slot_size_bytes == expected == small_config.slot_size_bytes

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -583,17 +583,12 @@ def _make_workload(num_users, num_turns, sys_len, turn_in, turn_out, seed):
     return work
 
 
-def _page_fingerprint(block_hash, slot_size):
-    """Deterministic bytes keyed by the window's block hash — stands in for the
-    real SWA-page KV; byte-identical read-back proves the slot round-tripped."""
-    rs = np.random.RandomState(block_hash & 0xFFFFFFFF)
-    return rs.randint(0, 256, size=slot_size, dtype=np.uint8)
-
-
 class _SWAWorkloadDriver:
     """Minimal port of the former benchmark Driver: match(get) -> store(put)
-    with an SWA page mounted on each stored tail node, real byte IO on hit, and
-    ground-truth pool invariant sweeps."""
+    with an SWA slot mounted on each stored tail node, and ground-truth pool
+    invariant sweeps (slot-id accounting: no double-free / use-after-free / leak).
+    The SWA pool is a pure slot-id allocator (bytes live in the StorageEngine
+    is_swa buffer), so this driver tracks slot lifecycle, not page bytes."""
 
     def __init__(self, num_cpu_blocks, swa_slots, slot_bytes):
         from flexkv.cache.cache_engine import CacheEngineAccel
@@ -609,11 +604,9 @@ class _SWAWorkloadDriver:
             enabled=True, num_slots=swa_slots, window_size=_WTPB,
             num_swa_layers=1, bytes_per_token_per_layer=max(1, slot_bytes // _WTPB),
         ))
-        self.slot_size = self.engine.swa_pool.slot_size_bytes
         self._slot_expect: Dict[int, int] = {}
         self.violations: List[str] = []
         self.swa_hits = 0
-        self.bytes_verified = 0
 
     def _seq(self, token_ids):
         aligned = (len(token_ids) // self.tpb) * self.tpb
@@ -640,14 +633,6 @@ class _SWAWorkloadDriver:
                 sm, upper_bound_blocks=full_hit, lock_for_load=False)
             if swa_hit > 0 and slot >= 0:
                 self.swa_hits += 1
-                got = np.asarray(self.engine.swa_pool.read_copy(slot)).ravel()
-                exp_hash = self._slot_expect.get(int(slot))
-                if exp_hash is not None:
-                    exp = _page_fingerprint(exp_hash, self.slot_size)
-                    if got.shape == exp.shape and np.array_equal(got, exp):
-                        self.bytes_verified += 1
-                    else:
-                        self.violations.append(f"SWA byte mismatch on slot {slot}")
 
         num_new = nblocks - full_hit
         if num_new > 0:
@@ -670,7 +655,6 @@ class _SWAWorkloadDriver:
         if slot == -1:
             return
         tail_hash = int(sm.block_hashes[nblocks - 1])
-        self.engine.swa_pool.write(slot, _page_fingerprint(tail_hash, self.slot_size))
         self._slot_expect[int(slot)] = tail_hash
         self.engine.set_swa(node, slot)
         self._reconcile()
@@ -711,17 +695,16 @@ class _SWAWorkloadDriver:
 def test_workload_pressure_no_leak_no_corruption(cpu_blocks, swa_slots):
     """Stochastic multi-turn workload on the production path: under Full and SWA
     pool pressure, the two pools stay in lock-step — no double-free, no
-    use-after-free of a live window, byte-identical SWA read-back, no leak after
-    reset. (Folded from benchmark_swa_nodemount.py; small params for CI.)"""
+    use-after-free of a live window, no slot leak after reset. (Folded from
+    benchmark_swa_nodemount.py; small params for CI.)"""
     work = _make_workload(num_users=24, num_turns=6, sys_len=8 * _WTPB,
                           turn_in=6 * _WTPB, turn_out=2 * _WTPB, seed=1234)
     drv = _SWAWorkloadDriver(cpu_blocks, swa_slots, slot_bytes=4096)
     violations = drv.run(work, check_every=25)
     assert not violations, "invariant violations:\n" + "\n".join(violations[:20])
-    # Sanity: the workload actually exercised SWA hits + real byte verify (so a
-    # silent no-op regression that stops mounting/reading SWA is caught).
+    # Sanity: the workload actually exercised SWA hits (so a silent no-op
+    # regression that stops mounting/matching SWA slots is caught).
     assert drv.swa_hits > 0, "workload produced no SWA hits — coverage regressed"
-    assert drv.bytes_verified > 0, "no SWA byte round-trip verified"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_swa_peer_op.py
+++ b/tests/test_swa_peer_op.py
@@ -322,20 +322,21 @@ def test_match_cpu_preferred_then_ssd_then_remote():
     mgr = _mgr_tiers(cpu=_FakeSWANode(0, -1, -1),
                      ssd=_FakeSWANode(2, 22, 222),
                      remote=_FakeSWANode(5, 33, 333))
-    r = mgr.match_prefix(_Seq(), 6, 6, 6)
+    r = mgr.match_prefix(_Seq(), 6)
     assert r.cpu_hit_blocks == 0
     assert r.ssd_hit_blocks == 2 and r.ssd_slot == 22
     assert r.remote_hit_blocks == 5 and r.remote_slot == 33
     assert r.best_hit_blocks == 5
 
 
-def test_match_per_tier_clamp_to_full_hit():
+def test_match_clamp_to_full_hit():
+    """Every tier's SWA hit is clamped to the single ``max_full_hit_blocks``
+    upper bound (SWA subset of Full)."""
     mgr = _mgr_tiers(cpu=_FakeSWANode(0, -1, -1),
                      ssd=_FakeSWANode(9, 22, 222),
                      remote=_FakeSWANode(9, 33, 333))
-    r = mgr.match_prefix(_Seq(), cpu_full_hit_blocks=0,
-                         ssd_full_hit_blocks=2, remote_full_hit_blocks=3)
-    assert r.ssd_hit_blocks == 2 and r.remote_hit_blocks == 3
+    r = mgr.match_prefix(_Seq(), max_full_hit_blocks=3)
+    assert r.ssd_hit_blocks == 3 and r.remote_hit_blocks == 3
 
 
 def test_match_no_cpu_index_empty():
@@ -350,15 +351,15 @@ def test_match_propagates_per_tier_keys():
     mgr = _mgr_tiers(cpu=_FakeSWANode(1, 10, 100),
                      ssd=_FakeSWANode(2, 22, 222),
                      remote=_FakeSWANode(5, 33, 333))
-    r = mgr.match_prefix(_Seq(), 6, 6, 6)
+    r = mgr.match_prefix(_Seq(), 6)
     assert r.cpu_hit_blocks == 1 and r.cpu_slot == 10 and r.cpu_key == 100
     assert r.ssd_key == 222 and r.remote_key == 333
     assert r.best_hit_blocks == 5        # cross-tier max (REMOTE here)
 
 
 def test_match_forwards_upper_bound_and_lock_per_tier():
-    """Each tier's match_swa is called with THAT tier's Full-KV hit as the upper
-    bound (SWA subset of Full) and the caller's lock_for_load is forwarded."""
+    """Each tier's match_swa is called with the single ``max_full_hit_blocks``
+    upper bound (SWA subset of Full) and the caller's lock_for_load is forwarded."""
     calls = {}
 
     def _engine(tier):
@@ -373,10 +374,8 @@ def test_match_forwards_upper_bound_and_lock_per_tier():
                DeviceType.REMOTE: _engine("remote")}
     gce = SimpleNamespace(cache_engines=engines,
                           cache_config=SimpleNamespace(enable_swa_transfer=True))
-    SWACacheManager(gce).match_prefix(_Seq(), cpu_full_hit_blocks=3,
-                                      ssd_full_hit_blocks=5,
-                                      remote_full_hit_blocks=7,
+    SWACacheManager(gce).match_prefix(_Seq(), max_full_hit_blocks=5,
                                       lock_for_load=True)
-    assert calls["cpu"] == (3, True)
+    assert calls["cpu"] == (5, True)
     assert calls["ssd"] == (5, True)
-    assert calls["remote"] == (7, True)
+    assert calls["remote"] == (5, True)


### PR DESCRIPTION
1. Removed the redundant slot_size dimension from SWAHostPool: it was allocating a [num_slots, slot_size_bytes] shadow buffer whose write/read/buffer interface had zero callers in production — the actual SWA KV bytes live in the StorageEngine is_swa=True buffer that the transfer worker reads/writes. SWAHostPool is now a pure slot-id allocator (free-list), eliminating the per-tier resident memory waste; the byte-fingerprint checks in the affected tests were switched to slot-id lifecycle invariants.
2. remove three parameter reference of full_hit_blocks to one single max_full_hit_blocks=full_hit_blocks.