### PR TITLE
Clean up SWA page metadata and tests

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -95,15 +95,10 @@ class CacheEngineAccel:
         """Initialize the SWA host pool for node-mounted SWA on this engine.
 
         Node-mount: the radix tree nodes hold the SWA state; this pool only
-        supplies slot bytes + a free-list. The window must be a whole number of
-        blocks (page-granular SWA); DSv4 has window_size == tokens_per_block.
+        supplies slot bytes + a free-list. SWA is page-granular, so the physical
+        SWA page size must match ``tokens_per_block``.
         """
         from flexkv.swa.swa_host_pool import SWAHostPool
-        if swa_config.window_size % self.tokens_per_block != 0:
-            raise ValueError(
-                f"SWAPoolConfig.window_size ({swa_config.window_size}) must be a "
-                f"multiple of tokens_per_block ({self.tokens_per_block})"
-            )
         self.swa_pool = SWAHostPool(swa_config)
 
     @property
@@ -155,7 +150,7 @@ class CacheEngineAccel:
     def match_swa(self,
                   sequence_meta: SequenceMeta,
                   upper_bound_blocks: int,
-                  lock_for_load: bool = False) -> Tuple[int, int, int]:
+                  lock_for_load: bool = False) -> Tuple[int, int]:
         """Match the longest reusable trailing-SWA prefix within an upper bound.
 
         Node-mount: the SWA hit is read from the Full-KV radix ``match_prefix``
@@ -163,15 +158,14 @@ class CacheEngineAccel:
         the prefix truncated to ``upper_bound_blocks`` (this tier's Full-KV hit)
         so the SWA hit is naturally clamped, enforcing SWA-subset-of-Full.
 
-        Returns ``(swa_hit_blocks, slot_id, swa_key)``. ``swa_key`` is the slot id
-        (the completion-callback handle); -1 / 0 when no SWA on the path.
+        Returns ``(swa_hit_blocks, slot_id)``; -1 / 0 when no SWA on the path.
         """
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1
+            return 0, -1
         sequence_meta.gen_hashes()
         num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
         if num_blocks <= 0:
-            return 0, -1, -1
+            return 0, -1
         block_hashes = torch.from_numpy(
             sequence_meta.block_hashes[:num_blocks]).to(torch.int64)
         # update_cache_info=False: a match-only probe must not bump LRU here.
@@ -179,10 +173,10 @@ class CacheEngineAccel:
         swa_node = getattr(mr, "last_swa_node", None)
         swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1
+            return 0, -1
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1
+            return 0, -1
         # Read-hit保温: move the hit node to SWA-LRU MRU (a match-only probe is a
         # real "use" — this is the LRU-thrash fix). Independent of lock_for_load.
         self.index.promote_swa(swa_node)
@@ -190,42 +184,42 @@ class CacheEngineAccel:
             # Pin the SWA against eviction until the load completes. Paired
             # unlock is the data-plane completion callback (kept off until wired).
             swa_node.inc_swa_lock_ref()
-        return swa_hit, slot, slot
+        return swa_hit, slot
 
     def match_swa_locked(self,
                          sequence_meta: SequenceMeta,
-                         upper_bound_blocks: int) -> Tuple[int, int, int, "CRadixNode"]:
+                         upper_bound_blocks: int) -> Tuple[int, int, Optional["CRadixNode"]]:
         """Like match_swa(lock_for_load=True) but ALSO returns the pinned node.
 
         The data plane needs the node handle to release the pin (dec_swa_lock_ref)
-        when the SWA H2D completes. Returns ``(swa_hit, slot, swa_key, node)``;
-        ``(0, -1, -1, None)`` on miss (nothing pinned)."""
+        when the SWA H2D completes. Returns ``(swa_hit, slot, node)``;
+        ``(0, -1, None)`` on miss (nothing pinned)."""
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         sequence_meta.gen_hashes()
         num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
         if num_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         block_hashes = torch.from_numpy(
             sequence_meta.block_hashes[:num_blocks]).to(torch.int64)
         mr = self.index.match_prefix(block_hashes, num_blocks, False)
         swa_node = getattr(mr, "last_swa_node", None)
         swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         swa_node.inc_swa_lock_ref()
-        return swa_hit, slot, slot, swa_node
+        return swa_hit, slot, swa_node
 
     def match_swa_from_result(self,
                               match_result,
                               sequence_meta: SequenceMeta,
                               upper_bound_blocks: int,
                               lock_for_load: bool = False,
-                              ) -> Tuple[int, int, int, "CRadixNode"]:
+                              ) -> Tuple[int, int, Optional["CRadixNode"]]:
         """Resolve the SWA hit by REUSING an already-computed Full-KV match
         instead of re-walking the radix tree.
 
@@ -238,32 +232,32 @@ class CacheEngineAccel:
         so we fall back to the clamped ``match_swa`` probe to find the deepest SWA
         node WITHIN the bound.
 
-        Returns ``(swa_hit, slot, swa_key, node)`` (node is the pinned node when
-        ``lock_for_load`` else None); ``(0, -1, -1, None)`` on miss.
+        Returns ``(swa_hit, slot, node)`` (node is the pinned node when
+        ``lock_for_load`` else None); ``(0, -1, None)`` on miss.
         """
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
         swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         if swa_hit > upper_bound_blocks:
             # Deepest SWA lies past the reusable Full hit — re-probe clamped.
             if lock_for_load:
                 return self.match_swa_locked(sequence_meta, upper_bound_blocks)
-            swa_hit2, slot2, key2 = self.match_swa(
+            swa_hit2, slot2 = self.match_swa(
                 sequence_meta, upper_bound_blocks, lock_for_load=False)
-            return swa_hit2, slot2, key2, None
+            return swa_hit2, slot2, None
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         # REUSE branch: promote here. The fallback branch above delegates to
         # match_swa[_locked], which promote internally — do NOT double-promote.
         self.index.promote_swa(swa_node)
         if lock_for_load:
             swa_node.inc_swa_lock_ref()
-            return swa_hit, slot, slot, swa_node
-        return swa_hit, slot, slot, None
+            return swa_hit, slot, swa_node
+        return swa_hit, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -460,11 +454,6 @@ class CacheEngine:
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
         from flexkv.swa.swa_host_pool import SWAHostPool
-        if swa_config.window_size % self.tokens_per_block != 0:
-            raise ValueError(
-                f"SWAPoolConfig.window_size ({swa_config.window_size}) must be a "
-                f"multiple of tokens_per_block ({self.tokens_per_block})"
-            )
         self.swa_pool = SWAHostPool(swa_config)
 
     @property
@@ -503,88 +492,88 @@ class CacheEngine:
     def match_swa(self,
                   sequence_meta: SequenceMeta,
                   upper_bound_blocks: int,
-                  lock_for_load: bool = False) -> Tuple[int, int, int]:
+                  lock_for_load: bool = False) -> Tuple[int, int]:
         """Node-mounted SWA match on the Python RadixTreeIndex mirror.
 
