### PR TITLE
Move SWA pool initialization into cache engines

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -55,7 +55,8 @@ class CacheEngineAccel:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 swa_config: Optional["SWAPoolConfig"] = None):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -87,9 +88,14 @@ class CacheEngineAccel:
         # flexkv/cache/radixtree.py); this engine only owns the SWA host-pool
         # (slot bytes + free-list) and the slot alloc/free/drain plumbing. SWA
         # and Full eviction are UNIFIED through the one tree so the two pools
-        # never drift (see deployments/swa_design/08_节点挂载SWA架构.md). Created
-        # lazily via init_swa(); None until then.
+        # never drift (see deployments/swa_design/08_节点挂载SWA架构.md). This
+        # engine owns SWA initialization for its tier; init_swa() remains public
+        # for tests and explicit embedding.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine.
@@ -427,7 +433,8 @@ class CacheEngine:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 swa_config: Optional["SWAPoolConfig"] = None):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -453,9 +460,13 @@ class CacheEngine:
         self.event_collector = event_collector
         self._metrics_collector = metrics_collector
 
-        # Node-mounted SWA host pool (non-accel Python RadixTreeIndex mirror);
-        # None until init_swa(). See CacheEngineAccel for the semantics.
+        # Node-mounted SWA host pool (non-accel Python RadixTreeIndex mirror).
+        # See CacheEngineAccel for the semantics.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
@@ -750,7 +761,8 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             else:
                 self.cpu_cache_engine = CacheEngine(DeviceType.CPU,
                                                 cache_config.num_cpu_blocks,
@@ -760,22 +772,9 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
-            # Initialize the node-mounted SWA host pool on the CPU engine when SWA
-            # is enabled (DSv4). Without this the SWA pool is never constructed and
-            # a SWA-aware get finds no SWA. Guarded by hasattr because the non-accel
-            # CacheEngine fallback (Python RadixTreeIndex) also supports it.
-            swa_config = getattr(cache_config, "swa", None)
-            if swa_config is not None and getattr(swa_config, "enabled", False):
-                if hasattr(self.cpu_cache_engine, "init_swa"):
-                    self.cpu_cache_engine.init_swa(swa_config)
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] cache_config.swa is enabled but the CPU cache "
-                        f"engine {type(self.cpu_cache_engine).__name__} has no "
-                        "init_swa(); SWA matching disabled."
-                    )
         if cache_config.enable_ssd:
             if cache_config.enable_p2p_ssd:
                 self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta)
@@ -788,7 +787,8 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             else:
                 self.ssd_cache_engine = CacheEngine(DeviceType.SSD,
                                                 cache_config.num_ssd_blocks,
@@ -798,22 +798,9 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
-            # SSD SWA tier (mirrors the CPU SWA tier above): a node-mounted SWA
-            # host pool on the SSD engine, num_ssd_slots slots. Enables CPU<->SSD SWA tiering (write-through on
-            # store, SWA_SSD2H->SWA_H2D on load). Skipped when num_ssd_slots == 0.
-            swa_config_ssd = getattr(cache_config, "swa", None)
-            if (swa_config_ssd is not None and getattr(swa_config_ssd, "enabled", False)
-                    and getattr(swa_config_ssd, "num_ssd_slots", 0) > 0):
-                if hasattr(self.ssd_cache_engine, "init_swa"):
-                    self.ssd_cache_engine.init_swa(swa_config_ssd.for_ssd_tier())
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] SSD SWA requested but the SSD cache engine "
-                        f"{type(self.ssd_cache_engine).__name__} has no init_swa(); "
-                        "SSD SWA tier disabled."
-                    )
         if cache_config.enable_remote:
             if cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
@@ -827,7 +814,8 @@ class GlobalCacheEngine:
                                                    self.evict_start_threshold,
                                                    self.eviction_policy,
                                                    None,
-                                                   self._metrics_collector)
+                                                   self._metrics_collector,
+                                                   swa_config=cache_config.swa)
             else:
                 self.remote_cache_engine = CacheEngine(DeviceType.REMOTE,
                                                    cache_config.num_remote_blocks,
@@ -837,21 +825,9 @@ class GlobalCacheEngine:
                                                    self.evict_start_threshold,
                                                    self.eviction_policy,
                                                    None,
-                                                   self._metrics_collector)
+                                                   self._metrics_collector,
+                                                   swa_config=cache_config.swa)
             self.cache_engines[DeviceType.REMOTE] = self.remote_cache_engine
-            # REMOTE SWA tier (mirrors the CPU/SSD SWA tiers): a node-mounted SWA
-            # host pool on the REMOTE engine, num_remote_slots slots. Skipped when 0.
-            swa_config_remote = getattr(cache_config, "swa", None)
-            if (swa_config_remote is not None and getattr(swa_config_remote, "enabled", False)
-                    and getattr(swa_config_remote, "num_remote_slots", 0) > 0):
-                if hasattr(self.remote_cache_engine, "init_swa"):
-                    self.remote_cache_engine.init_swa(swa_config_remote.for_remote_tier())
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] REMOTE SWA requested but the REMOTE cache engine "
-                        f"{type(self.remote_cache_engine).__name__} has no init_swa(); "
-                        "REMOTE SWA tier disabled."
-                    )
 
         # SWA control plane: multi-tier match + peer-op graph construction. Built
         # after the per-tier cache engines (and their swa_pool) exist; reaches

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -38,7 +38,8 @@ class HierarchyLRCacheEngine:
                  evict_start_threshold: float = 1.0,
                  hit_reward_seconds: int = 0,
                  eviction_policy: str = "lru",
