### PR TITLE
Simplify SWA match API

### DIFF
--- a/docs/swa_match_api_zh.md
+++ b/docs/swa_match_api_zh.md
@@ -1,0 +1,211 @@
+# SWA Match API 梳理
+
+## 结论
+
+当前只保留一个 SWA 匹配入口：
+
+```python
+engine.match_swa(
+    sequence_meta,
+    upper_bound_blocks,
+    match_result=mr,        # 可选：复用已有 Full-KV match 结果
+    lock_for_load=True,     # 可选：GET H2D 前 pin 住 SWA 源 node
+    return_node=True,       # 可选：返回 node handle，供完成回调释放 pin
+)
+```
+
+返回值：
+
+- 默认返回 `(swa_hit_blocks, slot_id)`。
+- `return_node=True` 或 `lock_for_load=True` 时返回 `(swa_hit_blocks, slot_id, node)`。
+- miss 返回 `0, -1` 或 `0, -1, None`。
+
+旧的 `match_swa_locked()` / `match_swa_from_result()` 没有外部调用，已经删除。它们不是新的语义，只是把同一个 `match_swa()` 行为拆成了两个额外名字：一个代表 `lock_for_load=True`，一个代表 `match_result=...`。
+
+## 先看 Full-KV 怎么做
+
+先区分两个名字相近但层级不同的 match：
+
+- `KVManager.get_match()` / `KVTaskEngine.get_match()` 是对外任务 API。它会用 fake `slot_mapping` 创建一个 `UNREADY` GET task，并在创建任务时调用 `GlobalCacheEngine.get()` 把 graph 先建好；后续 `launch()` 只 late-bind 真实 GPU block ids，不再重新 match。
+- `GlobalCacheEngine.match_local()` / `match_all()` / `match_local_accel()` / `match_all_accel()` 是 cache engine 内部的 per-tier radix match 聚合。它们返回 CPU/SSD/REMOTE 的 `MatchResult`，只服务本次 `GlobalCacheEngine.get()` 构图。
+
+所以看起来像“get_match 之后 get 又查了一遍”，实际不是两个阶段重复查。`get_match()` 的实现本身就是通过 `GlobalCacheEngine.get()` 完成 match + graph build；`launch()` 只是把 graph 里 placeholder GPU blocks 替换成真实 slot mapping。
+
+Full-KV 的控制面不是“match 直接返回 graph”，而是分三层。现在 GET 路径把中间结果显式收成 `FullKVGetPlan`，避免上层继续解长 tuple：
+
+```text
+match_*() -> MatchResult
+_get_impl_*() -> FullKVGetPlan
+get() -> resolve SWA source, append SWA graph, lock nodes, attach callbacks
+_put_impl_*() -> TransferOpGraph + node_to_unlock + callbacks
+put() -> append SWA store graph, lock nodes, attach callbacks
+```
+
+`match_*()` 只做索引层前缀匹配。它返回 `MatchResult`，里面有：
+
+- `num_ready_matched_blocks` / `physical_blocks`：这次能直接复用的 Full-KV block。
+- `last_ready_node`：已经 ready 的匹配边界 node。GET 会把它放进 `node_to_unlock`，在 graph 执行期间 lock 住，避免被 Full-KV eviction 回收。
+- `last_node`：用于 `take(..., protected_node=last_node)`，分配 staging/new blocks 时保护当前匹配路径。
+- `last_node_matched_length` 等插入所需信息。
+
+`_get_impl_local()` / `_get_impl_global()` 使用这些 `MatchResult` 来做三件事：
+
+- 切出 CPU/SSD/REMOTE 各 tier 已命中的 physical blocks，构建 H2D、DISK2H、REMOTE2H、H2DISK 等 Full-KV op。
+- 如果需要把 lower tier 数据 staged 回 CPU/SSD，会 `take()` 新 block，并用 `insert(..., is_ready=False, match_result=...)` 把即将落地的数据先挂到 radix tree 上。
+- 产出 `node_to_unlock` 和 `op_node_to_ready`：前者由最终 transfer callback 统一 unlock/set_ready，后者在某个具体 op 完成时把新插入 node 标成 ready。
+
+`FullKVGetPlan` 承接这些 GET 元数据：
+
+- `transfer_graph` / `finished_ops_ids`：Full-KV 已经建好的 graph 和 barrier 终点。
+- `node_to_unlock` / `op_node_to_ready`：Full-KV node 生命周期。
+- `buffer_to_free`：未插入 radix tree 的临时 staging block。
+- `num_gpu_blocks_to_transfer`：本次 Full-KV GET 最终会搬到 GPU 的 block 数。
+- `tier_match_results`：CPU/SSD/REMOTE 同一轮 Full-KV match 结果，供 SWA source resolver 复用。
+
+`get()` / `put()` 在 graph 返回给执行层之前，会对 `node_to_unlock` 里的 Full-KV node 调 `lock_node()`；graph 完成后 `_transfer_callback()` 再 `unlock()` 并 `set_ready()`。这就是 Full-KV 的生命周期：match 只返回元数据，lock 保护异步传输期，callback 释放。
+
+## SWA 为什么也需要 result
+
+SWA 是 node-mounted 的：SWA slot 挂在 Full-KV radix node 上，不是独立索引。Full-KV `match_prefix()` 在同一次 radix 前缀匹配里已经顺手产出了：
+
+- `last_swa_node`：匹配路径上最深的、ready 的、挂着 live SWA slot 的 node。
+- `swa_hit_blocks`：这个 SWA window 对应的 prefix block 数。
+
+所以 SWA slot resolution 应该优先复用 Full-KV `MatchResult`，原因有三个：
+
+- 避免 `_resolve_swa_get_source()` 为每个 tier 再走一次 radix tree。
+- 保证 Full-KV hit 和 SWA hit 来自同一轮 match 视图，降低控制面时序漂移。
+- `_clamp_end_to_swa()` 已经用同一批 match result 算 `usable = min(full_hit, swa_hit)`，后面 `_resolve_swa_get_source()` 继续用这批 result 才一致。
+
+但不能无条件直接拿 `match_result.last_swa_node`。`upper_bound_blocks` 是当前请求真正可复用的 Full-KV 上界；如果已有 match result 里的 `swa_hit_blocks > upper_bound_blocks`，说明那个 SWA node 在本次 usable prefix 之外。此时不能简单 `min(swa_hit, upper_bound)`，因为 slot/node 仍然指向更深的旧 node，会读错 window。正确做法是对截断到 `upper_bound_blocks` 的 prefix 做一次 clamped probe，找 bound 内最深的 SWA node。
+
+## SWA 为什么也需要 lock
+
+Full-KV 的 `lock_node()` 保护的是 Full-KV node/physical blocks，防止异步 transfer 期间被 Full-KV eviction 回收。SWA 也有同样问题，但保护对象不同：
+
+- SWA H2D 读的是 SWA host-pool slot。
+- 这个 slot 挂在 radix node 上。
+- SWA-only eviction 可以在 Full-KV node 还存在时单独释放 SWA slot。
+
+因此 `_resolve_swa_get_source()` 一旦决定某个 tier 的 SWA slot 会作为 GET 源，就必须在构图阶段对源 node 增加 `swa_lock_ref`。SWA H2D 完成后，`_swa_release_load_lock()` 再释放这个 pin。这样 SWA-only eviction 在异步 H2D 读 slot 期间不会把 slot 回收并复用给别的 window。
+
+这和 Full-KV 的 `node_to_unlock` 是同一个生命周期模式：
+
+```text
+Full-KV: node_to_unlock -> lock_node() -> H2D/DISK2H/... -> _transfer_callback() unlock()
+SWA    : match_swa(lock_for_load=True) -> inc_swa_lock_ref()
+         -> SWA H2D/DISK2H/... -> _swa_release_load_lock() dec_swa_lock_ref()
+```
+
+## GET 时序
+
+CPU 命中 SWA 的 GET：
+
+```text
+GlobalCacheEngine.get()
+  -> _get_impl_local/_get_impl_global()
+       -> match_local_accel()/match_all_accel()
+            -> per-tier Full-KV MatchResult
+       -> build Full-KV transfer graph
+       -> return FullKVGetPlan(graph, callbacks, tier_match_results, ...)
+  -> _resolve_swa_get_source(full_plan.tier_match_results, full_hit_blocks)
+       -> CPU first
+       -> cpu_engine.match_swa(
+              match_result=cpu_match,
+              upper_bound_blocks=full_hit_blocks,
+              lock_for_load=True,
+              return_node=True)
+            -> reuse last_swa_node/swa_hit_blocks when inside bound
+            -> otherwise clamped probe
+            -> promote SWA LRU
+            -> inc_swa_lock_ref()
+       -> return SWAGetSource(CPU slot + pinned node)
+  -> SWACacheManager.build_get_chain()
+       -> add SWA H2D op into full_plan.graph
+  -> get()
+       -> add virtual op over full_plan.finished_ops_ids + SWA H2D
+       -> lock full_plan.node_to_unlock
+       -> attach SWA H2D callback
+  -> execution completes
+       -> SWA callback: dec_swa_lock_ref()
+       -> Full-KV callback: unlock()/set_ready()
+```
+
+SSD/REMOTE 命中 SWA、CPU 没有 SWA 的 GET：
+
+```text
+_resolve_swa_get_source()
+  -> CPU match_swa miss
+  -> SSD/REMOTE match_swa(..., lock_for_load=True, return_node=True)
+       -> pin source-tier SWA node
+  -> allocate transient CPU SWA staging slot
+  -> build DISK2H/REMOTE2H -> H2D SWA chain
+  -> H2D callback:
+       -> release source-tier SWA lock
+       -> free transient CPU staging slot
+```
+
+这里 staging slot 不挂 radix node，只是 SWA H2D 的临时 CPU source，所以完成后直接 free。
+
+`SWAGetSource` 是 GET 侧一次性解析出来的 SWA source plan：
+
+- `hit_blocks` / `source_tier`：这次 SWA window 从哪个 tier 命中。
+- `gpu_slots` / `cpu_slots` / `ssd_slots` / `remote_slots`：直接传给 `SWACacheManager.build_get_chain()` 的 slot ids。
+- `lock_node`：被 `match_swa(lock_for_load=True)` pin 住的源 node。
+- `staging_slot`：SSD/REMOTE staging 到 CPU 时临时分配的 CPU SWA slot，H2D 完成后释放。
+
+## PUT 时序
+
+SWA PUT 不需要 match lock，因为它不是读取旧 SWA slot，而是在 Full-KV store node 上写入新的 trailing window：
+
+```text
+GlobalCacheEngine.put()
+  -> _put_impl_local/_put_impl_global()
+       -> Full-KV match
+       -> allocate/insert Full-KV store nodes
+       -> return node_to_unlock
+  -> _swa_put_slots(..., node_to_unlock)
+       -> allocate CPU SWA slot
+       -> set_swa(cpu_store_node, slot)
+       -> optionally allocate SSD/REMOTE SWA slots when Full-KV also stores there
+       -> set_swa(lower_tier_store_node, tier_slot)
+  -> SWACacheManager.build_put_chain()
+       -> add SWA D2H and optional H2DISK/H2REMOTE write-through ops
+  -> put()
+       -> lock Full-KV node_to_unlock
+  -> callbacks
+       -> Full-KV unlock/set_ready
+```
+
+PUT 的保护主要依赖 Full-KV 已有 `node_to_unlock`；SWA slot 是新分配并挂到 store node 上的，不存在“异步读取旧 slot 前被 eviction 回收”的问题。
+
+## 为什么不是 CacheEngine.match_swa 一次返回所有信息
+
+如果“一次返回所有信息”指的是 GET 需要的 source tier、slot、lock node、staging slot，那么这个入口应该是 `GlobalCacheEngine._resolve_swa_get_source()`，不是单 tier 的 `CacheEngine.match_swa()`。
+
+原因是 `CacheEngine.match_swa()` 属于单 tier 索引层，只知道“这个 tier 的 radix tree 上有没有可复用 SWA node”。它不知道：
+
+- GPU slot mapping。
+- CPU/SSD/REMOTE 的优先级。
+- 本次 Full-KV hit 的 global usable bound。
+- CPU staging slot 是否能分配成功。
+- SWA GPU placeholder 和 launch-time late bind。
+- op dependency、finished op、ready callback、unlock callback。
+
+这些都是 Global GET 的请求级上下文。因此现在的边界是：
+
+```text
+CacheEngine.match_swa()              -> 单 tier SWA node/slot 解析
+GlobalCacheEngine._resolve_swa_get_source() -> 多 tier GET source plan
+SWACacheManager.build_get_chain()    -> 根据 source plan 追加 graph ops
+```
+
+这样既保留了“GET 一次解析出所有 SWA 建图信息”的清晰度，又不把单 tier radix match 和 transfer graph 绑死。
+
+## 当前 API 边界
+
+- `match_swa()` 是唯一入口。
+- `match_result` 参数表示“复用 Full-KV 同一轮 match 的 SWA metadata”。
+- `lock_for_load` 参数表示“这个 slot 会被异步 SWA load 读取，需要 pin 到完成回调”。
+- `return_node` 参数表示“调用方需要拿 node handle 交给完成回调”。
+- `_resolve_swa_get_source()` 是唯一生产 GET 调用方：它同时需要 `match_result`、`lock_for_load=True`、`return_node=True`，并返回结构化 `SWAGetSource`。

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -17,7 +17,7 @@ import threading
 import time
 from functools import partial
 from queue import Queue