-        Returns ``(swa_hit_blocks, slot_id, swa_key)``; -1/0 when no SWA.
+        Returns ``(swa_hit_blocks, slot_id)``; -1/0 when no SWA.
         """
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1
+            return 0, -1
         sequence_meta.gen_hashes()
         num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
         if num_blocks <= 0:
-            return 0, -1, -1
+            return 0, -1
         clamped = SequenceMeta(token_ids=sequence_meta.token_ids[:num_blocks * self.tokens_per_block],
                                tokens_per_block=self.tokens_per_block)
         mr = self.index.match_prefix(clamped, update_cache_info=False)
         swa_node = getattr(mr, "last_swa_node", None)
         swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1
+            return 0, -1
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1
+            return 0, -1
         self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         if lock_for_load:
             swa_node.swa_lock_ref += 1
-        return swa_hit, slot, slot
+        return swa_hit, slot
 
     def match_swa_locked(self,
                          sequence_meta: SequenceMeta,
-                         upper_bound_blocks: int) -> Tuple[int, int, int, "RadixNode"]:
+                         upper_bound_blocks: int) -> Tuple[int, int, Optional["RadixNode"]]:
         """Like match_swa(lock_for_load=True) but ALSO returns the pinned node
         (mirror of CacheEngineAccel.match_swa_locked)."""
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         sequence_meta.gen_hashes()
         num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
         if num_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         clamped = SequenceMeta(token_ids=sequence_meta.token_ids[:num_blocks * self.tokens_per_block],
                                tokens_per_block=self.tokens_per_block)
         mr = self.index.match_prefix(clamped, update_cache_info=False)
         swa_node = getattr(mr, "last_swa_node", None)
         swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
         swa_node.swa_lock_ref += 1
-        return swa_hit, slot, slot, swa_node
+        return swa_hit, slot, swa_node
 
     def match_swa_from_result(self,
                               match_result,
                               sequence_meta: SequenceMeta,
                               upper_bound_blocks: int,
                               lock_for_load: bool = False,
-                              ) -> Tuple[int, int, int, "RadixNode"]:
+                              ) -> Tuple[int, int, Optional["RadixNode"]]:
         """Reuse an already-computed Full-KV match to resolve the SWA hit without
         re-walking the tree (mirror of CacheEngineAccel.match_swa_from_result;
         see it for the fallback rationale)."""
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
         swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
         if swa_node is None or swa_hit <= 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         if swa_hit > upper_bound_blocks:
             if lock_for_load:
                 return self.match_swa_locked(sequence_meta, upper_bound_blocks)
-            swa_hit2, slot2, key2 = self.match_swa(
+            swa_hit2, slot2 = self.match_swa(
                 sequence_meta, upper_bound_blocks, lock_for_load=False)
-            return swa_hit2, slot2, key2, None
+            return swa_hit2, slot2, None
         slot = int(swa_node.swa_host_slot)
         if slot < 0:
-            return 0, -1, -1, None
+            return 0, -1, None
         # REUSE branch: promote here. The fallback branch above delegates to
         # match_swa[_locked], which promote internally — do NOT double-promote.
         self.index.promote_swa(swa_node)
         if lock_for_load:
             swa_node.swa_lock_ref += 1
-            return swa_hit, slot, slot, swa_node
-        return swa_hit, slot, slot, None
+            return swa_hit, slot, swa_node
+        return swa_hit, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -996,7 +985,7 @@ class GlobalCacheEngine:
         # full-KV prefix resident after this get (the SWA hit's upper bound).
         num_full_hit = block_start_idx + num_gpu_blocks_to_transfer
         (swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots,
-         swa_key, swa_lock_node, swa_staging_slot) = \
+         swa_lock_node, swa_staging_slot) = \
             self._swa_get_slots(request_id, sequence_meta, block_start_idx,
                                 block_end_idx, num_full_hit,
                                 tier_match_results=tier_match_results)
@@ -1006,7 +995,6 @@ class GlobalCacheEngine:
             cpu_slot_ids=swa_cpu_slots,
             ssd_slot_ids=swa_ssd_slots,
             remote_slot_ids=swa_remote_slots,
-            swa_key=swa_key,
             dp_client_id=dp_client_id,
         )
         if swa_h2d_id is not None:
@@ -1573,7 +1561,7 @@ class GlobalCacheEngine:
         # set_swa); the GPU slot is a placeholder bound LATE from the request's
         # swa_slot_mapping. The stored tail node is node_to_unlock[CPU] (the new
         # ready prefix's deepest node); its trailing page is the SWA window.
-        swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots, swa_key = \
+        swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots = \
             self._swa_put_slots(request_id, sequence_meta, block_start_idx,
                                 block_end_idx, node_to_unlock)
         swa_d2h_id = self.swa_cache.build_put_chain(
@@ -1582,7 +1570,6 @@ class GlobalCacheEngine:
             cpu_slot_ids=swa_cpu_slots,
             ssd_slot_ids=swa_ssd_slots,
             remote_slot_ids=swa_remote_slots,
-            swa_key=swa_key,
             dp_client_id=dp_client_id,
         )
         if swa_d2h_id is not None:
@@ -2083,10 +2070,9 @@ class GlobalCacheEngine:
     def _empty_swa_slots(self, with_node: bool = False):
         empty = np.array([], dtype=np.int64)
         if with_node:
-            # (gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)
-            return empty, empty, empty, empty, -1, None, -1
-        # (gpu, cpu, ssd, remote, swa_key)
-        return empty, empty, empty, empty, -1
+            # (gpu, cpu, ssd, remote, lock_node, staging_slot)
+            return empty, empty, empty, empty, None, -1
+        return empty, empty, empty, empty
 
     def _swa_get_slots(self, request_id, sequence_meta, block_start_idx,
                        block_end_idx, full_hit_blocks, tier_match_results=None):
@@ -2109,7 +2095,7 @@ class GlobalCacheEngine:
         slot via ``match_swa_from_result`` (reuse it, no re-walk). When None, each
         tier falls back to a fresh ``match_swa_locked`` probe.
 
-        Returns ``(gpu, cpu, ssd, remote, swa_key, lock_node, staging_slot)``.
+        Returns ``(gpu, cpu, ssd, remote, lock_node, staging_slot)``.
         ``cpu`` is always the SWA H2D source (matched CPU slot OR staging slot);
         ``ssd``/``remote`` are non-empty only for a staged source; ``staging_slot``
         is the transient CPU slot to free on H2D completion (-1 when CPU-sourced).
@@ -2123,7 +2109,7 @@ class GlobalCacheEngine:
         empty = np.array([], dtype=np.int64)
 
         def _match_locked(engine, device_type):
-            """Resolve (hit, slot, key, node) for a tier, pinned for load. Reuse
+            """Resolve (hit, slot, node) for a tier, pinned for load. Reuse
             the given match result when available, else probe the tree."""
             mr = tier_match_results.get(device_type) if tier_match_results else None
             if mr is not None:
@@ -2135,11 +2121,11 @@ class GlobalCacheEngine:
 
         # 1) CPU tier first (preferred, no staging). The matched CPU SWA node is
         #    pinned; the H2D completion callback releases the pin.
-        swa_hit, cpu_slot, swa_key, lock_node = \
+        swa_hit, cpu_slot, lock_node = \
             _match_locked(cpu_engine, DeviceType.CPU)
         if swa_hit > 0 and cpu_slot >= 0:
             cpu = np.array([cpu_slot], dtype=np.int64)
-            return gpu, cpu, empty, empty, swa_key, lock_node, -1
+            return gpu, cpu, empty, empty, lock_node, -1
 
         # 2) Fall back to SSD then REMOTE: source tier stages into a transient
         #    CPU SWA slot (DISK2H/REMOTE2H -> CPU) that the SWA H2D then reads.
@@ -2147,7 +2133,7 @@ class GlobalCacheEngine:
             engine = self.cache_engines.get(device_type)
             if engine is None or not getattr(engine, "swa_enabled", False):
                 continue
-            tier_hit, tier_slot, tier_key, tier_node = \
+            tier_hit, tier_slot, tier_node = \
                 _match_locked(engine, device_type)
             if tier_hit <= 0 or tier_slot < 0:
                 continue
