### PR TITLE
Harden SWA test coverage

### DIFF
--- a/.github/workflows/swa-pytest.yml
+++ b/.github/workflows/swa-pytest.yml
@@ -1,0 +1,52 @@
+name: SWA Unit Smoke Pytest
+
+on:
+  pull_request:
+    branches: ["main", "dev", "dpskv4_refactor"]
+    paths:
+      - "flexkv/cache/**"
+      - "flexkv/common/**"
+      - "flexkv/kvtask.py"
+      - "flexkv/storage/**"
+      - "flexkv/swa/**"
+      - "tests/test_*swa*.py"
+      - "tests/test_layerwise*"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - ".github/workflows/swa-pytest.yml"
+  workflow_dispatch:
+
+jobs:
+  swa-unit-smoke:
+    name: SWA unit/smoke pytest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run SWA unit/smoke tests
+        run: |
+          python -m pytest -m "unit or smoke" \
+            tests/test_swa_host_pool.py \
+            tests/test_swa_storage_layout.py \
+            tests/test_swa_peer_op.py \
+            tests/test_set_gpu_blocks_swa.py \
+            tests/test_merge_to_batch_graph_swa_callbacks.py \
+            tests/test_swa_node_mount.py \
+            tests/test_swa_cnode_cascade.py \
+            tests/test_kvtask_lifecycle.py \
+            tests/test_swa_control_plane.py \
+            tests/test_swa_level2_single_pass.py

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -1014,9 +1014,8 @@ class GlobalCacheEngine:
         # on the SWA H2D op so it fires exactly once, alongside the full-KV ops.
         if swa_h2d_id is not None and (swa_lock_node is not None
                                        or swa_staging_slot >= 0):
-            op_callback_dict[swa_h2d_id] = partial(
-                self._swa_release_load_lock, node=swa_lock_node,
-                staging_slot=swa_staging_slot)
+            op_callback_dict[swa_h2d_id] = self._make_swa_release_load_callback(
+                node=swa_lock_node, staging_slot=swa_staging_slot)
 
         # Record metrics for GET operation
         if self._metrics_collector is not None:
@@ -2210,6 +2209,24 @@ class GlobalCacheEngine:
                     cpu_engine.swa_pool.free(int(staging_slot))
         except Exception:  # noqa: BLE001
             pass
+
+    def _make_swa_release_load_callback(self, node, staging_slot: int = -1):
+        """Return a one-shot SWA load completion callback.
+
+        The transfer scheduler should fire each op callback exactly once, but
+        failure/retry paths and tests can re-enter callbacks. A second release
+        must not free the same transient staging slot twice.
+        """
+        called = False
+
+        def _callback() -> None:
+            nonlocal called
+            if called:
+                return
+            called = True
+            self._swa_release_load_lock(node=node, staging_slot=staging_slot)
+
+        return _callback
 
     @nvtx.annotate("Match Prefix", color="yellow")
     def match_local(self,

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -16,14 +16,26 @@ class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * 64)]
 
 
-# Load CUDA runtime library
-try:
-    cudart = ctypes.CDLL("libcudart.so")
-except:
-    try:
-        cudart = ctypes.CDLL("libcudart.so.12")
-    except:
-        cudart = ctypes.CDLL("libcudart.so.11")
+_cudart = None
+_cudart_load_error = None
+
+
+def _get_cudart():
+    """Load CUDA runtime lazily so CPU-only tests can import this module."""
+    global _cudart, _cudart_load_error
+    if _cudart is None and _cudart_load_error is None:
+        errors = []
+        for name in ("libcudart.so", "libcudart.so.12", "libcudart.so.11"):
+            try:
+                _cudart = ctypes.CDLL(name)
+                break
+            except OSError as exc:
+                errors.append(f"{name}: {exc}")
+        if _cudart is None:
+            _cudart_load_error = OSError("; ".join(errors))
+    if _cudart is None:
+        raise RuntimeError(f"CUDA runtime library is unavailable: {_cudart_load_error}")
+    return _cudart
 
 # CUDA IPC handle size (64 bytes on Linux)
 CUDA_IPC_HANDLE_SIZE = 64
@@ -354,6 +366,7 @@ class TensorSharedHandle:
         ipc_handle = cudaIpcMemHandle_t()
 
         # Call cudaIpcGetMemHandle
+        cudart = _get_cudart()
         result = cudart.cudaIpcGetMemHandle(
             ctypes.byref(ipc_handle), ctypes.c_void_p(data_ptr)
         )
@@ -410,6 +423,7 @@ class TensorSharedHandle:
         ctypes.memmove(ctypes.byref(handle), ipc_handle, 64)
 
         # Open IPC memory handle to get base pointer
+        cudart = _get_cudart()
         base_ptr = ctypes.c_void_p()
         result = cudart.cudaIpcOpenMemHandle(
             ctypes.byref(base_ptr),

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1622,6 +1622,8 @@ class CPURemoteTransferWorker(TransferWorkerBase):
             end_time,
         )
 