-from typing import List, Tuple, Optional, Dict, Callable
+from typing import List, Tuple, Optional, Dict, Callable, Union
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -43,6 +43,45 @@ from flexkv.metrics import FlexKVMetricsCollector, init_global_collector, get_gl
 
 DEVICE_TYPE: List[str] = ['CPU', 'GPU', 'SSD', 'REMOTE']
 _VALID_EVICTION_POLICIES = {'lru', 'lfu', 'fifo', 'mru', 'filo'}
+
+
+@dataclass
+class FullKVGetPlan:
+    transfer_graph: TransferOpGraph
+    finished_ops_ids: List[int]
+    node_to_unlock: Dict[DeviceType, Tuple[object, int]]
+    op_node_to_ready: Dict[int, Tuple[DeviceType, object, int]]
+    buffer_to_free: Dict[DeviceType, np.ndarray]
+    num_gpu_blocks_to_transfer: int
+    tier_match_results: Dict[DeviceType, object] = field(default_factory=dict)
+
+    @classmethod
+    def empty(cls) -> "FullKVGetPlan":
+        return cls(
+            transfer_graph=TransferOpGraph.create_empty_graph(),
+            finished_ops_ids=[],
+            node_to_unlock={},
+            op_node_to_ready={},
+            buffer_to_free={},
+            num_gpu_blocks_to_transfer=0,
+            tier_match_results={},
+        )
+
+
+@dataclass
+class SWAGetSource:
+    hit_blocks: int = 0
+    source_tier: Optional[DeviceType] = None
+    gpu_slots: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
+    cpu_slots: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
+    ssd_slots: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
+    remote_slots: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.int64))
+    lock_node: Optional[object] = None
+    staging_slot: int = -1
+
+    @classmethod
+    def empty(cls) -> "SWAGetSource":
+        return cls()
 
 
 class CacheEngineAccel:
@@ -153,117 +192,82 @@ class CacheEngineAccel:
         """Mount an SWA slot on ``node``'s trailing page (store side)."""
         self.index.set_swa(node, int(slot))
 