@@ -2164,7 +2150,7 @@ class GlobalCacheEngine:
             tier = np.array([tier_slot], dtype=np.int64)
             ssd = tier if device_type == DeviceType.SSD else empty
             remote = tier if device_type == DeviceType.REMOTE else empty
-            return gpu, cpu, ssd, remote, tier_key, tier_node, staging_slot
+            return gpu, cpu, ssd, remote, tier_node, staging_slot
 
         return self._empty_swa_slots(with_node=True)
 
@@ -2181,7 +2167,7 @@ class GlobalCacheEngine:
         ``node_to_unlock`` keeps SWA a subset of Full PER TIER: SWA is written to
         a tier iff full-KV was.
 
-        Returns ``(gpu_placeholder, cpu=[slot], ssd, remote, swa_key)``. The CPU
+        Returns ``(gpu_placeholder, cpu=[slot], ssd, remote)``. The CPU
         slot is required (the D2H target); ssd/remote are non-empty only when
         that tier both stored full-KV and has an SWA host pool. All empty when
         SWA is disabled, there is no CPU store node, or the CPU pool is full and
@@ -2222,7 +2208,7 @@ class GlobalCacheEngine:
 
         ssd = _tier_slot(DeviceType.SSD)
         remote = _tier_slot(DeviceType.REMOTE)
-        return gpu, cpu, ssd, remote, slot
+        return gpu, cpu, ssd, remote
 
 
     def _swa_release_load_lock(self, node, staging_slot: int = -1) -> None:
@@ -2325,18 +2311,8 @@ class GlobalCacheEngine:
         return block_ids
 
     def swa_slot_mapping_to_slot_ids(self, swa_slot_mapping: np.ndarray) -> np.ndarray:
-        """Convert the connector's SWA slot_mapping (SWA-pool token index space)
-        into SWA-pool slot ids, one per window/page.
-
-        Mirror of slot_mapping_to_block_ids but folded by the SWA window size
-        (== one swa_page == one slot). On DSv4 window_size == tokens_per_block, so
-        this reduces to the same stride; kept separate so the two pools can have
-        different page geometry without coupling. Returns int64 slot ids."""
-        cpu = self.cpu_cache_engine
+        """Convert an SWA slot_mapping into page-granular SWA pool slot ids."""
         window = self.tokens_per_block
-        pool = getattr(cpu, "swa_pool", None) if cpu is not None else None
-        if pool is not None:
-            window = pool.config.window_size
         sm = np.asarray(swa_slot_mapping, dtype=np.int64)
         return sm[::window] // window
 

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -133,10 +133,10 @@ class HierarchyLRCacheEngine:
         """Node-mounted SWA match. Returns no-hit unless the (remote) radix index
         exposes last_swa_node on its match result."""
         if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, -1
+            return 0, -1
         # The distributed/remote radix index does not surface node-mounted SWA
         # yet; report no hit (SWA is served by the accel CPU tier for DSv4).
-        return 0, -1, -1
+        return 0, -1
 
     def start(self) -> None:
         if self._meta is None:

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -102,7 +102,6 @@ class SWACacheManager:
                      transfer_type: TransferType,
                      src_slot_ids: np.ndarray,
                      dst_slot_ids: np.ndarray,