-                 meta: Optional[RedisMeta] = None) -> None:
+                 meta: Optional[RedisMeta] = None,
+                 swa_config: Optional[SWAPoolConfig] = None) -> None:
         if num_total_blocks <= 0:
             raise ValueError(f"Invalid num_total_blocks: {num_total_blocks}")
         if tokens_per_block <= 0 or (tokens_per_block & (tokens_per_block - 1)) != 0:
@@ -106,6 +107,10 @@ class HierarchyLRCacheEngine:
         # only reports a hit when the underlying index exposes last_swa_node.
         # DSv4 uses CacheEngineAccel (index_accel), not this engine.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
@@ -566,6 +571,7 @@ class HierarchyLRCacheEngine:
             local_safety_ttl_ms=int(GLOBAL_CONFIG_FROM_ENV.safety_ttl_ms),
             eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
             meta=meta,
+            swa_config=getattr(cache_config, "swa", None),
         )
 
     #TODO is this enough for peercpu and peerssd?
@@ -607,5 +613,6 @@ class HierarchyLRCacheEngine:
                 hit_reward_seconds=int(GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds),
                 eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
                 meta=meta,
+                swa_config=getattr(cache_config, "swa", None),
             )
             raise ValueError("Invalid device type: {cache_config.device_type}")

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -509,6 +509,23 @@ class SWAPoolConfig:
         REMOTE SWA slots are not pinned host memory; pin_memory is forced off."""
         return replace(self, num_slots=self.num_remote_slots, pin_memory=False)
 
+    def for_cache_tier(self, device_type) -> Optional["SWAPoolConfig"]:
+        """Return the SWA config this cache tier should own, or None.
+
+        CPU uses the primary pool config. SSD and REMOTE use their tier-specific
+        slot counts and are disabled when that tier's slot count is zero.
+        """
+        if not self.enabled:
+            return None
+        device_name = getattr(device_type, "name", str(device_type))
+        if device_name == "CPU":
+            return self
+        if device_name == "SSD" and self.num_ssd_slots > 0:
+            return self.for_ssd_tier()
+        if device_name == "REMOTE" and self.num_remote_slots > 0:
+            return self.for_remote_tier()
+        return None
+
 
 @dataclass
 class CacheConfig:

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -380,5 +380,5 @@ class KVManager:
         if engine is None:
             return "cpu_cache_engine missing (no in-process engine)"
         if not getattr(engine, "swa_enabled", False):
-            return "SWA host pool not initialized (call init_swa)"
+            return "SWA host pool not initialized on cpu_cache_engine"
         return None

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -30,10 +30,10 @@ import torch
 
 pytest.importorskip("flexkv.c_ext")
 
-from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.cache.cache_engine import CacheEngineAccel, GlobalCacheEngine
 from flexkv.common.block import SequenceMeta
 from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
-from flexkv.common.transfer import TransferType
+from flexkv.common.transfer import DeviceType, TransferType
 from flexkv.common.debug import flexkv_logger
 
 flexkv_logger.set_level("OFF")
@@ -97,6 +97,25 @@ def _full_ops(graph):
 def _tokens(n_blocks, base):
     rs = np.random.RandomState(base)
     return rs.randint(0, 30000, size=n_blocks * TPB, dtype=np.int64)
+
+
+def test_cpu_cache_engine_initializes_swa_pool_from_constructor():
+    swa_config = SWAPoolConfig(
+        enabled=True,
+        num_slots=7,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
+    eng = CacheEngineAccel(
+        DeviceType.CPU,
+        num_total_blocks=32,
+        tokens_per_block=TPB,
+        evict_ratio=0.1,
+        swa_config=swa_config,
+    )
+
+    assert eng.swa_enabled
+    assert eng.swa_pool.num_slots == 7
 
 
 def _complete(op_cb, cb):


### PR DESCRIPTION
## Summary

- Move node-mounted SWA host-pool initialization into the per-tier cache engine constructors.
- Keep `GlobalCacheEngine` responsible for creating and wiring CPU/SSD/REMOTE engines, while each engine derives its own SWA tier config from `cache_config.swa`.
- Add `SWAPoolConfig.for_cache_tier()` to centralize CPU/SSD/REMOTE SWA pool selection.
- Cover the CPU constructor path with a control-plane regression test.

## Why

`GlobalCacheEngine` semantically orchestrates multiple cache tiers. Having it manually initialize the CPU/SSD/REMOTE SWA pools made the tier ownership boundary unclear and duplicated tier-specific SWA checks in the global engine. This refactor keeps SWA pool ownership with the cache engine that owns the corresponding radix tree and mempool.

## Validation

- `python3 -m py_compile flexkv/common/config.py flexkv/cache/cache_engine.py flexkv/cache/hie_cache_engine.py flexkv/kvmanager.py tests/test_swa_control_plane.py`
- `git diff --check origin/dpskv4_refactor...HEAD`

`pytest` was not run locally because the available Python environment is missing `torch`.