+    def _probe_swa_match(self, sequence_meta: SequenceMeta,
+                         upper_bound_blocks: int):
+        """Run a clamped SWA probe without updating Full-KV cache heat."""
+        sequence_meta.gen_hashes()
+        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
+        if num_blocks <= 0:
+            return None
+        block_hashes = torch.from_numpy(
+            sequence_meta.block_hashes[:num_blocks]).to(torch.int64)
+        return self.index.match_prefix(block_hashes, num_blocks, False)
+
+    def _resolve_swa_match(self,
+                           sequence_meta: SequenceMeta,
+                           upper_bound_blocks: int,
+                           match_result=None,
+                           lock_for_load: bool = False,
+                           ) -> Tuple[int, int, Optional["CRadixNode"]]:
+        """Resolve the SWA hit from an existing Full-KV match or a clamped probe."""
+        if self.swa_pool is None or upper_bound_blocks <= 0:
+            return 0, -1, None
+        upper_bound_blocks = int(upper_bound_blocks)
+
+        mr = match_result
+        swa_node = getattr(mr, "last_swa_node", None) if mr is not None else None
+        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0) if mr is not None else 0
+
+        if swa_node is not None and swa_hit > upper_bound_blocks:
+            # The reused Full-KV result saw an SWA node past this tier's usable
+            # bound. Re-probe the clamped prefix to find the deepest legal SWA.
+            mr = None
+
+        if mr is None:
+            mr = self._probe_swa_match(sequence_meta, upper_bound_blocks)
+            swa_node = getattr(mr, "last_swa_node", None) if mr is not None else None
+            swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0) if mr is not None else 0
+
+        if swa_node is None or swa_hit <= 0 or swa_hit > upper_bound_blocks:
+            return 0, -1, None
+        slot = int(swa_node.swa_host_slot)
+        if slot < 0:
+            return 0, -1, None
+
+        # Read-hit heat: both reused results and clamped probes represent an actual
+        # SWA reuse, so refresh the SWA-LRU independently of Full-KV heat.
+        self.index.promote_swa(swa_node)
+        if lock_for_load:
+            swa_node.inc_swa_lock_ref()
+        return swa_hit, slot, swa_node
+
     def match_swa(self,
                   sequence_meta: SequenceMeta,
                   upper_bound_blocks: int,
-                  lock_for_load: bool = False) -> Tuple[int, int]:
+                  lock_for_load: bool = False,
+                  match_result=None,
+                  return_node: bool = False,
+                  ) -> Union[Tuple[int, int], Tuple[int, int, Optional["CRadixNode"]]]:
         """Match the longest reusable trailing-SWA prefix within an upper bound.
 
-        Node-mount: the SWA hit is read from the Full-KV radix ``match_prefix``
-        (the deepest fully-matched, ready node carrying a live SWA slot). We match
-        the prefix truncated to ``upper_bound_blocks`` (this tier's Full-KV hit)
-        so the SWA hit is naturally clamped, enforcing SWA-subset-of-Full.
+        This is the canonical SWA match entry point. Pass ``match_result`` when a
+        Full-KV ``match()`` result is already available; otherwise this performs a
+        clamped, match-only probe. When ``lock_for_load`` is true, the matched SWA
+        node is pinned until the SWA H2D completion callback releases it, and the
+        node handle can be returned as the third tuple item.
 
-        Returns ``(swa_hit_blocks, slot_id)``; -1 / 0 when no SWA on the path.
+        Returns ``(swa_hit_blocks, slot_id)`` by default, or
+        ``(swa_hit_blocks, slot_id, node)`` when ``return_node`` or
+        ``lock_for_load`` is true. The node is pinned only when
+        ``lock_for_load`` is true. Miss is ``0, -1[, None]``.
         """
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1
-        sequence_meta.gen_hashes()
-        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
-        if num_blocks <= 0:
-            return 0, -1
-        block_hashes = torch.from_numpy(
-            sequence_meta.block_hashes[:num_blocks]).to(torch.int64)
-        # update_cache_info=False: a match-only probe must not bump LRU here.
-        mr = self.index.match_prefix(block_hashes, num_blocks, False)
-        swa_node = getattr(mr, "last_swa_node", None)
-        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1
-        # Read-hit保温: move the hit node to SWA-LRU MRU (a match-only probe is a
-        # real "use" — this is the LRU-thrash fix). Independent of lock_for_load.
-        self.index.promote_swa(swa_node)
-        if lock_for_load:
-            # Pin the SWA against eviction until the load completes. Paired
-            # unlock is the data-plane completion callback (kept off until wired).
-            swa_node.inc_swa_lock_ref()
+        include_node = return_node or lock_for_load
+        swa_hit, slot, node = self._resolve_swa_match(
+            sequence_meta, upper_bound_blocks, match_result=match_result,
+            lock_for_load=lock_for_load)
+        if include_node:
+            return swa_hit, slot, node
         return swa_hit, slot
-
-    def match_swa_locked(self,
-                         sequence_meta: SequenceMeta,
-                         upper_bound_blocks: int) -> Tuple[int, int, Optional["CRadixNode"]]:
-        """Like match_swa(lock_for_load=True) but ALSO returns the pinned node.
-
-        The data plane needs the node handle to release the pin (dec_swa_lock_ref)
-        when the SWA H2D completes. Returns ``(swa_hit, slot, node)``;
-        ``(0, -1, None)`` on miss (nothing pinned)."""
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, None
-        sequence_meta.gen_hashes()
-        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
-        if num_blocks <= 0:
-            return 0, -1, None
-        block_hashes = torch.from_numpy(
-            sequence_meta.block_hashes[:num_blocks]).to(torch.int64)
-        mr = self.index.match_prefix(block_hashes, num_blocks, False)
-        swa_node = getattr(mr, "last_swa_node", None)
-        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1, None
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1, None
-        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
-        swa_node.inc_swa_lock_ref()
-        return swa_hit, slot, swa_node
-
-    def match_swa_from_result(self,
-                              match_result,
-                              sequence_meta: SequenceMeta,
-                              upper_bound_blocks: int,
-                              lock_for_load: bool = False,
-                              ) -> Tuple[int, int, Optional["CRadixNode"]]:
-        """Resolve the SWA hit by REUSING an already-computed Full-KV match
-        instead of re-walking the radix tree.
-
-        ``match_result`` is the tier's Full-KV match (carrying ``last_swa_node`` /
-        ``swa_hit_blocks`` from the same single forward pass). When the SWA hit
-        fits within ``upper_bound_blocks`` (the tier's clamped Full-KV hit) we use
-        it directly — the common case, zero extra traversal. When it EXCEEDS the
-        bound (a masked prefix gap made the reusable Full hit shallower than the
-        deepest SWA node), a plain ``min()`` would point past the reusable prefix,
-        so we fall back to the clamped ``match_swa`` probe to find the deepest SWA
-        node WITHIN the bound.
-
-        Returns ``(swa_hit, slot, node)`` (node is the pinned node when
-        ``lock_for_load`` else None); ``(0, -1, None)`` on miss.
-        """
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, None
-        swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
-        swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1, None
-        if swa_hit > upper_bound_blocks:
-            # Deepest SWA lies past the reusable Full hit — re-probe clamped.
-            if lock_for_load:
-                return self.match_swa_locked(sequence_meta, upper_bound_blocks)
-            swa_hit2, slot2 = self.match_swa(
-                sequence_meta, upper_bound_blocks, lock_for_load=False)
-            return swa_hit2, slot2, None
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1, None
-        # REUSE branch: promote here. The fallback branch above delegates to
-        # match_swa[_locked], which promote internally — do NOT double-promote.
-        self.index.promote_swa(swa_node)
-        if lock_for_load:
-            swa_node.inc_swa_lock_ref()
-            return swa_hit, slot, swa_node
-        return swa_hit, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -500,91 +504,76 @@ class CacheEngine:
     def set_swa(self, node: "RadixNode", slot: int) -> None:
         self.index.set_swa(node, int(slot))
 
+    def _probe_swa_match(self, sequence_meta: SequenceMeta,
+                         upper_bound_blocks: int):
+        """Run a clamped SWA probe without updating Full-KV cache heat."""
+        sequence_meta.gen_hashes()
+        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
+        if num_blocks <= 0:
+            return None
+        clamped = SequenceMeta(
+            token_ids=sequence_meta.token_ids[:num_blocks * self.tokens_per_block],
+            tokens_per_block=self.tokens_per_block,
+            namespace=getattr(sequence_meta, "_namespace", None),
+        )
+        return self.index.match_prefix(clamped, update_cache_info=False)
+
+    def _resolve_swa_match(self,
+                           sequence_meta: SequenceMeta,
+                           upper_bound_blocks: int,
+                           match_result=None,
+                           lock_for_load: bool = False,
+                           ) -> Tuple[int, int, Optional["RadixNode"]]:
+        """Resolve the SWA hit from an existing Full-KV match or a clamped probe."""
+        if self.swa_pool is None or upper_bound_blocks <= 0:
+            return 0, -1, None
+        upper_bound_blocks = int(upper_bound_blocks)
+
+        mr = match_result
+        swa_node = getattr(mr, "last_swa_node", None) if mr is not None else None
+        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0) if mr is not None else 0
+
+        if swa_node is not None and swa_hit > upper_bound_blocks:
+            mr = None
+
+        if mr is None:
+            mr = self._probe_swa_match(sequence_meta, upper_bound_blocks)
+            swa_node = getattr(mr, "last_swa_node", None) if mr is not None else None
+            swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0) if mr is not None else 0
+
+        if swa_node is None or swa_hit <= 0 or swa_hit > upper_bound_blocks:
+            return 0, -1, None
+        slot = int(swa_node.swa_host_slot)
+        if slot < 0:
+            return 0, -1, None
+
+        self.index.promote_swa(swa_node)
+        if lock_for_load:
+            swa_node.inc_swa_lock_ref()
+        return swa_hit, slot, swa_node
+
     def match_swa(self,
                   sequence_meta: SequenceMeta,
                   upper_bound_blocks: int,
-                  lock_for_load: bool = False) -> Tuple[int, int]:
-        """Node-mounted SWA match on the Python RadixTreeIndex mirror.
+                  lock_for_load: bool = False,
+                  match_result=None,
+                  return_node: bool = False,
+                  ) -> Union[Tuple[int, int], Tuple[int, int, Optional["RadixNode"]]]:
+        """Canonical node-mounted SWA match on the Python RadixTreeIndex mirror.
 