-                     swa_key: int = -1,
                      dp_client_id: int = 0) -> Optional[int]:
         """Add one peer SWA transfer op (``is_swa=True``) to ``graph``; return op_id.
 
@@ -126,7 +125,6 @@ class SWACacheManager:
             dst_block_ids=dst,
             dp_client_id=dp_client_id,
             is_swa=True,
-            swa_key=int(swa_key),
         )
         graph.add_transfer_op(op)
         return op.op_id
@@ -137,7 +135,6 @@ class SWACacheManager:
                         cpu_slot_ids: np.ndarray,
                         ssd_slot_ids: Optional[np.ndarray] = None,
                         remote_slot_ids: Optional[np.ndarray] = None,
-                        swa_key: int = -1,
                         dp_client_id: int = 0) -> Optional[int]:
         """Build the GET-side SWA load chain into ``graph``; return the terminal
         SWA ``H2D`` op_id (to be appended to the graph's finished_ops_ids so it
@@ -151,21 +148,21 @@ class SWACacheManager:
         """
         h2d_id = self.build_swa_op(
             graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
-            swa_key=swa_key, dp_client_id=dp_client_id,
+            dp_client_id=dp_client_id,
         )
         if h2d_id is None:
             return None
         if ssd_slot_ids is not None and np.asarray(ssd_slot_ids).size > 0:
             ssd2h_id = self.build_swa_op(
                 graph, TransferType.DISK2H, ssd_slot_ids, cpu_slot_ids,
-                swa_key=swa_key, dp_client_id=dp_client_id,
+                dp_client_id=dp_client_id,
             )
             if ssd2h_id is not None:
                 graph.add_dependency(h2d_id, ssd2h_id)
         if remote_slot_ids is not None and np.asarray(remote_slot_ids).size > 0:
             remote2h_id = self.build_swa_op(
                 graph, TransferType.REMOTE2H, remote_slot_ids, cpu_slot_ids,
-                swa_key=swa_key, dp_client_id=dp_client_id,
+                dp_client_id=dp_client_id,
             )
             if remote2h_id is not None:
                 graph.add_dependency(h2d_id, remote2h_id)
@@ -177,7 +174,6 @@ class SWACacheManager:
                         cpu_slot_ids: np.ndarray,
                         ssd_slot_ids: Optional[np.ndarray] = None,
                         remote_slot_ids: Optional[np.ndarray] = None,
-                        swa_key: int = -1,
                         dp_client_id: int = 0) -> Optional[int]:
         """Build the PUT-side SWA store chain into ``graph``; return the SWA
         ``D2H`` op_id (to be appended to the graph's finished_ops_ids).
@@ -190,21 +186,21 @@ class SWACacheManager:
         """
         d2h_id = self.build_swa_op(
             graph, TransferType.D2H, gpu_slot_ids, cpu_slot_ids,
-            swa_key=swa_key, dp_client_id=dp_client_id,
+            dp_client_id=dp_client_id,
         )
         if d2h_id is None:
             return None
         if ssd_slot_ids is not None and np.asarray(ssd_slot_ids).size > 0:
             h2ssd_id = self.build_swa_op(
                 graph, TransferType.H2DISK, cpu_slot_ids, ssd_slot_ids,
-                swa_key=swa_key, dp_client_id=dp_client_id,
+                dp_client_id=dp_client_id,
             )
             if h2ssd_id is not None:
                 graph.add_dependency(h2ssd_id, d2h_id)
         if remote_slot_ids is not None and np.asarray(remote_slot_ids).size > 0:
             h2remote_id = self.build_swa_op(
                 graph, TransferType.H2REMOTE, cpu_slot_ids, remote_slot_ids,
-                swa_key=swa_key, dp_client_id=dp_client_id,
+                dp_client_id=dp_client_id,
             )
             if h2remote_id is not None:
                 graph.add_dependency(h2remote_id, d2h_id)

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -468,34 +468,17 @@ class SWAPoolConfig:
     """Configuration for SWA (Sliding Window Attention) host pool(s).
 
     SWA is managed at PAGE granularity: one pool slot stores exactly one
-    swa_page of window KV, and all SWA IO moves a whole page (one slot) at a
-    time. Despite the field name, ``window_size`` below carries the physical
-    ``swa_page_size`` (DSv4 = 256, hard-coded in integration/config.py), NOT the
-    HF attention sliding_window (128). Because ``window_size == tokens_per_block
-    == swa_page_size`` on DSv4, one window == one page == one block == one slot.
+    ``tokens_per_block`` page of SWA KV, and all SWA IO moves a whole page
+    (one slot) at a time.
     """
     enabled: bool = False
     num_slots: int = 1024              # Number of CPU SWA pool slots
     num_ssd_slots: int = 0             # Number of SSD SWA pool slots (0 = no SSD SWA tier)
     num_remote_slots: int = 0          # Number of REMOTE SWA pool slots (0 = no REMOTE SWA tier)
-    window_size: int = 128             # = physical swa_page_size (DSv4=256), one slot = one swa_page
     num_swa_layers: int = 61           # Number of SWA layers (all 61 for DSv4)
     bytes_per_token_per_layer: int = 584  # nope_fp8(448) + rope_bf16(128) + scale(8)
     evict_ratio: float = 0.1           # Fraction of pool to evict when full
     pin_memory: bool = True            # Use pinned memory for async DMA
-
-    @property
-    def slot_size_bytes(self) -> int:
-        """Total bytes per slot (= one swa_page) = window_size * layers * bytes_per_token_per_layer."""
-        return self.window_size * self.num_swa_layers * self.bytes_per_token_per_layer
-
-    @property
-    def total_size_bytes(self) -> int:
-        return self.num_slots * self.slot_size_bytes
-
-    @property
-    def total_size_gb(self) -> float:
-        return self.total_size_bytes / (1024 ** 3)
 
     def for_ssd_tier(self) -> "SWAPoolConfig":
         """Derive the SSD-tier SWA config (same slot geometry, num_ssd_slots slots).

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -112,11 +112,8 @@ class TransferOp:
     # its own slot-id space), so the transfer engine routes it to the dedicated
     # SWA worker (_swa_worker_map) instead of the main-KV worker. The op reuses the
     # standard transfer_type (D2H/H2D/DISK2H/H2DISK/REMOTE2H/H2REMOTE); src/dst
-    # block ids are SWA-pool slot ids, NOT full-KV block ids. ``swa_key`` is the
-    # SWA slot key the completion callback uses to drive set_ready (store) /
-    # unlock (load).
+    # block ids are SWA-pool slot ids, NOT full-KV block ids.
     is_swa: bool = False
-    swa_key: int = -1
 
     def __post_init__(self) -> None:
         if self.transfer_type != TransferType.VIRTUAL and \
@@ -318,6 +315,7 @@ class TransferOpGraph:
     def set_gpu_blocks(self,
                        gpu_blocks: np.ndarray,
                        swa_gpu_blocks: Optional[np.ndarray] = None) -> None:
+        swa_offset = 0
         for op_id in self._gpu_transfer_op_id:
             op = self._op_map[op_id]
             target_gpu_blocks = gpu_blocks
@@ -327,8 +325,18 @@ class TransferOpGraph:
             if getattr(op, "is_swa", False):
                 if swa_gpu_blocks is None:
                     continue
-                target_gpu_blocks = swa_gpu_blocks
             transfer_type = op.transfer_type
+            if getattr(op, "is_swa", False):
+                count = op.dst_block_ids.size if transfer_type.name.endswith("2D") \
+                    else op.src_block_ids.size
+                next_swa_offset = swa_offset + count
+                if next_swa_offset > swa_gpu_blocks.size:
+                    raise ValueError(
+                        f"not enough SWA GPU blocks to bind op {op_id}: "
+                        f"need {next_swa_offset}, got {swa_gpu_blocks.size}"
+                    )
+                target_gpu_blocks = swa_gpu_blocks[swa_offset:next_swa_offset]
+                swa_offset = next_swa_offset
             if transfer_type.name.endswith("2D"):
                 if transfer_type == TransferType.DISK2D:
                     op.dst_block_ids = target_gpu_blocks[-op.dst_block_ids.size:]
@@ -363,12 +371,23 @@ class TransferOpGraph:
         ``swa_gpu_blocks`` are SWA-pool slot ids (already converted from the
         connector's swa_slot_mapping). The CPU/SSD/REMOTE side of each SWA op was
         set at build time (node-mounted radix slot) and is left untouched."""
+        offset = 0
         for op_id in self._swa_gpu_transfer_op_id:
             op = self._op_map[op_id]
+            count = op.dst_block_ids.size if op.transfer_type.name.endswith("2D") \
+                else op.src_block_ids.size
+            next_offset = offset + count
+            if next_offset > swa_gpu_blocks.size:
+                raise ValueError(
+                    f"not enough SWA GPU blocks to bind op {op_id}: "
+                    f"need {next_offset}, got {swa_gpu_blocks.size}"
+                )
+            gpu_slice = swa_gpu_blocks[offset:next_offset]
             if op.transfer_type.name.endswith("2D"):   # H2D: GPU is dst
-                op.dst_block_ids = swa_gpu_blocks[:op.dst_block_ids.size]
+                op.dst_block_ids = gpu_slice
             else:                                       # D2H: GPU is src
-                op.src_block_ids = swa_gpu_blocks[:op.src_block_ids.size]
+                op.src_block_ids = gpu_slice
+            offset = next_offset
             assert op.src_block_ids.size == op.dst_block_ids.size, \
                 f"swa src.size={op.src_block_ids.size}, dst.size={op.dst_block_ids.size}"
 

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -495,8 +495,8 @@ class FlexKVConfig:
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
         # ---- SWA host pool config (DeepSeek V4 all-SWA models) ----
-        # DSv4 stores its sliding-window KV in a dedicated paged pool whose
-        # physical page/window is swa_page_size (hard-asserted == 256 in
+        # DSv4 stores its sliding-window KV in a dedicated paged pool. FlexKV's
+        # SWA page size is cache_config.tokens_per_block (hard-asserted as 256 by
         # sglang model_runner_kv_cache_mixin), NOT the HF attention
         # sliding_window (128). The per-token byte size is hard-asserted to
         # 584 (qk_nope_head_dim fp8 448 + qk_rope_head_dim bf16 128 + scale 8)
@@ -505,7 +505,7 @@ class FlexKVConfig:
         # get finds no SWA, so SWA KV is never matched/reused for this all-SWA model.
         is_dsv4 = bool(getattr(sglang_config, "is_deepseek_v4_arch", False))
         if is_dsv4 and self.cache_config.swa is None:
-            swa_window = 256  # physical swa_page_size, asserted == 256 by sglang
+            swa_page_size = self.cache_config.tokens_per_block
             # bytes_per_token_per_layer MUST match the GPU SWA buffer's *padded*
             # per-token stride, not the logical 584. DeepSeekV4SingleKVPool packs
             # each page as bytes_per_page_padded = ceil_div(swa_page * 584, 576) *
@@ -517,10 +517,9 @@ class FlexKVConfig:
             # bytes by 1/token/page and corrupt the SWA KV. See connector
             # _register_to_server_dsv4 (swa_layout head_size) and deployments/
             # swa_design/process/实现计划_SWA数据面端到端_connector.md.
-            swa_bytes_per_token = _dsv4_swa_padded_bytes_per_token(swa_window, 584)
+            swa_bytes_per_token = _dsv4_swa_padded_bytes_per_token(swa_page_size, 584)
             self.cache_config.swa = SWAPoolConfig(
                 enabled=True,
-                window_size=swa_window,
                 num_swa_layers=self.model_config.num_layers,
                 bytes_per_token_per_layer=swa_bytes_per_token,
             )
@@ -533,11 +532,10 @@ class FlexKVConfig:
             )
             logger.info(
                 f"[FlexKV sglang] Constructed SWAPoolConfig for DSv4: "
-                f"window_size={swa_window}, "
+                f"swa_page_size={swa_page_size}, "
                 f"num_swa_layers={self.model_config.num_layers}, "
                 f"bytes_per_token_per_layer={swa_bytes_per_token} (padded), "
                 f"num_slots={self.cache_config.swa.num_slots}, "
-                f"slot_size_bytes={self.cache_config.swa.slot_size_bytes}, "
                 f"enable_swa_transfer={self.cache_config.enable_swa_transfer}"
             )
 

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -394,8 +394,8 @@ class KVTaskManager:
         graph_ids = self.cache_engine.slot_mapping_to_block_ids(slot_mapping,
                                                                 self.cache_config.tokens_per_block)
         # Late-bind the GPU-side SWA slots via the unified set_gpu_blocks(gpu,
-        # swa_gpu) path (PR#191). On DSv4 window == tokens_per_block, so the SWA
-        # mapping folds by the same stride as full-KV (slot_mapping_to_block_ids).
+        # swa_gpu) path (PR#191). SWA is page-granular, so the mapping folds by
+        # the same stride as full-KV (slot_mapping_to_block_ids).
         # A None swa_slot_mapping leaves the graph's SWA ops at their built ids.
         swa_sm = swa_slot_mapping if swa_slot_mapping is not None else task.swa_slot_mapping
         swa_graph_ids = None

--- a/flexkv/storage/storage_engine.py
+++ b/flexkv/storage/storage_engine.py
@@ -136,15 +136,17 @@ class StorageEngine:
         # SWA pool allocate
         self._swa_cpu_layout: Optional[KVCacheLayout] = None
         self._swa_ssd_layout: Optional[KVCacheLayout] = None
+        self._swa_remote_layout: Optional[KVCacheLayout] = None
         swa_cfg = getattr(self._cache_config, "swa", None)
         if swa_cfg is not None and swa_cfg.enabled:
+            swa_tokens_per_block = self._cache_config.tokens_per_block
             if self._cache_config.enable_cpu:
                 # uint8, num_head=1, is_mla=True; per-token-per-layer bytes -> head_size.
                 self._swa_cpu_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
                     num_layer=swa_cfg.num_swa_layers,
                     num_block=swa_cfg.num_slots,
-                    tokens_per_block=swa_cfg.window_size,
+                    tokens_per_block=swa_tokens_per_block,
                     num_head=1,
                     head_size=swa_cfg.bytes_per_token_per_layer,
                     is_mla=True,
@@ -160,7 +162,9 @@ class StorageEngine:
                 )
 
 
-            if self._cache_config.enable_ssd:
+            if self._cache_config.enable_ssd and swa_cfg.num_ssd_slots > 0:
+                if self._swa_cpu_layout is None:
+                    raise ValueError("SWA SSD tier requires the SWA CPU tier")
                 if not GLOBAL_CONFIG_FROM_ENV.ssd_layout_type == self._swa_cpu_layout.type:
                     raise ValueError(
                         f"SWA SSD layout type must match SWA CPU layout type: "
@@ -169,8 +173,8 @@ class StorageEngine:
                 self._swa_ssd_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.ssd_layout_type,
                     num_layer=swa_cfg.num_swa_layers,
-                    num_block=swa_cfg.num_slots,
-                    tokens_per_block=swa_cfg.window_size,
+                    num_block=swa_cfg.num_ssd_slots,
+                    tokens_per_block=swa_tokens_per_block,
                     num_head=1,
                     head_size=swa_cfg.bytes_per_token_per_layer,
                     is_mla=True,
@@ -186,7 +190,9 @@ class StorageEngine:
                     max_file_size_gb=GLOBAL_CONFIG_FROM_ENV.max_file_size_gb,
                 )
 
-            if self._cache_config.enable_remote:
+            if self._cache_config.enable_remote and swa_cfg.num_remote_slots > 0:
+                if self._swa_cpu_layout is None:
+                    raise ValueError("SWA REMOTE tier requires the SWA CPU tier")
                 if not GLOBAL_CONFIG_FROM_ENV.remote_layout_type == self._swa_cpu_layout.type:
                     raise ValueError(
                         f"SWA Remote layout type must match SWA CPU layout type: "
@@ -195,8 +201,8 @@ class StorageEngine:
                 self._swa_remote_layout = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
                     num_layer=swa_cfg.num_swa_layers,
-                    num_block=swa_cfg.num_slots,
-                    tokens_per_block=swa_cfg.window_size,
+                    num_block=swa_cfg.num_remote_slots,
+                    tokens_per_block=swa_tokens_per_block,
                     num_head=1,
                     head_size=swa_cfg.bytes_per_token_per_layer,
                     is_mla=True,

--- a/flexkv/swa/swa_host_pool.py
+++ b/flexkv/swa/swa_host_pool.py
@@ -1,14 +1,13 @@
 """SWA Host Pool — CPU-side slot-id allocator for SWA pages.
 
-SWA is managed at PAGE granularity: each slot denotes exactly one swa_page of
-window KV = swa_page_size tokens x num_swa_layers layers x bytes_per_token_per_layer
-(``window_size`` in SWAPoolConfig carries the physical swa_page_size). All SWA
-IO addresses a whole slot (= one page) at a time.
+SWA is managed at PAGE granularity: each slot denotes exactly one cache page of
+SWA KV. Cache/storage code derives the page size from ``tokens_per_block`` and
+all SWA IO addresses a whole slot (= one page) at a time.
 
 This pool is purely a slot-id allocator / free-list (stack): it hands out and
 reclaims integer slot ids and keeps the used/free accounting. It does NOT hold
 the SWA KV bytes — those live in the ``StorageEngine`` buffer allocated with
-``is_swa=True`` (sized from the SAME SWAPoolConfig geometry) and are read/written
+``is_swa=True`` (sized from the cache page geometry) and are read/written
 by the transfer worker via the storage handle, addressed by slot id. When the
 pool is full, the caller (cache engine) triggers SWA-LRU eviction before retrying.
 """
@@ -61,15 +60,6 @@ class SWAHostPool:
     @property
     def num_slots(self) -> int:
         return self._num_slots
-
-    @property
-    def slot_size_bytes(self) -> int:
-        """Bytes per slot (= one swa_page), forwarded from the config.
-
-        The bytes themselves live in the StorageEngine ``is_swa=True`` buffer,
-        not here; this is exposed only so callers can size that buffer / slot.
-        """
-        return self._config.slot_size_bytes
 
     @property
     def config(self) -> SWAPoolConfig:

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -115,7 +115,7 @@ def test_get_match_swa_usable_is_min(full_hit, swa_hit, exp_usable):
 
 @pytest.mark.parametrize("swa_hit", [1, 3, 6])
 def test_get_match_swa_trailing_window_is_one_block(swa_hit):
-    """M16.1: SWA is page-granular (window == tokens_per_block), so return_mask_swa
+    """M16.1: SWA is page-granular, so return_mask_swa
     marks exactly ONE block, ending at swa_hit."""
     tpb, num_tokens = 16, 6 * 16
     _, _, swa_mask = _usable_and_swa_mask(6, swa_hit, num_tokens, tpb)
@@ -151,8 +151,12 @@ def _engine():
                      use_mla=True, dtype=torch.bfloat16, tp_size=1, dp_size=1)
     cc = CacheConfig(tokens_per_block=TPB, enable_cpu=True, enable_ssd=False,
                      enable_remote=False, num_cpu_blocks=4096)
-    cc.swa = SWAPoolConfig(enabled=True, num_slots=256, window_size=TPB,
-                           num_swa_layers=1, bytes_per_token_per_layer=64)
+    cc.swa = SWAPoolConfig(
+        enabled=True,
+        num_slots=256,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
     cc.enable_swa_transfer = True
     return GlobalCacheEngine(cc, mc)
 
@@ -185,7 +189,7 @@ def test_get_pins_then_releases_swa_lock():
 
     # After building the GET graph, the matched CPU SWA node is pinned.
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
-    hit, slot, key = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
+    hit, slot = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
     assert hit == 4
     # The node carries the load pin (>=1) taken by _swa_get_slots.
     node = eng.cpu_cache_engine.index.match_prefix(

--- a/tests/test_set_gpu_blocks_swa.py
+++ b/tests/test_set_gpu_blocks_swa.py
@@ -81,3 +81,56 @@ def test_set_gpu_blocks_can_fill_swa_when_explicit_mapping_provided():
 
     assert np.array_equal(main_h2d.dst_block_ids, np.array([100, 101], dtype=np.int64))
     assert np.array_equal(swa_h2d.dst_block_ids, np.array([900, 901], dtype=np.int64))
+
+
+def test_set_gpu_blocks_explicit_swa_mapping_consumes_per_op():
+    graph = TransferOpGraph()
+    first = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.H2D,
+        src_block_ids=np.array([10], dtype=np.int64),
+        dst_block_ids=np.array([0], dtype=np.int64),
+        is_swa=True,
+    )
+    second = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.H2D,
+        src_block_ids=np.array([11], dtype=np.int64),
+        dst_block_ids=np.array([0], dtype=np.int64),
+        is_swa=True,
+    )
+    graph.add_transfer_op(first)
+    graph.add_transfer_op(second)
+
+    graph.set_gpu_blocks(
+        np.array([], dtype=np.int64),
+        np.array([900, 901], dtype=np.int64),
+    )
+
+    assert np.array_equal(first.dst_block_ids, np.array([900], dtype=np.int64))
+    assert np.array_equal(second.dst_block_ids, np.array([901], dtype=np.int64))
+
+
+def test_set_swa_gpu_blocks_consumes_per_op():
+    graph = TransferOpGraph()
+    first = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.H2D,
+        src_block_ids=np.array([10], dtype=np.int64),
+        dst_block_ids=np.array([0], dtype=np.int64),
+        is_swa=True,
+    )
+    second = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.D2H,
+        src_block_ids=np.array([0], dtype=np.int64),
+        dst_block_ids=np.array([11], dtype=np.int64),
+        is_swa=True,
+    )
+    graph.add_transfer_op(first)
+    graph.add_transfer_op(second)
+
+    graph.set_swa_gpu_blocks(np.array([900, 901], dtype=np.int64))
+
+    assert np.array_equal(first.dst_block_ids, np.array([900], dtype=np.int64))
+    assert np.array_equal(second.src_block_ids, np.array([901], dtype=np.int64))

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -57,8 +57,10 @@ def _cache_config(enable_swa_transfer: bool = True):
         num_cpu_blocks=4096,
     )
     cc.swa = SWAPoolConfig(
-        enabled=True, num_slots=256, window_size=TPB,
-        num_swa_layers=1, bytes_per_token_per_layer=64,
+        enabled=True,
+        num_slots=256,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
     )
     cc.enable_swa_transfer = enable_swa_transfer
     return cc
