### PR TITLE
feat(nvfp4): NVFP4 KV cache support for FlexKV + vLLM integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ssd_cache*/
 *cache*/
 benchmarks/nvcomp_benchmarks/inputs
 benchmarks/nvcomp_benchmarks/runs
+uv.lock

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -499,7 +499,7 @@ class UserConfig:
     local_ip: Optional[str] = None
     redis_password: Optional[str] = None
     node_ttl_seconds: Optional[int] = None
-    kv_cache_dtype: Optional[str] = None  # Override kv_cache_dtype when TRT config uses "auto". Supported values: "fp8", "float8", "e4m3", "fp16", "float16", "bf16", "bfloat16", "fp32", "float32"
+    kv_cache_dtype: Optional[str] = None  # Override kv_cache_dtype when TRT config uses "auto". Supported values: "fp8", "float8", "e4m3", "fp16", "float16", "bf16", "bfloat16", "fp32", "float32", "nvfp4" (packed fp4+fp8-scale, stored as uint8)
 
     def __post_init__(self):
         if self.cpu_cache_gb <= 0:

--- a/flexkv/common/storage.py
+++ b/flexkv/common/storage.py
@@ -79,7 +79,7 @@ class KVCacheLayout:
             elif self.type == KVCacheLayoutType.LAYERBLOCK:  # vLLM >= 0.23 non-MLA GPU layout
                 self._kv_shape = torch.Size([self.num_layer,
                                              self.num_block,
-                                             self._kv_dim,
+                                             self.kv_dim,
                                              self.tokens_per_block,
                                              self.num_head,
                                              self.head_size])

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -17,6 +17,49 @@ if TYPE_CHECKING:
 logger = flexkv_logger
 
 
+def _is_nvfp4_dtype_str(dtype_str: Optional[str]) -> bool:
+    """Return True if *dtype_str* selects the NVFP4 packed KV cache layout."""
+    return isinstance(dtype_str, str) and dtype_str.lower() in ("nvfp4", "fp4", "e2m1")
+
+
+def nvfp4_kv_cache_full_dim(head_size: int) -> int:
+    """Packed last-dim size (in bytes / uint8 elements) for an NVFP4 KV cache.
+
+    Mirrors vLLM's ``vllm.utils.torch_utils.nvfp4_kv_cache_full_dim``:
+    each head packs ``head_size // 2`` bytes of fp4 data (2 fp4 values per byte)
+    plus ``head_size // 16`` bytes of fp8 block scales (1 scale per 16 elements).
+    """
+    return head_size // 2 + head_size // 16
+
+
+def _warn_nvfp4_unsupported_framework(dtype_str: Optional[str], framework: str) -> None:
+    """Warn if NVFP4 KV cache is requested from a framework whose FlexKV adapter
+    has not yet implemented the nvfp4 packed-layout ``head_size`` fold.
+
+    Only the vLLM adapter (``post_init_from_vllm_config``) folds the packed width
+    ``head_size//2 + head_size//16`` into ``head_size`` so the CPU/SSD mirror
+    matches the framework's packed GPU tensor byte-for-byte. Without that fold the
+    CPU mirror is sized for the *logical* head_size and offload/reload would be
+    byte-misaligned. Until each framework's packed nvfp4 layout is verified we
+    only warn here rather than silently produce a corrupt mirror.
+    """
+    if not _is_nvfp4_dtype_str(dtype_str):
+        return
+    # TODO(nvfp4): implement + verify the nvfp4 packed head_size fold for the
+    # {framework} adapter (mirror post_init_from_vllm_config: guard non-MLA,
+    # set model_config.head_size = nvfp4_kv_cache_full_dim(head_size)). Confirm
+    # the framework stores nvfp4 KV as a single packed uint8 tensor with the same
+    # (head_size//2 + head_size//16) last-dim layout as vLLM before enabling.
+    logger.warning(
+        f"[FlexKV {framework}] kv_cache_dtype='{dtype_str}' (NVFP4) requested, but "
+        f"the {framework} FlexKV adapter does NOT yet apply the nvfp4 packed "
+        f"head_size fold. The CPU/SSD mirror may be byte-misaligned with the "
+        f"packed GPU tensor -> offload/reload correctness is NOT guaranteed. "
+        f"NVFP4 is currently verified only through the vLLM adapter. "
+        f"See TODO(nvfp4) in flexkv/integration/config.py."
+    )
+
+
 @dataclass
 class FlexKVConfig:
     enable_flexkv: bool = True