-        Returns ``(swa_hit_blocks, slot_id)``; -1/0 when no SWA.
+        Pass ``match_result`` to reuse an existing Full-KV match; otherwise this
+        runs a clamped match-only probe. Returns ``(hit, slot)`` by default, or
+        ``(hit, slot, node)`` when ``return_node`` or ``lock_for_load`` is true.
+        The node is pinned only when ``lock_for_load`` is true. Miss is
+        ``0, -1[, None]``.
         """
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1
-        sequence_meta.gen_hashes()
-        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
-        if num_blocks <= 0:
-            return 0, -1
-        clamped = SequenceMeta(token_ids=sequence_meta.token_ids[:num_blocks * self.tokens_per_block],
-                               tokens_per_block=self.tokens_per_block)
-        mr = self.index.match_prefix(clamped, update_cache_info=False)
-        swa_node = getattr(mr, "last_swa_node", None)
-        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1
-        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
-        if lock_for_load:
-            swa_node.swa_lock_ref += 1
+        include_node = return_node or lock_for_load
+        swa_hit, slot, node = self._resolve_swa_match(
+            sequence_meta, upper_bound_blocks, match_result=match_result,
+            lock_for_load=lock_for_load)
+        if include_node:
+            return swa_hit, slot, node
         return swa_hit, slot
-
-    def match_swa_locked(self,
-                         sequence_meta: SequenceMeta,
-                         upper_bound_blocks: int) -> Tuple[int, int, Optional["RadixNode"]]:
-        """Like match_swa(lock_for_load=True) but ALSO returns the pinned node
-        (mirror of CacheEngineAccel.match_swa_locked)."""
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, None
-        sequence_meta.gen_hashes()
-        num_blocks = min(int(upper_bound_blocks), sequence_meta.num_blocks)
-        if num_blocks <= 0:
-            return 0, -1, None
-        clamped = SequenceMeta(token_ids=sequence_meta.token_ids[:num_blocks * self.tokens_per_block],
-                               tokens_per_block=self.tokens_per_block)
-        mr = self.index.match_prefix(clamped, update_cache_info=False)
-        swa_node = getattr(mr, "last_swa_node", None)
-        swa_hit = int(getattr(mr, "swa_hit_blocks", 0) or 0)
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1, None
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1, None
-        self.index.promote_swa(swa_node)  # read-hit保温 (before pin)
-        swa_node.swa_lock_ref += 1
-        return swa_hit, slot, swa_node
-
-    def match_swa_from_result(self,
-                              match_result,
-                              sequence_meta: SequenceMeta,
-                              upper_bound_blocks: int,
-                              lock_for_load: bool = False,
-                              ) -> Tuple[int, int, Optional["RadixNode"]]:
-        """Reuse an already-computed Full-KV match to resolve the SWA hit without
-        re-walking the tree (mirror of CacheEngineAccel.match_swa_from_result;
-        see it for the fallback rationale)."""
-        if self.swa_pool is None or upper_bound_blocks <= 0:
-            return 0, -1, None
-        swa_node = getattr(match_result, "last_swa_node", None) if match_result is not None else None
-        swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result is not None else 0
-        if swa_node is None or swa_hit <= 0:
-            return 0, -1, None
-        if swa_hit > upper_bound_blocks:
-            if lock_for_load:
-                return self.match_swa_locked(sequence_meta, upper_bound_blocks)
-            swa_hit2, slot2 = self.match_swa(
-                sequence_meta, upper_bound_blocks, lock_for_load=False)
-            return swa_hit2, slot2, None
-        slot = int(swa_node.swa_host_slot)
-        if slot < 0:
-            return 0, -1, None
-        # REUSE branch: promote here. The fallback branch above delegates to
-        # match_swa[_locked], which promote internally — do NOT double-promote.
-        self.index.promote_swa(swa_node)
-        if lock_for_load:
-            swa_node.swa_lock_ref += 1
-            return swa_hit, slot, swa_node
-        return swa_hit, slot, None
 
     def reset(self) -> None:
         self.index.reset()
@@ -826,11 +815,9 @@ class GlobalCacheEngine:
         #TODO move this to kvmanager.start()
         self.start()
 
-        # The trailing dict is the per-tier Full-KV match results (DeviceType ->
-        # MatchResult), so SWA slot resolution can reuse them (no re-walk).
         # Empty on a full miss.
-        self._empty_get_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, Dict]] = \
-            lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0, {})
+        self._empty_get_return: Callable[[int], FullKVGetPlan] = \
+            lambda request_id: FullKVGetPlan.empty()
         self._empty_put_return: Callable[[int], Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int, int]] = \
             lambda request_id: (TransferOpGraph.create_empty_graph(), [], {}, {}, {}, 0, 0)
 
@@ -922,34 +909,28 @@ class GlobalCacheEngine:
 
         if not self.cache_config.enable_remote or temp_cache_strategy.ignore_remote:
             # from this entrance, we will also handle the case of peer_cpu and peer_ssd
-            (transfer_graph, finished_ops_ids, node_to_unlock,
-             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer,
-             tier_match_results) = \
-                self._get_impl_local(
-                    request_id,
-                    sequence_meta,
-                    block_start_idx,
-                    block_end_idx,
-                    gpu_block_ids,
-                    temp_cache_strategy,
-                    dp_client_id,
-                    swa_aware=swa_aware,
-                )
+            full_plan = self._get_impl_local(
+                request_id,
+                sequence_meta,
+                block_start_idx,
+                block_end_idx,
+                gpu_block_ids,
+                temp_cache_strategy,
+                dp_client_id,
+                swa_aware=swa_aware,
+            )
         else:
             #TODO pcfs will be supported later
-            (transfer_graph, finished_ops_ids, node_to_unlock,
-             op_node_to_ready, buffer_to_free, num_gpu_blocks_to_transfer,
-             tier_match_results) = \
-                self._get_impl_global(
-                    request_id,
-                    sequence_meta,
-                    block_start_idx,
-                    block_end_idx,
-                    gpu_block_ids,
-                    temp_cache_strategy,
-                    dp_client_id,
-                    swa_aware=swa_aware,
-                )
+            full_plan = self._get_impl_global(
+                request_id,
+                sequence_meta,
+                block_start_idx,
+                block_end_idx,
+                gpu_block_ids,
+                temp_cache_strategy,
+                dp_client_id,
+                swa_aware=swa_aware,
+            )
 
         # SWA peer-op: build the SWA load chain into the SAME graph as the full-KV
         # ops and append its terminal SWA H2D to finished_ops_ids, so the VIRTUAL
@@ -959,31 +940,29 @@ class GlobalCacheEngine:
         # (graph.set_swa_gpu_blocks). build_get_chain is a no-op unless SWA
         # transfer is on and a tier has a live SWA hit. num_full_hit = the ready
         # full-KV prefix resident after this get (the SWA hit's upper bound).
-        num_full_hit = block_start_idx + num_gpu_blocks_to_transfer
-        (swa_gpu_slots, swa_cpu_slots, swa_ssd_slots, swa_remote_slots,
-         swa_lock_node, swa_staging_slot) = \
-            self._swa_get_slots(request_id, sequence_meta, block_start_idx,
-                                block_end_idx, num_full_hit,
-                                tier_match_results=tier_match_results)
+        num_full_hit = block_start_idx + full_plan.num_gpu_blocks_to_transfer
+        swa_source = self._resolve_swa_get_source(
+            request_id, sequence_meta, block_start_idx, block_end_idx,
+            num_full_hit, tier_match_results=full_plan.tier_match_results)
         swa_h2d_id = self.swa_cache.build_get_chain(
-            transfer_graph,
-            gpu_slot_ids=swa_gpu_slots,
-            cpu_slot_ids=swa_cpu_slots,
-            ssd_slot_ids=swa_ssd_slots,
-            remote_slot_ids=swa_remote_slots,
+            full_plan.transfer_graph,
+            gpu_slot_ids=swa_source.gpu_slots,
+            cpu_slot_ids=swa_source.cpu_slots,
+            ssd_slot_ids=swa_source.ssd_slots,
+            remote_slot_ids=swa_source.remote_slots,
             dp_client_id=dp_client_id,
         )
         if swa_h2d_id is not None:
-            finished_ops_ids.append(swa_h2d_id)
+            full_plan.finished_ops_ids.append(swa_h2d_id)
         transfer_graph, task_end_op_id = add_virtual_op_for_multiple_finished_ops(
-            transfer_graph,
-            finished_ops_ids,
+            full_plan.transfer_graph,
+            full_plan.finished_ops_ids,
             dp_client_id,
             )
 
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
         return_mask[block_start_idx* self.tokens_per_block:
-                    (block_start_idx + num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
+                    (block_start_idx + full_plan.num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
 
         # if layer_num // layer_granularity != 1:
         #     transfer_graph, finished_ops_ids = convert_read_graph_to_layer_wise_graph(transfer_graph=transfer_graph,
@@ -991,32 +970,32 @@ class GlobalCacheEngine:
         #                                                                         layer_num=layer_num,
         #                                                                         layer_granularity=layer_granularity)
 
-        for device_type in node_to_unlock:
-            self.cache_engines[device_type].lock_node(node_to_unlock[device_type][0])
+        for device_type in full_plan.node_to_unlock:
+            self.cache_engines[device_type].lock_node(full_plan.node_to_unlock[device_type][0])
 
         callback = partial(self._transfer_callback,
-                           node_to_unlock=node_to_unlock,
-                           buffer_to_free=buffer_to_free)
+                           node_to_unlock=full_plan.node_to_unlock,
+                           buffer_to_free=full_plan.buffer_to_free)
 
         op_callback_dict = {} # dict, op_id -> callback
-        for op_id in op_node_to_ready:
+        for op_id in full_plan.op_node_to_ready:
             op_callback_dict[op_id] = partial(self._op_callback,
-                                              device_type=op_node_to_ready[op_id][0],
-                                              node_to_ready=op_node_to_ready[op_id][1],
-                                              ready_length=op_node_to_ready[op_id][2])
+                                              device_type=full_plan.op_node_to_ready[op_id][0],
+                                              node_to_ready=full_plan.op_node_to_ready[op_id][1],
+                                              ready_length=full_plan.op_node_to_ready[op_id][2])
 
-        # SWA load lock release: _swa_get_slots pinned the matched CPU SWA node
+        # SWA load lock release: _resolve_swa_get_source pinned the matched SWA node
         # (lock_for_load) so it can't be evicted before the SWA H2D reads it. When
         # that H2D completes, release the pin. Keyed on the SWA H2D op so it fires
         # exactly once on completion, alongside the full-KV op callbacks.
         # The SWA H2D completion callback releases the source-tier pin and, for a
         # staged (SSD/REMOTE) source, frees the transient CPU staging slot. Keyed
         # on the SWA H2D op so it fires exactly once, alongside the full-KV ops.
-        if swa_h2d_id is not None and (swa_lock_node is not None
-                                       or swa_staging_slot >= 0):
+        if swa_h2d_id is not None and (swa_source.lock_node is not None
+                                       or swa_source.staging_slot >= 0):
             op_callback_dict[swa_h2d_id] = partial(
-                self._swa_release_load_lock, node=swa_lock_node,
-                staging_slot=swa_staging_slot)
+                self._swa_release_load_lock, node=swa_source.lock_node,
+                staging_slot=swa_source.staging_slot)
 
         # Record metrics for GET operation
         if self._metrics_collector is not None:
@@ -1034,7 +1013,7 @@ class GlobalCacheEngine:
             temp_cache_strategy: CacheStrategy,
             dp_client_id: int,
             swa_aware: bool = False) \
-                 -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
+                 -> FullKVGetPlan:
         """
         transfer pattern:
 