@@ -77,8 +79,11 @@ def _cache_config_ssd(enable_swa_transfer: bool = True):
         ssd_cache_dir="./ssd_cache_swa_test",
     )
     cc.swa = SWAPoolConfig(
-        enabled=True, num_slots=256, num_ssd_slots=256, window_size=TPB,
-        num_swa_layers=1, bytes_per_token_per_layer=64,
+        enabled=True,
+        num_slots=256,
+        num_ssd_slots=256,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
     )
     cc.enable_swa_transfer = enable_swa_transfer
     return cc
@@ -138,7 +143,7 @@ def test_put_builds_full_plus_swa_store_chain():
     _complete(op_cb, cb)
     # after completion the SWA slot is mounted on the stored tail node.
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
-    hit, slot, key = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
+    hit, slot = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
     assert hit == 4 and slot >= 0
 
 
@@ -165,7 +170,7 @@ def test_get_builds_full_plus_swa_load_chain():
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
     _complete(gop_cb, gcb)
     # after release, the node's SWA is unlocked (a fresh match can lock again).
-    hit, slot, key, node = eng.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=4)
+    hit, slot, node = eng.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=4)
     assert node is not None and node.swa_lock_ref == 1
     node.dec_swa_lock_ref()
 
@@ -186,7 +191,7 @@ def test_gate_off_no_swa_ops_in_control_plane_graph():
 # 2. launch-time late-bind of the SWA GPU slot                                #
 # =========================================================================== #
 