@@ -55,6 +98,15 @@ class FlexKVConfig:
             "float8": torch.float8_e4m3fn,
             "e4m3": torch.float8_e4m3fn,
             "fp8_e4m3": torch.float8_e4m3fn,
+            # NVFP4: vLLM stores the packed fp4 data + fp8 block scales in a
+            # single uint8 tensor, so FlexKV mirrors it as a 1-byte-per-element
+            # buffer. The packed per-head element count is folded into head_size
+            # elsewhere (see ``nvfp4_kv_cache_full_dim`` /
+            # ``post_init_from_vllm_config``).
+            "nvfp4": torch.uint8,
+            "fp4": torch.uint8,
+            "e2m1": torch.uint8,
+            "fp4_e2m1": torch.uint8,
         }
         return dtype_map.get(dtype_str.lower(), torch.bfloat16)
 
@@ -163,7 +215,36 @@ class FlexKVConfig:
             framework_dtype_str=vllm_kv_cache_dtype if isinstance(vllm_kv_cache_dtype, str) else None,
             fallback_dtype=getattr(vllm_config.model_config, 'dtype', torch.bfloat16),
         )
-        self.model_config.use_mla = vllm_config.model_config.is_deepseek_mla
+        is_mla = vllm_config.model_config.is_deepseek_mla
+        self.model_config.use_mla = is_mla
+
+        # NVFP4: vLLM stores the packed fp4 data + fp8 block scales in a single
+        # uint8 tensor whose per-head last dim is head_size//2 + head_size//16.
+        # _resolve_dtype has already mapped nvfp4 -> uint8; here we fold the
+        # packed width into head_size so the CPU/SSD mirror matches vLLM's packed
+        # GPU tensor byte-for-byte. The effective dtype string follows the same
+        # user-first-else-framework priority _resolve_dtype uses.
+        effective_dtype_str = (
+            self.user_config.kv_cache_dtype
+            if self.user_config.kv_cache_dtype is not None
+            else (vllm_kv_cache_dtype if isinstance(vllm_kv_cache_dtype, str) else None)
+        )
+        if _is_nvfp4_dtype_str(effective_dtype_str) and not is_mla:
+            logical_head_size = self.model_config.head_size
+            packed_head_size = nvfp4_kv_cache_full_dim(logical_head_size)
+            self.model_config.head_size = packed_head_size
+            logger.info(
+                f"[FlexKV vllm] NVFP4 KV cache detected: folding packed layout "
+                f"into head_size (logical={logical_head_size} -> "
+                f"packed={packed_head_size}, dtype=uint8)"
+            )
+        elif _is_nvfp4_dtype_str(effective_dtype_str) and is_mla:
+            logger.warning(
+                "[FlexKV vllm] kv_cache_dtype='nvfp4' requested for an MLA "
+                "model. vLLM MLA backends do NOT support nvfp4 KV cache now; "
+                "skipping the nvfp4 head_size fold. If vLLM rejects this "
+                "config, use fp8/fp8_ds_mla for MLA instead."
+            )
         self.model_config.tp_size = vllm_config.parallel_config.tensor_parallel_size
         self.model_config.dp_size = vllm_config.parallel_config.data_parallel_size
         self.model_config.pp_size = vllm_config.parallel_config.pipeline_parallel_size
@@ -292,6 +373,12 @@ class FlexKVConfig:
             framework_dtype_str=kv_cache_dtype,
             fallback_dtype=getattr(sglang_config, "dtype", torch.bfloat16),
         )
+        # NVFP4 packed head_size fold is only implemented/verified for vLLM.
+        _warn_nvfp4_unsupported_framework(
+            self.user_config.kv_cache_dtype
+            if self.user_config.kv_cache_dtype is not None else kv_cache_dtype,
+            framework="sglang",
+        )
 
         if use_mla and getattr(sglang_config, "index_head_dim", None) is not None:
             kv_lora_rank = int(getattr(sglang_config, "kv_lora_rank", 0))
@@ -388,6 +475,13 @@ class FlexKVConfig:
             self.model_config.dtype = self._parse_dtype_str(dtype_str)
         else:
             self.model_config.dtype = dtype_str
+        # NVFP4 packed head_size fold is only implemented/verified for vLLM.
+        _warn_nvfp4_unsupported_framework(
+            self.user_config.kv_cache_dtype
+            if self.user_config.kv_cache_dtype is not None
+            else (dtype_str if isinstance(dtype_str, str) else None),
+            framework="trtllm",
+        )
 
         # Set model config (parallel configs part)
         if config.mapping.enable_attention_dp:

--- a/flexkv/integration/dynamo/collector.py
+++ b/flexkv/integration/dynamo/collector.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# TODO(nvfp4): Dynamo integration currently drives FlexKV through the vLLM
+# adapter (post_init_from_vllm_config), which is the only path that applies the
+# nvfp4 packed head_size fold (head_size -> head_size//2 + head_size//16). If a
+# Dynamo-specific FlexKVConfig init path is ever added, mirror that fold there
+# (see _warn_nvfp4_unsupported_framework in flexkv/integration/config.py);
+# otherwise NVFP4 KV cache is only verified via the vLLM adapter.
+
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 from queue import Queue
 import threading

--- a/flexkv/storage/allocator.py
+++ b/flexkv/storage/allocator.py
@@ -101,7 +101,7 @@ class CPUAllocator(BaseStorageAllocator):
                  **kwargs: Any) -> StorageHandle:
         total_size = layout.get_total_elements()
         # although the kv layout may have multiple dimensions, we only have one-dim CPU tensor
-        flexkv_logger.info(f"CPU allocate total_size: {2 * total_size/1024/1024/1024} GB")
+        flexkv_logger.info(f"CPU allocate total_size: {dtype.itemsize * total_size/1024/1024/1024} GB")
         physical_tensor = torch.empty(
                             size=(total_size,),
                             dtype=dtype,

--- a/setup.py
+++ b/setup.py
@@ -34,26 +34,75 @@ NVCOMP_HEADERS = [
 ]
 
 
+# Mainstream datacenter + workstation architectures we want the shipped
+# c_ext.so to run on out of the box (Ampere -> Hopper -> Blackwell). The final
+# list is intersected with what the local nvcc actually supports, so this stays
+# buildable on older CUDA toolkits that lack sm_100/sm_120.
+MAINSTREAM_ARCHS = ["8.0", "8.6", "8.9", "9.0", "10.0", "12.0"]
+
+
+def _nvcc_supported_archs():
+    """Return the set of 'major.minor' arches the local nvcc can target.
+
+    Parses ``nvcc --list-gpu-arch`` (lines like ``compute_90``). Returns an
+    empty set if nvcc is unavailable, in which case callers should not filter."""
+    import re
+    import shutil
+    import subprocess
+    nvcc = shutil.which("nvcc") or os.path.join(
+        os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", "nvcc")
+    try:
+        out = subprocess.run([nvcc, "--list-gpu-arch"],
+                             capture_output=True, text=True, check=True).stdout
+    except Exception as e:
+        print(f"Could not query nvcc for supported arches: {e}")
+        return set()
+    archs = set()
+    for m in re.finditer(r"compute_(\d+)", out):
+        code = m.group(1)  # e.g. "90" -> 9.0, "100" -> 10.0, "120" -> 12.0
+        archs.add(f"{int(code[:-1])}.{code[-1]}")
+    return archs
+
+
 def detect_cuda_arch():
-    """Auto-detect GPU compute capability. Returns a semicolon-separated arch list.
-    Falls back to a safe default when no GPU is available."""
+    """Return a semicolon-separated TORCH_CUDA_ARCH_LIST.
+
+    By default we build a *multi-arch* binary covering mainstream datacenter and
+    workstation GPUs so a single c_ext.so is portable across machines (this
+    avoids the "no kernel image is available for execution on the device" error
+    that a single-arch build hits when moved to a different GPU). The mainstream
+    set is filtered to what the local nvcc supports, the locally-detected arch is
+    always added, and +PTX is appended to the newest arch for forward-compat JIT
+    onto future GPUs."""
+    supported = _nvcc_supported_archs()
+
+    # Start from the mainstream set, filtered by what nvcc can actually build.
+    archs = {a for a in MAINSTREAM_ARCHS if not supported or a in supported}
+
+    # Always cover the GPU(s) present on the build host, even if not mainstream.
+    local = set()
     try:
         import torch
         if torch.cuda.is_available():
-            archs = set()
             for i in range(torch.cuda.device_count()):
                 major, minor = torch.cuda.get_device_capability(i)
-                archs.add(f"{major}.{minor}")
-            if archs:
-                arch_list = ";".join(sorted(archs))
-                print(f"Auto-detected GPU architectures: {arch_list}")
-                return arch_list
+                local.add(f"{major}.{minor}")
     except Exception as e:
         print(f"GPU architecture auto-detection failed: {e}")
-    # Fallback: common architectures (Ampere + Hopper)
-    fallback = "8.0;8.6;9.0"
-    print(f"No GPU detected, using fallback architectures: {fallback}")
-    return fallback
+    archs |= {a for a in local if not supported or a in supported}
+
+    if not archs:
+        # nvcc query failed AND no torch/GPU: fall back to a broad static list.
+        fallback = "8.0;8.6;9.0"
+        print(f"No arch info available, using fallback architectures: {fallback}")
+        return fallback
+
+    ordered = sorted(archs, key=lambda a: tuple(int(x) for x in a.split(".")))
+    # Emit PTX for the newest arch so unknown future GPUs can JIT from PTX.
+    arch_list = ";".join(ordered[:-1] + [f"{ordered[-1]}+PTX"])
+    print(f"Building for architectures: {arch_list} "
+          f"(mainstream default + local {sorted(local) or 'none'})")
+    return arch_list
 
 
 def _probe_nvcomp_root(root, source):

--- a/tests/test_nvfp4_roundtrip.py
+++ b/tests/test_nvfp4_roundtrip.py
@@ -1,0 +1,221 @@
+"""Byte-exact round-trip test for FlexKV nvfp4 KV cache offload.
+
+vLLM stores an nvfp4 KV cache as a single ``torch.uint8`` tensor whose per-head
+last dim is the packed width ``full_dim = head_size//2 + head_size//16`` (fp4
+data + fp8 block scales, inline). FlexKV mirrors that tensor byte-for-byte to
+CPU. This test drives the real production offload path:
+
+    KVTPClient.register_to_server  ->  KVManager.put_async (D2H)
+    clear GPU  ->  KVManager.get_match + launch (H2D)  ->  verify
+
+using uint8 GPU tensors shaped exactly like vLLM's nvfp4 output, and a
+deterministic *byte* pattern (the float-hash verifier in common_utils cannot
+represent uint8). A perfect round trip proves the packed nvfp4 bytes (data AND
+fp8 scales) survive GPU->CPU->GPU intact.
+
+The CPU cache is sized to honour the project constraint of cpu_cache_gb <= 1
+(here far below 1 GB — a few MB — since only a handful of blocks are needed).
+
+Run directly (single GPU):  python tests/test_nvfp4_roundtrip.py
+"""
+import sys
+import time
+import multiprocessing as mp
+
+import torch
+
+from flexkv.common.config import ModelConfig, CacheConfig, RankInfo
+from flexkv.common.config import convert_to_block_num
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.common.request import KVResponseStatus
+from flexkv.common.memory_handle import TensorSharedHandle
+from flexkv.kvmanager import KVManager
+from flexkv.server.client import KVTPClient
+from flexkv.integration.config import nvfp4_kv_cache_full_dim
+from flexkv.common.debug import flexkv_logger
+
+
+# ---- Model shape: a small nvfp4 model (matches Qwen2.5-0.5B head_dim=64) ----
+LOGICAL_HEAD_SIZE = 64                      # vLLM logical head_size
+PACKED_HEAD_SIZE = nvfp4_kv_cache_full_dim(LOGICAL_HEAD_SIZE)  # 64//2 + 64//16 = 36
+NUM_LAYERS = 4
+NUM_KV_HEADS = 2
+TOKENS_PER_BLOCK = 16
+NUM_GPU_BLOCKS = 64
+BLOCKS_PER_REQUEST = 16
+
+
+def _byte_value(layer_id: int, kv_id: int, block_id: int) -> int:
+    """Deterministic non-zero byte for a (layer, kv, block) triple."""
+    return ((layer_id * 37 + kv_id * 101 + int(block_id) * 7) % 251) + 1
+
+
+def run_tp_client(server_recv_port, conn):
+    """Subprocess: create uint8 nvfp4-shaped GPU KV tensors, register them with
+    the FlexKV server, and hand IPC handles back to the parent."""
+    try:
+        device_id = 0
+        gpu_layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=NUM_LAYERS,
+            num_block=NUM_GPU_BLOCKS,
+            tokens_per_block=TOKENS_PER_BLOCK,
+            num_head=NUM_KV_HEADS,
+            head_size=PACKED_HEAD_SIZE,
+            is_mla=False,
+        )
+        # LAYERFIRST per-layer tensor: (kv_dim=2, num_block, tpb, num_head, head_size)
+        gpu_blocks = []
+        for _ in range(NUM_LAYERS):
+            gpu_blocks.append(
+                torch.zeros(tuple(gpu_layout.kv_shape[1:]),
+                            dtype=torch.uint8, device=f"cuda:{device_id}")
+            )
+        tp_client = KVTPClient(server_recv_port, dp_client_id=0, pp_rank=0,
+                               device_id=device_id)
+        tp_client.register_to_server(gpu_blocks, gpu_layout)
+        conn.send([TensorSharedHandle(t) for t in gpu_blocks])
+        conn.close()
+        while True:
+            time.sleep(1)
+    except Exception:  # noqa: BLE001
+        import traceback
+        traceback.print_exc()
+        try:
+            conn.send(None)
+            conn.close()
+        except Exception:
+            pass
+
+
+def fill_blocks(gpu_tensors, block_ids):
+    """Fill each (layer, kv, block) slice with its deterministic byte value."""
+    for layer_id, t in enumerate(gpu_tensors):          # t: (2, nblk, tpb, nhead, hs)
+        for kv_id in range(2):
+            for b in block_ids:
+                t[kv_id, int(b), :, :, :] = _byte_value(layer_id, kv_id, b)
+
+
+def clear_blocks(gpu_tensors, block_ids):
+    for t in gpu_tensors:
+        for kv_id in range(2):
+            for b in block_ids:
+                t[kv_id, int(b), :, :, :] = 0
+
+
+def verify_blocks(gpu_tensors, block_ids) -> bool:
+    ok = True
+    for layer_id, t in enumerate(gpu_tensors):
+        for kv_id in range(2):
+            for b in block_ids:
+                expected = _byte_value(layer_id, kv_id, b)
+                sl = t[kv_id, int(b), :, :, :]
+                if not torch.all(sl == expected):
+                    ok = False
+                    ndiff = int((sl != expected).sum().item())
+                    print(f"  MISMATCH layer={layer_id} kv={kv_id} block={int(b)}: "
+                          f"expected byte {expected}, {ndiff}/{sl.numel()} bytes differ")
+    return ok
+
+
+def main() -> int:
+    if not torch.cuda.is_available():
+        print("SKIP: no CUDA device")
+        return 0
+
+    # --- honour cpu_cache_gb <= 1 (compute blocks from a 1 GB budget) ---
+    model_config = ModelConfig(
+        num_layers=NUM_LAYERS, num_kv_heads=NUM_KV_HEADS,
+        head_size=PACKED_HEAD_SIZE, use_mla=False,
+        dtype=torch.uint8, tp_size=1, dp_size=1,
+    )
+    rank_info = RankInfo(model_config=model_config, tp_rank=0,
+                         pp_start_layer=0, pp_end_layer=NUM_LAYERS)
+    block_bytes = rank_info.token_size_in_bytes_per_pp_stage * TOKENS_PER_BLOCK
+    max_blocks_1gb = convert_to_block_num(1, block_bytes)   # blocks that fit in 1 GB
+    # Only a handful are actually needed; cap well under the 1 GB ceiling to keep
+    # RAM usage tiny while still satisfying "num_cpu_blocks >= num_gpu_blocks"
+    # (so we expect a 100% cache hit).
+    num_cpu_blocks = min(max_blocks_1gb, 256)
+    assert num_cpu_blocks >= NUM_GPU_BLOCKS
+    print(f"[cfg] packed head_size={PACKED_HEAD_SIZE} (logical {LOGICAL_HEAD_SIZE}), "
+          f"dtype=uint8, block_bytes={block_bytes}, "
+          f"1GB budget -> {max_blocks_1gb} blocks; using num_cpu_blocks={num_cpu_blocks} "
+          f"({num_cpu_blocks*block_bytes/1024/1024:.2f} MB, <= 1 GB)")
+
+    cache_config = CacheConfig(
+        tokens_per_block=TOKENS_PER_BLOCK,
+        enable_cpu=True, enable_ssd=False,
+        num_cpu_blocks=num_cpu_blocks,
+    )
+
+    kvmanager = KVManager(model_config=model_config, cache_config=cache_config,
+                          dp_client_id=0)
+    kvmanager.start()
+
+    mp_ctx = mp.get_context("spawn")
+    parent_conn, child_conn = mp_ctx.Pipe()
+    proc = mp_ctx.Process(target=run_tp_client,
+                          args=(kvmanager.gpu_register_port, child_conn),
+                          daemon=True)
+    proc.start()
+    shared = parent_conn.recv()
+    parent_conn.close()
+    if shared is None:
+        print("FAIL: tp_client failed to register GPU blocks")
+        kvmanager.shutdown()
+        return 1
+    gpu_tensors = [h.get_tensor() for h in shared]
+
+    while not kvmanager.is_ready():
+        time.sleep(0.5)
+        flexkv_logger.info("waiting for flexkv to be ready")
+
+    # Deterministic token ids for one request covering BLOCKS_PER_REQUEST blocks.
+    torch.manual_seed(1234)
+    token_ids = torch.randint(0, 100,
+                              (BLOCKS_PER_REQUEST * TOKENS_PER_BLOCK,),
+                              dtype=torch.int64)
+    block_ids = torch.arange(0, BLOCKS_PER_REQUEST, dtype=torch.int64)
+    slot_mapping = block_ids.repeat_interleave(TOKENS_PER_BLOCK) * TOKENS_PER_BLOCK
+
+    print("=== PUT (D2H offload of packed nvfp4 bytes) ===")
+    fill_blocks(gpu_tensors, block_ids)
+    torch.cuda.synchronize()
+    put_id = kvmanager.put_async(token_ids=token_ids, slot_mapping=slot_mapping,
+                                 token_mask=None, namespace=None)
+    res = kvmanager.wait([put_id], completely=True)
+    assert res[put_id].status == KVResponseStatus.SUCCESS, f"PUT failed: {res[put_id].status}"
+
+    print("=== clear GPU, then GET (H2D reload from FlexKV) ===")
+    clear_blocks(gpu_tensors, block_ids)
+    torch.cuda.synchronize()
+    assert torch.all(gpu_tensors[0][0, 0] == 0), "clear did not zero GPU blocks"
+
+    get_id, matched = kvmanager.get_match(token_ids=token_ids, token_mask=None,
+                                          namespace=None)
+    num_matched = int(matched.sum().item())
+    print(f"  get_match matched {num_matched} / {len(token_ids)} tokens")
+    assert num_matched == len(token_ids), (
+        f"expected full cache hit, matched only {num_matched}/{len(token_ids)}")
+    kvmanager.launch(get_id, slot_mapping)
+    gres = kvmanager.wait([get_id], completely=True)
+    assert gres[get_id].status == KVResponseStatus.SUCCESS, f"GET failed: {gres[get_id].status}"
+    torch.cuda.synchronize()
+
+    print("=== VERIFY byte-exact round trip ===")
+    ok = verify_blocks(gpu_tensors, block_ids)
+
+    if proc.is_alive():
+        proc.terminate(); proc.join(timeout=5)
+    kvmanager.shutdown()
+
+    if ok:
+        print("=== NVFP4 FLEXKV ROUND-TRIP OK: all packed uint8 bytes match ===")
+        return 0
+    print("=== NVFP4 FLEXKV ROUND-TRIP FAILED ===")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
vLLM stores an nvfp4 KV cache as a single packed uint8 tensor whose per-head last dim is head_size//2 + head_size//16 (fp4 data + fp8 block scales inline). FlexKV's transfer/storage core is byte-based, so support needs only a dtype map + a head_size fold so the CPU/SSD mirror matches the packed GPU tensor.

- integration/config.py: map nvfp4/fp4/e2m1 -> uint8 in _parse_dtype_str; add _is_nvfp4_dtype_str + nvfp4_kv_cache_full_dim helpers; fold packed width into head_size in post_init_from_vllm_config (non-MLA guarded, MLA warns).
- integration/config.py: warn + TODO(nvfp4) when nvfp4 is requested via the sglang / trtllm adapters, which do not yet apply the packed head_size fold.
- integration/dynamo/collector.py: TODO(nvfp4) noting Dynamo drives FlexKV via the vLLM adapter (the only verified nvfp4 path).
- common/config.py: document nvfp4 in UserConfig.kv_cache_dtype.
- common/storage.py: fix _kv_dim typo in the LAYERBLOCK branch (blocked all dtypes through the vLLM >=0.23 non-MLA layout, not just nvfp4).
- setup.py: build c_ext for a mainstream multi-arch list (sm80-sm120 + PTX, filtered by local nvcc) so one .so is portable across GPUs.
- tests/test_nvfp4_roundtrip.py: byte-exact nvfp4 offload/reload roundtrip.
- .gitignore: stop tracking uv.lock.

Verified on B200 (sm_100): roundtrip 256/256 bytes match; live vLLM byte-exact integration test reloads nvfp4 KV byte-for-byte across all 28 layers.

The test script integrated with vLLM was not placed in the test folder here. Tests should be self-contained.