@@ -1232,12 +1211,18 @@ class GlobalCacheEngine:
         # NOTE: for now in build transfer graph, we assume that cpu works as a cache for ssd
         # Trailing dict: per-tier Full-KV match results, so SWA slot resolution
         # reuses them instead of re-walking the tree.
-        return (
-            transfer_graph, finished_ops_ids, node_to_unlock, {}, buffer_to_free,
-            len(fragment123_gpu_blocks) if enable_gpu else 0,  # op_node_to_ready: {}
-            {DeviceType.CPU: cpu_matched_result,
-             DeviceType.SSD: ssd_matched_result,
-             DeviceType.REMOTE: remote_matched_result},
+        return FullKVGetPlan(
+            transfer_graph=transfer_graph,
+            finished_ops_ids=finished_ops_ids,
+            node_to_unlock=node_to_unlock,
+            op_node_to_ready={},
+            buffer_to_free=buffer_to_free,
+            num_gpu_blocks_to_transfer=len(fragment123_gpu_blocks) if enable_gpu else 0,
+            tier_match_results={
+                DeviceType.CPU: cpu_matched_result,
+                DeviceType.SSD: ssd_matched_result,
+                DeviceType.REMOTE: remote_matched_result,
+            },
         )
 
     def _get_impl_local(self,
@@ -1249,7 +1234,7 @@ class GlobalCacheEngine:
                         temp_cache_strategy: CacheStrategy,
                         dp_client_id: int,
                         swa_aware: bool = False) \
-                            -> Tuple[TransferOpGraph, List[int], Dict, Dict, Dict, int]:
+                            -> FullKVGetPlan:
         """
         transfer pattern:
 
@@ -1467,11 +1452,17 @@ class GlobalCacheEngine:
         nvtx.end_range(nvtx_range)
         # Trailing dict: per-tier Full-KV match results, so SWA slot resolution
         # reuses them instead of re-walking the tree.
-        return (
-            transfer_graph, finished_ops_ids, node_to_unlock, op_node_to_ready,
-            buffer_to_free, len(fragment12_gpu_blocks) if enable_gpu else 0,
-            {DeviceType.CPU: cpu_matched_result,
-             DeviceType.SSD: ssd_matched_result},
+        return FullKVGetPlan(
+            transfer_graph=transfer_graph,
+            finished_ops_ids=finished_ops_ids,
+            node_to_unlock=node_to_unlock,
+            op_node_to_ready=op_node_to_ready,
+            buffer_to_free=buffer_to_free,
+            num_gpu_blocks_to_transfer=len(fragment12_gpu_blocks) if enable_gpu else 0,
+            tier_match_results={
+                DeviceType.CPU: cpu_matched_result,
+                DeviceType.SSD: ssd_matched_result,
+            },
         )
 
     def put(self,
@@ -2003,7 +1994,7 @@ class GlobalCacheEngine:
         Each tier's match_prefix returned ``swa_hit_blocks`` on the same pass that
         produced its Full-KV hit, already <= that tier's Full-KV hit (SWA subset
         of Full). Returns 0 when SWA is disabled or no tier has a live SWA hit.
-        Read-only: the promote/pin happens later in _swa_get_slots.
+        Read-only: the promote/pin happens later in _resolve_swa_get_source.
         """
         if not self.swa_cache.enabled or not tier_match_results:
             return 0
@@ -2043,16 +2034,14 @@ class GlobalCacheEngine:
 
     _SWA_GPU_PLACEHOLDER = np.array([0], dtype=np.int64)
 
-    def _empty_swa_slots(self, with_node: bool = False):
+    def _empty_swa_put_slots(self):
         empty = np.array([], dtype=np.int64)
-        if with_node:
-            # (gpu, cpu, ssd, remote, lock_node, staging_slot)
-            return empty, empty, empty, empty, None, -1
         return empty, empty, empty, empty
 
-    def _swa_get_slots(self, request_id, sequence_meta, block_start_idx,
-                       block_end_idx, full_hit_blocks, tier_match_results=None):
-        """Resolve SWA-pool slots for a GET (load), sourced across tiers.
+    def _resolve_swa_get_source(self, request_id, sequence_meta, block_start_idx,
+                                block_end_idx, full_hit_blocks,
+                                tier_match_results=None) -> SWAGetSource:
+        """Resolve the complete SWA GET source plan across tiers.
 
         Mirrors full-KV multi-tier staging: the trailing SWA window (page
         granular, one slot) is sourced from the highest-priority tier that holds
@@ -2068,32 +2057,29 @@ class GlobalCacheEngine:
 
         ``tier_match_results`` (DeviceType -> MatchResult), when provided, is the
         Full-KV match already computed for this get; each tier resolves its SWA
-        slot via ``match_swa_from_result`` (reuse it, no re-walk). When None, each
-        tier falls back to a fresh ``match_swa_locked`` probe.
+        slot via the canonical ``match_swa(..., match_result=..., lock_for_load)``
+        path. Without a match result, ``match_swa`` performs a fresh clamped probe.
 
-        Returns ``(gpu, cpu, ssd, remote, lock_node, staging_slot)``.
-        ``cpu`` is always the SWA H2D source (matched CPU slot OR staging slot);
-        ``ssd``/``remote`` are non-empty only for a staged source; ``staging_slot``
-        is the transient CPU slot to free on H2D completion (-1 when CPU-sourced).
-        Empty when SWA is disabled or no tier holds the window."""
+        Returns an ``SWAGetSource`` carrying both graph slots and lifecycle
+        metadata. ``cpu_slots`` is always the SWA H2D source (matched CPU slot OR
+        staging slot); ``ssd_slots``/``remote_slots`` are non-empty only for a
+        staged source; ``staging_slot`` is the transient CPU slot to free on H2D
+        completion (-1 when CPU-sourced). Empty when SWA is disabled or no tier
+        holds the window."""
         if not self.swa_cache.enabled or full_hit_blocks <= 0:
-            return self._empty_swa_slots(with_node=True)
+            return SWAGetSource.empty()
         cpu_engine = self.cpu_cache_engine
         if cpu_engine is None or not getattr(cpu_engine, "swa_enabled", False):
-            return self._empty_swa_slots(with_node=True)
+            return SWAGetSource.empty()
         gpu = self._SWA_GPU_PLACEHOLDER.copy()
         empty = np.array([], dtype=np.int64)
 
         def _match_locked(engine, device_type):
-            """Resolve (hit, slot, node) for a tier, pinned for load. Reuse
-            the given match result when available, else probe the tree."""
+            """Resolve (hit, slot, node) for a tier, pinned for load."""
             mr = tier_match_results.get(device_type) if tier_match_results else None
-            if mr is not None:
-                return engine.match_swa_from_result(
-                    mr, sequence_meta, upper_bound_blocks=full_hit_blocks,
-                    lock_for_load=True)
-            return engine.match_swa_locked(
-                sequence_meta, upper_bound_blocks=full_hit_blocks)
+            return engine.match_swa(
+                sequence_meta, upper_bound_blocks=full_hit_blocks,
+                lock_for_load=True, match_result=mr, return_node=True)
 
         # 1) CPU tier first (preferred, no staging). The matched CPU SWA node is
         #    pinned; the H2D completion callback releases the pin.
@@ -2101,7 +2087,16 @@ class GlobalCacheEngine:
             _match_locked(cpu_engine, DeviceType.CPU)
         if swa_hit > 0 and cpu_slot >= 0:
             cpu = np.array([cpu_slot], dtype=np.int64)
-            return gpu, cpu, empty, empty, lock_node, -1
+            return SWAGetSource(
+                hit_blocks=swa_hit,
+                source_tier=DeviceType.CPU,
+                gpu_slots=gpu,
+                cpu_slots=cpu,
+                ssd_slots=empty,
+                remote_slots=empty,
+                lock_node=lock_node,
+                staging_slot=-1,
+            )
 
         # 2) Fall back to SSD then REMOTE: source tier stages into a transient
         #    CPU SWA slot (DISK2H/REMOTE2H -> CPU) that the SWA H2D then reads.
@@ -2121,14 +2116,23 @@ class GlobalCacheEngine:
                 if tier_node is not None and getattr(tier_node, "swa_lock_ref", 0) > 0:
                     tier_node.dec_swa_lock_ref()
                 cpu_engine._drain_swa_slots()
-                return self._empty_swa_slots(with_node=True)
+                return SWAGetSource.empty()
             cpu = np.array([staging_slot], dtype=np.int64)
             tier = np.array([tier_slot], dtype=np.int64)
             ssd = tier if device_type == DeviceType.SSD else empty
             remote = tier if device_type == DeviceType.REMOTE else empty
-            return gpu, cpu, ssd, remote, tier_node, staging_slot
+            return SWAGetSource(
+                hit_blocks=tier_hit,
+                source_tier=device_type,
+                gpu_slots=gpu,
+                cpu_slots=cpu,
+                ssd_slots=ssd,
+                remote_slots=remote,
+                lock_node=tier_node,
+                staging_slot=staging_slot,
+            )
 
-        return self._empty_swa_slots(with_node=True)
+        return SWAGetSource.empty()
 
     def _swa_put_slots(self, request_id, sequence_meta, block_start_idx,
                        block_end_idx, node_to_unlock):
@@ -2153,13 +2157,13 @@ class GlobalCacheEngine:
                           if node_to_unlock and DeviceType.CPU in node_to_unlock
                           else None)
         if not self.swa_cache.enabled or cpu_store_node is None:
-            return self._empty_swa_slots()
+            return self._empty_swa_put_slots()
         cpu_engine = self.cpu_cache_engine
         if cpu_engine is None or not getattr(cpu_engine, "swa_enabled", False):
-            return self._empty_swa_slots()
+            return self._empty_swa_put_slots()
         slot = cpu_engine.swa_alloc_slot()
         if slot < 0:
-            return self._empty_swa_slots()
+            return self._empty_swa_put_slots()
         cpu_engine.set_swa(cpu_store_node, slot)
         cpu_engine._drain_swa_slots()
         cpu = np.array([slot], dtype=np.int64)

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -55,7 +55,8 @@ class CacheEngineAccel:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 swa_config: Optional["SWAPoolConfig"] = None):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -87,9 +88,14 @@ class CacheEngineAccel:
         # flexkv/cache/radixtree.py); this engine only owns the SWA host-pool
         # (slot bytes + free-list) and the slot alloc/free/drain plumbing. SWA
         # and Full eviction are UNIFIED through the one tree so the two pools
-        # never drift (see deployments/swa_design/08_节点挂载SWA架构.md). Created
-        # lazily via init_swa(); None until then.
+        # never drift (see deployments/swa_design/08_节点挂载SWA架构.md). This
+        # engine owns SWA initialization for its tier; init_swa() remains public
+        # for tests and explicit embedding.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine.
@@ -421,7 +427,8 @@ class CacheEngine:
                  evict_start_threshold: float = 1.0,
                  eviction_policy: str = "lru",
                  event_collector: Optional[KVEventCollector] = None,
-                 metrics_collector = None):
+                 metrics_collector = None,
+                 swa_config: Optional["SWAPoolConfig"] = None):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -447,9 +454,13 @@ class CacheEngine:
         self.event_collector = event_collector
         self._metrics_collector = metrics_collector
 
-        # Node-mounted SWA host pool (non-accel Python RadixTreeIndex mirror);
-        # None until init_swa(). See CacheEngineAccel for the semantics.
+        # Node-mounted SWA host pool (non-accel Python RadixTreeIndex mirror).
+        # See CacheEngineAccel for the semantics.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
@@ -739,7 +750,8 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             else:
                 self.cpu_cache_engine = CacheEngine(DeviceType.CPU,
                                                 cache_config.num_cpu_blocks,
@@ -749,22 +761,9 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
-            # Initialize the node-mounted SWA host pool on the CPU engine when SWA
-            # is enabled (DSv4). Without this the SWA pool is never constructed and
-            # a SWA-aware get finds no SWA. Guarded by hasattr because the non-accel
-            # CacheEngine fallback (Python RadixTreeIndex) also supports it.
-            swa_config = getattr(cache_config, "swa", None)
-            if swa_config is not None and getattr(swa_config, "enabled", False):
-                if hasattr(self.cpu_cache_engine, "init_swa"):
-                    self.cpu_cache_engine.init_swa(swa_config)
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] cache_config.swa is enabled but the CPU cache "
-                        f"engine {type(self.cpu_cache_engine).__name__} has no "
-                        "init_swa(); SWA matching disabled."
-                    )
         if cache_config.enable_ssd:
             if cache_config.enable_p2p_ssd:
                 self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta)
@@ -777,7 +776,8 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             else:
                 self.ssd_cache_engine = CacheEngine(DeviceType.SSD,
                                                 cache_config.num_ssd_blocks,
@@ -787,22 +787,9 @@ class GlobalCacheEngine:
                                                 self.evict_start_threshold,
                                                 self.eviction_policy,
                                                 event_collector,
-                                                self._metrics_collector)
+                                                self._metrics_collector,
+                                                swa_config=cache_config.swa)
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
-            # SSD SWA tier (mirrors the CPU SWA tier above): a node-mounted SWA
-            # host pool on the SSD engine, num_ssd_slots slots. Enables CPU<->SSD SWA tiering (write-through on
-            # store, SWA_SSD2H->SWA_H2D on load). Skipped when num_ssd_slots == 0.
-            swa_config_ssd = getattr(cache_config, "swa", None)
-            if (swa_config_ssd is not None and getattr(swa_config_ssd, "enabled", False)
-                    and getattr(swa_config_ssd, "num_ssd_slots", 0) > 0):
-                if hasattr(self.ssd_cache_engine, "init_swa"):
-                    self.ssd_cache_engine.init_swa(swa_config_ssd.for_ssd_tier())
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] SSD SWA requested but the SSD cache engine "
-                        f"{type(self.ssd_cache_engine).__name__} has no init_swa(); "
-                        "SSD SWA tier disabled."
-                    )
         if cache_config.enable_remote:
             if cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
@@ -816,7 +803,8 @@ class GlobalCacheEngine:
                                                    self.evict_start_threshold,
                                                    self.eviction_policy,
                                                    None,