-def test_swa_slot_mapping_to_slot_ids_folds_by_window():
+def test_swa_slot_mapping_to_slot_ids_folds_by_page():
     eng = GlobalCacheEngine(_cache_config(), _model_config())
     # 3 windows worth of token-index slot_mapping starting at GPU slot 5,6,7.
     sm = np.concatenate([
@@ -313,9 +318,9 @@ def test_get_ssd_staging_when_only_ssd_has_swa():
     eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
 
     seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
-    cpu_hit, _s, _k = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    cpu_hit, _s = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=4)
     assert cpu_hit == 0, "precondition: CPU SWA must be gone"
-    ssd_hit, _s2, _k2 = eng.ssd_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    ssd_hit, _s2 = eng.ssd_cache_engine.match_swa(seq, upper_bound_blocks=4)
     assert ssd_hit > 0, "precondition: SSD SWA must still hold the window"
 
     graph, _rm2, gcb, gop, _ge = eng.get(
@@ -378,8 +383,8 @@ def test_multitier_match_promotes_swa_in_each_tier():
 
     seq_b = SequenceMeta(token_ids=tok_b, tokens_per_block=TPB); seq_b.gen_hashes()
     for name, engine in (("cpu", eng.cpu_cache_engine), ("ssd", eng.ssd_cache_engine)):
-        a_hit, _sa, _ka = engine.match_swa(seq_a, upper_bound_blocks=4)
-        b_hit, _sb, _kb = engine.match_swa(seq_b, upper_bound_blocks=4)
+        a_hit, _sa = engine.match_swa(seq_a, upper_bound_blocks=4)
+        b_hit, _sb = engine.match_swa(seq_b, upper_bound_blocks=4)
         assert a_hit == 4, f"{name}: reused SWA A was evicted (tier not promoted)"
         assert b_hit == 0, f"{name}: never-reused SWA B should have been evicted"
 

--- a/tests/test_swa_control_plane_e2e.py
+++ b/tests/test_swa_control_plane_e2e.py
@@ -121,7 +121,7 @@ def main() -> int:
         tokens_per_block=TOKENS_PER_BLOCK, enable_cpu=True, enable_ssd=False,
         enable_remote=False, num_cpu_blocks=NUM_BLOCKS_CPU,
         swa=SWAPoolConfig(enabled=True, num_slots=NUM_SWA_SLOTS,
-                          window_size=TOKENS_PER_BLOCK, num_swa_layers=NUM_LAYERS,
+                          num_swa_layers=NUM_LAYERS,
                           bytes_per_token_per_layer=BYTES_PER_TOKEN_PER_LAYER,
                           pin_memory=True))
     cache_config.enable_swa_transfer = True
@@ -229,7 +229,7 @@ def main() -> int:
 
     # SWA lock released by the H2D callback (no leak).
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK); sm.gen_hashes()
-    hit, slot, key, node = engine.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=1)
+    hit, slot, node = engine.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=1)
     if node is not None:
         lock_ok = (node.swa_lock_ref == 1)  # our fresh probe lock; prior load lock released
         node.dec_swa_lock_ref()