+        return True
+
 class GDSTransferWorker(TransferWorkerBase):
     def __init__(
         self,

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -22,6 +22,12 @@ import numpy as np
 import pytest
 import torch
 
+# ``flexkv.kvtask`` imports flexkv.cache.cache_engine, whose package __init__
+# eagerly runs ``import flexkv.c_ext``. Skip the whole module (incl. the pure
+# KVTask state-machine tests) when the extension isn't built, instead of erroring
+# at collection. c_ext is present in every real dev/test env.
+pytest.importorskip("flexkv.c_ext")
+
 from flexkv.kvtask import KVTask, TaskType, TaskStatus
 
 pytestmark = pytest.mark.unit

--- a/tests/test_layerwise_dsv4_multi_group_swa_roundtrip.py
+++ b/tests/test_layerwise_dsv4_multi_group_swa_roundtrip.py
@@ -37,6 +37,8 @@ from test_layerwise_multi_group_swa import (
     _make_multi_group_cpu_layout,
 )
 
+pytestmark = pytest.mark.e2e
+
 IOURING_ENTRIES = 512
 IOURING_FLAGS = 0
 

--- a/tests/test_layerwise_eventfd_timing.py
+++ b/tests/test_layerwise_eventfd_timing.py
@@ -53,6 +53,8 @@ from test_layerwise_multi_group_swa import (
     _seed_swa_cpu_layer,
 )
 
+pytestmark = pytest.mark.e2e
+
 _libc = ctypes.CDLL("libc.so.6", use_errno=True)
 _EFD_SEMAPHORE = 0x1
 

--- a/tests/test_layerwise_multi_group_swa.py
+++ b/tests/test_layerwise_multi_group_swa.py
@@ -20,6 +20,8 @@ from flexkv.c_ext import LayerwiseTransferGroup
 from flexkv.common.config import LayerGroupSpec, build_layer_member_map
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 
+pytestmark = pytest.mark.e2e
+
 # -------------------------- shared geometry --------------------------
 DEVICE_ID = 0
 NUM_GPU_BLOCKS = 8

--- a/tests/test_merge_to_batch_graph_swa_callbacks.py
+++ b/tests/test_merge_to_batch_graph_swa_callbacks.py
@@ -1,5 +1,6 @@
 """merge_to_batch_graph: SWA + main per-op callbacks survive fusion."""
 import numpy as np
+import pytest
 
 from flexkv.common.transfer import (
     LayerwiseTransferOp,
@@ -8,6 +9,8 @@ from flexkv.common.transfer import (
     TransferType,
     merge_to_batch_graph,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def _graph_with_get_ops(*, with_swa: bool) -> tuple[TransferOpGraph, dict[int, object]]:

--- a/tests/test_set_gpu_blocks_swa.py
+++ b/tests/test_set_gpu_blocks_swa.py
@@ -1,7 +1,10 @@
 """set_gpu_blocks must not overwrite SWA ops with main-KV slot_mapping slices."""
 import numpy as np
+import pytest
 
 from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType
+
+pytestmark = pytest.mark.unit
 
 
 def test_set_gpu_blocks_skips_swa_h2d():

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -66,6 +66,17 @@ def _cache_config(enable_swa_transfer: bool = True):
     return cc
 
 
+def _cache_config_small_swa(num_slots: int):
+    cc = _cache_config()
+    cc.swa = SWAPoolConfig(
+        enabled=True,
+        num_slots=num_slots,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
+    return cc
+
+
 def _cache_config_ssd(enable_swa_transfer: bool = True):
     """CPU + SSD tiers, both with an SWA host pool. The SSD cache engine is an
     in-memory radix+mempool+swa_pool (no real SSD files at construction — files
@@ -82,6 +93,47 @@ def _cache_config_ssd(enable_swa_transfer: bool = True):
         enabled=True,
         num_slots=256,
         num_ssd_slots=256,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
+    cc.enable_swa_transfer = enable_swa_transfer
+    return cc
+
+
+def _cache_config_small_swa_ssd(num_slots: int, num_ssd_slots: int):
+    cc = _cache_config_ssd()
+    cc.swa = SWAPoolConfig(
+        enabled=True,
+        num_slots=num_slots,
+        num_ssd_slots=num_ssd_slots,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
+    return cc
+
+
+def _cache_config_remote(enable_swa_transfer: bool = True):
+    """CPU + REMOTE tiers using the local REMOTE cache engine.
+
+    This exercises the production REMOTE control-plane graph and SWA slot
+    lifecycle without requiring a PCFS server; byte movement remains covered by
+    explicitly gated E2E environments.
+    """
+    cc = CacheConfig(
+        tokens_per_block=TPB,
+        enable_cpu=True,
+        enable_remote=True,
+        enable_3rd_remote=False,
+        enable_kv_sharing=False,
+        num_cpu_blocks=4096,
+        num_remote_blocks=4096,
+    )
+    cc.enable_remote = True
+    cc.enable_kv_sharing = False
+    cc.swa = SWAPoolConfig(
+        enabled=True,
+        num_slots=256,
+        num_remote_slots=256,
         num_swa_layers=1,
         bytes_per_token_per_layer=64,
     )
@@ -354,6 +406,99 @@ def test_get_ssd_staging_when_only_ssd_has_swa():
     _complete(gop, gcb)
 
 
+def test_put_writethrough_remote_builds_swa_h2remote():
+    """REMOTE write-through: SWA store allocates a REMOTE SWA slot and emits
+    H2REMOTE dependent on the SWA D2H, mirroring full-KV remote write-through."""
+    eng = GlobalCacheEngine(_cache_config_remote(), _model_config())
+    tok = _tokens(4, base=24)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+
+    graph, _rm, cb, op_cb, _e = eng.put(1, tok, mask, sm, dp_client_id=0)
+    swa = _swa_ops(graph)
+    kinds = sorted(o.transfer_type.name for o in swa)
+    assert "D2H" in kinds, kinds
+    assert "H2REMOTE" in kinds, f"SWA remote write-through missing: {kinds}"
+    swa_d2h = [o for o in swa if o.transfer_type == TransferType.D2H][0]
+    swa_h2remote = [o for o in swa if o.transfer_type == TransferType.H2REMOTE][0]
+    assert swa_d2h.op_id in swa_h2remote.predecessors
+    assert eng.remote_cache_engine.swa_pool.num_used == 1
+    _complete(op_cb, cb)
+
+
+def test_get_remote_staging_when_only_remote_has_swa():
+    """REMOTE-sourced GET stages REMOTE->CPU then CPU->GPU and releases both
+    source pin and transient CPU staging slot on the H2D completion callback."""
+    eng = GlobalCacheEngine(_cache_config_remote(), _model_config())
+    tok = _tokens(4, base=25)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
+    _complete(pop, pcb)
+    eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
+
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
+    cpu_hit, _ = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    remote_hit, _ = eng.remote_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    assert cpu_hit == 0
+    assert remote_hit > 0
+    before_cpu_used = eng.cpu_cache_engine.swa_pool.num_used
+
+    graph, _rm2, gcb, gop, _ge = eng.get(
+        request_id=2, token_ids=tok, token_mask=mask, slot_mapping=sm, dp_client_id=0)
+    swa = _swa_ops(graph)
+    kinds = sorted(o.transfer_type.name for o in swa)
+    assert "H2D" in kinds and "REMOTE2H" in kinds, kinds
+    swa_h2d = [o for o in swa if o.transfer_type == TransferType.H2D][0]
+    swa_remote2h = [o for o in swa if o.transfer_type == TransferType.REMOTE2H][0]
+    assert swa_remote2h.op_id in swa_h2d.predecessors
+    assert eng.cpu_cache_engine.swa_pool.num_used == before_cpu_used + 1
+
+    remote_mr = eng.remote_cache_engine.match(seq)
+    remote_node = getattr(remote_mr, "last_swa_node", None)
+    assert remote_node is not None
+    assert remote_node.swa_lock_ref == 1
+
+    _complete(gop, gcb)
+    assert remote_node.swa_lock_ref == 0
+    assert eng.cpu_cache_engine.swa_pool.num_used == before_cpu_used
+
+
+def test_remote_source_pin_released_when_cpu_staging_slot_unavailable():
+    """If a lower-tier SWA hit is pinned but no CPU staging slot is available,
+    _swa_get_slots must drop the source pin and emit no SWA ops."""
+    eng = GlobalCacheEngine(_cache_config_remote(), _model_config())
+    tok = _tokens(4, base=26)
+    mask = np.ones_like(tok, dtype=np.int64)
+    sm = np.arange(tok.shape[0], dtype=np.int64)
+    _pg, _rm, pcb, pop, _pe = eng.put(1, tok, mask, sm, dp_client_id=0)
+    _complete(pop, pcb)
+    eng.cpu_cache_engine._evict_swa(eng.cpu_cache_engine.swa_pool.num_used)
+    held_slots = []
+    while True:
+        slot = eng.cpu_cache_engine.swa_alloc_slot()
+        if slot < 0:
+            break
+        held_slots.append(slot)
+    assert eng.cpu_cache_engine.swa_pool.num_free == 0
+
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
+    remote_hit, _ = eng.remote_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    assert remote_hit > 0
+
+    graph, _rm2, gcb, gop, _ge = eng.get(
+        request_id=2, token_ids=tok, token_mask=mask, slot_mapping=sm, dp_client_id=0)
+    assert _swa_ops(graph) == []
+    remote_hit2, _slot, remote_node = eng.remote_cache_engine.match_swa_locked(
+        seq, upper_bound_blocks=4)
+    assert remote_hit2 > 0 and remote_node is not None
+    assert remote_node.swa_lock_ref == 1
+    remote_node.dec_swa_lock_ref()
+    _complete(gop, gcb)
+    for slot in held_slots:
+        eng.cpu_cache_engine.swa_pool.free(slot)
+
+
 def test_get_prefers_cpu_when_both_tiers_have_swa():
     """Tier priority CPU>SSD: when CPU still holds the SWA window, GET sources
     from CPU (plain H2D, no staging) even though SSD also has it."""
@@ -371,6 +516,157 @@ def test_get_prefers_cpu_when_both_tiers_have_swa():
     assert "H2D" in kinds, kinds
     assert "DISK2H" not in kinds, f"CPU-resident SWA must not stage from SSD: {kinds}"
     _complete(gop, gcb)
+
+
+def test_put_skips_swa_when_all_cpu_swa_nodes_are_locked():
+    """When every CPU SWA slot is locked and no eviction is possible, PUT should
+    leave full-KV store intact but emit no SWA store ops."""
+    eng = GlobalCacheEngine(_cache_config_small_swa(num_slots=3), _model_config())
+    locked_nodes = []
+    for req in range(1, eng.cpu_cache_engine.swa_pool.num_slots + 1):
+        tok = _tokens(4, base=1000 + req)
+        _pg, _rm, cb, op_cb, _e = eng.put(
+            req, tok, np.ones_like(tok, dtype=np.int64),
+            np.arange(tok.shape[0], dtype=np.int64), dp_client_id=0)
+        _complete(op_cb, cb)
+        seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB)
+        hit, _slot, node = eng.cpu_cache_engine.match_swa_locked(seq, upper_bound_blocks=4)
+        assert hit == 4 and node is not None
+        locked_nodes.append(node)
+    assert eng.cpu_cache_engine.swa_pool.num_free == 0
+
+    tok = _tokens(4, base=2000)
+    graph, _rm, cb, op_cb, _e = eng.put(
+        9999, tok, np.ones_like(tok, dtype=np.int64),
+        np.arange(tok.shape[0], dtype=np.int64), dp_client_id=0)
+    assert any(op.transfer_type == TransferType.D2H for op in _full_ops(graph))
+    assert _swa_ops(graph) == []
+    _complete(op_cb, cb)
+    for node in locked_nodes:
+        node.dec_swa_lock_ref()
+
+
+def test_put_keeps_cpu_swa_when_lower_tier_pool_full_and_locked():
+    """A full locked lower-tier SWA pool should skip write-through only; the CPU
+    SWA copy still gets allocated and mounted."""
+    eng = GlobalCacheEngine(
+        _cache_config_small_swa_ssd(num_slots=8, num_ssd_slots=3),
+        _model_config(),
+    )
+    locked_nodes = []
+    for req in range(1, eng.ssd_cache_engine.swa_pool.num_slots + 1):
+        tok = _tokens(4, base=3000 + req)
+        _pg, _rm, cb, op_cb, _e = eng.put(
+            req, tok, np.ones_like(tok, dtype=np.int64),
+            np.arange(tok.shape[0], dtype=np.int64), dp_client_id=0)
+        _complete(op_cb, cb)
+        seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB)
+        hit, _slot, node = eng.ssd_cache_engine.match_swa_locked(seq, upper_bound_blocks=4)
+        assert hit == 4 and node is not None
+        locked_nodes.append(node)
+    assert eng.ssd_cache_engine.swa_pool.num_free == 0
+
+    tok = _tokens(4, base=4000)
+    graph, _rm, cb, op_cb, _e = eng.put(
+        9999, tok, np.ones_like(tok, dtype=np.int64),
+        np.arange(tok.shape[0], dtype=np.int64), dp_client_id=0)
+    kinds = sorted(op.transfer_type.name for op in _swa_ops(graph))
+    assert "D2H" in kinds
+    assert "H2DISK" not in kinds
+    _complete(op_cb, cb)
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB)
+    cpu_hit, _slot = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=4)
+    assert cpu_hit == 4
+    for node in locked_nodes:
+        node.dec_swa_lock_ref()
+
+
+def test_swa_load_release_callback_is_idempotent_for_staging_slot():
+    """Callback re-entry must not double-free transient staging slots."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    slot = eng.cpu_cache_engine.swa_alloc_slot()
+    assert slot >= 0
+    free_before = eng.cpu_cache_engine.swa_pool.num_free
+    cb = eng._make_swa_release_load_callback(node=None, staging_slot=slot)
+
+    cb()
+    assert eng.cpu_cache_engine.swa_pool.num_free == free_before + 1
+    cb()
+    assert eng.cpu_cache_engine.swa_pool.num_free == free_before + 1
+
+
+def test_swa_load_release_callback_frees_staging_even_if_source_unlock_raises(monkeypatch):
+    """Source unlock exceptions must not leak the transient CPU staging slot."""
+    eng = GlobalCacheEngine(_cache_config_ssd(), _model_config())
+    slot = eng.cpu_cache_engine.swa_alloc_slot()
+    assert slot >= 0
+    free_before = eng.cpu_cache_engine.swa_pool.num_free
+
+    class BadNode:
+        swa_lock_ref = 1
+
+        def dec_swa_lock_ref(self):
+            raise RuntimeError("boom")
+
+    eng._swa_release_load_lock(BadNode(), staging_slot=slot)
+    assert eng.cpu_cache_engine.swa_pool.num_free == free_before + 1
+
+
+def test_remote_worker_successful_launch_reports_completion(monkeypatch):
+    """REMOTE worker launch_transfer must return True after a successful copy.
+
+    The base worker only posts completed op ids when launch_transfer returns
+    True. A missing return here makes REMOTE2H/H2REMOTE look hung even if the C++
+    transfer completed.
+    """
+    from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+
+    worker_mod = pytest.importorskip("flexkv.transfer.worker")
+    layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=1,
+        num_block=4,
+        tokens_per_block=TPB,
+        num_head=1,
+        head_size=64,
+        is_mla=True,
+    )
+    worker = worker_mod.CPURemoteTransferWorker.__new__(worker_mod.CPURemoteTransferWorker)
+    worker.cpu_kv_layout = layout
+    worker.remote_kv_layout = layout
+    worker.dtype = torch.uint8
+    worker.chunk_size_in_bytes = TPB * 64
+    worker.num_layers = 1
+    worker.kv_dim = 1
+
+    seen = {}
+
+    def fake_get_transfer_block_ids(_op):
+        return (
+            torch.tensor([0], dtype=torch.int64),
+            torch.tensor([1], dtype=torch.int64),
+        )
+
+    def fake_transfer_impl(src_block_ids, dst_block_ids, transfer_type, **kwargs):
+        seen["src"] = src_block_ids
+        seen["dst"] = dst_block_ids
+        seen["type"] = transfer_type
+        seen["kwargs"] = kwargs
+
+    monkeypatch.setattr(worker, "get_transfer_block_ids", fake_get_transfer_block_ids)
+    monkeypatch.setattr(worker, "_transfer_impl", fake_transfer_impl)
+    monkeypatch.setattr(worker, "_log_transfer_performance", lambda *args, **kwargs: None)
+
+    class DummyOp:
+        transfer_op_id = 123
+        transfer_graph_id = 456
+        transfer_type = TransferType.REMOTE2H
+        valid_block_num = 1
+        src_block_node_ids = np.array([7], dtype=np.int64)
+
+    assert worker.launch_transfer(DummyOp()) is True
+    assert seen["type"] == TransferType.REMOTE2H
+    assert seen["kwargs"]["src_block_node_ids"].tolist() == [7]
 
 
 def test_multitier_match_promotes_swa_in_each_tier():

--- a/tests/test_swa_level2_single_pass.py
+++ b/tests/test_swa_level2_single_pass.py
@@ -25,6 +25,7 @@ pytest.importorskip("flexkv.c_ext")
 from flexkv.cache.cache_engine import GlobalCacheEngine
 from flexkv.common.block import SequenceMeta
 from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
+from flexkv.common.transfer import TransferType
 from flexkv.common.debug import flexkv_logger
 
 flexkv_logger.set_level("OFF")
@@ -151,6 +152,49 @@ def test_swa_aware_get_clamps_full_to_usable():
     assert int(return_mask.sum()) == 4 * TPB
     swa = [o for o in graph._op_map.values() if getattr(o, "is_swa", False)]
     assert len(swa) == 1, "SWA H2D must still attach to the same graph"
+    _complete(op_cb, cb)
+
+
+def test_swa_aware_get_clamps_when_full_hit_exceeds_swa_hit():
+    """Production path: full_hit can be longer than swa_hit.
+
+    Store a 2-block prefix with SWA, then store a 4-block extension with SWA
+    transfer temporarily disabled. The Full-KV tree can then serve 4 blocks,
+    while the deepest live SWA page remains at block 2. A SWA-aware GET must
+    clamp the real transfer window to 2 blocks and still attach an SWA H2D.
+    """
+    eng = GlobalCacheEngine(_cache_config(), _model_config())
+    tok4 = _tokens(4, base=34)
+    tok2 = tok4[:2 * TPB]
+    _put(eng, tok2, req=1)
+
+    eng.cache_config.enable_swa_transfer = False
+    _put(eng, tok4, req=2)
+    eng.cache_config.enable_swa_transfer = True
+
+    seq = SequenceMeta(token_ids=tok4, tokens_per_block=TPB)
+    full_hit = eng.cpu_cache_engine.match(seq).num_ready_matched_blocks
+    swa_hit, _slot = eng.cpu_cache_engine.match_swa(seq, upper_bound_blocks=full_hit)
+    assert full_hit == 4
+    assert swa_hit == 2
+
+    graph, return_mask, cb, op_cb, _end_id = eng.get(
+        request_id=3,
+        token_ids=tok4,
+        token_mask=np.ones_like(tok4, dtype=np.int64),
+        slot_mapping=np.arange(tok4.shape[0], dtype=np.int64),
+        dp_client_id=0,
+        swa_aware=True,
+    )
+
+    assert int(return_mask.sum()) == 2 * TPB
+    full_h2d = [
+        op for op in graph._op_map.values()
+        if not op.is_swa and op.transfer_type == TransferType.H2D
+    ]
+    assert full_h2d and full_h2d[0].src_block_ids.size == 2
+    swa = [op for op in graph._op_map.values() if getattr(op, "is_swa", False)]
+    assert len(swa) == 1 and swa[0].transfer_type == TransferType.H2D
     _complete(op_cb, cb)
 
 

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -34,6 +34,12 @@ from typing import Dict, List
 import numpy as np
 import pytest
 
+# ``flexkv.cache.radixtree`` pulls flexkv.cache.__init__, which eagerly runs
+# ``import flexkv.c_ext``. Skip the whole module (incl. the pure-Python spec) when
+# the extension isn't built, rather than erroring at collection. c_ext is present
+# in every real dev/test env; only the no-c_ext CI gate skips here.
+pytest.importorskip("flexkv.c_ext")
+
 from flexkv.common.block import SequenceMeta
 from flexkv.cache.radixtree import RadixTreeIndex
 

--- a/tests/test_swa_peer_op.py
+++ b/tests/test_swa_peer_op.py
@@ -23,7 +23,15 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-if 'flexkv.c_ext' not in sys.modules:
+# flexkv.cache.__init__ eagerly runs ``import flexkv.c_ext``, so importing the
+# pure control-plane symbols below pulls in c_ext. This file exercises only the
+# transfer-graph logic and never calls into c_ext, so we stub it just long enough
+# to satisfy that import. Crucially we then DROP the stub: if it leaked into
+# sys.modules it would defeat ``pytest.importorskip('flexkv.c_ext')`` in sibling
+# test files sharing this pytest process (they would run against the mock instead
+# of skipping when the extension isn't built).
+_c_ext_was_absent = 'flexkv.c_ext' not in sys.modules
+if _c_ext_was_absent:
     sys.modules['flexkv.c_ext'] = MagicMock()
 
 import numpy as np
@@ -34,6 +42,9 @@ from flexkv.common.transfer import (
 )
 from flexkv.cache.transfer_pattern import add_virtual_op_for_multiple_finished_ops
 from flexkv.cache.swa_cache_engine import SWACacheManager
+
+if _c_ext_was_absent:
+    del sys.modules['flexkv.c_ext']
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_swa_remote_staging_e2e.py
+++ b/tests/test_swa_remote_staging_e2e.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Gated REMOTE SWA staging E2E with real byte movement.
+
+This test uses the production control plane and data plane:
+
+  PUT   : GlobalCacheEngine.put() emits full D2H plus SWA D2H/H2REMOTE.
+  EVICT : CPU SWA is removed so the SWA window only survives in REMOTE.
+  GET   : GlobalCacheEngine.get() emits SWA REMOTE2H -> H2D.
+
+It is skipped by default because it requires a CFS-enabled build and a reachable
+PCFS service. Run it explicitly with:
+
+    FLEXKV_RUN_REMOTE_E2E=1 \
+    FLEXKV_PCFS_FSID=<fsid> \
+    FLEXKV_PCFS_PORT=<port> \
+    FLEXKV_PCFS_IP=<ip> \
+    FLEXKV_PCFS_PARENT_NODEID=<nodeid> \
+    FLEXKV_REMOTE_CACHE_PATH=<remote-file-prefix> \
+    CUDA_VISIBLE_DEVICES=0 \
+    python -m pytest -m e2e tests/test_swa_remote_staging_e2e.py
+"""
+import os
+import sys
+import time
+
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("flexkv.c_ext")
+
+from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
+from flexkv.common.memory_handle import TensorSharedHandle
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.common.transfer import DeviceType, TransferType, WorkerKey
+from flexkv.storage.storage_engine import StorageEngine
+from flexkv.transfer.transfer_engine import TransferEngine
+from flexkv.transfer import worker as transfer_worker
+
+NUM_LAYERS = 4
+NUM_BLOCKS_GPU = 64
+NUM_BLOCKS_CPU = 64
+NUM_BLOCKS_REMOTE = 128
+TOKENS_PER_BLOCK = 16
+BYTES_PER_TOKEN_PER_LAYER = 64
+DEVICE_ID = 0
+NUM_SWA_SLOTS = 32
+NUM_SWA_REMOTE_SLOTS = 32
+SWA_GPU_SLOT = 9
+
+_REMOTE_E2E_ENV = "FLEXKV_RUN_REMOTE_E2E"
+_PCFS_ENV_KEYS = (
+    "FLEXKV_PCFS_FSID",
+    "FLEXKV_PCFS_PORT",
+    "FLEXKV_PCFS_IP",
+    "FLEXKV_PCFS_PARENT_NODEID",
+)
+
+
+def _remote_e2e_enabled() -> bool:
+    return os.getenv(_REMOTE_E2E_ENV) == "1"
+
+
+def _missing_remote_env() -> list[str]:
+    missing = [key for key in _PCFS_ENV_KEYS if not os.getenv(key)]
+    if not os.getenv("FLEXKV_REMOTE_CACHE_PATH"):
+        missing.append("FLEXKV_REMOTE_CACHE_PATH")
+    return missing
+
+
+def _remote_config() -> dict:
+    missing = [key for key in _PCFS_ENV_KEYS if not os.getenv(key)]
+    if missing:
+        raise RuntimeError(f"missing PCFS env for REMOTE E2E: {', '.join(missing)}")
+    return {
+        "pcfs_fsid": os.environ["FLEXKV_PCFS_FSID"],
+        "pcfs_port": int(os.environ["FLEXKV_PCFS_PORT"]),
+        "pcfs_ip": os.environ["FLEXKV_PCFS_IP"],
+        "pcfs_parent_nodeid": int(os.environ["FLEXKV_PCFS_PARENT_NODEID"]),
+    }
+
+
+def make_gpu_pool(num_blocks):
+    return torch.zeros(
+        (NUM_LAYERS, num_blocks, TOKENS_PER_BLOCK, BYTES_PER_TOKEN_PER_LAYER),
+        dtype=torch.uint8,
+        device=f"cuda:{DEVICE_ID}",
+    )
+
+
+def seed_block(pool, block, salt):
+    for layer in range(NUM_LAYERS):
+        plane = torch.zeros(
+            (TOKENS_PER_BLOCK, BYTES_PER_TOKEN_PER_LAYER),
+            dtype=torch.uint8,
+        )
+        for tok in range(TOKENS_PER_BLOCK):
+            for b in range(BYTES_PER_TOKEN_PER_LAYER):
+                plane[tok, b] = ((layer * 31 + tok + salt) ^ b) & 0xFF
+        pool[layer, block].copy_(plane.to(pool.device))
+
+
+def block_bytes(pool, block):
+    chunks = [
+        pool[layer, block].contiguous().view(-1).cpu().clone()
+        for layer in range(NUM_LAYERS)
+    ]
+    return torch.cat(chunks).numpy().tobytes()
+
+
+def make_layout(num_blocks):
+    return KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=NUM_LAYERS,
+        num_block=num_blocks,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        num_head=1,
+        head_size=BYTES_PER_TOKEN_PER_LAYER,
+        is_mla=True,
+    )
+
+
+def wait_for_op(te, op_ids, timeout_s=60.0):
+    pending = set(op_ids)
+    deadline = time.monotonic() + timeout_s
+    while pending and time.monotonic() < deadline:
+        for completed in te.get_completed_graphs_and_ops(timeout=1.0):
+            pending.discard(completed.op_id)
+        if pending:
+            time.sleep(0.01)
+    if pending:
+        raise TimeoutError(f"Ops {pending} did not complete in {timeout_s}s")
+
+
+def _run_graph(te, graph, op_cb, cb, full_gpu_blocks, swa_gpu_slot, reported_op_ids):
+    graph.set_gpu_blocks(np.asarray(full_gpu_blocks, dtype=np.int64))
+    if graph._swa_gpu_transfer_op_id:
+        graph.set_swa_gpu_blocks(np.asarray([swa_gpu_slot], dtype=np.int64))
+    te.submit_transfer_graph(graph)
+    wait_for_op(te, reported_op_ids)
+    torch.cuda.synchronize()
+    for callback in op_cb.values():
+        callback()
+    cb()
+
+
+def _cache_config(remote_cache_path: str, remote_config: dict) -> CacheConfig:
+    cache_config = CacheConfig(
+        tokens_per_block=TOKENS_PER_BLOCK,
+        enable_cpu=True,
+        enable_ssd=False,
+        enable_remote=True,
+        enable_3rd_remote=False,
+        enable_kv_sharing=False,
+        num_cpu_blocks=NUM_BLOCKS_CPU,
+        num_remote_blocks=NUM_BLOCKS_REMOTE,
+        remote_cache_path=remote_cache_path,
+        remote_config_custom=remote_config,
+        swa=SWAPoolConfig(
+            enabled=True,
+            num_slots=NUM_SWA_SLOTS,
+            num_remote_slots=NUM_SWA_REMOTE_SLOTS,
+            num_swa_layers=NUM_LAYERS,
+            bytes_per_token_per_layer=BYTES_PER_TOKEN_PER_LAYER,
+            pin_memory=True,
+        ),
+    )
+    cache_config.enable_remote = True
+    cache_config.enable_kv_sharing = False
+    cache_config.enable_swa_transfer = True
+    return cache_config
+
+
+def main() -> int:
+    if not _remote_e2e_enabled():
+        print(f"[verify] set {_REMOTE_E2E_ENV}=1 to run REMOTE E2E", flush=True)
+        return 2
+    missing = _missing_remote_env()
+    if missing:
+        print(f"[verify] missing REMOTE E2E env: {', '.join(missing)}", flush=True)
+        return 2
+    if transfer_worker.transfer_kv_blocks_remote is None:
+        print("[verify] transfer_kv_blocks_remote unavailable; build with FLEXKV_ENABLE_CFS=1", flush=True)
+        return 2
+    if not torch.cuda.is_available():
+        print("[verify] CUDA not available", flush=True)
+        return 2
+
+    remote_config = _remote_config()
+    remote_cache_path = os.environ["FLEXKV_REMOTE_CACHE_PATH"]
+    torch.cuda.set_device(DEVICE_ID)
+    print(f"[verify] device cuda:{DEVICE_ID}, remote_path={remote_cache_path}", flush=True)
+
+    model_config = ModelConfig(
+        num_layers=NUM_LAYERS,
+        num_kv_heads=1,
+        head_size=BYTES_PER_TOKEN_PER_LAYER,
+        use_mla=True,
+        dtype=torch.uint8,
+        tp_size=1,
+        pp_size=1,
+        dp_size=1,
+        cp_size=1,
+    )
+    cache_config = _cache_config(remote_cache_path, remote_config)
+
+    mk_pool = make_gpu_pool(NUM_BLOCKS_GPU)
+    sw_pool = make_gpu_pool(NUM_SWA_SLOTS)
+    put_full_gpu, get_full_gpu = 0, 3
+    seed_block(mk_pool, put_full_gpu, salt=0xC1)
+    seed_block(sw_pool, SWA_GPU_SLOT, salt=0xD2)
+    expected_sw = block_bytes(sw_pool, SWA_GPU_SLOT)
+
+    mk_handles = [
+        TensorSharedHandle(mk_pool[layer].contiguous(), DEVICE_ID)
+        for layer in range(NUM_LAYERS)
+    ]
+    sw_handles = [
+        TensorSharedHandle(sw_pool[layer].contiguous(), DEVICE_ID)
+        for layer in range(NUM_LAYERS)
+    ]
+
+    se = StorageEngine(model_config, cache_config, num_layers_per_pp_stage=NUM_LAYERS)
+    assert se.has_storage_handle(DeviceType.REMOTE, device_id=0, is_swa=True), (
+        "SWA REMOTE pool missing"
+    )
+    se.register_gpu_blocks(
+        mk_handles,
+        make_layout(NUM_BLOCKS_GPU),
+        device_id=DEVICE_ID,
+        dtype=torch.uint8,
+    )
+    se.register_swa_gpu_blocks(
+        sw_handles,
+        make_layout(NUM_SWA_SLOTS),
+        device_id=DEVICE_ID,
+        dtype=torch.uint8,
+    )
+
+    worker_key = WorkerKey(dp_client_id=0, pp_rank=0)
+    te = TransferEngine(
+        gpu_handles={worker_key: [se.get_storage_handle(DeviceType.GPU, device_id=DEVICE_ID)]},
+        model_config=model_config,
+        cache_config=cache_config,
+        cpu_handle=se.get_storage_handle(DeviceType.CPU),
+        remote_handle=se.get_storage_handle(DeviceType.REMOTE),
+        swa_gpu_handles={worker_key: [se.get_swa_storage_handle(DEVICE_ID)]},
+        swa_cpu_handle=se.get_storage_handle(DeviceType.CPU, device_id=0, is_swa=True),
+        swa_remote_handle=se.get_storage_handle(DeviceType.REMOTE, device_id=0, is_swa=True),
+    )
+    te.start()
+    print("[verify] TransferEngine started (main-KV + SWA CPU/REMOTE workers)", flush=True)
+
+    engine = GlobalCacheEngine(cache_config, model_config)
+    assert engine.remote_cache_engine is not None and engine.remote_cache_engine.swa_enabled, (
+        "engine REMOTE SWA tier not enabled"
+    )
+
+    tok = np.arange(1, TOKENS_PER_BLOCK + 1, dtype=np.int64)
+    put_slot_mapping = np.arange(
+        put_full_gpu * TOKENS_PER_BLOCK,
+        (put_full_gpu + 1) * TOKENS_PER_BLOCK,
+        dtype=np.int64,
+    )
+    mask = np.ones_like(tok, dtype=np.int64)
+
+    put_graph, _rm, put_cb, put_op_cb, put_end = engine.put(
+        request_id=1,
+        token_ids=tok,
+        token_mask=mask,
+        slot_mapping=put_slot_mapping,
+        dp_client_id=0,
+    )
+    swa_put_ops = [
+        op for op in put_graph._op_map.values() if getattr(op, "is_swa", False)
+    ]
+    kinds = sorted(op.transfer_type.name for op in swa_put_ops)
+    assert "D2H" in kinds and "H2REMOTE" in kinds, (
+        f"expected SWA D2H + H2REMOTE, got {kinds}"
+    )
+    reported = {put_end} | {op.op_id for op in swa_put_ops}
+    print(f"[verify] PUT graph: SWA ops={kinds} (write-through to REMOTE)", flush=True)
+    _run_graph(
+        te,
+        put_graph,
+        put_op_cb,
+        put_cb,
+        full_gpu_blocks=[put_full_gpu],
+        swa_gpu_slot=SWA_GPU_SLOT,
+        reported_op_ids=reported,
+    )
+    print("[verify] PUT done (SWA in CPU pool + REMOTE files)", flush=True)
+
+    engine.cpu_cache_engine._evict_swa(engine.cpu_cache_engine.swa_pool.num_used)
+    seq = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK)
+    seq.gen_hashes()
+    cpu_hit, _cpu_slot = engine.cpu_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    remote_hit, _remote_slot = engine.remote_cache_engine.match_swa(seq, upper_bound_blocks=1)
+    assert cpu_hit == 0 and remote_hit > 0, (
+        f"precondition failed: cpu_hit={cpu_hit} remote_hit={remote_hit}"
+    )
+    sw_pool.zero_()
+    mk_pool.zero_()
+    torch.cuda.synchronize()
+
+    get_slot_mapping = np.arange(
+        get_full_gpu * TOKENS_PER_BLOCK,
+        (get_full_gpu + 1) * TOKENS_PER_BLOCK,
+        dtype=np.int64,
+    )
+    get_graph, _rm2, get_cb, get_op_cb, get_end = engine.get(
+        request_id=2,
+        token_ids=tok,
+        token_mask=np.ones_like(tok, dtype=np.int64),
+        slot_mapping=get_slot_mapping,
+        dp_client_id=0,
+    )
+    failed = False
+    swa_get_ops = [
+        op for op in get_graph._op_map.values() if getattr(op, "is_swa", False)
+    ]
+    get_kinds = sorted(op.transfer_type.name for op in swa_get_ops)
+    assert "REMOTE2H" in get_kinds and "H2D" in get_kinds, (
+        f"expected SWA REMOTE2H + H2D, got {get_kinds}"
+    )
+    remote_mr = engine.remote_cache_engine.match(seq)
+    remote_node = getattr(remote_mr, "last_swa_node", None)
+    assert remote_node is not None and remote_node.swa_lock_ref == 1
+    swa_h2d = [op for op in swa_get_ops if op.transfer_type == TransferType.H2D][0]
+    swa_remote2h = [
+        op for op in swa_get_ops if op.transfer_type == TransferType.REMOTE2H
+    ][0]
+    assert swa_remote2h.op_id in swa_h2d.predecessors
+    barrier = get_graph._op_map[get_end]
+    reported2 = {swa_h2d.op_id} | set(barrier.predecessors)
+    print(f"[verify] GET graph: SWA ops={get_kinds} (REMOTE staging chain)", flush=True)
+    _run_graph(
+        te,
+        get_graph,
+        get_op_cb,
+        get_cb,
+        full_gpu_blocks=[get_full_gpu],
+        swa_gpu_slot=SWA_GPU_SLOT,
+        reported_op_ids=reported2,
+    )
+    print("[verify] GET done (SWA restored via REMOTE->CPU->GPU)", flush=True)
+    if remote_node.swa_lock_ref != 0:
+        print(
+            f"[verify] FAIL REMOTE source SWA lock leaked (lock_ref={remote_node.swa_lock_ref})",
+            flush=True,
+        )
+        failed = True
+    else:
+        print("[verify] OK    REMOTE source SWA lock released", flush=True)
+
+    actual_sw = block_bytes(sw_pool, SWA_GPU_SLOT)
+    byte_failed = actual_sw != expected_sw
+    failed = failed or byte_failed
+    if byte_failed:
+        print("[verify] FAIL SWA byte mismatch after REMOTE staging", flush=True)
+    else:
+        print(
+            f"[verify] OK    SWA: {len(expected_sw)} bytes match "
+            "GPU->CPU/REMOTE->(evict CPU)->REMOTE2H->H2D->GPU",
+            flush=True,
+        )
+
+    staging_used = engine.cpu_cache_engine.swa_pool.num_used
+    if staging_used != 0:
+        print(
+            f"[verify] FAIL transient CPU staging slot leaked (num_used={staging_used})",
+            flush=True,
+        )
+        failed = True
+    else:
+        print("[verify] OK    transient CPU staging slot freed (no leak)", flush=True)
+
+    te.shutdown()
+    if failed:
+        return 4
+    print("[verify] PASS: REMOTE SWA staging byte-exact, transient slot freed", flush=True)
+    return 0
+
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not _remote_e2e_enabled(), reason="set FLEXKV_RUN_REMOTE_E2E=1")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SWA REMOTE staging e2e needs a GPU")
+@pytest.mark.skipif(
+    transfer_worker.transfer_kv_blocks_remote is None,
+    reason="requires CFS-enabled build with transfer_kv_blocks_remote",
+)
+def test_swa_remote_staging_e2e_byte_exact():
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_swa_ssd_staging_e2e.py
+++ b/tests/test_swa_ssd_staging_e2e.py
@@ -86,6 +86,8 @@ def wait_for_op(te, op_ids, timeout_s=30.0):
     while pending and time.monotonic() < deadline:
         for c in te.get_completed_graphs_and_ops(timeout=1.0):
             pending.discard(c.op_id)
+        if pending:
+            time.sleep(0.01)
     if pending:
         raise TimeoutError(f"Ops {pending} did not complete in {timeout_s}s")
 
@@ -177,7 +179,7 @@ def main() -> int:
     kinds = sorted(o.transfer_type.name for o in swa_put_ops)
     assert "D2H" in kinds and "H2DISK" in kinds, f"expected SWA D2H + H2DISK, got {kinds}"
     assert engine.ssd_cache_engine.swa_pool.num_used == 1, "SSD SWA slot not allocated on put"
-    reported = {put_end} | {o.op_id for o in swa_put_ops if o.transfer_type.name == "D2H"}
+    reported = {put_end} | {o.op_id for o in swa_put_ops}
     print(f"[verify] PUT graph: SWA ops={kinds} (write-through to SSD)", flush=True)
     _run_graph(te, put_graph, put_op_cb, put_cb,
                full_gpu_blocks=[PUT_FULL_GPU], swa_gpu_slot=SWA_GPU_SLOT,
@@ -205,6 +207,9 @@ def main() -> int:
     swa_get_ops = [o for o in get_graph._op_map.values() if getattr(o, "is_swa", False)]
     gkinds = sorted(o.transfer_type.name for o in swa_get_ops)
     assert "DISK2H" in gkinds and "H2D" in gkinds, f"expected SWA DISK2H+H2D staging, got {gkinds}"
+    ssd_mr = engine.ssd_cache_engine.match(seq)
+    ssd_node = getattr(ssd_mr, "last_swa_node", None)
+    assert ssd_node is not None and ssd_node.swa_lock_ref == 1
     swa_h2d = [o for o in swa_get_ops if o.transfer_type.name == "H2D"][0]
     swa_disk2h = [o for o in swa_get_ops if o.transfer_type.name == "DISK2H"][0]
     assert swa_disk2h.op_id in swa_h2d.predecessors, "SWA H2D must depend on SSD DISK2H"
@@ -215,11 +220,18 @@ def main() -> int:
                full_gpu_blocks=[GET_FULL_GPU], swa_gpu_slot=SWA_GPU_SLOT,
                reported_op_ids=reported2)
     print("[verify] GET done (SWA restored via SSD->CPU->GPU)", flush=True)
+    failed = False
+    if ssd_node.swa_lock_ref != 0:
+        print(f"[verify] FAIL SSD source SWA lock leaked (lock_ref={ssd_node.swa_lock_ref})", flush=True)
+        failed = True
+    else:
+        print("[verify] OK    SSD source SWA lock released", flush=True)
 
     # ===== byte-exact compare ==================================================
     actual_sw = block_bytes(sw_pool, SWA_GPU_SLOT)
-    failed = actual_sw != expected_sw
-    if failed:
+    byte_failed = actual_sw != expected_sw
+    failed = failed or byte_failed
+    if byte_failed:
         print("[verify] FAIL SWA byte mismatch after SSD staging", flush=True)
     else:
         print(f"[verify] OK    SWA: {len(expected_sw)} bytes match "


### PR DESCRIPTION
## Summary

- Add SWA control-plane coverage for REMOTE write-through/staging, full-hit greater than SWA-hit, capacity exhaustion, lower-tier pool exhaustion, source pin release, staging slot cleanup, and callback re-entry.
- Add a gated REMOTE SWA staging E2E that exercises real H2REMOTE/REMOTE2H byte movement when CFS/PCFS is available.
- Fix the REMOTE transfer worker success path to report completion, make SWA load-release callbacks one-shot, and lazy-load CUDA runtime for CPU-only collection.
- Add missing pytest markers for SWA/layerwise tests and a lightweight SWA unit/smoke workflow.

## Validation

- `python3 -m compileall -q flexkv tests`
- `git diff --check`
- marker scan for `tests/test_*swa*.py` and `tests/test_layerwise*`

Full pytest was not run locally because this environment is missing pytest/pyzmq/nvtx and the REMOTE E2E requires a CFS-enabled build plus PCFS configuration.