-                                                   self._metrics_collector)
+                                                   self._metrics_collector,
+                                                   swa_config=cache_config.swa)
             else:
                 self.remote_cache_engine = CacheEngine(DeviceType.REMOTE,
                                                    cache_config.num_remote_blocks,
@@ -826,21 +814,9 @@ class GlobalCacheEngine:
                                                    self.evict_start_threshold,
                                                    self.eviction_policy,
                                                    None,
-                                                   self._metrics_collector)
+                                                   self._metrics_collector,
+                                                   swa_config=cache_config.swa)
             self.cache_engines[DeviceType.REMOTE] = self.remote_cache_engine
-            # REMOTE SWA tier (mirrors the CPU/SSD SWA tiers): a node-mounted SWA
-            # host pool on the REMOTE engine, num_remote_slots slots. Skipped when 0.
-            swa_config_remote = getattr(cache_config, "swa", None)
-            if (swa_config_remote is not None and getattr(swa_config_remote, "enabled", False)
-                    and getattr(swa_config_remote, "num_remote_slots", 0) > 0):
-                if hasattr(self.remote_cache_engine, "init_swa"):
-                    self.remote_cache_engine.init_swa(swa_config_remote.for_remote_tier())
-                else:
-                    flexkv_logger.warning(
-                        "[SWA] REMOTE SWA requested but the REMOTE cache engine "
-                        f"{type(self.remote_cache_engine).__name__} has no init_swa(); "
-                        "REMOTE SWA tier disabled."
-                    )
 
         # SWA control plane: multi-tier match + peer-op graph construction. Built
         # after the per-tier cache engines (and their swa_pool) exist; reaches

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -134,13 +134,22 @@ class HierarchyLRCacheEngine:
     def match_swa(self,
                   sequence_meta: "SequenceMeta",
                   upper_bound_blocks: int,
-                  lock_for_load: bool = False):
-        """Node-mounted SWA match. Returns no-hit unless the (remote) radix index
-        exposes last_swa_node on its match result."""
+                  lock_for_load: bool = False,
+                  match_result=None,
+                  return_node: bool = False):
+        """Node-mounted SWA match no-op for hierarchical remote indexes.
+
+        Kept signature-compatible with CacheEngine[Accel].match_swa so callers can
+        resolve SWA slots without branching on the concrete tier engine.
+        """
         if self.swa_pool is None or upper_bound_blocks <= 0:
+            if return_node or lock_for_load:
+                return 0, -1, None
             return 0, -1
         # The distributed/remote radix index does not surface node-mounted SWA
         # yet; report no hit (SWA is served by the accel CPU tier for DSv4).
+        if return_node or lock_for_load:
+            return 0, -1, None
         return 0, -1
 
     def start(self) -> None:

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -38,7 +38,8 @@ class HierarchyLRCacheEngine:
                  evict_start_threshold: float = 1.0,
                  hit_reward_seconds: int = 0,
                  eviction_policy: str = "lru",
-                 meta: Optional[RedisMeta] = None) -> None:
+                 meta: Optional[RedisMeta] = None,
+                 swa_config: Optional[SWAPoolConfig] = None) -> None:
         if num_total_blocks <= 0:
             raise ValueError(f"Invalid num_total_blocks: {num_total_blocks}")
         if tokens_per_block <= 0 or (tokens_per_block & (tokens_per_block - 1)) != 0:
@@ -106,6 +107,10 @@ class HierarchyLRCacheEngine:
         # only reports a hit when the underlying index exposes last_swa_node.
         # DSv4 uses CacheEngineAccel (index_accel), not this engine.
         self.swa_pool = None
+        tier_swa_config = (swa_config.for_cache_tier(device_type)
+                           if swa_config is not None else None)
+        if tier_swa_config is not None:
+            self.init_swa(tier_swa_config)
 
     def init_swa(self, swa_config: "SWAPoolConfig") -> None:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
@@ -566,6 +571,7 @@ class HierarchyLRCacheEngine:
             local_safety_ttl_ms=int(GLOBAL_CONFIG_FROM_ENV.safety_ttl_ms),
             eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
             meta=meta,
+            swa_config=getattr(cache_config, "swa", None),
         )
 
     #TODO is this enough for peercpu and peerssd?
@@ -607,5 +613,6 @@ class HierarchyLRCacheEngine:
                 hit_reward_seconds=int(GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds),
                 eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
                 meta=meta,
+                swa_config=getattr(cache_config, "swa", None),
             )
             raise ValueError("Invalid device type: {cache_config.device_type}")

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -492,6 +492,23 @@ class SWAPoolConfig:
         REMOTE SWA slots are not pinned host memory; pin_memory is forced off."""
         return replace(self, num_slots=self.num_remote_slots, pin_memory=False)
 
+    def for_cache_tier(self, device_type) -> Optional["SWAPoolConfig"]:
+        """Return the SWA config this cache tier should own, or None.
+
+        CPU uses the primary pool config. SSD and REMOTE use their tier-specific
+        slot counts and are disabled when that tier's slot count is zero.
+        """
+        if not self.enabled:
+            return None
+        device_name = getattr(device_type, "name", str(device_type))
+        if device_name == "CPU":
+            return self
+        if device_name == "SSD" and self.num_ssd_slots > 0:
+            return self.for_ssd_tier()
+        if device_name == "REMOTE" and self.num_remote_slots > 0:
+            return self.for_remote_tier()
+        return None
+
 
 @dataclass
 class CacheConfig:

--- a/flexkv/common/type.py
+++ b/flexkv/common/type.py
@@ -17,7 +17,7 @@ class MatchResultAccel:
     insert_to_local_cpu_index: bool = True
     # ===== SWA (node-mounted) — passed through from CMatchResult so the SWA
     # slot resolution can reuse the SAME forward match instead of re-walking the
-    # tree (see CacheEngineAccel.match_swa_from_result). The deepest
+    # tree (see CacheEngineAccel.match_swa(..., match_result=...)). The deepest
     # fully-matched ready node carrying a live SWA slot, and the ready-prefix
     # block count ending at it. None / 0 when no SWA on the matched path.
     last_swa_node: Optional['CRadixNode'] = None

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -380,5 +380,5 @@ class KVManager:
         if engine is None:
             return "cpu_cache_engine missing (no in-process engine)"
         if not getattr(engine, "swa_enabled", False):
-            return "SWA host pool not initialized (call init_swa)"
+            return "SWA host pool not initialized on cpu_cache_engine"
         return None

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -8,8 +8,8 @@ Two concerns, both cheap (no TransferManager subprocess, no GPU):
    the new ``swa_slot_mapping`` field, and shed_heavy_resources.
 
 2. The SWA load-lock lifecycle on ``GlobalCacheEngine``: a GET pins the matched
-   CPU SWA node (``_swa_get_slots`` -> match_swa_locked), and the SWA H2D
-   completion callback releases it (``_swa_release_load_lock``), leaving the
+   CPU SWA node (``_resolve_swa_get_source`` -> match_swa(lock_for_load=True)),
+   and the SWA H2D completion callback releases it (``_swa_release_load_lock``), leaving the
    node cached (dec_swa_lock_ref, NOT dec_swa_lock_only). This documents that
    the SWA lock follows the SAME lifecycle as the full-KV node lock (both taken
    in get()/put(), both released via the op/transfer callbacks) — so a fresh
@@ -191,7 +191,7 @@ def test_get_pins_then_releases_swa_lock():
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
     hit, slot = eng.cpu_cache_engine.match_swa(sm, upper_bound_blocks=4)
     assert hit == 4
-    # The node carries the load pin (>=1) taken by _swa_get_slots.
+    # The node carries the load pin (>=1) taken by _resolve_swa_get_source.
     node = eng.cpu_cache_engine.index.match_prefix(
         torch.from_numpy(sm.block_hashes[:4]).to(torch.int64), 4, False).last_swa_node
     assert node.swa_lock_ref >= 1

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -30,10 +30,10 @@ import torch
 
 pytest.importorskip("flexkv.c_ext")
 
-from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.cache.cache_engine import CacheEngineAccel, GlobalCacheEngine
 from flexkv.common.block import SequenceMeta
 from flexkv.common.config import CacheConfig, ModelConfig, SWAPoolConfig
-from flexkv.common.transfer import TransferType
+from flexkv.common.transfer import DeviceType, TransferType
 from flexkv.common.debug import flexkv_logger
 
 flexkv_logger.set_level("OFF")
@@ -102,6 +102,25 @@ def _full_ops(graph):
 def _tokens(n_blocks, base):
     rs = np.random.RandomState(base)
     return rs.randint(0, 30000, size=n_blocks * TPB, dtype=np.int64)
+
+
+def test_cpu_cache_engine_initializes_swa_pool_from_constructor():
+    swa_config = SWAPoolConfig(
+        enabled=True,
+        num_slots=7,
+        num_swa_layers=1,
+        bytes_per_token_per_layer=64,
+    )
+    eng = CacheEngineAccel(
+        DeviceType.CPU,
+        num_total_blocks=32,
+        tokens_per_block=TPB,
+        evict_ratio=0.1,
+        swa_config=swa_config,
+    )
+
+    assert eng.swa_enabled
+    assert eng.swa_pool.num_slots == 7
 
 
 def _complete(op_cb, cb):

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -70,7 +70,7 @@ def _cache_config_ssd(enable_swa_transfer: bool = True):
     """CPU + SSD tiers, both with an SWA host pool. The SSD cache engine is an
     in-memory radix+mempool+swa_pool (no real SSD files at construction — files
     are only touched by the data-plane worker at transfer time), so multi-tier