--- a/tests/test_swa_dispatch.py
+++ b/tests/test_swa_dispatch.py
@@ -157,7 +157,6 @@ def main() -> int:
         swa=SWAPoolConfig(
             enabled=True,
             num_slots=NUM_BLOCKS_CPU,
-            window_size=TOKENS_PER_BLOCK,
             num_swa_layers=NUM_LAYERS,
             bytes_per_token_per_layer=BYTES_PER_TOKEN_PER_LAYER,
             pin_memory=True,

--- a/tests/test_swa_host_pool.py
+++ b/tests/test_swa_host_pool.py
@@ -12,7 +12,6 @@ def small_config():
     return SWAPoolConfig(
         enabled=True,
         num_slots=8,
-        window_size=4,
         num_swa_layers=2,
         bytes_per_token_per_layer=8,
         pin_memory=False,  # CPU-only tests
@@ -66,8 +65,12 @@ class TestSWAHostPoolAllocation:
         assert pool.num_free == 8
         assert pool.num_used == 0
 
-    def test_slot_size_bytes_forwarded_from_config(self, pool, small_config):
-        # slot_size_bytes is a pure forward of the config geometry; the pool
-        # holds no bytes (those live in the StorageEngine is_swa buffer).
-        expected = 4 * 2 * 8  # window_size * layers * bytes_per_token_per_layer
-        assert pool.slot_size_bytes == expected == small_config.slot_size_bytes
+    def test_config_rejects_legacy_window_size(self):
+        with pytest.raises(TypeError):
+            SWAPoolConfig(
+                enabled=True,
+                num_slots=8,
+                window_size=4,
+                num_swa_layers=2,
+                bytes_per_token_per_layer=8,
+            )

--- a/tests/test_swa_level2_single_pass.py
+++ b/tests/test_swa_level2_single_pass.py
@@ -48,8 +48,10 @@ def _cache_config():
         num_cpu_blocks=4096,
     )
     cc.swa = SWAPoolConfig(
-        enabled=True, num_slots=256, window_size=TPB,
-        num_swa_layers=1, bytes_per_token_per_layer=64,
+        enabled=True,
+        num_slots=256,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
     )
     cc.enable_swa_transfer = True
     return cc
@@ -211,4 +213,3 @@ def test_get_match_threads_swa_aware():
         "must drive exactly one _get_match_impl with swa_aware=True"
     assert tid == 7
     assert int(mask.sum()) == 4 * TPB
-

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -244,8 +244,12 @@ def test_py_reset_rearms_swa_pool_via_host_pool():
     """SWAHostPool.reset re-arms every slot free (tree reset drops all nodes)."""
     from flexkv.swa.swa_host_pool import SWAHostPool
     from flexkv.common.config import SWAPoolConfig
-    cfg = SWAPoolConfig(enabled=True, num_slots=4, window_size=TPB,
-                        num_swa_layers=1, bytes_per_token_per_layer=2)
+    cfg = SWAPoolConfig(
+        enabled=True,
+        num_slots=4,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=2,
+    )
     pool = SWAHostPool(cfg)
     a, b = pool.allocate(), pool.allocate()
     assert a is not None and b is not None and pool.num_free == 2
@@ -682,8 +686,10 @@ class _SWAWorkloadDriver:
             evict_start_threshold=1.0, eviction_policy="lru",
         )
         self.engine.init_swa(SWAPoolConfig(
-            enabled=True, num_slots=swa_slots, window_size=_WTPB,
-            num_swa_layers=1, bytes_per_token_per_layer=max(1, slot_bytes // _WTPB),
+            enabled=True,
+            num_slots=swa_slots,
+            num_swa_layers=1,
+            bytes_per_token_per_layer=max(1, slot_bytes // _WTPB),
         ))
         self._slot_expect: Dict[int, int] = {}
         self.violations: List[str] = []
@@ -710,7 +716,7 @@ class _SWAWorkloadDriver:
         mr = self.engine.match(sm)
         full_hit = int(mr.num_ready_matched_blocks)
         if full_hit > 0:
-            swa_hit, slot, _key = self.engine.match_swa(
+            swa_hit, slot = self.engine.match_swa(
                 sm, upper_bound_blocks=full_hit, lock_for_load=False)
             if swa_hit > 0 and slot >= 0:
                 self.swa_hits += 1

--- a/tests/test_swa_peer_op.py
+++ b/tests/test_swa_peer_op.py
@@ -53,7 +53,6 @@ def dump_graph(graph: TransferOpGraph) -> str:
         lines.append(
             f"  op#{op_id} [{tag}] {op.transfer_type.name} "
             f"src={src} dst={dst} deps={preds}"
-            + (f" swa_key={op.swa_key}" if getattr(op, 'is_swa', False) else "")
         )
     return "\n".join(lines)
 
@@ -140,12 +139,14 @@ def test_get_full_plus_swa_cpu():
     mgr = _mgr(enabled=True)
     g = TransferOpGraph()
     full = _full_h2d(g)
-    swa_id = mgr.build_get_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU, swa_key=7)
+    swa_id = mgr.build_get_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU)
     g, end = add_virtual_op_for_multiple_finished_ops(g, [full.op_id, swa_id], 0)
     _print_scenario("GET full + SWA(CPU)", g, end)
     swa = _swa_ops(g)
     assert len(swa) == 1 and swa[0].transfer_type == TransferType.H2D
-    assert swa[0].is_swa and swa[0].swa_key == 7
+    assert swa[0].is_swa
+    np.testing.assert_array_equal(swa[0].src_block_ids, SWA_CPU)
+    np.testing.assert_array_equal(swa[0].dst_block_ids, SWA_GPU)
     assert len(swa[0].predecessors) == 0          # CPU-resident: no staging dep
     # barrier waits for BOTH full and SWA
     barrier = g._op_map[end]
@@ -159,7 +160,7 @@ def test_get_full_plus_swa_ssd_staging():
     g = TransferOpGraph()
     full = _full_h2d(g)
     swa_id = mgr.build_get_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU,
-                                 ssd_slot_ids=SWA_SSD, swa_key=7)
+                                 ssd_slot_ids=SWA_SSD)
     g, end = add_virtual_op_for_multiple_finished_ops(g, [full.op_id, swa_id], 0)
     _print_scenario("GET full + SWA(SSD staging)", g, end)
     swa_h2d = g._op_map[swa_id]
@@ -176,7 +177,7 @@ def test_get_full_plus_swa_ssd_and_remote_staging():
     g = TransferOpGraph()
     full = _full_h2d(g)
     swa_id = mgr.build_get_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU,
-                                 ssd_slot_ids=SWA_SSD, remote_slot_ids=SWA_REMOTE, swa_key=7)
+                                 ssd_slot_ids=SWA_SSD, remote_slot_ids=SWA_REMOTE)
     g, end = add_virtual_op_for_multiple_finished_ops(g, [full.op_id, swa_id], 0)
     _print_scenario("GET full + SWA(SSD+REMOTE staging)", g, end)
     swa_h2d = g._op_map[swa_id]
@@ -194,7 +195,7 @@ def test_put_full_plus_swa_cpu_only():
     mgr = _mgr(enabled=True)
     g = TransferOpGraph()
     full = _full_d2h(g)
-    swa_id = mgr.build_put_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU, swa_key=7)
+    swa_id = mgr.build_put_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU)
     g, end = add_virtual_op_for_multiple_finished_ops(g, [full.op_id, swa_id], 0)
     _print_scenario("PUT full + SWA(CPU)", g, end)
     swa = _swa_ops(g)