-    SWA orchestration (_swa_put_slots / _swa_get_slots) is testable at smoke
+    SWA orchestration (_swa_put_slots / _resolve_swa_get_source) is testable at smoke
     level without disk I/O."""
     cc = CacheConfig(
         tokens_per_block=TPB,
@@ -189,9 +189,36 @@ def test_get_builds_full_plus_swa_load_chain():
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
     _complete(gop_cb, gcb)
     # after release, the node's SWA is unlocked (a fresh match can lock again).
-    hit, slot, node = eng.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=4)
+    hit, slot, node = eng.cpu_cache_engine.match_swa(
+        sm, upper_bound_blocks=4, lock_for_load=True, return_node=True)
     assert node is not None and node.swa_lock_ref == 1
     node.dec_swa_lock_ref()
+
+
+def test_match_swa_canonical_reuses_match_result_and_clamps():
+    eng = GlobalCacheEngine(_cache_config(True), _model_config())
+    tok = _tokens(4, base=31)
+    mask = np.ones_like(tok, dtype=np.int64)
+    slot_mapping = np.arange(tok.shape[0], dtype=np.int64)
+    _g, _rm, cb, op_cb, _e = eng.put(
+        request_id=1, token_ids=tok, token_mask=mask,
+        slot_mapping=slot_mapping, dp_client_id=0)
+    _complete(op_cb, cb)
+
+    sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB)
+    mr = eng.cpu_cache_engine.match(sm)
+
+    hit, slot, node = eng.cpu_cache_engine.match_swa(
+        sm, upper_bound_blocks=4, match_result=mr,
+        lock_for_load=True, return_node=True)
+    assert hit == 4 and slot >= 0
+    assert node is not None and node.swa_lock_ref == 1
+    node.dec_swa_lock_ref()
+
+    hit2, slot2, node2 = eng.cpu_cache_engine.match_swa(
+        sm, upper_bound_blocks=2, match_result=mr,
+        lock_for_load=True, return_node=True)
+    assert (hit2, slot2, node2) == (0, -1, None)
 
 
 def test_gate_off_no_swa_ops_in_control_plane_graph():
@@ -295,7 +322,7 @@ def test_no_swa_slot_mapping_leaves_placeholder():
 
 # =========================================================================== #
 # 3. multi-tier SWA orchestration (CPU + SSD): write-through + get staging     #
-#    These exercise _swa_put_slots / _swa_get_slots across tiers (the layer    #
+#    These exercise _swa_put_slots / _resolve_swa_get_source across tiers.     #
 #    that was CPU-only). Written TDD-first: they FAIL against CPU-only code.    #
 # =========================================================================== #
 

--- a/tests/test_swa_control_plane_e2e.py
+++ b/tests/test_swa_control_plane_e2e.py
@@ -5,7 +5,7 @@
 
 This is the production-path proof for the SWA data plane: the transfer graph is
 produced by ``GlobalCacheEngine.put()`` / ``get()`` (which call the now-wired
-``_swa_put_slots`` / ``_swa_get_slots`` — real SWA-pool alloc + node-mounted
+``_swa_put_slots`` / ``_resolve_swa_get_source`` — real SWA-pool alloc + node-mounted
 match, plus the size-1 GPU placeholder), the GPU sides are bound LATE via
 ``set_gpu_blocks`` (full-KV) and ``set_swa_gpu_blocks`` (SWA) exactly as
 ``KVTaskEngine.launch`` does, and the resulting graph is submitted to a real
@@ -191,7 +191,7 @@ def main() -> int:
     # zero the GPU pools so GET must source from CPU
     mk_pool.zero_(); sw_pool.zero_(); torch.cuda.synchronize()
 
-    # ===== GET via GlobalCacheEngine.get() (real _swa_get_slots) ===============
+    # ===== GET via GlobalCacheEngine.get() (real _resolve_swa_get_source) ======
     get_slot_mapping = np.arange(GET_FULL_GPU * TOKENS_PER_BLOCK,
                                  (GET_FULL_GPU + 1) * TOKENS_PER_BLOCK, dtype=np.int64)
     get_graph, _rm2, get_cb, get_op_cb, get_end = engine.get(
@@ -229,7 +229,8 @@ def main() -> int:
 
     # SWA lock released by the H2D callback (no leak).
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK); sm.gen_hashes()
-    hit, slot, node = engine.cpu_cache_engine.match_swa_locked(sm, upper_bound_blocks=1)
+    hit, slot, node = engine.cpu_cache_engine.match_swa(
+        sm, upper_bound_blocks=1, lock_for_load=True, return_node=True)
     if node is not None:
         lock_ok = (node.swa_lock_ref == 1)  # our fresh probe lock; prior load lock released
         node.dec_swa_lock_ref()

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -870,11 +870,11 @@ def test_full_evict_no_cascade_when_swa_disabled():
 
 
 # --------------------------------------------------------------------------- #
-# Double-match elimination: match_swa_from_result reuse + fallback             #
+# Double-match elimination: match_swa(match_result=...) reuse + fallback       #
 # --------------------------------------------------------------------------- #
 
-def test_match_swa_from_result_reuses_within_bound():
-    """match_swa_from_result reuses the Full-KV match when swa_hit <= bound."""
+def test_match_swa_match_result_reuses_within_bound():
+    """match_swa(match_result=...) reuses the Full-KV match when swa_hit <= bound."""
     idx = RadixTreeIndex(tokens_per_block=TPB)
     n1 = idx.insert(_seq([1, 2, 3, 4, 5, 6, 7, 8]), _phys(0, 1, 2, 3), is_ready=True)
     idx.set_swa(n1, slot=100)

--- a/tests/test_swa_ssd_staging_e2e.py
+++ b/tests/test_swa_ssd_staging_e2e.py
@@ -14,9 +14,9 @@ does not cover:
   GET : engine.get() -> graph {full H2D, SWA DISK2H (SSD->CPU staging) -> SWA H2D
         (CPU->GPU)} -> bytes restored to a fresh GPU SWA slot -> byte-exact.
 
-This exercises the multi-tier _swa_put_slots (write-through) and _swa_get_slots
-(SSD->CPU transient staging slot + H2D), plus the transient staging slot free on
-H2D completion.
+This exercises the multi-tier _swa_put_slots (write-through) and
+_resolve_swa_get_source (SSD->CPU transient staging slot + H2D), plus the
+transient staging slot free on H2D completion.
 
 Run INSIDE the container on a free GPU:
     CUDA_VISIBLE_DEVICES=0 python3 tests/test_swa_ssd_staging_e2e.py


### PR DESCRIPTION
## Summary
- build this branch on top of #205 and the #207 SWA-pool initialization move; it does not include the follow-up `harden swa test coverage` commit
- consolidate per-tier SWA matching into the canonical `match_swa(...)` entry point
- remove `match_swa_locked()` and `match_swa_from_result()` because there are no external callers
- replace the GET-side long tuple with `FullKVGetPlan` so Full-KV graph metadata is passed as one named object
- replace `_swa_get_slots()` with `_resolve_swa_get_source()` returning `SWAGetSource`, which carries source tier, graph slots, source pin, and transient staging-slot metadata
- update docs to explain external `get_match()` vs internal Full-KV match, Full-KV metadata flow, why `match_result` and `lock_for_load` are needed, and GET/PUT timing diagrams

## Validation
- `python3 -m py_compile flexkv/cache/cache_engine.py flexkv/cache/hie_cache_engine.py flexkv/common/type.py flexkv/common/config.py flexkv/kvmanager.py tests/test_swa_control_plane.py tests/test_swa_control_plane_e2e.py tests/test_kvtask_lifecycle.py tests/test_swa_node_mount.py tests/test_swa_ssd_staging_e2e.py`
- `git diff --check origin/dpskv4_refactor...HEAD`
- old helper search: no `_swa_get_slots`, `match_swa_locked`, or `match_swa_from_result` references remain
- `python3 -m pytest tests/test_swa_node_mount.py tests/test_swa_control_plane.py tests/test_swa_control_plane_e2e.py tests/test_kvtask_lifecycle.py` not run locally: system Python reports `No module named pytest`