@@ -207,7 +208,7 @@ def test_put_swa_writethrough_ssd_remote_fire_and_forget():
     g = TransferOpGraph()
     full = _full_d2h(g)
     swa_d2h_id = mgr.build_put_chain(g, gpu_slot_ids=SWA_GPU, cpu_slot_ids=SWA_CPU,
-                                     ssd_slot_ids=SWA_SSD, remote_slot_ids=SWA_REMOTE, swa_key=7)
+                                     ssd_slot_ids=SWA_SSD, remote_slot_ids=SWA_REMOTE)
     finished = [full.op_id, swa_d2h_id]   # only D2H ops reported
     g, end = add_virtual_op_for_multiple_finished_ops(g, finished, 0)
     _print_scenario("PUT full + SWA write-through(SSD+REMOTE)", g, end)

--- a/tests/test_swa_ssd_staging_e2e.py
+++ b/tests/test_swa_ssd_staging_e2e.py
@@ -122,7 +122,7 @@ def main() -> int:
         num_ssd_blocks=NUM_BLOCKS_SSD, ssd_cache_dir=SSD_CACHE_DIR,
         swa=SWAPoolConfig(enabled=True, num_slots=NUM_SWA_SLOTS,
                           num_ssd_slots=NUM_SWA_SSD_SLOTS,
-                          window_size=TOKENS_PER_BLOCK, num_swa_layers=NUM_LAYERS,
+                          num_swa_layers=NUM_LAYERS,
                           bytes_per_token_per_layer=BYTES_PER_TOKEN_PER_LAYER,
                           pin_memory=True))
     cache_config.enable_swa_transfer = True
@@ -188,8 +188,8 @@ def main() -> int:
     n_cpu = engine.cpu_cache_engine.swa_pool.num_used
     engine.cpu_cache_engine._evict_swa(n_cpu)
     seq = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK); seq.gen_hashes()
-    cpu_hit, _s, _k = engine.cpu_cache_engine.match_swa(seq, upper_bound_blocks=1)
-    ssd_hit, _s2, _k2 = engine.ssd_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    cpu_hit, _s = engine.cpu_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    ssd_hit, _s2 = engine.ssd_cache_engine.match_swa(seq, upper_bound_blocks=1)
     assert cpu_hit == 0 and ssd_hit > 0, f"precondition failed: cpu_hit={cpu_hit} ssd_hit={ssd_hit}"
     print(f"[verify] evicted CPU SWA (cpu_hit=0, ssd_hit={ssd_hit}); GET must stage from SSD", flush=True)
 

--- a/tests/test_swa_storage_layout.py
+++ b/tests/test_swa_storage_layout.py
@@ -1,0 +1,114 @@
+"""Tests for SWA StorageEngine backing layout geometry."""
+
+import pytest
+import torch
+
+from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
+from flexkv.common.transfer import DeviceType
+from flexkv.storage.storage_engine import StorageEngine
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config():
+    return ModelConfig(
+        num_layers=2,
+        num_kv_heads=1,
+        head_size=8,
+        use_mla=True,
+        dtype=torch.uint8,
+        tp_size=1,
+        pp_size=1,
+        dp_size=1,
+        cp_size=1,
+    )
+
+
+def _capture_allocations(monkeypatch):
+    allocations = []
+
+    def fake_allocate(self, device_type, layout, dtype, device_id=0, raw_data=None, **kwargs):
+        allocations.append({
+            "device_type": device_type,
+            "layout": layout,
+            "dtype": dtype,
+            "is_swa": bool(kwargs.get("is_swa", False)),
+        })
+        return True
+
+    monkeypatch.setattr(StorageEngine, "allocate", fake_allocate)
+    return allocations
+
+
+def _swa_layout_by_device(allocations):
+    return {
+        item["device_type"]: item["layout"]
+        for item in allocations
+        if item["is_swa"]
+    }
+
+
+def test_swa_storage_layout_uses_tier_specific_slot_counts(monkeypatch, tmp_path):
+    allocations = _capture_allocations(monkeypatch)
+    cache_config = CacheConfig(
+        tokens_per_block=16,
+        enable_cpu=True,
+        enable_ssd=True,
+        enable_3rd_remote=True,
+        num_cpu_blocks=64,
+        num_ssd_blocks=64,
+        num_remote_blocks=64,
+        ssd_cache_dir=str(tmp_path / "ssd"),
+        remote_cache_path=str(tmp_path / "remote"),
+        remote_config_custom={"test": True},
+        swa=SWAPoolConfig(
+            enabled=True,
+            num_slots=3,
+            num_ssd_slots=5,
+            num_remote_slots=7,
+            num_swa_layers=2,
+            bytes_per_token_per_layer=8,
+            pin_memory=False,
+        ),
+    )
+
+    StorageEngine(_model_config(), cache_config, num_layers_per_pp_stage=2)
+
+    layouts = _swa_layout_by_device(allocations)
+    assert layouts[DeviceType.CPU].num_block == 3
+    assert layouts[DeviceType.SSD].num_block == 5
+    assert layouts[DeviceType.REMOTE].num_block == 7
+    assert layouts[DeviceType.SSD].tokens_per_block == cache_config.tokens_per_block
+    assert layouts[DeviceType.REMOTE].tokens_per_block == cache_config.tokens_per_block
+
+
+def test_swa_storage_layout_skips_empty_optional_tiers(monkeypatch, tmp_path):
+    allocations = _capture_allocations(monkeypatch)
+    cache_config = CacheConfig(
+        tokens_per_block=16,
+        enable_cpu=True,
+        enable_ssd=True,
+        enable_3rd_remote=True,
+        num_cpu_blocks=64,
+        num_ssd_blocks=64,
+        num_remote_blocks=64,
+        ssd_cache_dir=str(tmp_path / "ssd"),
+        remote_cache_path=str(tmp_path / "remote"),
+        remote_config_custom={"test": True},
+        swa=SWAPoolConfig(
+            enabled=True,
+            num_slots=3,
+            num_ssd_slots=0,
+            num_remote_slots=0,
+            num_swa_layers=2,
+            bytes_per_token_per_layer=8,
+            pin_memory=False,
+        ),
+    )
+
+    StorageEngine(_model_config(), cache_config, num_layers_per_pp_stage=2)
+
+    layouts = _swa_layout_by_device(allocations)
+    assert DeviceType.CPU in layouts
+    assert DeviceType.SSD not in layouts
+    assert DeviceType.REMOTE not in layouts


### PR DESCRIPTION
## Summary

- Removed redundant SWA metadata from the transfer/control plane: `swa_key` is no longer carried on `TransferOp`, and SWA completion state is derived from the op source/destination slots plus the existing callback/node handles.
- Removed `SWAPoolConfig.window_size` and related slot-size helpers. SWA page geometry now follows `cache_config.tokens_per_block` consistently in control-plane mapping and storage layouts.
- Fixed multi-op SWA GPU slot binding so `set_gpu_blocks(..., swa_gpu_blocks=...)` and `set_swa_gpu_blocks(...)` consume SWA GPU slots per op instead of rebinding each op to the same prefix.
- Fixed SWA SSD/REMOTE backing layouts to use `num_ssd_slots` / `num_remote_slots` and to skip optional tier backing allocation when that tier has zero SWA slots.
- Expanded tests around legacy config rejection, multi-op SWA binding, and tier-specific SWA storage layout sizing.

## Validation

- `python3 -m compileall -q flexkv tests`
- `git diff --check`
- Direct execution of all `tests/test_set_gpu_blocks_swa.py` test functions via `importlib`
- `rg -n "window_size=|\.window_size|slot_size_bytes|total_size_bytes|total_size_gb|\bswa_key\b" flexkv tests --glob '!**/__pycache__/**'` only reports the intentional legacy `window_size` rejection test

Full pytest was not run locally because this environment is missing `pytest` / `pyzmq`, and the current macOS runtime also lacks the CUDA/Linux libraries needed by import-time test dependencies.
