### PR TITLE
Add and harden FlexKV stress benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ cover/
 
 # logs
 *.log
+
+# Benchmark outputs
+benchmark_results/

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""FlexKV benchmark helpers."""

--- a/benchmarks/flexkv_stress/DESIGN.md
+++ b/benchmarks/flexkv_stress/DESIGN.md
@@ -7,7 +7,7 @@ load/store、layerwise、SWA、并发和异步接口，重点验证长时间运�
 有效载荷吞吐。它不模拟模型计算，也不把 token 生成时间计入 FlexKV 传输性能。
 
 CPU stub 用于无加速卡环境下的控制流回归。它会真实分配 CPU PyTorch tensor，并验证
-TP/DP 路由、prefix、PUT/GET、readback 和 byte pattern，但不覆盖 CUDA/ROCm IPC、原生
+TP/DP 路由、prefix、PUT/GET、readback 和 byte pattern，但不覆盖 CUDA IPC、原生
 kernel、eventfd 或 SSD，因此不能替代硬件压力测试。
 
 ## 执行链路
@@ -127,13 +127,13 @@ operation 和可选目标 payload 后停止；match、workload 生成和 readbac
 
 ## 带宽与容量口径
 
-`transfer_bytes` 是 FlexKV launch 的逻辑有效载荷，不是 PCIe/ROCm profiler 读到的总线
+`transfer_bytes` 是 FlexKV launch 的逻辑有效载荷，不是 PCIe profiler 读到的总线
 transaction bytes。主 KV 按去重后的物理 page 数乘 `main_page_bytes`；SWA 按 SWA page
 数乘 `swa_page_bytes`。因此该口径包含压缩后的 group 和 SWA 数据，但不包含协议头、对齐
 padding、重试或设备驱动开销。
 
 对于 q-split CP，该口径统计 cache 中的唯一 payload，不重复计算广播到多个 CP GPU 的
-副本；若需要 PCIe/ROCm aggregate traffic，必须以硬件 profiler 为准。
+副本；若需要 PCIe aggregate traffic，必须以硬件 profiler 为准。
 
 所有容量使用十进制 GB（`bytes / 1e9`），带宽使用十进制 GB/s（不是 Gb/s），时延使用
 ms，比例使用 `[0,1]`。DP/CP 广播副本不重复计入逻辑 cache payload；硬件 aggregate
@@ -169,8 +169,8 @@ observation，内存占用不随运行时长增长。CSV 与 JSON 从同一语�
 | `run_id` | 运行 ID（`时间戳_PID`），也是结果目录名 |
 | `mode` | `latency_hit` 或 `bandwidth` |
 | `scenario` | 场景名。`latency_hit` 下为 `unloaded`/`loaded`；`bandwidth` 下为 path 名（`gpu_to_cpu_save` 等） |
-| `backend` | `cuda` / `rocm` / `cpu_stub` |
-| `performance_valid` | 性能数字是否可信；CPU stub 下为 `false`（SVG 顶部会加醒目水印） |
+| `backend` | `cuda` / `cpu_stub` |
+| `performance_valid` | 性能数字是否可信；CPU stub 下为 `false` |
 | `model` / `architecture` | preset 名与架构标识 |
 | `composite_tp` | SGLang composite TP world size（每个 DP shard 的物理 worker 数） |
 | `kv_tp` | KV/attention TP 宽度 = `composite_tp / cp` |
@@ -247,8 +247,8 @@ observation，内存占用不随运行时长增长。CSV 与 JSON 从同一语�
 1. `--dry-run`：校验 preset、压缩比、layer group、page 大小、容量和 GPU 数量。
 2. `dsv4_cpu_smoke.yaml`：在无 GPU 主机上跑通多 group + SWA 的完整控制流。
 3. `glm5_cpu_smoke.yaml`：验证 composite TP=4、KV TP=2、CP=2 的重叠 rank 和异步接口。
-4. `dsv4_pro.yaml` / `dsv4_flash.yaml`：在目标 CUDA/ROCm 节点验证 IPC、layerwise、
+4. `dsv4_pro.yaml` / `dsv4_flash.yaml`：在目标 CUDA 节点验证 IPC、layerwise、
    eventfd、SSD 和真实传输带宽。
 
-硬件运行前应确认 FlexKV extension 与当前 CUDA/ROCm 匹配、SSD 目录容量充足，并根据
+硬件运行前应确认 FlexKV extension 与当前 CUDA 匹配、SSD 目录容量充足，并根据
 机器显存调整 `gpu_blocks_per_rank` 与 `swa_num_slots`。

--- a/benchmarks/flexkv_stress/DESIGN.md
+++ b/benchmarks/flexkv_stress/DESIGN.md
@@ -84,6 +84,15 @@ page 传入连续的 `page_tokens` 个 slot；FlexKV 再将其折叠为 SWA slot
 运行时异常，退出码即为 `1`，否则为 `0`。warmup 轮的失败同样只记录并计入退出码，不中断
 后续测量场景。
 
+**GPU 池尺寸与批量回读**：`model.gpu_blocks_per_rank` 是模拟推理引擎的 GPU KV 池块数。
+批量回读校验会把一个 batch 内所有在途 turn 的数据载入一段**连续**的 GPU slot；当这段长度
+超过池容量时会绕回，导致同 batch 内不同 turn 的 slot 相互覆盖，被抽样的 turn 便会读到别的
+turn 的字节，**报出假的 byte-validation 失败**（仅在 `batch_size>1` 且命中抽样时发生）。因此
+`gpu_blocks_per_rank` 必须 ≥ 一个 batch 的最坏在途块数，约
+`batch_size × (system_prompt_blocks + turns_max × (max_input_blocks + max_output_blocks))`。
+配置低于该值时启动会打 WARNING。空载（`batch_size=1`）不受影响，所以「unloaded 全绿、loaded
+零星 byte 失败」这一模式通常是 GPU 池偏小，而非 FlexKV 传输 bug。
+
 ## 双模式与计时口径
 
 `latency_hit` 模式会**依次**跑两个 profile，两者共用同一套 workload、各自跑满
@@ -200,7 +209,7 @@ observation，内存占用不随运行时长增长。CSV 与 JSON 从同一语�
 | `byte_validation_accuracy` | 被抽样请求中 byte pattern 完全一致的比例；`1.0` = 传输零损坏 |
 | `gpu_memory_gb` | 采样到的 GPU 显存占用峰值（所有 worker 之和） |
 | `rss_gb` | 主机 RSS（加速卡模式为各 worker 进程之和） |
-| `ssd_used_gb` | SSD cache 目录实际占用 |
+| `ssd_used_gb` | 本 run SSD cache 的实际磁盘占用。每个 run 独占 `<ssd_cache_dir>/<run_id>/` 子目录，故只统计本 run 自己的 .bin（不含同目录下历史 run 残留）；按实际分配块（`st_blocks×512`）计，而非稀疏文件的 apparent size，避免虚高。run 结束（含异常/中断）在 `finally` 里删除该子目录，不再攒盘。 |
 
 命中与精度公式见上一节「双模式与计时口径」。
 

--- a/benchmarks/flexkv_stress/DESIGN.md
+++ b/benchmarks/flexkv_stress/DESIGN.md
@@ -76,13 +76,30 @@ page 传入连续的 `page_tokens` 个 slot；FlexKV 再将其折叠为 SWA slot
 - 被抽样的 byte pattern 完全一致；
 - async/SSD probe（启用时）成功。
 
-`minimum_success_rate` 决定进程最终退出码，`stop_on_mismatch` 决定 byte mismatch 后是否
-立即停止。运行时异常和失败操作写入按需创建的 `errors.csv`。
+运行**永不因为校验失败而提前中断**。byte mismatch、hit 偏差、失败的 transfer 都会把
+对应请求计为失败、写入按需创建的 `errors.csv`，并拉低所在窗口的
+`byte_validation_accuracy` / `request_success_rate`，但测试会继续跑完整个 workload，
+以便一次性暴露所有问题，而不是停在第一个错误上。校验结果只影响进程**最终退出码**：任一
+场景的 `request_success_rate` 低于 `minimum_success_rate`、出现任何 byte mismatch、或发生
+运行时异常，退出码即为 `1`，否则为 `0`。warmup 轮的失败同样只记录并计入退出码，不中断
+后续测量场景。
 
 ## 双模式与计时口径
 
-`latency_hit` 自动运行两种 profile：`unloaded` 固定 batch/concurrency 为 1，`loaded`
-使用配置值。match 是 `get_match`；load 是 `launch_get + wait(completely=True)`；save 从
+`latency_hit` 模式会**依次**跑两个 profile，两者共用同一套 workload、各自跑满
+`duration_seconds`（或 `rounds`）。因此一次 `latency_hit` 的墙上时间约为
+`2 × duration_seconds`：
+
+- **`unloaded`（空载）**：强制 `batch_size=1`、`max_inflight_per_dp=1`，任一时刻只有一个
+  请求在途。测的是**单请求最优延迟**——没有排队、没有争用时 match/load/save 各自要多久，
+  是延迟的下界基线。
+- **`loaded`（满载）**：使用配置里的 `concurrency.batch_size` 与 `max_inflight_per_dp`
+  并发打流。测的是**并发压力下的延迟与吞吐**——排队、锁争用、传输带宽饱和都会体现在这里，
+  更接近线上高负载表现。
+
+把两个场景对照，就能看出并发把延迟抬高了多少、把吞吐（QPS）提升了多少。
+
+计时口径：match 是 `get_match`；load 是 `launch_get + wait(completely=True)`；save 从
 `put_match` 开始，到 `launch_put + wait` 结束。readback 只判定正确性，不进入这三段时延。
 
 命中和精度公式为：
@@ -129,6 +146,93 @@ traffic 仍应由系统 profiler 测量。
 结果目录使用 `YYYYmmdd_HHMMSS_PID`，避免同一秒启动的任务相互覆盖。
 Reporter 使用固定大小、可合并的对数 histogram 汇总 p50/p95/p99，不在内存中保留长跑
 observation，内存占用不随运行时长增长。CSV 与 JSON 从同一语义汇总对象生成。
+
+## 指标字段说明
+
+`summary.csv` 是每个场景跑完后的最终汇总，`metrics.csv` 是同名字段的逐窗口趋势（多出
+`window_id` / `window_started_at` / `window_duration_s` 三个前缀列），`summary.json` 是把
+同一批字段按语义分组后的机器接口。字段随 `mode` 不同：`latency_hit` 与 `bandwidth` 各有
+一套。下面按分组解释。
+
+### 通用标识与拓扑（两种 mode 共有）
+
+| 字段 | 含义 |
+| --- | --- |
+| `run_id` | 运行 ID（`时间戳_PID`），也是结果目录名 |
+| `mode` | `latency_hit` 或 `bandwidth` |
+| `scenario` | 场景名。`latency_hit` 下为 `unloaded`/`loaded`；`bandwidth` 下为 path 名（`gpu_to_cpu_save` 等） |
+| `backend` | `cuda` / `rocm` / `cpu_stub` |
+| `performance_valid` | 性能数字是否可信；CPU stub 下为 `false`（SVG 顶部会加醒目水印） |
+| `model` / `architecture` | preset 名与架构标识 |
+| `composite_tp` | SGLang composite TP world size（每个 DP shard 的物理 worker 数） |
+| `kv_tp` | KV/attention TP 宽度 = `composite_tp / cp` |
+| `cp` / `dp` | q-split CP 宽度 / DP 副本数 |
+| `gpu_count` | 实际使用的 GPU 数 = `dp × workers_per_dp` |
+| `page_tokens` | 每个 block 的 token 数（`tokens_per_block`） |
+| `main_page_gb` | 主 KV 单个 host page 的字节数（十进制 GB，含全部 KV-TP slice） |
+| `cpu_cache_gb` / `ssd_cache_gb` | CPU / SSD cache 容量 |
+| `layerwise` / `ssd_enabled` / `swa` | 是否启用 fused layerwise 传输 / SSD tier / SWA pool |
+
+### workload 参数（回显配置，让结果自解释）
+
+`conversations_per_round`、`turns_min`、`turns_max`、`system_prompt_blocks`、
+`first_input_blocks`、`added_input_blocks`、`output_blocks`、`partial_block_tokens`、
+`shared_system_prompt`、`read_after_put` 均直接回显对应的 `conversation.*` 配置。此外每行还带：
+
+| 字段 | 含义 |
+| --- | --- |
+| `batch_size` | 该场景每批提交的请求数 |
+| `concurrency` | 该场景每 DP 的最大在途请求数（`max_inflight_per_dp`） |
+
+### `latency_hit` 专有：延迟 / 命中 / 正确性 / 资源
+
+| 字段 | 含义 |
+| --- | --- |
+| `requests` | 该场景累计请求（turn）数 |
+| `qps` | `requests / 累计计时秒数` |
+| `match_p50/p95/p99_ms` | `get_match`（prefix 查询）延迟分位 |
+| `load_p50/p95/p99_ms` | `launch_get + wait`（H2D 读取命中 block）延迟分位 |
+| `save_p50/p95/p99_ms` | `put_match → launch_put + wait`（D2H 写入新 KV）延迟分位 |
+| `hit_ratio` | `actual_hit_tokens / query_tokens`，实际 prefix 命中占查询 token 的比例 |
+| `hit_exact_rate` | 命中量落在容差内的请求占比（命中 block 数是否与 oracle 精确一致） |
+| `hit_token_accuracy` | `1 - Σ\|actual-expected\| / Σquery_tokens`，命中 token 数的整体准确度 |
+| `request_success_rate` | success 请求 / 总请求（match+get+put+byte 校验全过才算 success） |
+| `byte_validation_accuracy` | 被抽样请求中 byte pattern 完全一致的比例；`1.0` = 传输零损坏 |
+| `gpu_memory_gb` | 采样到的 GPU 显存占用峰值（所有 worker 之和） |
+| `rss_gb` | 主机 RSS（加速卡模式为各 worker 进程之和） |
+| `ssd_used_gb` | SSD cache 目录实际占用 |
+
+命中与精度公式见上一节「双模式与计时口径」。
+
+### `bandwidth` 专有：吞吐 / 延迟 / 正确性 / 资源
+
+标识、拓扑、workload、`batch_size`/`concurrency`、资源字段与上面一致，差异部分：
+
+| 字段 | 含义 |
+| --- | --- |
+| `payload_gb` | 该 path×并发档累计的逻辑有效载荷（十进制 GB，去重后的物理 page） |
+| `operations` | 计入该 path 的传输 operation 数 |
+| `duration_s` | 该 path 累计的**活跃传输时间**（各 operation latency 之和，**非**墙上时间） |
+| `throughput_gb_s` | `payload_gb / duration_s`（十进制 GB/s） |
+| `latency_p50/p95/p99_ms` | 单次传输 operation 的延迟分位 |
+| `operation_success_rate` | 成功 operation / 总 operation |
+
+四条 path：`gpu_to_cpu_save`（D2H 存）、`cpu_to_gpu_load`（H2D 载）、
+`gpu_to_ssd_save_e2e`、`ssd_to_gpu_reload_e2e`（后两者为端到端口径）。
+
+### `summary.json`（schema `1.0`）分组
+
+同一批字段按语义嵌套为：`run`（run_id/mode/backend/started_at/duration_s）、`model`、
+`topology`、`cache`、`workload`，以及 `scenarios[]`。每个 scenario 内把延迟收进
+`latency_ms.{match,load,save}.{p50,p95,p99}`，命中收进 `hit.{ratio,exact_rate,token_accuracy}`，
+正确性收进 `correctness.{request_success_rate,byte_validation_accuracy,validation_samples}`，
+资源收进 `resources_gb.{gpu_memory,rss,ssd_used}`。
+
+### `errors.csv`（仅出错时创建）
+
+列为 `time` / `scenario` / `window_id` / `operation` / `error`。既然运行不再提前中断，出现问题时
+这里会累积**所有**失败记录——排查时先看它，再对照 `metrics.csv` 里哪个窗口的
+`byte_validation_accuracy` / `request_success_rate` 掉了。
 
 ## DSv4 验证层级
 

--- a/benchmarks/flexkv_stress/DESIGN.md
+++ b/benchmarks/flexkv_stress/DESIGN.md
@@ -141,16 +141,15 @@ traffic 仍应由系统 profiler 测量。
 
 ## 输出设计
 
-每次运行固定生成五个文件：
+每次运行固定生成四个文件：
 
 - `summary.csv`：给人查看的最终结论，按 mode 使用不同 schema；
 - `metrics.csv`：每个统计窗口的同名指标和资源趋势；
 - `summary.json`：schema `1.0` 的正式机器接口；
-- `charts.svg`：标准库生成的单文件四面板 Dashboard；
 - `effective_config.yaml`：完全展开、可复现的运行配置；
 
 只有发生错误时才创建 `errors.csv`，不生成 turn/operation/resource 中间 CSV。CPU stub
-也生成完整结果，但 `performance_valid=false`，SVG 顶部显示性能数字无效的醒目标记。
+也生成完整结果，但 `performance_valid=false`。
 
 结果目录使用 `YYYYmmdd_HHMMSS_PID`，避免同一秒启动的任务相互覆盖。
 Reporter 使用固定大小、可合并的对数 histogram 汇总 p50/p95/p99，不在内存中保留长跑

--- a/benchmarks/flexkv_stress/DESIGN.md
+++ b/benchmarks/flexkv_stress/DESIGN.md
@@ -1,0 +1,142 @@
+# FlexKV stress benchmark 设计
+
+## 目标与边界
+
+`flexkv_stress` 用合成 KV tensor 持续驱动 FlexKV 的 prefix match、GPU/CPU/SSD
+load/store、layerwise、SWA、并发和异步接口，重点验证长时间运行中的正确性、稳定性和
+有效载荷吞吐。它不模拟模型计算，也不把 token 生成时间计入 FlexKV 传输性能。
+
+CPU stub 用于无加速卡环境下的控制流回归。它会真实分配 CPU PyTorch tensor，并验证
+TP/DP 路由、prefix、PUT/GET、readback 和 byte pattern，但不覆盖 CUDA/ROCm IPC、原生
+kernel、eventfd 或 SSD，因此不能替代硬件压力测试。
+
+## 执行链路
+
+每轮先按 seed 生成多轮会话。每个 turn 依次执行：
+
+1. `get_match`：查询已经缓存的 block prefix，并与本地 `PrefixOracle` 对照。
+2. `launch_get`：把命中 block 加载到模拟推理引擎的 GPU pool。
+3. 写入确定性的 block pattern，执行 `put_match`，只提交未命中的完整 block。
+4. `launch_put`：把新 KV 写入 FlexKV。
+5. `launch_readback`：立即重新加载刚写入的序列；抽样请求会先清零目标，再逐 byte 验证。
+6. 按配置周期执行 async API 或强制 SSD reload probe。
+
+多个 DP rank 由独立 `ManagerDriver` 驱动；会话按 `conversation_id % dp_size` 路由。TP 和
+CP worker 共享同一个 DP manager，并通过各自的设备注册信息处理对应 slice。
+
+加速卡模式下，每个物理 rank 由一个独立 OS process 驱动且只绑定一张 `cuda:N` 卡。
+CPU stub 为了轻量和可调试性使用进程内 virtual worker；它验证 worker 数、rank 路由和
+KV 内容，但不验证多进程/CUDA IPC 隔离。
+
+## TP/CP 拓扑
+
+`model.tp_size` 与 SGLang 的 composite TP world size 对齐，表示每个 DP shard 的物理
+worker 数。q-split CP 从这个 world 内划分 rank，不额外相乘：
+
+```text
+kv_tp_size     = tp_size / cp_size
+workers_per_dp = tp_size = kv_tp_size × cp_size
+required_gpus  = dp_size × workers_per_dp
+```
+
+因此 TP=4、CP=2 时只启动四个 worker，按 CP-major 顺序映射为
+`(tp0,cp0), (tp1,cp0), (tp0,cp1), (tp1,cp1)`。同一个 KV-TP rank 在不同 q-split
+CP rank 上持有相同的全量 KV slice；CPU/SSD cache 只保存唯一 KV-TP slice，不因 CP
+副本数扩容。`tp_size` 必须能被 `cp_size` 整除。这与 SGLang adapter 中
+`attn_tp_size = sglang_tp_size / (attn_dp_size × attn_cp_size)` 的处理一致；stress 配置的
+`tp_size` 是每个 DP shard 的 composite world，因此 DP 仍作为外层独立副本相乘。
+
+## 模型与物理布局
+
+模型 preset 只描述 KV 几何，不加载权重。每个 layer group 独立声明 layer、head size、
+dtype 和压缩比。主 KV host page 的字节数为所有 group 的物理 footprint 之和，并包含
+全部 TP slice：
+
+```text
+main_page_bytes = KV_TP × Σ(layers × kv_dim × page_tokens/compress_ratio
+                            × kv_heads × head_size × dtype_bytes)
+```
+
+DSv4 还带独立的 SWA pool。一个 SWA slot 是一个完整 page：
+
+```text
+swa_page_bytes = page_tokens × swa_layers × swa_head_size   # uint8
+```
+
+SWA 的 launch 参数是 token-index slot mapping，而不是 page id。benchmark 为每个 SWA
+page 传入连续的 `page_tokens` 个 slot；FlexKV 再将其折叠为 SWA slot id。这个约定必须与
+普通 KV slot mapping 保持一致，否则 page 1 以后会错误地落到 page 0。
+
+## 正确性判定
+
+一轮成功需要同时满足：
+
+- 实际 prefix hit 与 oracle 一致（允许按配置设置 block 容差）；
+- 所有 GET/PUT/readback transfer 返回 `SUCCESS`；
+- 被抽样的 byte pattern 完全一致；
+- async/SSD probe（启用时）成功。
+
+`minimum_success_rate` 决定进程最终退出码，`stop_on_mismatch` 决定 byte mismatch 后是否
+立即停止。运行时异常和失败操作写入按需创建的 `errors.csv`。
+
+## 双模式与计时口径
+
+`latency_hit` 自动运行两种 profile：`unloaded` 固定 batch/concurrency 为 1，`loaded`
+使用配置值。match 是 `get_match`；load 是 `launch_get + wait(completely=True)`；save 从
+`put_match` 开始，到 `launch_put + wait` 结束。readback 只判定正确性，不进入这三段时延。
+
+命中和精度公式为：
+
+```text
+hit_ratio          = actual_hit_tokens / query_tokens
+hit_exact_rate     = 在容差内的请求数 / 请求数
+hit_token_accuracy = 1 - Σ|actual-expected| / Σquery_tokens
+byte_accuracy      = passed_samples / validation_samples
+```
+
+`bandwidth` 独立报告四条 path：`gpu_to_cpu_save`、`cpu_to_gpu_load`、
+`gpu_to_ssd_save_e2e` 和 `ssd_to_gpu_reload_e2e`。SSD 两项是端到端指标；现有接口不提供
+可靠的纯 CPU→SSD 分段，因此不从总时间中反推。每个并发档同时达到最小时长、最少
+operation 和可选目标 payload 后停止；match、workload 生成和 readback 不进入传输计时。
+
+## 带宽与容量口径
+
+`transfer_bytes` 是 FlexKV launch 的逻辑有效载荷，不是 PCIe/ROCm profiler 读到的总线
+transaction bytes。主 KV 按去重后的物理 page 数乘 `main_page_bytes`；SWA 按 SWA page
+数乘 `swa_page_bytes`。因此该口径包含压缩后的 group 和 SWA 数据，但不包含协议头、对齐
+padding、重试或设备驱动开销。
+
+对于 q-split CP，该口径统计 cache 中的唯一 payload，不重复计算广播到多个 CP GPU 的
+副本；若需要 PCIe/ROCm aggregate traffic，必须以硬件 profiler 为准。
+
+所有容量使用十进制 GB（`bytes / 1e9`），带宽使用十进制 GB/s（不是 Gb/s），时延使用
+ms，比例使用 `[0,1]`。DP/CP 广播副本不重复计入逻辑 cache payload；硬件 aggregate
+traffic 仍应由系统 profiler 测量。
+
+## 输出设计
+
+每次运行固定生成五个文件：
+
+- `summary.csv`：给人查看的最终结论，按 mode 使用不同 schema；
+- `metrics.csv`：每个统计窗口的同名指标和资源趋势；
+- `summary.json`：schema `1.0` 的正式机器接口；
+- `charts.svg`：标准库生成的单文件四面板 Dashboard；
+- `effective_config.yaml`：完全展开、可复现的运行配置；
+
+只有发生错误时才创建 `errors.csv`，不生成 turn/operation/resource 中间 CSV。CPU stub
+也生成完整结果，但 `performance_valid=false`，SVG 顶部显示性能数字无效的醒目标记。
+
+结果目录使用 `YYYYmmdd_HHMMSS_PID`，避免同一秒启动的任务相互覆盖。
+Reporter 使用固定大小、可合并的对数 histogram 汇总 p50/p95/p99，不在内存中保留长跑
+observation，内存占用不随运行时长增长。CSV 与 JSON 从同一语义汇总对象生成。
+
+## DSv4 验证层级
+
+1. `--dry-run`：校验 preset、压缩比、layer group、page 大小、容量和 GPU 数量。
+2. `dsv4_cpu_smoke.yaml`：在无 GPU 主机上跑通多 group + SWA 的完整控制流。
+3. `glm5_cpu_smoke.yaml`：验证 composite TP=4、KV TP=2、CP=2 的重叠 rank 和异步接口。
+4. `dsv4_pro.yaml` / `dsv4_flash.yaml`：在目标 CUDA/ROCm 节点验证 IPC、layerwise、
+   eventfd、SSD 和真实传输带宽。
+
+硬件运行前应确认 FlexKV extension 与当前 CUDA/ROCm 匹配、SSD 目录容量充足，并根据
+机器显存调整 `gpu_blocks_per_rank` 与 `swa_num_slots`。

--- a/benchmarks/flexkv_stress/README.md
+++ b/benchmarks/flexkv_stress/README.md
@@ -73,10 +73,9 @@ CUDA and ROCm both use PyTorch's `cuda:N` API. On ROCm, tensor sharing uses
 PyTorch IPC and never attempts to load or call `libcudart`. The FlexKV transfer
 extension itself must still have been built for HIP.
 
-Every run produces exactly `summary.csv`, `metrics.csv`, `summary.json`,
-`charts.svg`, and `effective_config.yaml`. `summary.csv` and `metrics.csv` use a
-mode-specific schema, while `summary.json` is the versioned (`1.0`) machine
-interface. `charts.svg` is a dependency-free four-panel dashboard. An
+Every run produces exactly `summary.csv`, `metrics.csv`, `summary.json`, and
+`effective_config.yaml`. `summary.csv` and `metrics.csv` use a mode-specific
+schema, while `summary.json` is the versioned (`1.0`) machine interface. An
 `errors.csv` file is added only when an error occurs; intermediate operation or
 turn CSV files are not emitted.
 

--- a/benchmarks/flexkv_stress/README.md
+++ b/benchmarks/flexkv_stress/README.md
@@ -69,9 +69,8 @@ stores only `put_match` misses, and performs an immediate read-back. Input and
 output lengths accept a fixed block count, a two-element range, or an explicit
 `{mode: list, blocks: [...]}` sequence. Cache state is retained across rounds.
 
-CUDA and ROCm both use PyTorch's `cuda:N` API. On ROCm, tensor sharing uses
-PyTorch IPC and never attempts to load or call `libcudart`. The FlexKV transfer
-extension itself must still have been built for HIP.
+The accelerator path uses PyTorch's `cuda:N` API and requires the FlexKV
+transfer extension to be built for CUDA.
 
 Every run produces exactly `summary.csv`, `metrics.csv`, `summary.json`, and
 `effective_config.yaml`. `summary.csv` and `metrics.csv` use a mode-specific
@@ -100,10 +99,9 @@ For logic checks on a host without an accelerator, `--cpu-stub` replaces the
 FlexKV manager and inference-engine workers with an in-memory implementation.
 It still allocates real CPU PyTorch KV tensors and validates prefix matching,
 batch launch, PUT/GET, async APIs, TP/DP routing, and byte-level readback. It
-does not validate CUDA/ROCm IPC, native transfer kernels, SSD, or eventfd
-signaling, and the reported latency is not a FlexKV performance measurement.
-CPU-stub runs still produce every report and chart, but set
-`performance_valid=false` and watermark the dashboard.
+does not validate CUDA IPC, native transfer kernels, SSD, or eventfd signaling,
+and the reported latency is not a FlexKV performance measurement. CPU-stub
+runs still produce every report, but set `performance_valid=false`.
 The real accelerator path launches one OS process per GPU and pins it to one
 `cuda:N` device. CPU stub uses lightweight in-process virtual workers, so it
 checks topology/routing and duplicated CP KV contents but not process or CUDA

--- a/benchmarks/flexkv_stress/README.md
+++ b/benchmarks/flexkv_stress/README.md
@@ -8,6 +8,28 @@ benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5.yaml --dry
 benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5.yaml --rounds 1000
 benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/dsv4_pro.yaml --duration 86400
 benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/cpu_stub.yaml --cpu-stub
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/dsv4_cpu_smoke.yaml
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5_cpu_smoke.yaml
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5_cpu_smoke.yaml --mode bandwidth
+```
+
+`run.mode` selects `latency_hit` or `bandwidth`. The latency/hit mode always
+runs an unloaded profile (`batch=1`, `concurrency=1`) and a loaded profile
+using the configured batch and concurrency. Bandwidth mode independently
+reports GPU→CPU save, CPU→GPU load, GPU→SSD save end-to-end, and SSD→GPU reload
+end-to-end for each configured concurrency level. SSD paths are omitted when
+the SSD tier is disabled.
+
+```yaml
+run:
+  mode: bandwidth
+bandwidth:
+  paths: [gpu_to_cpu_save, cpu_to_gpu_load, gpu_to_ssd_save_e2e, ssd_to_gpu_reload_e2e]
+  concurrency_levels: [1, 2, 4, 8, 16]
+  target_payload_gb: 0
+  min_duration_seconds: 30
+  min_operations: 100
+  window_seconds: 5
 ```
 
 The shipped presets are `dsv4_pro`, `dsv4_flash`, `glm5`, and `glm5_2`.
@@ -23,6 +45,13 @@ model:
   dp_size: 2
   cp_size: 1
 ```
+
+`model.tp_size` follows SGLang's composite TP world size **per DP shard**.
+Q-split CP ranks overlap that world instead of multiplying it. The benchmark
+derives `kv_tp_size = tp_size / cp_size`, starts `tp_size` physical GPU workers
+per DP shard, and passes `(kv_tp_size, cp_size)` to FlexKV. Therefore TP=4,
+CP=2 uses four processes/GPUs arranged as two KV-TP slices duplicated over two
+CP ranks, not eight GPUs. `tp_size` must be divisible by `cp_size`.
 
 `layer_groups` may be overridden directly. `layers` accepts an explicit list,
 `all`, `{compress_ratio: 4}`, or `{indexer_type: shared}`:
@@ -44,9 +73,20 @@ CUDA and ROCm both use PyTorch's `cuda:N` API. On ROCm, tensor sharing uses
 PyTorch IPC and never attempts to load or call `libcudart`. The FlexKV transfer
 extension itself must still have been built for HIP.
 
-The primary outputs are `rounds.csv`, `turns.csv`, `operations.csv`,
-`windows.csv`, `validation_samples.csv`, `resources.csv`, `errors.csv`,
-`summary.csv`, and `effective_config.yaml`.
+Every run produces exactly `summary.csv`, `metrics.csv`, `summary.json`,
+`charts.svg`, and `effective_config.yaml`. `summary.csv` and `metrics.csv` use a
+mode-specific schema, while `summary.json` is the versioned (`1.0`) machine
+interface. `charts.svg` is a dependency-free four-panel dashboard. An
+`errors.csv` file is added only when an error occurs; intermediate operation or
+turn CSV files are not emitted.
+
+Capacity is reported in decimal GB, throughput in decimal GB/s, latency in ms,
+and all accuracy/rate values in `[0,1]`. Bandwidth is logical KV payload divided
+by timed transfer duration. Match, workload creation, and byte readback are not
+inside the transfer timing boundary. It includes compressed main-KV groups and
+SWA pages, but excludes protocol and driver overhead. See
+[`DESIGN.md`](DESIGN.md) for the byte formula, concurrency caveats, execution
+flow, validation rules, and DSv4 verification levels.
 
 For a single-DP SSD run, `cache.force_ssd_reload_interval_rounds` periodically
 clears only the CPU tier through FlexKV's test hook and verifies an SSD reload.
@@ -63,3 +103,9 @@ It still allocates real CPU PyTorch KV tensors and validates prefix matching,
 batch launch, PUT/GET, async APIs, TP/DP routing, and byte-level readback. It
 does not validate CUDA/ROCm IPC, native transfer kernels, SSD, or eventfd
 signaling, and the reported latency is not a FlexKV performance measurement.
+CPU-stub runs still produce every report and chart, but set
+`performance_valid=false` and watermark the dashboard.
+The real accelerator path launches one OS process per GPU and pins it to one
+`cuda:N` device. CPU stub uses lightweight in-process virtual workers, so it
+checks topology/routing and duplicated CP KV contents but not process or CUDA
+IPC isolation.

--- a/benchmarks/flexkv_stress/README.md
+++ b/benchmarks/flexkv_stress/README.md
@@ -1,0 +1,65 @@
+# FlexKV stress benchmark
+
+This benchmark allocates synthetic inference-engine KV tensors and exercises
+FlexKV's match, load and store paths over configurable multi-turn conversations.
+
+```bash
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5.yaml --dry-run
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/glm5.yaml --rounds 1000
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/dsv4_pro.yaml --duration 86400
+benchmarks/flexkv_stress/run.sh benchmarks/flexkv_stress/configs/cpu_stub.yaml --cpu-stub
+```
+
+The shipped presets are `dsv4_pro`, `dsv4_flash`, `glm5`, and `glm5_2`.
+They create the physical GPU layouts used by SGLang: DSv4 c4/c128/indexer/SWA
+pools and GLM MLA/indexer pools. A local Hugging Face config can refresh the
+geometry without loading model weights:
+
+```yaml
+model:
+  preset: glm5_2
+  hf_config_path: /models/GLM-5.2/config.json
+  tp_size: 2
+  dp_size: 2
+  cp_size: 1
+```
+
+`layer_groups` may be overridden directly. `layers` accepts an explicit list,
+`all`, `{compress_ratio: 4}`, or `{indexer_type: shared}`:
+
+```yaml
+model:
+  preset: glm5
+  layer_groups:
+    - {name: main, layers: all, num_kv_heads: 1, head_size: 576, dtype: bfloat16}
+    - {name: indexer, layers: all, num_kv_heads: 1, head_size: 132, dtype: uint8}
+```
+
+Each turn first loads the reusable history, writes deterministic synthetic KV,
+stores only `put_match` misses, and performs an immediate read-back. Input and
+output lengths accept a fixed block count, a two-element range, or an explicit
+`{mode: list, blocks: [...]}` sequence. Cache state is retained across rounds.
+
+CUDA and ROCm both use PyTorch's `cuda:N` API. On ROCm, tensor sharing uses
+PyTorch IPC and never attempts to load or call `libcudart`. The FlexKV transfer
+extension itself must still have been built for HIP.
+
+The primary outputs are `rounds.csv`, `turns.csv`, `operations.csv`,
+`windows.csv`, `validation_samples.csv`, `resources.csv`, `errors.csv`,
+`summary.csv`, and `effective_config.yaml`.
+
+For a single-DP SSD run, `cache.force_ssd_reload_interval_rounds` periodically
+clears only the CPU tier through FlexKV's test hook and verifies an SSD reload.
+Set it to `0` to rely on natural eviction only.
+
+`get_async`/`put_async` probes run at
+`features.async_api_probe_interval_rounds` when layerwise and SWA are disabled.
+Those APIs use FlexKV's ordinary H2D worker, which is intentionally absent when
+the fused layerwise H2D worker is active.
+
+For logic checks on a host without an accelerator, `--cpu-stub` replaces the
+FlexKV manager and inference-engine workers with an in-memory implementation.
+It still allocates real CPU PyTorch KV tensors and validates prefix matching,
+batch launch, PUT/GET, async APIs, TP/DP routing, and byte-level readback. It
+does not validate CUDA/ROCm IPC, native transfer kernels, SSD, or eventfd
+signaling, and the reported latency is not a FlexKV performance measurement.

--- a/benchmarks/flexkv_stress/__init__.py
+++ b/benchmarks/flexkv_stress/__init__.py
@@ -1,0 +1,3 @@
+"""Long-running FlexKV correctness and performance benchmark."""
+
+__all__ = ["config", "device", "metrics", "models", "runner", "workload"]

--- a/benchmarks/flexkv_stress/config.py
+++ b/benchmarks/flexkv_stress/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 import copy
+import logging
 import os
 
 import yaml
@@ -189,6 +190,30 @@ class StressConfig:
             )
         if self.model.gpu_blocks_per_rank < 1:
             raise ValueError("model.gpu_blocks_per_rank must be >= 1")
+        # GPU pool sizing vs batching. The batched read-back verification stages
+        # every in-flight turn's data into a CONTIGUOUS run of GPU slots; a run
+        # longer than the pool wraps and turns' slots collide, so a sampled
+        # read-back verifies against another turn's bytes and reports a FALSE
+        # byte-validation failure (only under batch_size>1, only when sampled).
+        # Warn when the pool cannot hold one batch's worst-case live blocks.
+        max_input = max(
+            _spec_max_blocks(self.conversation.first_input_blocks),
+            _spec_max_blocks(self.conversation.added_input_blocks),
+        )
+        max_output = _spec_max_blocks(self.conversation.output_blocks)
+        max_seq_blocks = self.conversation.system_prompt_blocks + self.conversation.turns_max * (
+            max_input + max_output
+        )
+        needed_blocks = self.concurrency.batch_size * max_seq_blocks
+        if self.model.gpu_blocks_per_rank < needed_blocks:
+            logging.getLogger("flexkv_stress").warning(
+                "gpu_blocks_per_rank=%d may be too small for batch_size=%d: a batch "
+                "can stage up to ~%d live GPU blocks, so the batched read-back slots "
+                "wrap and collide, producing FALSE byte-validation failures under load. "
+                "Set model.gpu_blocks_per_rank >= %d.",
+                self.model.gpu_blocks_per_rank, self.concurrency.batch_size,
+                needed_blocks, needed_blocks,
+            )
         if self.tokens_per_block < 1:
             raise ValueError("tokens_per_block must be >= 1")
         if not 0 <= self.validation.sample_rate <= 1:
@@ -249,6 +274,21 @@ class StressConfig:
 
 def _section(cls, raw: dict[str, Any], name: str):
     return cls(**(raw.get(name) or {}))
+
+
+def _spec_max_blocks(spec: Any) -> int:
+    """Upper bound (in blocks) of a workload length spec (int / [lo,hi] /
+    {mode, blocks|values|value})."""
+    if isinstance(spec, int):
+        return spec
+    if isinstance(spec, list):
+        return max((int(v) for v in spec), default=0)
+    if isinstance(spec, dict):
+        values = spec.get("values", spec.get("blocks", spec.get("value", 0)))
+        if isinstance(values, list):
+            return max((int(v) for v in values), default=0)
+        return int(values)
+    return 0
 
 
 def _parse_layers(value: Any, num_layers: int, metadata: dict[str, Any]) -> tuple[int, ...]:

--- a/benchmarks/flexkv_stress/config.py
+++ b/benchmarks/flexkv_stress/config.py
@@ -13,12 +13,29 @@ from .models import LayerGroup, ModelPreset, get_preset, model_bytes_per_block, 
 
 @dataclass
 class RunConfig:
+    mode: str = "latency_hit"
     warmup_rounds: int = 1
     rounds: int = 100
     duration_seconds: float = 0
     stop_when: str = "either"
     seed: int = 42
     log_every_rounds: int = 1
+
+
+@dataclass
+class BandwidthConfig:
+    paths: list[str] = field(default_factory=lambda: [
+        "gpu_to_cpu_save",
+        "cpu_to_gpu_load",
+        "gpu_to_ssd_save_e2e",
+        "ssd_to_gpu_reload_e2e",
+    ])
+    concurrency_levels: list[int] = field(default_factory=lambda: [1, 2, 4, 8, 16])
+    target_payload_gb: float = 0
+    min_duration_seconds: float = 30
+    min_operations: int = 100
+    window_seconds: float = 5
+    validation_interval_operations: int = 100
 
 
 @dataclass
@@ -101,6 +118,7 @@ class OutputConfig:
 @dataclass
 class StressConfig:
     run: RunConfig
+    bandwidth: BandwidthConfig
     model: ModelBenchConfig
     cache: CacheBenchConfig
     features: FeatureConfig
@@ -117,34 +135,107 @@ class StressConfig:
 
     @property
     def required_gpus(self) -> int:
-        return self.model.tp_size * self.model.dp_size * self.model.cp_size
+        return self.workers_per_dp * self.model.dp_size
+
+    @property
+    def kv_tp_size(self) -> int:
+        """Attention/KV TP width after SGLang carves CP out of composite TP."""
+        return self.model.tp_size // self.model.cp_size
+
+    @property
+    def workers_per_dp(self) -> int:
+        """Physical SGLang ranks per DP shard (TP and CP ranks overlap)."""
+        return self.model.tp_size
+
+    def worker_ranks(self, worker_rank: int) -> tuple[int, int]:
+        """Return ``(kv_tp_rank, cp_rank)`` for a flattened physical rank."""
+        return worker_rank % self.kv_tp_size, worker_rank // self.kv_tp_size
 
     @property
     def bytes_per_block(self) -> int:
-        # FlexKV's heterogeneous host block stores all TP slices.
-        return self.bytes_per_gpu_block * self.model.tp_size
+        # CP is q-split and duplicates KV. Host blocks store only unique KV-TP slices.
+        return self.bytes_per_gpu_block * self.kv_tp_size
 
     @property
     def bytes_per_gpu_block(self) -> int:
         return model_bytes_per_block(self.preset, self.tokens_per_block)
 
+    @property
+    def swa_bytes_per_block(self) -> int:
+        if not self.features.swa:
+            return 0
+        return (
+            self.tokens_per_block
+            * self.preset.swa_num_layers
+            * self.preset.swa_head_size
+        )
+
     def validate(self) -> None:
+        if self.run.mode not in {"bandwidth", "latency_hit"}:
+            raise ValueError("run.mode must be 'bandwidth' or 'latency_hit'")
         if self.run.rounds <= 0 and self.run.duration_seconds <= 0:
             raise ValueError("Set run.rounds or run.duration_seconds")
+        if self.run.warmup_rounds < 0:
+            raise ValueError("run.warmup_rounds must be >= 0")
+        if self.run.log_every_rounds < 1:
+            raise ValueError("run.log_every_rounds must be >= 1")
         if self.run.stop_when not in {"either", "both"}:
             raise ValueError("run.stop_when must be 'either' or 'both'")
         if min(self.model.tp_size, self.model.dp_size, self.model.cp_size) < 1:
             raise ValueError("TP, DP and CP sizes must be >= 1")
+        if self.model.tp_size % self.model.cp_size:
+            raise ValueError(
+                "model.tp_size is the composite SGLang TP world size per DP and "
+                "must be divisible by model.cp_size"
+            )
         if self.model.gpu_blocks_per_rank < 1:
             raise ValueError("model.gpu_blocks_per_rank must be >= 1")
+        if self.tokens_per_block < 1:
+            raise ValueError("tokens_per_block must be >= 1")
         if not 0 <= self.validation.sample_rate <= 1:
             raise ValueError("validation.sample_rate must be in [0, 1]")
+        if not 0 <= self.validation.minimum_success_rate <= 1:
+            raise ValueError("validation.minimum_success_rate must be in [0, 1]")
+        if min(
+            self.validation.min_samples_per_round,
+            self.validation.sampled_layers_per_group,
+            self.validation.sampled_blocks_per_request,
+            self.validation.bytes_per_sample,
+        ) < 0:
+            raise ValueError("validation sample counts and bytes must be >= 0")
+        if min(self.concurrency.max_inflight_per_dp, self.concurrency.batch_size) < 1:
+            raise ValueError("concurrency batch_size and max_inflight_per_dp must be >= 1")
+        if self.concurrency.request_timeout_seconds <= 0:
+            raise ValueError("concurrency.request_timeout_seconds must be > 0")
+        if self.output.resource_interval_seconds < 0:
+            raise ValueError("output.resource_interval_seconds must be >= 0")
+        valid_paths = {
+            "gpu_to_cpu_save", "cpu_to_gpu_load",
+            "gpu_to_ssd_save_e2e", "ssd_to_gpu_reload_e2e",
+        }
+        unknown_paths = set(self.bandwidth.paths) - valid_paths
+        if unknown_paths:
+            raise ValueError(f"Unknown bandwidth paths: {sorted(unknown_paths)}")
+        if not self.bandwidth.concurrency_levels or any(
+            value < 1 for value in self.bandwidth.concurrency_levels
+        ):
+            raise ValueError("bandwidth.concurrency_levels must contain positive integers")
+        if min(
+            self.bandwidth.target_payload_gb,
+            self.bandwidth.min_duration_seconds,
+            self.bandwidth.min_operations,
+            self.bandwidth.window_seconds,
+            self.bandwidth.validation_interval_operations,
+        ) < 0:
+            raise ValueError("bandwidth targets and window settings must be >= 0")
         if self.conversation.turns_min < 1 or self.conversation.turns_max < self.conversation.turns_min:
             raise ValueError("Invalid conversation turn range")
         if self.features.swa and not self.preset.swa_enabled:
             raise ValueError(f"Preset {self.preset.name} does not define an SWA pool")
         if self.features.ssd and self.cache.ssd_cache_gb <= 0 and self.cache.num_ssd_blocks <= 0:
             raise ValueError("SSD is enabled but neither ssd_cache_gb nor num_ssd_blocks is set")
+        if self.features.ssd and not self.cache.ssd_cache_dir:
+            raise ValueError("SSD is enabled but cache.ssd_cache_dir is empty")
         if self.features.cpu_stub and self.features.ssd:
             raise ValueError("CPU stub mode does not emulate the FlexKV SSD tier")
         for group in self.preset.groups:
@@ -213,6 +304,7 @@ def load_config(path: str | os.PathLike[str]) -> StressConfig:
         preset = _override_groups(preset, model.layer_groups)
     config = StressConfig(
         run=_section(RunConfig, raw, "run"),
+        bandwidth=_section(BandwidthConfig, raw, "bandwidth"),
         model=model,
         cache=_section(CacheBenchConfig, raw, "cache"),
         features=_section(FeatureConfig, raw, "features"),
@@ -235,4 +327,9 @@ def config_as_dict(config: StressConfig) -> dict[str, Any]:
     from dataclasses import asdict
     result = asdict(config)
     result["source_path"] = str(config.source_path)
+    result["derived_parallelism"] = {
+        "kv_tp_size": config.kv_tp_size,
+        "workers_per_dp": config.workers_per_dp,
+        "required_gpus": config.required_gpus,
+    }
     return copy.deepcopy(result)

--- a/benchmarks/flexkv_stress/config.py
+++ b/benchmarks/flexkv_stress/config.py
@@ -78,7 +78,6 @@ class ValidationConfig:
     sampled_blocks_per_request: int = 2
     bytes_per_sample: int = 256
     hit_tolerance_blocks: int = 0
-    stop_on_mismatch: bool = True
     minimum_success_rate: float = 0.999
 
 

--- a/benchmarks/flexkv_stress/config.py
+++ b/benchmarks/flexkv_stress/config.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+import copy
+import os
+
+import yaml
+
+from .models import LayerGroup, ModelPreset, get_preset, model_bytes_per_block, update_from_hf_config
+
+
+@dataclass
+class RunConfig:
+    warmup_rounds: int = 1
+    rounds: int = 100
+    duration_seconds: float = 0
+    stop_when: str = "either"
+    seed: int = 42
+    log_every_rounds: int = 1
+
+
+@dataclass
+class FeatureConfig:
+    cpu_stub: bool = False
+    layerwise: bool = False
+    swa: bool = False
+    ssd: bool = False
+    concurrency: bool = False
+    async_api_probe_interval_rounds: int = 10
+
+
+@dataclass
+class ConversationConfig:
+    conversations_per_round: int = 10
+    turns_min: int = 2
+    turns_max: int = 5
+    system_prompt_blocks: int = 8
+    first_input_blocks: Any = field(default_factory=lambda: [2, 8])
+    added_input_blocks: Any = field(default_factory=lambda: [1, 4])
+    output_blocks: Any = field(default_factory=lambda: [1, 2])
+    partial_block_tokens: int = 0
+    shared_system_prompt: bool = True
+    read_after_put: bool = True
+
+
+@dataclass
+class ConcurrencyConfig:
+    max_inflight_per_dp: int = 16
+    batch_size: int = 4
+    target_qps: float = 0
+    request_timeout_seconds: float = 30
+
+
+@dataclass
+class ValidationConfig:
+    sample_rate: float = 0.001
+    min_samples_per_round: int = 1
+    sampled_layers_per_group: int = 2
+    sampled_blocks_per_request: int = 2
+    bytes_per_sample: int = 256
+    hit_tolerance_blocks: int = 0
+    stop_on_mismatch: bool = True
+    minimum_success_rate: float = 0.999
+
+
+@dataclass
+class CacheBenchConfig:
+    cpu_cache_gb: float = 8
+    ssd_cache_gb: float = 0
+    ssd_cache_dir: list[str] = field(default_factory=lambda: ["./flexkv_stress_ssd"])
+    num_cpu_blocks: int = 0
+    num_ssd_blocks: int = 0
+    enable_gds: bool = False
+    eviction_policy: str = "lru"
+    swa_num_slots: int = 1024
+    swa_ssd_slots: int = 0
+    force_ssd_reload_interval_rounds: int = 10
+
+
+@dataclass
+class ModelBenchConfig:
+    preset: str = "glm5"
+    hf_config_path: str | None = None
+    tp_size: int = 1
+    dp_size: int = 1
+    cp_size: int = 1
+    gpu_blocks_per_rank: int = 1024
+    tokens_per_block: int | None = None
+    dtype: str | None = None
+    layer_groups: list[dict[str, Any]] | None = None
+
+
+@dataclass
+class OutputConfig:
+    directory: str = "./benchmark_results/flexkv_stress"
+    resource_interval_seconds: float = 10
+
+
+@dataclass
+class StressConfig:
+    run: RunConfig
+    model: ModelBenchConfig
+    cache: CacheBenchConfig
+    features: FeatureConfig
+    conversation: ConversationConfig
+    concurrency: ConcurrencyConfig
+    validation: ValidationConfig
+    output: OutputConfig
+    preset: ModelPreset
+    source_path: Path
+
+    @property
+    def tokens_per_block(self) -> int:
+        return self.model.tokens_per_block or self.preset.tokens_per_block
+
+    @property
+    def required_gpus(self) -> int:
+        return self.model.tp_size * self.model.dp_size * self.model.cp_size
+
+    @property
+    def bytes_per_block(self) -> int:
+        # FlexKV's heterogeneous host block stores all TP slices.
+        return self.bytes_per_gpu_block * self.model.tp_size
+
+    @property
+    def bytes_per_gpu_block(self) -> int:
+        return model_bytes_per_block(self.preset, self.tokens_per_block)
+
+    def validate(self) -> None:
+        if self.run.rounds <= 0 and self.run.duration_seconds <= 0:
+            raise ValueError("Set run.rounds or run.duration_seconds")
+        if self.run.stop_when not in {"either", "both"}:
+            raise ValueError("run.stop_when must be 'either' or 'both'")
+        if min(self.model.tp_size, self.model.dp_size, self.model.cp_size) < 1:
+            raise ValueError("TP, DP and CP sizes must be >= 1")
+        if self.model.gpu_blocks_per_rank < 1:
+            raise ValueError("model.gpu_blocks_per_rank must be >= 1")
+        if not 0 <= self.validation.sample_rate <= 1:
+            raise ValueError("validation.sample_rate must be in [0, 1]")
+        if self.conversation.turns_min < 1 or self.conversation.turns_max < self.conversation.turns_min:
+            raise ValueError("Invalid conversation turn range")
+        if self.features.swa and not self.preset.swa_enabled:
+            raise ValueError(f"Preset {self.preset.name} does not define an SWA pool")
+        if self.features.ssd and self.cache.ssd_cache_gb <= 0 and self.cache.num_ssd_blocks <= 0:
+            raise ValueError("SSD is enabled but neither ssd_cache_gb nor num_ssd_blocks is set")
+        if self.features.cpu_stub and self.features.ssd:
+            raise ValueError("CPU stub mode does not emulate the FlexKV SSD tier")
+        for group in self.preset.groups:
+            if any(layer < 0 or layer >= self.preset.num_layers for layer in group.layer_indices):
+                raise ValueError(f"Layer group {group.name} contains an invalid layer index")
+            if self.tokens_per_block % group.compress_ratio:
+                raise ValueError(
+                    f"tokens_per_block={self.tokens_per_block} must be divisible by "
+                    f"{group.name}.compress_ratio={group.compress_ratio}"
+                )
+
+
+def _section(cls, raw: dict[str, Any], name: str):
+    return cls(**(raw.get(name) or {}))
+
+
+def _parse_layers(value: Any, num_layers: int, metadata: dict[str, Any]) -> tuple[int, ...]:
+    if value == "all":
+        return tuple(range(num_layers))
+    if isinstance(value, list):
+        return tuple(int(v) for v in value)
+    if isinstance(value, dict) and "compress_ratio" in value:
+        ratios = metadata.get("compress_ratios") or []
+        return tuple(i for i, ratio in enumerate(ratios) if ratio == int(value["compress_ratio"]))
+    if isinstance(value, dict) and "indexer_type" in value:
+        types = metadata.get("indexer_types") or []
+        return tuple(i for i, kind in enumerate(types) if kind == value["indexer_type"])
+    raise ValueError(f"Unsupported layer selector: {value!r}")
+
+
+def _override_groups(preset: ModelPreset, groups: list[dict[str, Any]]) -> ModelPreset:
+    parsed = []
+    metadata = preset.metadata or {}
+    for raw in groups:
+        parsed.append(LayerGroup(
+            name=str(raw["name"]),
+            layer_indices=_parse_layers(raw.get("layers", "all"), preset.num_layers, metadata),
+            num_kv_heads=int(raw.get("num_kv_heads", 1)),
+            head_size=int(raw["head_size"]),
+            dtype=str(raw.get("dtype", preset.dtype)),
+            compress_ratio=int(raw.get("compress_ratio", 1)),
+            sliding_window=raw.get("sliding_window"),
+        ))
+    from dataclasses import replace
+    return replace(preset, groups=tuple(parsed))
+
+
+def load_config(path: str | os.PathLike[str]) -> StressConfig:
+    source = Path(path).resolve()
+    raw = yaml.safe_load(source.read_text()) or {}
+    model = _section(ModelBenchConfig, raw, "model")
+    preset = get_preset(model.preset)
+    if model.hf_config_path:
+        hf_path = Path(model.hf_config_path)
+        if not hf_path.is_absolute():
+            hf_path = source.parent / hf_path
+        preset = update_from_hf_config(preset, hf_path)
+    if model.dtype:
+        from dataclasses import replace
+        groups = tuple(
+            replace(group, dtype=model.dtype) if group.dtype == preset.dtype else group
+            for group in preset.groups
+        )
+        preset = replace(preset, dtype=model.dtype, groups=groups)
+    if model.layer_groups:
+        preset = _override_groups(preset, model.layer_groups)
+    config = StressConfig(
+        run=_section(RunConfig, raw, "run"),
+        model=model,
+        cache=_section(CacheBenchConfig, raw, "cache"),
+        features=_section(FeatureConfig, raw, "features"),
+        conversation=_section(ConversationConfig, raw, "conversation"),
+        concurrency=_section(ConcurrencyConfig, raw, "concurrency"),
+        validation=_section(ValidationConfig, raw, "validation"),
+        output=_section(OutputConfig, raw, "output"),
+        preset=preset,
+        source_path=source,
+    )
+    if isinstance(config.cache.ssd_cache_dir, str):
+        config.cache.ssd_cache_dir = [
+            value.strip() for value in config.cache.ssd_cache_dir.split(";") if value.strip()
+        ]
+    config.validate()
+    return config
+
+
+def config_as_dict(config: StressConfig) -> dict[str, Any]:
+    from dataclasses import asdict
+    result = asdict(config)
+    result["source_path"] = str(config.source_path)
+    return copy.deepcopy(result)

--- a/benchmarks/flexkv_stress/configs/cpu_stub.yaml
+++ b/benchmarks/flexkv_stress/configs/cpu_stub.yaml
@@ -1,0 +1,54 @@
+model:
+  preset: glm5
+  tp_size: 2
+  dp_size: 2
+  cp_size: 1
+  gpu_blocks_per_rank: 64
+  tokens_per_block: 8
+  layer_groups:
+    - name: tiny_main
+      layers: [0, 1]
+      num_kv_heads: 1
+      head_size: 8
+      dtype: float32
+cache:
+  num_cpu_blocks: 512
+features:
+  cpu_stub: true
+  layerwise: false
+  swa: false
+  ssd: false
+  concurrency: true
+  async_api_probe_interval_rounds: 1
+run:
+  warmup_rounds: 1
+  rounds: 5
+  duration_seconds: 0
+  stop_when: either
+  seed: 42
+  log_every_rounds: 1
+conversation:
+  conversations_per_round: 6
+  turns_min: 3
+  turns_max: 3
+  system_prompt_blocks: 2
+  first_input_blocks: 1
+  added_input_blocks: 1
+  output_blocks: 1
+  shared_system_prompt: true
+  read_after_put: true
+concurrency:
+  max_inflight_per_dp: 4
+  batch_size: 2
+  request_timeout_seconds: 10
+validation:
+  sample_rate: 1.0
+  min_samples_per_round: 1
+  sampled_layers_per_group: 2
+  sampled_blocks_per_request: 2
+  bytes_per_sample: 256
+  hit_tolerance_blocks: 0
+  stop_on_mismatch: true
+  minimum_success_rate: 1.0
+output:
+  directory: ./benchmark_results/flexkv_stress/cpu_stub

--- a/benchmarks/flexkv_stress/configs/cpu_stub.yaml
+++ b/benchmarks/flexkv_stress/configs/cpu_stub.yaml
@@ -55,7 +55,6 @@ validation:
   sampled_blocks_per_request: 2
   bytes_per_sample: 256
   hit_tolerance_blocks: 0
-  stop_on_mismatch: true
   minimum_success_rate: 1.0
 output:
   directory: ./benchmark_results/flexkv_stress/cpu_stub

--- a/benchmarks/flexkv_stress/configs/dsv4_cpu_smoke.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_cpu_smoke.yaml
@@ -1,0 +1,60 @@
+model:
+  preset: dsv4_pro
+  # SGLang composite TP=2 with CP=2 => KV TP=1 and two full-KV CP workers.
+  tp_size: 2
+  dp_size: 1
+  cp_size: 2
+  gpu_blocks_per_rank: 8
+
+cache:
+  num_cpu_blocks: 32
+  swa_num_slots: 4
+
+features:
+  cpu_stub: true
+  layerwise: false
+  swa: true
+  ssd: false
+  concurrency: true
+  async_api_probe_interval_rounds: 0
+
+run:
+  mode: latency_hit
+  warmup_rounds: 1
+  rounds: 2
+  duration_seconds: 0
+  seed: 44
+
+bandwidth:
+  concurrency_levels: [1, 2]
+  min_duration_seconds: 0
+  min_operations: 1
+  window_seconds: 0
+  validation_interval_operations: 1
+
+conversation:
+  conversations_per_round: 1
+  turns_min: 2
+  turns_max: 2
+  system_prompt_blocks: 1
+  first_input_blocks: 1
+  added_input_blocks: 1
+  output_blocks: 1
+  read_after_put: true
+
+concurrency:
+  max_inflight_per_dp: 2
+  batch_size: 1
+  request_timeout_seconds: 10
+
+validation:
+  sample_rate: 1.0
+  min_samples_per_round: 1
+  sampled_layers_per_group: 1
+  sampled_blocks_per_request: 1
+  bytes_per_sample: 64
+  minimum_success_rate: 1.0
+
+output:
+  directory: ./benchmark_results/flexkv_stress/dsv4_cpu_smoke
+  resource_interval_seconds: 0

--- a/benchmarks/flexkv_stress/configs/dsv4_flash.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_flash.yaml
@@ -11,7 +11,7 @@ cache:
   swa_num_slots: 128
   swa_ssd_slots: 512
 features: {layerwise: true, swa: true, ssd: true, concurrency: true}
-run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
+run: {mode: latency_hit, warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
 conversation:
   conversations_per_round: 16
   turns_min: 2

--- a/benchmarks/flexkv_stress/configs/dsv4_flash.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_flash.yaml
@@ -1,0 +1,26 @@
+model:
+  preset: dsv4_flash
+  tp_size: 1
+  dp_size: 1
+  cp_size: 1
+  gpu_blocks_per_rank: 128
+cache:
+  cpu_cache_gb: 2
+  ssd_cache_gb: 8
+  ssd_cache_dir: [./flexkv_stress_ssd/dsv4_flash]
+  swa_num_slots: 128
+  swa_ssd_slots: 512
+features: {layerwise: true, swa: true, ssd: true, concurrency: true}
+run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
+conversation:
+  conversations_per_round: 16
+  turns_min: 2
+  turns_max: 6
+  system_prompt_blocks: 4
+  first_input_blocks: [1, 4]
+  added_input_blocks: {mode: range, blocks: [1, 4]}
+  output_blocks: {mode: range, blocks: [1, 2]}
+  read_after_put: true
+concurrency: {max_inflight_per_dp: 16, batch_size: 4, request_timeout_seconds: 60}
+validation: {sample_rate: 0.001, min_samples_per_round: 1}
+output: {directory: ./benchmark_results/flexkv_stress/dsv4_flash}

--- a/benchmarks/flexkv_stress/configs/dsv4_pro.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_pro.yaml
@@ -19,11 +19,19 @@ features:
   concurrency: true
 
 run:
+  mode: latency_hit
   warmup_rounds: 1
   rounds: 1000
   duration_seconds: 86400
   stop_when: either
   seed: 42
+
+bandwidth:
+  concurrency_levels: [1, 2, 4, 8, 16]
+  target_payload_gb: 0
+  min_duration_seconds: 30
+  min_operations: 100
+  window_seconds: 5
 
 conversation:
   conversations_per_round: 16

--- a/benchmarks/flexkv_stress/configs/dsv4_pro.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_pro.yaml
@@ -1,0 +1,48 @@
+model:
+  preset: dsv4_pro
+  tp_size: 1
+  dp_size: 1
+  cp_size: 1
+  gpu_blocks_per_rank: 128
+
+cache:
+  cpu_cache_gb: 2
+  ssd_cache_gb: 8
+  ssd_cache_dir: [./flexkv_stress_ssd/dsv4_pro]
+  swa_num_slots: 128
+  swa_ssd_slots: 512
+
+features:
+  layerwise: true
+  swa: true
+  ssd: true
+  concurrency: true
+
+run:
+  warmup_rounds: 1
+  rounds: 1000
+  duration_seconds: 86400
+  stop_when: either
+  seed: 42
+
+conversation:
+  conversations_per_round: 16
+  turns_min: 2
+  turns_max: 6
+  system_prompt_blocks: 4
+  first_input_blocks: [1, 4]
+  added_input_blocks: {mode: range, blocks: [1, 4]}
+  output_blocks: {mode: range, blocks: [1, 2]}
+  read_after_put: true
+
+concurrency:
+  max_inflight_per_dp: 16
+  batch_size: 4
+  request_timeout_seconds: 60
+
+validation:
+  sample_rate: 0.001
+  min_samples_per_round: 1
+
+output:
+  directory: ./benchmark_results/flexkv_stress/dsv4_pro

--- a/benchmarks/flexkv_stress/configs/dsv4_pro_dp2cp2tp4.yaml
+++ b/benchmarks/flexkv_stress/configs/dsv4_pro_dp2cp2tp4.yaml
@@ -1,0 +1,63 @@
+# DSv4-Pro long-stability stress: DP2 / CP2 / TP4 (= 8 GPUs).
+# Tuned to trigger CPU eviction + SSD demotion within the first few rounds:
+#   host main block @ kv_tp=2 ≈ 2.77 MB. 512 CPU blocks ≈ 1.42 GB fills in ~2 rounds;
+#   1536 SSD blocks ≈ 4.25 GB starts SSD-tier eviction after ~5-6 rounds.
+# latency_hit runs unloaded + loaded, each for duration_seconds → ~1h wall @ 1800s.
+model:
+  preset: dsv4_pro
+  tp_size: 4                   # composite SGLang TP world per DP shard
+  cp_size: 2                   # q-split CP → kv_tp = 4/2 = 2
+  dp_size: 2                   # required_gpus = dp × tp = 8
+  gpu_blocks_per_rank: 2048    # must hold one batch's live blocks (batch_size ×
+                               # max seq). 128 was too small for batch_size=8 →
+                               # batched read-back slots wrapped & self-collided
+                               # → FALSE byte-validation failures under load.
+
+cache:
+  num_cpu_blocks: 512          # explicit → eviction pace independent of page size
+  num_ssd_blocks: 1536
+  ssd_cache_dir: [./flexkv_stress_ssd/dsv4_pro_dp2cp2tp4]
+  swa_num_slots: 256           # SWA CPU pool ≈ 2.34 GB (9.14 MB/slot)
+  swa_ssd_slots: 512
+  eviction_policy: lru
+
+features:
+  layerwise: true
+  swa: true
+  ssd: true
+  concurrency: true
+
+run:
+  mode: latency_hit
+  warmup_rounds: 1
+  rounds: 0                    # duration-bound only
+  duration_seconds: 1800       # 2 scenarios × 30 min ≈ 1h wall
+  stop_when: either
+  seed: 42
+
+conversation:
+  conversations_per_round: 32  # bumped for pressure: ~500 unique blocks/round → CPU (512) evicts every round
+  turns_min: 2
+  turns_max: 6
+  system_prompt_blocks: 4      # shared prefix trunk in the radix tree
+  first_input_blocks: [1, 4]
+  added_input_blocks: {mode: range, blocks: [1, 4]}
+  output_blocks: {mode: range, blocks: [1, 2]}
+  read_after_put: true
+
+concurrency:
+  max_inflight_per_dp: 32      # bumped for pressure
+  batch_size: 16               # bumped for pressure; needed gpu blocks = 16×40 = 640 << 2048, no self-collision
+  request_timeout_seconds: 60
+
+validation:
+  sample_rate: 0.01            # bumped: actually catch rare corruption over 1h
+  min_samples_per_round: 2
+  sampled_layers_per_group: 2
+  sampled_blocks_per_request: 2
+  bytes_per_sample: 256
+  hit_tolerance_blocks: 2      # absorb dp>1 per-DP-oracle vs shared-global-cache jitter
+  minimum_success_rate: 0.99
+
+output:
+  directory: ./benchmark_results/flexkv_stress/dsv4_pro_dp2cp2tp4

--- a/benchmarks/flexkv_stress/configs/glm5.yaml
+++ b/benchmarks/flexkv_stress/configs/glm5.yaml
@@ -1,0 +1,24 @@
+model:
+  preset: glm5
+  tp_size: 1
+  dp_size: 1
+  cp_size: 1
+  gpu_blocks_per_rank: 128
+cache:
+  cpu_cache_gb: 4
+  ssd_cache_gb: 16
+  ssd_cache_dir: [./flexkv_stress_ssd/glm5]
+features: {layerwise: true, swa: false, ssd: true, concurrency: true}
+run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
+conversation:
+  conversations_per_round: 16
+  turns_min: 2
+  turns_max: 6
+  system_prompt_blocks: 8
+  first_input_blocks: [2, 8]
+  added_input_blocks: {mode: range, blocks: [1, 4]}
+  output_blocks: {mode: range, blocks: [1, 2]}
+  read_after_put: true
+concurrency: {max_inflight_per_dp: 16, batch_size: 4, request_timeout_seconds: 60}
+validation: {sample_rate: 0.001, min_samples_per_round: 1}
+output: {directory: ./benchmark_results/flexkv_stress/glm5}

--- a/benchmarks/flexkv_stress/configs/glm5.yaml
+++ b/benchmarks/flexkv_stress/configs/glm5.yaml
@@ -9,7 +9,13 @@ cache:
   ssd_cache_gb: 16
   ssd_cache_dir: [./flexkv_stress_ssd/glm5]
 features: {layerwise: true, swa: false, ssd: true, concurrency: true}
-run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
+run: {mode: latency_hit, warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 42}
+bandwidth:
+  concurrency_levels: [1, 2, 4, 8, 16]
+  target_payload_gb: 0
+  min_duration_seconds: 30
+  min_operations: 100
+  window_seconds: 5
 conversation:
   conversations_per_round: 16
   turns_min: 2

--- a/benchmarks/flexkv_stress/configs/glm5_2.yaml
+++ b/benchmarks/flexkv_stress/configs/glm5_2.yaml
@@ -1,0 +1,24 @@
+model:
+  preset: glm5_2
+  tp_size: 1
+  dp_size: 1
+  cp_size: 1
+  gpu_blocks_per_rank: 128
+cache:
+  cpu_cache_gb: 4
+  ssd_cache_gb: 16
+  ssd_cache_dir: [./flexkv_stress_ssd/glm5_2]
+features: {layerwise: true, swa: false, ssd: true, concurrency: true}
+run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 52}
+conversation:
+  conversations_per_round: 16
+  turns_min: 2
+  turns_max: 8
+  system_prompt_blocks: 8
+  first_input_blocks: [2, 8]
+  added_input_blocks: {mode: list, blocks: [2, 4, 1, 8]}
+  output_blocks: {mode: range, blocks: [1, 2]}
+  read_after_put: true
+concurrency: {max_inflight_per_dp: 16, batch_size: 4, request_timeout_seconds: 60}
+validation: {sample_rate: 0.001, min_samples_per_round: 1}
+output: {directory: ./benchmark_results/flexkv_stress/glm5_2}

--- a/benchmarks/flexkv_stress/configs/glm5_2.yaml
+++ b/benchmarks/flexkv_stress/configs/glm5_2.yaml
@@ -9,7 +9,7 @@ cache:
   ssd_cache_gb: 16
   ssd_cache_dir: [./flexkv_stress_ssd/glm5_2]
 features: {layerwise: true, swa: false, ssd: true, concurrency: true}
-run: {warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 52}
+run: {mode: latency_hit, warmup_rounds: 1, rounds: 1000, duration_seconds: 86400, stop_when: either, seed: 52}
 conversation:
   conversations_per_round: 16
   turns_min: 2

--- a/benchmarks/flexkv_stress/configs/glm5_cpu_smoke.yaml
+++ b/benchmarks/flexkv_stress/configs/glm5_cpu_smoke.yaml
@@ -1,9 +1,10 @@
 model:
   preset: glm5
-  tp_size: 2
-  dp_size: 2
-  cp_size: 1
-  gpu_blocks_per_rank: 64
+  # Four physical workers per DP: KV TP=2, duplicated across two q-split CP ranks.
+  tp_size: 4
+  dp_size: 1
+  cp_size: 2
+  gpu_blocks_per_rank: 16
   tokens_per_block: 8
   layer_groups:
     - name: tiny_main
@@ -11,8 +12,15 @@ model:
       num_kv_heads: 1
       head_size: 8
       dtype: float32
+    - name: tiny_indexer
+      layers: [0, 1]
+      num_kv_heads: 1
+      head_size: 4
+      dtype: uint8
+
 cache:
-  num_cpu_blocks: 512
+  num_cpu_blocks: 128
+
 features:
   cpu_stub: true
   layerwise: false
@@ -20,42 +28,44 @@ features:
   ssd: false
   concurrency: true
   async_api_probe_interval_rounds: 1
+
 run:
   mode: latency_hit
   warmup_rounds: 1
-  rounds: 5
+  rounds: 2
   duration_seconds: 0
-  stop_when: either
-  seed: 42
-  log_every_rounds: 1
+  seed: 55
+
 bandwidth:
-  concurrency_levels: [1, 2, 4]
+  concurrency_levels: [1, 2]
   min_duration_seconds: 0
   min_operations: 1
   window_seconds: 0
   validation_interval_operations: 1
+
 conversation:
-  conversations_per_round: 6
-  turns_min: 3
-  turns_max: 3
-  system_prompt_blocks: 2
+  conversations_per_round: 2
+  turns_min: 2
+  turns_max: 2
+  system_prompt_blocks: 1
   first_input_blocks: 1
   added_input_blocks: 1
   output_blocks: 1
-  shared_system_prompt: true
   read_after_put: true
+
 concurrency:
-  max_inflight_per_dp: 4
+  max_inflight_per_dp: 2
   batch_size: 2
   request_timeout_seconds: 10
+
 validation:
   sample_rate: 1.0
   min_samples_per_round: 1
-  sampled_layers_per_group: 2
-  sampled_blocks_per_request: 2
-  bytes_per_sample: 256
-  hit_tolerance_blocks: 0
-  stop_on_mismatch: true
+  sampled_layers_per_group: 1
+  sampled_blocks_per_request: 1
+  bytes_per_sample: 64
   minimum_success_rate: 1.0
+
 output:
-  directory: ./benchmark_results/flexkv_stress/cpu_stub
+  directory: ./benchmark_results/flexkv_stress/glm5_cpu_smoke
+  resource_interval_seconds: 0

--- a/benchmarks/flexkv_stress/cpu_stub.py
+++ b/benchmarks/flexkv_stress/cpu_stub.py
@@ -47,6 +47,7 @@ class CpuTorchWorker:
         self.config = config
         self.dp_rank = dp_rank
         self.effective_rank = effective_rank
+        self.kv_tp_rank, self.cp_rank = config.worker_ranks(effective_rank)
         self.device_id = device_id
         self.tensors_per_group: list[list[torch.Tensor]] = []
         for group in config.preset.groups:
@@ -81,13 +82,16 @@ class CpuTorchWorker:
         patterns = [int(value) for value in command.get("patterns", [])]
         if operation == "seed":
             for group_id, tensors in enumerate(self.tensors_per_group):
-                _fill_blocks(tensors, block_ids, patterns, self.effective_rank, group_id)
+                _fill_blocks(tensors, block_ids, patterns, self.kv_tp_rank, group_id)
             if self.swa_tensors is not None and command.get("swa_block_ids"):
+                swa_patterns = [
+                    int(value) for value in command.get("swa_patterns", patterns[-1:])
+                ]
                 _fill_blocks(
                     self.swa_tensors,
                     [int(value) for value in command["swa_block_ids"]],
-                    [patterns[-1]],
-                    self.effective_rank,
+                    swa_patterns,
+                    self.kv_tp_rank,
                     len(self.tensors_per_group),
                 )
             return {"ok": True}
@@ -111,17 +115,20 @@ class CpuTorchWorker:
                     tensors,
                     block_ids,
                     patterns,
-                    self.effective_rank,
+                    self.kv_tp_rank,
                     group_id,
                     max_layers,
                     max_bytes,
                 ))
             if self.swa_tensors is not None and command.get("swa_block_ids"):
+                swa_patterns = [
+                    int(value) for value in command.get("swa_patterns", patterns[-1:])
+                ]
                 errors.extend(_verify_blocks(
                     self.swa_tensors,
                     [int(value) for value in command["swa_block_ids"]],
-                    [patterns[-1]],
-                    self.effective_rank,
+                    swa_patterns,
+                    self.kv_tp_rank,
                     len(self.tensors_per_group),
                     max_layers,
                     max_bytes,
@@ -274,7 +281,10 @@ class CpuStubManager:
                     self._copy_worker_block_to_node(worker, block_id, child)
             node = child
         if swa_slot_mapping is not None and len(np.asarray(swa_slot_mapping).reshape(-1)):
-            swa_block = int(np.asarray(swa_slot_mapping).reshape(-1)[0])
+            swa_block = int(
+                np.asarray(swa_slot_mapping).reshape(-1)[0]
+                // self.config.tokens_per_block
+            )
             for worker in self.workers:
                 if worker.swa_tensors is not None:
                     node.swa_data[worker.effective_rank] = [
@@ -310,7 +320,10 @@ class CpuStubManager:
                 self._copy_node_to_worker_block(node, worker, block_id)
         if task.nodes and swa_slot_mapping is not None and len(np.asarray(swa_slot_mapping).reshape(-1)):
             terminal = task.nodes[-1]
-            swa_block = int(np.asarray(swa_slot_mapping).reshape(-1)[0])
+            swa_block = int(
+                np.asarray(swa_slot_mapping).reshape(-1)[0]
+                // self.config.tokens_per_block
+            )
             for worker in self.workers:
                 cached = terminal.swa_data.get(worker.effective_rank)
                 if cached is None or worker.swa_tensors is None:
@@ -351,7 +364,7 @@ class CpuStubManager:
 
 def start_cpu_workers(config) -> list[CpuTorchWorker]:
     workers = []
-    effective_size = config.model.tp_size * config.model.cp_size
+    effective_size = config.workers_per_dp
     for dp_rank in range(config.model.dp_size):
         for effective_rank in range(effective_size):
             device_id = dp_rank * effective_size + effective_rank

--- a/benchmarks/flexkv_stress/cpu_stub.py
+++ b/benchmarks/flexkv_stress/cpu_stub.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import resource
+import sys
+from typing import Any
+
+import numpy as np
+import torch
+
+from .gpu_worker import _fill_blocks, _verify_blocks, _zero_blocks
+
+
+@dataclass
+class _CacheNode:
+    children: dict[tuple[int, ...], "_CacheNode"] = field(default_factory=dict)
+    references: int = 0
+    # effective_rank -> group -> layer tensor for one logical KV block
+    data: dict[int, list[list[torch.Tensor]]] = field(default_factory=dict)
+    # effective_rank -> layer tensor for the sequence's SWA slot
+    swa_data: dict[int, list[torch.Tensor]] = field(default_factory=dict)
+
+
+@dataclass
+class _Task:
+    operation: str
+    tokens: tuple[int, ...]
+    nodes: list[_CacheNode]
+    missing_start: int = 0
+
+
+class _SuccessStatus:
+    name = "SUCCESS"
+
+
+class _SuccessResponse:
+    status = _SuccessStatus()
+
+
+class CpuTorchWorker:
+    """In-process stand-in for one inference-engine GPU KV pool."""
+
+    def __init__(self, config, dp_rank: int, effective_rank: int, device_id: int):
+        from .device import torch_dtype
+
+        self.config = config
+        self.dp_rank = dp_rank
+        self.effective_rank = effective_rank
+        self.device_id = device_id
+        self.tensors_per_group: list[list[torch.Tensor]] = []
+        for group in config.preset.groups:
+            group_tpb = config.tokens_per_block // group.compress_ratio
+            shape = (
+                config.model.gpu_blocks_per_rank,
+                group_tpb,
+                group.num_kv_heads,
+                group.head_size,
+            )
+            self.tensors_per_group.append([
+                torch.zeros(shape, dtype=torch_dtype(group.dtype))
+                for _ in range(group.num_layers)
+            ])
+        self.swa_tensors: list[torch.Tensor] | None = None
+        if config.features.swa:
+            shape = (
+                config.cache.swa_num_slots,
+                config.tokens_per_block,
+                1,
+                config.preset.swa_head_size,
+            )
+            self.swa_tensors = [
+                torch.zeros(shape, dtype=torch.uint8)
+                for _ in range(config.preset.swa_num_layers)
+            ]
+
+    def request(self, command: dict[str, Any], timeout: float = 60) -> dict[str, Any]:
+        del timeout
+        operation = command["operation"]
+        block_ids = [int(value) for value in command.get("block_ids", [])]
+        patterns = [int(value) for value in command.get("patterns", [])]
+        if operation == "seed":
+            for group_id, tensors in enumerate(self.tensors_per_group):
+                _fill_blocks(tensors, block_ids, patterns, self.effective_rank, group_id)
+            if self.swa_tensors is not None and command.get("swa_block_ids"):
+                _fill_blocks(
+                    self.swa_tensors,
+                    [int(value) for value in command["swa_block_ids"]],
+                    [patterns[-1]],
+                    self.effective_rank,
+                    len(self.tensors_per_group),
+                )
+            return {"ok": True}
+        if operation == "zero":
+            max_layers = command.get("max_layers")
+            for tensors in self.tensors_per_group:
+                _zero_blocks(tensors, block_ids, max_layers)
+            if self.swa_tensors is not None and command.get("swa_block_ids"):
+                _zero_blocks(
+                    self.swa_tensors,
+                    [int(value) for value in command["swa_block_ids"]],
+                    max_layers,
+                )
+            return {"ok": True}
+        if operation == "verify":
+            errors = []
+            max_layers = int(command.get("max_layers", 2))
+            max_bytes = int(command.get("max_bytes", 256))
+            for group_id, tensors in enumerate(self.tensors_per_group):
+                errors.extend(_verify_blocks(
+                    tensors,
+                    block_ids,
+                    patterns,
+                    self.effective_rank,
+                    group_id,
+                    max_layers,
+                    max_bytes,
+                ))
+            if self.swa_tensors is not None and command.get("swa_block_ids"):
+                errors.extend(_verify_blocks(
+                    self.swa_tensors,
+                    [int(value) for value in command["swa_block_ids"]],
+                    [patterns[-1]],
+                    self.effective_rank,
+                    len(self.tensors_per_group),
+                    max_layers,
+                    max_bytes,
+                ))
+            return {"ok": not errors, "errors": errors[:20]}
+        if operation == "memory":
+            tensors = [tensor for group in self.tensors_per_group for tensor in group]
+            tensors.extend(self.swa_tensors or [])
+            allocated = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+            rss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+            return {
+                "ok": True,
+                "allocated_bytes": allocated,
+                "reserved_bytes": allocated,
+                "max_allocated_bytes": allocated,
+                # macOS reports bytes, Linux reports KiB.
+                "rss_bytes": rss if sys.platform == "darwin" else rss * 1024,
+            }
+        if operation == "shutdown":
+            return {"ok": True}
+        raise ValueError(f"Unknown CPU stub worker operation {operation!r}")
+
+    def shutdown(self) -> None:
+        pass
+
+
+class CpuStubManager:
+    """CPU implementation of the KVManager API used by the stress driver.
+
+    The manager maintains the same block-prefix/refcount model as PrefixOracle
+    and copies real PyTorch tensor blocks between worker pools and an in-memory
+    cache. It intentionally does not exercise FlexKV IPC, native transfer, SSD,
+    or eventfd implementations.
+    """
+
+    def __init__(self, config, dp_rank: int, workers: list[CpuTorchWorker], capacity_blocks: int):
+        self.config = config
+        self.dp_rank = dp_rank
+        self.workers = [worker for worker in workers if worker.dp_rank == dp_rank]
+        self.capacity_blocks = capacity_blocks
+        self.root = _CacheNode()
+        self.sequences: deque[tuple[tuple[int, ...], ...]] = deque()
+        self.logical_blocks = 0
+        self.tasks: dict[int, _Task] = {}
+        self.next_task_id = 1
+
+    def start(self) -> None:
+        pass
+
+    def is_ready(self) -> bool:
+        return True
+
+    def shutdown(self) -> None:
+        pass
+
+    def _keys(self, tokens) -> tuple[tuple[int, ...], ...]:
+        values = tuple(int(value) for value in tokens)
+        tpb = self.config.tokens_per_block
+        aligned = len(values) // tpb * tpb
+        return tuple(tuple(values[start:start + tpb]) for start in range(0, aligned, tpb))
+
+    def _new_task(self, task: _Task, *, retain: bool = True) -> int:
+        task_id = self.next_task_id
+        self.next_task_id += 1
+        if retain:
+            self.tasks[task_id] = task
+        return task_id
+
+    def get_match(self, tokens, swa_aware: bool = False):
+        del swa_aware
+        keys = self._keys(tokens)
+        node = self.root
+        nodes = []
+        for key in keys:
+            child = node.children.get(key)
+            if child is None:
+                break
+            nodes.append(child)
+            node = child
+        hit_tokens = len(nodes) * self.config.tokens_per_block
+        mask = np.zeros(len(tokens), dtype=np.int64)
+        mask[:hit_tokens] = 1
+        task_id = self._new_task(
+            _Task("get", tuple(int(v) for v in tokens), nodes),
+            retain=bool(nodes),
+        )
+        return task_id, mask
+
+    def put_match(self, tokens):
+        keys = self._keys(tokens)
+        node = self.root
+        nodes = []
+        for key in keys:
+            child = node.children.get(key)
+            if child is None:
+                break
+            nodes.append(child)
+            node = child
+        matched_blocks = len(nodes)
+        mask = np.zeros(len(tokens), dtype=bool)
+        mask[matched_blocks * self.config.tokens_per_block:len(keys) * self.config.tokens_per_block] = True
+        task_id = self._new_task(
+            _Task("put", tuple(int(v) for v in tokens), nodes, missing_start=matched_blocks),
+            retain=matched_blocks < len(keys),
+        )
+        return task_id, mask
+
+    def _mapping_blocks(self, slot_mapping, expected_blocks: int) -> list[int]:
+        slots = np.asarray(slot_mapping, dtype=np.int64).reshape(-1)
+        tpb = self.config.tokens_per_block
+        if len(slots) != expected_blocks * tpb:
+            raise ValueError(
+                f"CPU stub expected {expected_blocks * tpb} slots, got {len(slots)}"
+            )
+        return [int(slots[index * tpb] // tpb) for index in range(expected_blocks)]
+
+    def _copy_worker_block_to_node(self, worker: CpuTorchWorker, block_id: int,
+                                   node: _CacheNode) -> None:
+        node.data[worker.effective_rank] = [
+            [tensor[block_id].clone() for tensor in group]
+            for group in worker.tensors_per_group
+        ]
+
+    def _copy_node_to_worker_block(self, node: _CacheNode, worker: CpuTorchWorker,
+                                   block_id: int) -> None:
+        cached_groups = node.data.get(worker.effective_rank)
+        if cached_groups is None:
+            raise RuntimeError(
+                f"CPU stub cache is missing rank {worker.effective_rank} data"
+            )
+        for tensors, cached_layers in zip(worker.tensors_per_group, cached_groups):
+            for tensor, cached in zip(tensors, cached_layers):
+                tensor[block_id].copy_(cached)
+
+    def _commit_put(self, task: _Task, slot_mapping, swa_slot_mapping=None) -> None:
+        keys = self._keys(task.tokens)
+        missing = len(keys) - task.missing_start
+        source_blocks = self._mapping_blocks(slot_mapping, missing)
+        node = self.root
+        node.references += 1
+        for index, key in enumerate(keys):
+            child = node.children.get(key)
+            if child is None:
+                child = _CacheNode()
+                node.children[key] = child
+            child.references += 1
+            if index >= task.missing_start:
+                block_id = source_blocks[index - task.missing_start]
+                for worker in self.workers:
+                    self._copy_worker_block_to_node(worker, block_id, child)
+            node = child
+        if swa_slot_mapping is not None and len(np.asarray(swa_slot_mapping).reshape(-1)):
+            swa_block = int(np.asarray(swa_slot_mapping).reshape(-1)[0])
+            for worker in self.workers:
+                if worker.swa_tensors is not None:
+                    node.swa_data[worker.effective_rank] = [
+                        tensor[swa_block].clone() for tensor in worker.swa_tensors
+                    ]
+        self.sequences.append(keys)
+        self.logical_blocks += len(keys)
+        while self.capacity_blocks and self.logical_blocks > self.capacity_blocks and self.sequences:
+            self._remove(self.sequences.popleft())
+
+    def _remove(self, keys: tuple[tuple[int, ...], ...]) -> None:
+        node = self.root
+        path = []
+        node.references -= 1
+        for key in keys:
+            child = node.children.get(key)
+            if child is None:
+                return
+            path.append((node, key, child))
+            child.references -= 1
+            node = child
+        for parent, key, child in reversed(path):
+            if child.references == 0:
+                del parent.children[key]
+            else:
+                break
+        self.logical_blocks -= len(keys)
+
+    def _load_get(self, task: _Task, slot_mapping, swa_slot_mapping=None) -> None:
+        target_blocks = self._mapping_blocks(slot_mapping, len(task.nodes))
+        for node, block_id in zip(task.nodes, target_blocks):
+            for worker in self.workers:
+                self._copy_node_to_worker_block(node, worker, block_id)
+        if task.nodes and swa_slot_mapping is not None and len(np.asarray(swa_slot_mapping).reshape(-1)):
+            terminal = task.nodes[-1]
+            swa_block = int(np.asarray(swa_slot_mapping).reshape(-1)[0])
+            for worker in self.workers:
+                cached = terminal.swa_data.get(worker.effective_rank)
+                if cached is None or worker.swa_tensors is None:
+                    continue
+                for tensor, source in zip(worker.swa_tensors, cached):
+                    tensor[swa_block].copy_(source)
+
+    def launch(self, task_ids, slot_mappings, swa_slot_mappings=None, **kwargs):
+        del kwargs
+        swa_mappings = swa_slot_mappings or [None] * len(task_ids)
+        for task_id, slot_mapping, swa_mapping in zip(task_ids, slot_mappings, swa_mappings):
+            task = self.tasks.pop(int(task_id))
+            if task.operation == "put":
+                self._commit_put(task, slot_mapping, swa_mapping)
+            elif task.operation == "get":
+                self._load_get(task, slot_mapping, swa_mapping)
+            else:
+                raise ValueError(f"Unknown CPU stub task operation {task.operation!r}")
+        return list(task_ids)
+
+    def wait(self, task_ids, **kwargs):
+        del kwargs
+        return {int(task_id): _SuccessResponse() for task_id in task_ids}
+
+    def put_async(self, tokens, slot_mapping):
+        task_id, mask = self.put_match(tokens)
+        if mask.any():
+            self._commit_put(self.tasks.pop(task_id), np.asarray(slot_mapping)[mask])
+        return [task_id]
+
+    def get_async(self, tokens, slot_mapping):
+        task_id, mask = self.get_match(tokens)
+        if int(mask.sum()) != len(tokens):
+            raise KeyError(f"CPU stub async GET matched {int(mask.sum())}/{len(tokens)} tokens")
+        self._load_get(self.tasks.pop(task_id), slot_mapping)
+        return [task_id]
+
+
+def start_cpu_workers(config) -> list[CpuTorchWorker]:
+    workers = []
+    effective_size = config.model.tp_size * config.model.cp_size
+    for dp_rank in range(config.model.dp_size):
+        for effective_rank in range(effective_size):
+            device_id = dp_rank * effective_size + effective_rank
+            workers.append(CpuTorchWorker(config, dp_rank, effective_rank, device_id))
+    return workers

--- a/benchmarks/flexkv_stress/device.py
+++ b/benchmarks/flexkv_stress/device.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DeviceBackend:
+    name: str
+    is_rocm: bool
+
+    @classmethod
+    def detect(cls, torch_module: Any = None) -> "DeviceBackend":
+        if torch_module is None:
+            import torch as torch_module
+        is_rocm = getattr(torch_module.version, "hip", None) is not None
+        return cls(name="rocm" if is_rocm else "cuda", is_rocm=is_rocm)
+
+    def device(self, device_id: int):
+        import torch
+        return torch.device(f"cuda:{device_id}")
+
+    def set_device(self, device_id: int) -> None:
+        import torch
+        torch.cuda.set_device(device_id)
+
+    def empty(self, shape, dtype, device_id: int, *, fill_zero: bool = False):
+        import torch
+        factory = torch.zeros if fill_zero else torch.empty
+        return factory(shape, dtype=dtype, device=self.device(device_id))
+
+    def synchronize(self, device_id: int | None = None) -> None:
+        import torch
+        torch.cuda.synchronize(device_id)
+
+    def memory(self, device_id: int) -> dict[str, int]:
+        import torch
+        return {
+            "allocated_bytes": int(torch.cuda.memory_allocated(device_id)),
+            "reserved_bytes": int(torch.cuda.memory_reserved(device_id)),
+            "max_allocated_bytes": int(torch.cuda.max_memory_allocated(device_id)),
+        }
+
+
+def torch_dtype(name: str):
+    import torch
+    aliases = {
+        "fp16": "float16", "bf16": "bfloat16", "fp32": "float32",
+        "fp8": "float8_e4m3fn", "e4m3": "float8_e4m3fn",
+    }
+    attr = aliases.get(name.lower(), name.lower())
+    if not hasattr(torch, attr):
+        raise ValueError(f"PyTorch does not provide dtype {name!r}")
+    return getattr(torch, attr)

--- a/benchmarks/flexkv_stress/device.py
+++ b/benchmarks/flexkv_stress/device.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass(frozen=True)
 class DeviceBackend:
-    name: str
-    is_rocm: bool
+    name: str = "cuda"
 
     @classmethod
-    def detect(cls, torch_module: Any = None) -> "DeviceBackend":
-        if torch_module is None:
-            import torch as torch_module
-        is_rocm = getattr(torch_module.version, "hip", None) is not None
-        return cls(name="rocm" if is_rocm else "cuda", is_rocm=is_rocm)
+    def detect(cls) -> "DeviceBackend":
+        return cls()
 
     def device(self, device_id: int):
         import torch

--- a/benchmarks/flexkv_stress/eventfd.py
+++ b/benchmarks/flexkv_stress/eventfd.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import ctypes
+import os
+import socket
+import struct
+import threading
+import time
+
+
+_EFD_NONBLOCK = 0x800
+
+
+def _create_eventfd() -> int:
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    fd = libc.eventfd(ctypes.c_uint(0), ctypes.c_int(_EFD_NONBLOCK))
+    if fd == -1:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return int(fd)
+
+
+def _send_fds(sock: socket.socket, fds: list[int], counter_id: int) -> None:
+    packed = struct.pack(f"{len(fds)}i", *fds)
+    sock.sendmsg(
+        [struct.pack("i", counter_id)],
+        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, packed)],
+    )
+
+
+class EventfdGroup:
+    """Minimal SGLang-compatible layer completion counter client."""
+
+    def __init__(self, socket_path: str, tp_size: int, num_layers: int, num_counters: int = 3):
+        self.socket_path = socket_path
+        self.tp_size = tp_size
+        self.num_layers = num_layers
+        self.num_counters = num_counters
+        self.fds = [
+            [[_create_eventfd() for _ in range(num_layers)] for _ in range(tp_size)]
+            for _ in range(num_counters)
+        ]
+        self.threads: list[threading.Thread] = []
+        self.errors: list[str] = []
+
+    def start(self) -> None:
+        for rank in range(self.tp_size):
+            thread = threading.Thread(target=self._connect, args=(rank,), daemon=True)
+            thread.start()
+            self.threads.append(thread)
+
+    def _connect(self, rank: int) -> None:
+        try:
+            client = None
+            for _ in range(240):
+                candidate = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    candidate.connect(self.socket_path)
+                    client = candidate
+                    break
+                except (FileNotFoundError, ConnectionRefusedError):
+                    candidate.close()
+                    time.sleep(0.25)
+            if client is None:
+                raise TimeoutError(f"eventfd socket did not appear: {self.socket_path}")
+            with client:
+                client.sendall(struct.pack("iiii", rank, self.tp_size, self.num_layers, self.num_counters))
+                for counter_id in range(self.num_counters):
+                    _send_fds(client, self.fds[counter_id][rank], counter_id)
+                client.settimeout(30)
+                if client.recv(1) != b"\x01":
+                    raise RuntimeError(f"eventfd registration rejected for rank {rank}")
+        except Exception as exc:
+            self.errors.append(str(exc))
+
+    def wait_ready(self, timeout: float = 65) -> None:
+        deadline = time.monotonic() + timeout
+        for thread in self.threads:
+            thread.join(max(0, deadline - time.monotonic()))
+        if any(thread.is_alive() for thread in self.threads):
+            raise TimeoutError("eventfd registration timed out")
+        if self.errors:
+            raise RuntimeError("; ".join(self.errors))
+
+    def read_counter(self, counter_id: int) -> list[list[int]]:
+        values = []
+        for rank_fds in self.fds[counter_id]:
+            rank_values = []
+            for fd in rank_fds:
+                try:
+                    rank_values.append(struct.unpack("Q", os.read(fd, 8))[0])
+                except BlockingIOError:
+                    rank_values.append(0)
+            values.append(rank_values)
+        return values
+
+    def close(self) -> None:
+        for counter in self.fds:
+            for rank in counter:
+                for fd in rank:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass

--- a/benchmarks/flexkv_stress/gpu_worker.py
+++ b/benchmarks/flexkv_stress/gpu_worker.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import multiprocessing as mp
+import traceback
+from typing import Any
+
+
+def _value(base: int, rank: int, group_id: int, layer_id: int) -> int:
+    return 1 + (base + rank * 17 + group_id * 29 + layer_id * 7) % 127
+
+
+def _fill_blocks(tensors, block_ids: list[int], patterns: list[int], rank: int, group_id: int) -> None:
+    for layer_id, tensor in enumerate(tensors):
+        for block_id, pattern in zip(block_ids, patterns):
+            tensor[block_id].fill_(_value(pattern, rank, group_id, layer_id))
+
+
+def _zero_blocks(tensors, block_ids: list[int], max_layers: int | None = None) -> None:
+    selected = tensors if max_layers is None else tensors[:max_layers]
+    for tensor in selected:
+        for block_id in block_ids:
+            tensor[block_id].zero_()
+
+
+def _verify_blocks(tensors, block_ids: list[int], patterns: list[int], rank: int,
+                   group_id: int, max_layers: int, max_bytes: int) -> list[str]:
+    import torch
+    errors = []
+    for layer_id, tensor in enumerate(tensors[:max_layers]):
+        for block_id, pattern in zip(block_ids, patterns):
+            expected = _value(pattern, rank, group_id, layer_id)
+            actual = tensor[block_id].reshape(-1)
+            itemsize = max(1, actual.element_size())
+            actual = actual[:max(1, max_bytes // itemsize)]
+            if not bool(torch.all(actual == expected)):
+                errors.append(
+                    f"rank={rank} group={group_id} layer={layer_id} block={block_id} expected={expected}"
+                )
+    return errors
+
+
+def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_id: int,
+                 gpu_register_port: str) -> None:
+    try:
+        import torch
+        from flexkv.common.config import LayerGroupSpec
+        from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+        from flexkv.server.client import KVTPClient
+
+        from .device import DeviceBackend, torch_dtype
+
+        backend = DeviceBackend.detect(torch)
+        backend.set_device(device_id)
+        groups = config.preset.groups
+        num_blocks = config.model.gpu_blocks_per_rank
+        layer_specs = []
+        layouts = []
+        tensors_per_group = []
+        for group in groups:
+            group_tpb = config.tokens_per_block // group.compress_ratio
+            spec = LayerGroupSpec(
+                num_layers=group.num_layers,
+                num_kv_heads=group.num_kv_heads,
+                head_size=group.head_size,
+                layer_indices=list(group.layer_indices),
+                sliding_window=group.sliding_window,
+                dtype=torch_dtype(group.dtype),
+                compress_ratio=group.compress_ratio,
+            )
+            layout = KVCacheLayout(
+                type=KVCacheLayoutType.LAYERFIRST,
+                num_layer=group.num_layers,
+                num_block=num_blocks,
+                tokens_per_block=group_tpb,
+                num_head=group.num_kv_heads,
+                head_size=group.head_size,
+                is_mla=True,
+            )
+            tensors = [
+                backend.empty(
+                    (num_blocks, group_tpb, group.num_kv_heads, group.head_size),
+                    torch_dtype(group.dtype),
+                    device_id,
+                    fill_zero=True,
+                )
+                for _ in range(group.num_layers)
+            ]
+            layer_specs.append(spec)
+            layouts.append(layout)
+            tensors_per_group.append(tensors)
+
+        swa_tensors = None
+        swa_layout = None
+        if config.features.swa:
+            swa_slots = config.cache.swa_num_slots
+            swa_layout = KVCacheLayout(
+                type=KVCacheLayoutType.LAYERFIRST,
+                num_layer=config.preset.swa_num_layers,
+                num_block=swa_slots,
+                tokens_per_block=config.tokens_per_block,
+                num_head=1,
+                head_size=config.preset.swa_head_size,
+                is_mla=True,
+            )
+            swa_tensors = [
+                backend.empty(
+                    (swa_slots, config.tokens_per_block, 1, config.preset.swa_head_size),
+                    torch.uint8,
+                    device_id,
+                    fill_zero=True,
+                )
+                for _ in range(config.preset.swa_num_layers)
+            ]
+
+        tp_client = KVTPClient(gpu_register_port, dp_rank, device_id, pp_rank=0)
+        flat_tensors = [tensor for group in tensors_per_group for tensor in group]
+        tp_client.register_to_server(
+            kv_caches=flat_tensors,
+            kv_layout=layouts[0],
+            layer_groups=layer_specs,
+            gpu_layouts=layouts,
+            handles_per_group=tensors_per_group,
+            swa_caches=swa_tensors,
+            swa_layout=swa_layout,
+        )
+        backend.synchronize(device_id)
+        connection.send({
+            "ok": True,
+            "backend": backend.name,
+            "device_id": device_id,
+            "groups": [tuple(tensor.shape) for tensor in (group[0] for group in tensors_per_group)],
+        })
+
+        while True:
+            command = connection.recv()
+            operation = command["operation"]
+            if operation == "shutdown":
+                connection.send({"ok": True})
+                break
+            block_ids = [int(v) for v in command.get("block_ids", [])]
+            patterns = [int(v) for v in command.get("patterns", [])]
+            if operation == "seed":
+                for group_id, tensors in enumerate(tensors_per_group):
+                    _fill_blocks(tensors, block_ids, patterns, effective_rank, group_id)
+                if swa_tensors is not None and command.get("swa_block_ids"):
+                    _fill_blocks(
+                        swa_tensors,
+                        [int(v) for v in command["swa_block_ids"]],
+                        [patterns[-1]],
+                        effective_rank,
+                        len(tensors_per_group),
+                    )
+                backend.synchronize(device_id)
+                connection.send({"ok": True})
+            elif operation == "zero":
+                max_layers = command.get("max_layers")
+                for tensors in tensors_per_group:
+                    _zero_blocks(tensors, block_ids, max_layers)
+                if swa_tensors is not None and command.get("swa_block_ids"):
+                    _zero_blocks(
+                        swa_tensors, [int(v) for v in command["swa_block_ids"]], max_layers
+                    )
+                backend.synchronize(device_id)
+                connection.send({"ok": True})
+            elif operation == "verify":
+                errors = []
+                max_layers = int(command.get("max_layers", 2))
+                max_bytes = int(command.get("max_bytes", 256))
+                for group_id, tensors in enumerate(tensors_per_group):
+                    errors.extend(_verify_blocks(
+                        tensors, block_ids, patterns, effective_rank, group_id, max_layers, max_bytes
+                    ))
+                if swa_tensors is not None and command.get("swa_block_ids"):
+                    errors.extend(_verify_blocks(
+                        swa_tensors,
+                        [int(v) for v in command["swa_block_ids"]],
+                        [patterns[-1]],
+                        effective_rank,
+                        len(tensors_per_group),
+                        max_layers,
+                        max_bytes,
+                    ))
+                connection.send({"ok": not errors, "errors": errors[:20]})
+            elif operation == "memory":
+                import resource
+                rss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+                # Linux reports KiB; GPU execution environments for FlexKV are Linux.
+                connection.send({"ok": True, **backend.memory(device_id), "rss_bytes": rss * 1024})
+            else:
+                raise ValueError(f"Unknown GPU worker operation {operation!r}")
+    except BaseException as exc:
+        try:
+            connection.send({"ok": False, "error": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc()})
+        except Exception:
+            pass
+        raise
+
+
+@dataclass
+class GpuWorker:
+    dp_rank: int
+    effective_rank: int
+    device_id: int
+    process: mp.Process
+    connection: Any
+
+    def request(self, command: dict[str, Any], timeout: float = 60) -> dict[str, Any]:
+        if not self.process.is_alive():
+            raise RuntimeError(f"GPU worker {self.device_id} exited with code {self.process.exitcode}")
+        self.connection.send(command)
+        if not self.connection.poll(timeout):
+            raise TimeoutError(f"GPU worker {self.device_id} timed out on {command['operation']}")
+        response = self.connection.recv()
+        if not response.get("ok", False) and command["operation"] != "verify":
+            raise RuntimeError(response.get("error", str(response)))
+        return response
+
+    def shutdown(self) -> None:
+        if self.process.is_alive():
+            try:
+                self.request({"operation": "shutdown"}, timeout=10)
+            except Exception:
+                pass
+            self.process.join(timeout=10)
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(timeout=5)
+
+
+def start_gpu_workers(config, gpu_register_port: str) -> list[GpuWorker]:
+    context = mp.get_context("spawn")
+    workers = []
+    effective_size = config.model.tp_size * config.model.cp_size
+    for dp_rank in range(config.model.dp_size):
+        for effective_rank in range(effective_size):
+            device_id = dp_rank * effective_size + effective_rank
+            parent, child = context.Pipe()
+            process = context.Process(
+                target=_worker_main,
+                args=(child, config, dp_rank, effective_rank, device_id, gpu_register_port),
+                daemon=False,
+            )
+            process.start()
+            worker = GpuWorker(dp_rank, effective_rank, device_id, process, parent)
+            if not parent.poll(180):
+                worker.shutdown()
+                raise TimeoutError(f"GPU worker {device_id} did not register in 180 seconds")
+            response = parent.recv()
+            if not response.get("ok"):
+                worker.shutdown()
+                raise RuntimeError(response.get("traceback", response.get("error", str(response))))
+            workers.append(worker)
+    return workers
+
+
+def command_dp(workers: list[GpuWorker], dp_rank: int, command: dict[str, Any],
+               timeout: float = 60) -> list[dict[str, Any]]:
+    return [worker.request(command, timeout) for worker in workers if worker.dp_rank == dp_rank]

--- a/benchmarks/flexkv_stress/gpu_worker.py
+++ b/benchmarks/flexkv_stress/gpu_worker.py
@@ -117,9 +117,30 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
 
         tp_client = KVTPClient(gpu_register_port, dp_rank, device_id, pp_rank=0)
         flat_tensors = [tensor for group in tensors_per_group for tensor in group]
+        # Whole-stage representative layout. FlexKV derives num_layers_per_pp_stage
+        # from this singular kv_layout's num_layer (transfer_manager.py), and that
+        # becomes the main-KV layer count the fused-layerwise SWA path asserts
+        # against (swa_num_layers == num_layers). It must span the full
+        # attention-layer index space shared by all groups + SWA
+        # (== preset.num_layers == swa_num_layers), NOT a single group's subset.
+        # layouts[0] is only the primary (first) pool — for multi-pool models like
+        # DSv4 its num_layer is a subset (e.g. c4=29 of 61), which mis-sets the
+        # stage count and trips the SWA assertion. Build a separate layout so the
+        # per-group entries in ``gpu_layouts`` keep their own counts. Mirrors the
+        # sglang connector, which registers num_layer=num_layers_per_pp_stage.
+        primary = groups[0]
+        main_layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=config.preset.num_layers,
+            num_block=num_blocks,
+            tokens_per_block=config.tokens_per_block // primary.compress_ratio,
+            num_head=primary.num_kv_heads,
+            head_size=primary.head_size,
+            is_mla=True,
+        )
         tp_client.register_to_server(
             kv_caches=flat_tensors,
-            kv_layout=layouts[0],
+            kv_layout=main_layout,
             layer_groups=layer_specs,
             gpu_layouts=layouts,
             handles_per_group=tensors_per_group,
@@ -137,6 +158,14 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
             "groups": [tuple(tensor.shape) for tensor in (group[0] for group in tensors_per_group)],
         })
 
+        # MLA (use_mla) KV is a shared latent that is TP-replicated, NOT sharded
+        # across ranks: every TP rank holds an identical copy, and FlexKV stores
+        # one copy per block. So seed/verify must be rank-independent for MLA —
+        # otherwise rank>0 verifies against a rank-specific value it never had
+        # (it legitimately holds rank 0's bytes). For non-MLA (head-sharded) KV
+        # the per-rank value is meaningful.
+        seed_rank = 0 if config.preset.use_mla else kv_tp_rank
+
         while True:
             command = connection.recv()
             operation = command["operation"]
@@ -147,14 +176,14 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
             patterns = [int(v) for v in command.get("patterns", [])]
             if operation == "seed":
                 for group_id, tensors in enumerate(tensors_per_group):
-                    _fill_blocks(tensors, block_ids, patterns, kv_tp_rank, group_id)
+                    _fill_blocks(tensors, block_ids, patterns, seed_rank, group_id)
                 if swa_tensors is not None and command.get("swa_block_ids"):
                     swa_patterns = [int(v) for v in command.get("swa_patterns", patterns[-1:])]
                     _fill_blocks(
                         swa_tensors,
                         [int(v) for v in command["swa_block_ids"]],
                         swa_patterns,
-                        kv_tp_rank,
+                        seed_rank,
                         len(tensors_per_group),
                     )
                 backend.synchronize(device_id)
@@ -175,7 +204,7 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
                 max_bytes = int(command.get("max_bytes", 256))
                 for group_id, tensors in enumerate(tensors_per_group):
                     errors.extend(_verify_blocks(
-                        tensors, block_ids, patterns, kv_tp_rank, group_id, max_layers, max_bytes
+                        tensors, block_ids, patterns, seed_rank, group_id, max_layers, max_bytes
                     ))
                 if swa_tensors is not None and command.get("swa_block_ids"):
                     swa_patterns = [int(v) for v in command.get("swa_patterns", patterns[-1:])]
@@ -183,7 +212,7 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
                         swa_tensors,
                         [int(v) for v in command["swa_block_ids"]],
                         swa_patterns,
-                        kv_tp_rank,
+                        seed_rank,
                         len(tensors_per_group),
                         max_layers,
                         max_bytes,

--- a/benchmarks/flexkv_stress/gpu_worker.py
+++ b/benchmarks/flexkv_stress/gpu_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import multiprocessing as mp
+import os
 import traceback
 from typing import Any
 
@@ -52,6 +53,7 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
 
         backend = DeviceBackend.detect(torch)
         backend.set_device(device_id)
+        kv_tp_rank, cp_rank = config.worker_ranks(effective_rank)
         groups = config.preset.groups
         num_blocks = config.model.gpu_blocks_per_rank
         layer_specs = []
@@ -129,6 +131,9 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
             "ok": True,
             "backend": backend.name,
             "device_id": device_id,
+            "pid": os.getpid(),
+            "kv_tp_rank": kv_tp_rank,
+            "cp_rank": cp_rank,
             "groups": [tuple(tensor.shape) for tensor in (group[0] for group in tensors_per_group)],
         })
 
@@ -142,13 +147,14 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
             patterns = [int(v) for v in command.get("patterns", [])]
             if operation == "seed":
                 for group_id, tensors in enumerate(tensors_per_group):
-                    _fill_blocks(tensors, block_ids, patterns, effective_rank, group_id)
+                    _fill_blocks(tensors, block_ids, patterns, kv_tp_rank, group_id)
                 if swa_tensors is not None and command.get("swa_block_ids"):
+                    swa_patterns = [int(v) for v in command.get("swa_patterns", patterns[-1:])]
                     _fill_blocks(
                         swa_tensors,
                         [int(v) for v in command["swa_block_ids"]],
-                        [patterns[-1]],
-                        effective_rank,
+                        swa_patterns,
+                        kv_tp_rank,
                         len(tensors_per_group),
                     )
                 backend.synchronize(device_id)
@@ -169,14 +175,15 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
                 max_bytes = int(command.get("max_bytes", 256))
                 for group_id, tensors in enumerate(tensors_per_group):
                     errors.extend(_verify_blocks(
-                        tensors, block_ids, patterns, effective_rank, group_id, max_layers, max_bytes
+                        tensors, block_ids, patterns, kv_tp_rank, group_id, max_layers, max_bytes
                     ))
                 if swa_tensors is not None and command.get("swa_block_ids"):
+                    swa_patterns = [int(v) for v in command.get("swa_patterns", patterns[-1:])]
                     errors.extend(_verify_blocks(
                         swa_tensors,
                         [int(v) for v in command["swa_block_ids"]],
-                        [patterns[-1]],
-                        effective_rank,
+                        swa_patterns,
+                        kv_tp_rank,
                         len(tensors_per_group),
                         max_layers,
                         max_bytes,
@@ -201,6 +208,8 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
 class GpuWorker:
     dp_rank: int
     effective_rank: int
+    kv_tp_rank: int
+    cp_rank: int
     device_id: int
     process: mp.Process
     connection: Any
@@ -231,7 +240,7 @@ class GpuWorker:
 def start_gpu_workers(config, gpu_register_port: str) -> list[GpuWorker]:
     context = mp.get_context("spawn")
     workers = []
-    effective_size = config.model.tp_size * config.model.cp_size
+    effective_size = config.workers_per_dp
     for dp_rank in range(config.model.dp_size):
         for effective_rank in range(effective_size):
             device_id = dp_rank * effective_size + effective_rank
@@ -242,11 +251,17 @@ def start_gpu_workers(config, gpu_register_port: str) -> list[GpuWorker]:
                 daemon=False,
             )
             process.start()
-            worker = GpuWorker(dp_rank, effective_rank, device_id, process, parent)
             if not parent.poll(180):
-                worker.shutdown()
+                process.terminate()
+                process.join(timeout=5)
                 raise TimeoutError(f"GPU worker {device_id} did not register in 180 seconds")
             response = parent.recv()
+            worker = GpuWorker(
+                dp_rank, effective_rank,
+                int(response.get("kv_tp_rank", effective_rank)),
+                int(response.get("cp_rank", 0)),
+                device_id, process, parent,
+            )
             if not response.get("ok"):
                 worker.shutdown()
                 raise RuntimeError(response.get("traceback", response.get("error", str(response))))

--- a/benchmarks/flexkv_stress/gpu_worker.py
+++ b/benchmarks/flexkv_stress/gpu_worker.py
@@ -51,7 +51,7 @@ def _worker_main(connection, config, dp_rank: int, effective_rank: int, device_i
 
         from .device import DeviceBackend, torch_dtype
 
-        backend = DeviceBackend.detect(torch)
+        backend = DeviceBackend.detect()
         backend.set_device(device_id)
         kv_tp_rank, cp_rank = config.worker_ranks(effective_rank)
         groups = config.preset.groups

--- a/benchmarks/flexkv_stress/main.py
+++ b/benchmarks/flexkv_stress/main.py
@@ -109,6 +109,10 @@ def _run_latency_hit(config, runtime, reporter, stop_requested) -> bool:
 
     runner = StressRunner(config, runtime)
     workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
+    # Warm the shared prefix so its boundary carries an SWA snapshot before any
+    # conversation matches it (cross-conversation SWA reuse). No-op without a
+    # shared system prompt.
+    runner.warm_shared_prefix(workload.shared_system)
     _warmup(config, runner, workload, reporter)
     original = (
         config.features.concurrency,
@@ -184,6 +188,10 @@ def _run_bandwidth(config, runtime, reporter, stop_requested) -> bool:
 
     runner = StressRunner(config, runtime)
     workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
+    # Warm the shared prefix so its boundary carries an SWA snapshot before any
+    # conversation matches it (cross-conversation SWA reuse). No-op without a
+    # shared system prompt.
+    runner.warm_shared_prefix(workload.shared_system)
     _warmup(config, runner, workload, reporter)
     failed = False
     window_id = 0

--- a/benchmarks/flexkv_stress/main.py
+++ b/benchmarks/flexkv_stress/main.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+import yaml
+
+from .config import config_as_dict, load_config
+from .metrics import Reporter
+from .models import model_bytes_per_block
+from .workload import WorkloadGenerator
+
+
+LOG = logging.getLogger("flexkv_stress")
+
+
+def _directory_bytes(paths: list[str]) -> int:
+    total = 0
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.exists():
+            total += sum(file.stat().st_size for file in path.rglob("*") if file.is_file())
+    return total
+
+
+def _describe(config) -> None:
+    LOG.info(
+        "model=%s architecture=%s layers=%d TP=%d DP=%d CP=%d page=%d required_gpus=%d",
+        config.preset.name, config.preset.architecture, config.preset.num_layers,
+        config.model.tp_size, config.model.dp_size, config.model.cp_size,
+        config.tokens_per_block, config.required_gpus,
+    )
+    for group in config.preset.groups:
+        LOG.info(
+            "group=%s layers=%d heads=%d head_size=%d dtype=%s compress=%d",
+            group.name, group.num_layers, group.num_kv_heads, group.head_size,
+            group.dtype, group.compress_ratio,
+        )
+    gpu_bytes = config.bytes_per_gpu_block * config.model.gpu_blocks_per_rank
+    LOG.info(
+        "main_kv_bytes_per_block=%d estimated_main_gpu_bytes_per_rank=%d features=%s",
+        config.bytes_per_block, gpu_bytes, config.features,
+    )
+    if config.features.swa:
+        swa_bytes = (
+            config.cache.swa_num_slots * config.tokens_per_block
+            * config.preset.swa_num_layers * config.preset.swa_head_size
+        )
+        LOG.info("estimated_swa_gpu_bytes_per_rank=%d", swa_bytes)
+
+
+def _should_stop(config, completed_rounds: int, elapsed: float) -> bool:
+    round_done = config.run.rounds > 0 and completed_rounds >= config.run.rounds
+    time_done = config.run.duration_seconds > 0 and elapsed >= config.run.duration_seconds
+    enabled = []
+    if config.run.rounds > 0:
+        enabled.append(round_done)
+    if config.run.duration_seconds > 0:
+        enabled.append(time_done)
+    return any(enabled) if config.run.stop_when == "either" else all(enabled)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="FlexKV long-running correctness and stress benchmark")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--rounds", type=int, help="Override run.rounds")
+    parser.add_argument("--duration", type=float, help="Override run.duration_seconds")
+    parser.add_argument("--dry-run", action="store_true", help="Validate config and print memory geometry")
+    parser.add_argument(
+        "--cpu-stub",
+        action="store_true",
+        help="Run with in-memory CPU PyTorch workers instead of FlexKV/CUDA",
+    )
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args(argv)
+
+
+def run(argv=None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    config = load_config(args.config)
+    if args.rounds is not None:
+        config.run.rounds = args.rounds
+    if args.duration is not None:
+        config.run.duration_seconds = args.duration
+    if args.cpu_stub:
+        config.features.cpu_stub = True
+    config.validate()
+    _describe(config)
+    if args.dry_run:
+        print(yaml.safe_dump(config_as_dict(config), sort_keys=False))
+        return 0
+
+    # These variables must exist before FlexKV modules read GLOBAL_CONFIG_FROM_ENV.
+    os.environ["FLEXKV_ENABLE_LAYERWISE_TRANSFER"] = "1" if config.features.layerwise else "0"
+    os.environ.setdefault("FLEXKV_SERVER_RECV_PORT", f"ipc:///tmp/flexkv_stress_server_{os.getpid()}")
+
+    from .runner import FlexKVRuntime, StressRunner
+
+    reporter = Reporter(config.output.directory)
+    (reporter.directory / "effective_config.yaml").write_text(
+        yaml.safe_dump(config_as_dict(config), sort_keys=False)
+    )
+    runtime = FlexKVRuntime(config)
+    stop_requested = False
+
+    def request_stop(signum, _frame):
+        nonlocal stop_requested
+        LOG.warning("received signal %s; finishing the current batch", signum)
+        stop_requested = True
+
+    previous_handlers = {
+        signum: signal.signal(signum, request_stop)
+        for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    failed = False
+    started = time.monotonic()
+    try:
+        runtime.start()
+        runner = StressRunner(config, runtime)
+        workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
+        for warmup in range(config.run.warmup_rounds):
+            LOG.info("warmup round %d/%d", warmup + 1, config.run.warmup_rounds)
+            warmup_results, warmup_operations = runner.run_round(
+                workload.generate_round(1_000_000_000 + warmup), -1
+            )
+            if any(not result.success for result in warmup_results) or any(
+                not operation.success for operation in warmup_operations
+            ):
+                raise RuntimeError("warmup failed; inspect FlexKV logs before starting the soak run")
+
+        completed = 0
+        while not stop_requested and not _should_stop(config, completed, time.monotonic() - started):
+            round_started = time.perf_counter()
+            conversations = workload.generate_round(completed)
+            results, operations = runner.run_round(conversations, completed)
+            row = reporter.write_round(completed, round_started, results, operations)
+            for result in results:
+                if not result.success:
+                    reporter.write_error(
+                        completed,
+                        "turn",
+                        f"hit_delta={result.hit_delta_tokens}, validation_ok={result.validation_ok}",
+                        result.conversation_id,
+                        result.turn_id,
+                    )
+            for operation in operations:
+                if not operation.success:
+                    reporter.write_error(completed, operation.operation, operation.error or "operation failed")
+            ssd_bytes = _directory_bytes(config.cache.ssd_cache_dir) if config.features.ssd else 0
+            for worker in runtime.workers:
+                memory = worker.request({"operation": "memory"})
+                reporter.write_resource(completed, worker.device_id, {
+                    "allocated_bytes": memory.get("allocated_bytes", 0),
+                    "reserved_bytes": memory.get("reserved_bytes", 0),
+                    "max_allocated_bytes": memory.get("max_allocated_bytes", 0),
+                    "rss_bytes": memory.get("rss_bytes", 0),
+                    "ssd_bytes": ssd_bytes,
+                })
+            if completed % config.run.log_every_rounds == 0:
+                LOG.info(
+                    "round=%d turns=%d success=%.5f qps=%.2f hit_ratio=%.5f "
+                    "hit_delta=%d p99_ms=%.2f samples=%d sample_failures=%d",
+                    completed, row["turns"], row["success_rate"], row["qps"], row["hit_ratio"],
+                    row["hit_delta_tokens"], row["latency_p99_ms"], row["validation_samples"],
+                    row["validation_failures"],
+                )
+            if row["success_rate"] < config.validation.minimum_success_rate:
+                failed = True
+            if any(not operation.success for operation in operations):
+                failed = True
+            if row["validation_failures"]:
+                failed = True
+                if config.validation.stop_on_mismatch:
+                    break
+            completed += 1
+    except Exception as exc:
+        failed = True
+        reporter.write_error(-1, "runtime", f"{type(exc).__name__}: {exc}")
+        LOG.exception("benchmark failed")
+    finally:
+        runtime.close()
+        reporter.close()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        LOG.info("results=%s", reporter.directory)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/benchmarks/flexkv_stress/main.py
+++ b/benchmarks/flexkv_stress/main.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 import os
 from pathlib import Path
+import shutil
 import signal
 import sys
 import time
@@ -20,17 +21,49 @@ LOG = logging.getLogger("flexkv_stress")
 
 
 def _directory_bytes(paths: list[str]) -> int:
+    """Real on-disk usage of the run's SSD cache dirs.
+
+    SSD .bin files are sparsely pre-allocated, so sum actually-allocated blocks
+    (st_blocks * 512) rather than apparent size (st_size), which over-reports by
+    the whole pre-allocation. Paths here are the per-run subdirs from
+    _isolate_ssd_dirs(), so this never counts stale .bin left behind by earlier
+    runs that share the same parent cache dir."""
     total = 0
     for raw_path in paths:
         path = Path(raw_path)
-        if path.exists():
-            for file in path.rglob("*"):
-                try:
-                    if file.is_file():
-                        total += file.stat().st_size
-                except OSError:
+        if not path.exists():
+            continue
+        for file in path.rglob("*"):
+            try:
+                if not file.is_file():
                     continue
+                st = file.stat()
+                blocks = getattr(st, "st_blocks", 0)
+                total += blocks * 512 if blocks else st.st_size
+            except OSError:
+                continue
     return total
+
+
+def _isolate_ssd_dirs(config, run_id: str) -> list[str]:
+    """Point this run's SSD cache at per-run subdirs (named by run_id) so
+    ssd_used_gb counts only this run's files and cleanup can delete just this
+    run's cache without touching a concurrent run sharing the same parent dir.
+    Mutates config.cache.ssd_cache_dir in place and returns the subdirs."""
+    if not (config.features.ssd and config.cache.ssd_cache_dir):
+        return []
+    run_dirs = [str(Path(raw) / run_id) for raw in config.cache.ssd_cache_dir]
+    for run_dir in run_dirs:
+        Path(run_dir).mkdir(parents=True, exist_ok=True)
+    config.cache.ssd_cache_dir = run_dirs
+    return run_dirs
+
+
+def _cleanup_ssd_dirs(run_dirs: list[str]) -> None:
+    """Remove this run's SSD cache subdirs so pre-allocated .bin don't pile up
+    across runs. Best-effort: missing dirs and races are ignored."""
+    for run_dir in run_dirs:
+        shutil.rmtree(run_dir, ignore_errors=True)
 
 
 def _describe(config) -> None:
@@ -336,6 +369,7 @@ def run(argv=None) -> int:
     from .runner import FlexKVRuntime
 
     reporter = Reporter(config)
+    ssd_run_dirs = _isolate_ssd_dirs(config, reporter.run_id)
     (reporter.directory / "effective_config.yaml").write_text(
         yaml.safe_dump(config_as_dict(config), sort_keys=False), encoding="utf-8"
     )
@@ -367,6 +401,9 @@ def run(argv=None) -> int:
     finally:
         if runtime is not None:
             runtime.close()
+        _cleanup_ssd_dirs(ssd_run_dirs)
+        if ssd_run_dirs:
+            LOG.info("removed SSD cache dir(s): %s", ", ".join(ssd_run_dirs))
         reporter.close()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)

--- a/benchmarks/flexkv_stress/main.py
+++ b/benchmarks/flexkv_stress/main.py
@@ -95,13 +95,20 @@ def _record_failures(reporter, scenario, window_id, results, operations) -> bool
     return failed
 
 
-def _warmup(config, runner, workload, reporter) -> None:
+def _warmup(config, runner, workload, reporter) -> bool:
+    """Run warmup rounds. Failures are recorded to errors.csv and folded into
+    the exit code, but never abort the run: a diagnostic run should surface
+    every failure across the full workload rather than stop at a warmup miss.
+    Returns True if any warmup round had failures."""
+    failed = False
     for warmup in range(config.run.warmup_rounds):
         LOG.info("warmup round %d/%d", warmup + 1, config.run.warmup_rounds)
         conversations = workload.generate_round(1_000_000_000 + warmup)
         results, operations = runner.run_round(conversations, -1)
         if _record_failures(reporter, "warmup", -1, results, operations):
-            raise RuntimeError("warmup failed; inspect errors.csv")
+            LOG.warning("warmup round %d had failures; see errors.csv (continuing)", warmup + 1)
+            failed = True
+    return failed
 
 
 def _run_latency_hit(config, runtime, reporter, stop_requested) -> bool:
@@ -113,13 +120,12 @@ def _run_latency_hit(config, runtime, reporter, stop_requested) -> bool:
     # conversation matches it (cross-conversation SWA reuse). No-op without a
     # shared system prompt.
     runner.warm_shared_prefix(workload.shared_system)
-    _warmup(config, runner, workload, reporter)
+    failed = _warmup(config, runner, workload, reporter)
     original = (
         config.features.concurrency,
         config.concurrency.batch_size,
         config.concurrency.max_inflight_per_dp,
     )
-    failed = False
     global_window = 0
     round_offset = 0
     for scenario in ("unloaded", "loaded"):
@@ -149,8 +155,10 @@ def _run_latency_hit(config, runtime, reporter, stop_requested) -> bool:
             failed |= _record_failures(reporter, scenario, global_window, results, operations)
             if row["request_success_rate"] < config.validation.minimum_success_rate:
                 failed = True
-            if row["byte_validation_accuracy"] < 1 and config.validation.stop_on_mismatch:
-                return True
+            if row["byte_validation_accuracy"] < 1:
+                # Record the mismatch and keep going. A diagnostic run must expose
+                # every failure across the full workload, not stop at the first one.
+                failed = True
             LOG.info(
                 "scenario=%s window=%d requests=%d qps=%.2f hit=%.5f "
                 "match/load/save_p99_ms=%.3f/%.3f/%.3f",
@@ -192,8 +200,7 @@ def _run_bandwidth(config, runtime, reporter, stop_requested) -> bool:
     # conversation matches it (cross-conversation SWA reuse). No-op without a
     # shared system prompt.
     runner.warm_shared_prefix(workload.shared_system)
-    _warmup(config, runner, workload, reporter)
-    failed = False
+    failed = _warmup(config, runner, workload, reporter)
     window_id = 0
     round_id = 0
     original_ssd_interval = config.cache.force_ssd_reload_interval_rounds

--- a/benchmarks/flexkv_stress/main.py
+++ b/benchmarks/flexkv_stress/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import argparse
 import logging
 import os
@@ -12,7 +13,6 @@ import yaml
 
 from .config import config_as_dict, load_config
 from .metrics import Reporter
-from .models import model_bytes_per_block
 from .workload import WorkloadGenerator
 
 
@@ -24,34 +24,28 @@ def _directory_bytes(paths: list[str]) -> int:
     for raw_path in paths:
         path = Path(raw_path)
         if path.exists():
-            total += sum(file.stat().st_size for file in path.rglob("*") if file.is_file())
+            for file in path.rglob("*"):
+                try:
+                    if file.is_file():
+                        total += file.stat().st_size
+                except OSError:
+                    continue
     return total
 
 
 def _describe(config) -> None:
     LOG.info(
-        "model=%s architecture=%s layers=%d TP=%d DP=%d CP=%d page=%d required_gpus=%d",
-        config.preset.name, config.preset.architecture, config.preset.num_layers,
-        config.model.tp_size, config.model.dp_size, config.model.cp_size,
-        config.tokens_per_block, config.required_gpus,
+        "mode=%s model=%s architecture=%s composite_tp=%d kv_tp=%d DP=%d CP=%d "
+        "page=%d required_gpus=%d",
+        config.run.mode, config.preset.name, config.preset.architecture,
+        config.model.tp_size, config.kv_tp_size, config.model.dp_size,
+        config.model.cp_size, config.tokens_per_block, config.required_gpus,
     )
-    for group in config.preset.groups:
-        LOG.info(
-            "group=%s layers=%d heads=%d head_size=%d dtype=%s compress=%d",
-            group.name, group.num_layers, group.num_kv_heads, group.head_size,
-            group.dtype, group.compress_ratio,
-        )
-    gpu_bytes = config.bytes_per_gpu_block * config.model.gpu_blocks_per_rank
     LOG.info(
-        "main_kv_bytes_per_block=%d estimated_main_gpu_bytes_per_rank=%d features=%s",
-        config.bytes_per_block, gpu_bytes, config.features,
+        "main_page_gb=%.9f CPU_GB=%.3f SSD_GB=%.3f features=%s",
+        config.bytes_per_block / 1e9, config.cache.cpu_cache_gb,
+        config.cache.ssd_cache_gb, config.features,
     )
-    if config.features.swa:
-        swa_bytes = (
-            config.cache.swa_num_slots * config.tokens_per_block
-            * config.preset.swa_num_layers * config.preset.swa_head_size
-        )
-        LOG.info("estimated_swa_gpu_bytes_per_rank=%d", swa_bytes)
 
 
 def _should_stop(config, completed_rounds: int, elapsed: float) -> bool:
@@ -65,17 +59,237 @@ def _should_stop(config, completed_rounds: int, elapsed: float) -> bool:
     return any(enabled) if config.run.stop_when == "either" else all(enabled)
 
 
-def parse_args(argv=None):
-    parser = argparse.ArgumentParser(description="FlexKV long-running correctness and stress benchmark")
-    parser.add_argument("--config", required=True)
-    parser.add_argument("--rounds", type=int, help="Override run.rounds")
-    parser.add_argument("--duration", type=float, help="Override run.duration_seconds")
-    parser.add_argument("--dry-run", action="store_true", help="Validate config and print memory geometry")
-    parser.add_argument(
-        "--cpu-stub",
-        action="store_true",
-        help="Run with in-memory CPU PyTorch workers instead of FlexKV/CUDA",
+def _sample_resources(config, runtime) -> list[dict[str, int]]:
+    ssd_bytes = _directory_bytes(config.cache.ssd_cache_dir) if config.features.ssd else 0
+    resources = []
+    for worker in runtime.workers:
+        memory = worker.request({"operation": "memory"})
+        resources.append({
+            "device_id": worker.device_id,
+            "allocated_bytes": memory.get("allocated_bytes", 0),
+            "reserved_bytes": memory.get("reserved_bytes", 0),
+            "max_allocated_bytes": memory.get("max_allocated_bytes", 0),
+            "rss_bytes": memory.get("rss_bytes", 0),
+            "ssd_bytes": ssd_bytes,
+        })
+    return resources
+
+
+def _record_failures(reporter, scenario, window_id, results, operations) -> bool:
+    failed = False
+    for result in results:
+        if not result.success:
+            failed = True
+            reporter.write_error(
+                window_id, "request",
+                f"hit_delta={result.hit_delta_tokens}, validation_ok={result.validation_ok}",
+                scenario=scenario,
+            )
+    for operation in operations:
+        if not operation.success:
+            failed = True
+            reporter.write_error(
+                window_id, operation.operation, operation.error or "operation failed",
+                scenario=scenario,
+            )
+    return failed
+
+
+def _warmup(config, runner, workload, reporter) -> None:
+    for warmup in range(config.run.warmup_rounds):
+        LOG.info("warmup round %d/%d", warmup + 1, config.run.warmup_rounds)
+        conversations = workload.generate_round(1_000_000_000 + warmup)
+        results, operations = runner.run_round(conversations, -1)
+        if _record_failures(reporter, "warmup", -1, results, operations):
+            raise RuntimeError("warmup failed; inspect errors.csv")
+
+
+def _run_latency_hit(config, runtime, reporter, stop_requested) -> bool:
+    from .runner import StressRunner
+
+    runner = StressRunner(config, runtime)
+    workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
+    _warmup(config, runner, workload, reporter)
+    original = (
+        config.features.concurrency,
+        config.concurrency.batch_size,
+        config.concurrency.max_inflight_per_dp,
     )
+    failed = False
+    global_window = 0
+    round_offset = 0
+    for scenario in ("unloaded", "loaded"):
+        if scenario == "unloaded":
+            config.features.concurrency = False
+            config.concurrency.batch_size = 1
+            config.concurrency.max_inflight_per_dp = 1
+        else:
+            (config.features.concurrency, config.concurrency.batch_size,
+             config.concurrency.max_inflight_per_dp) = original
+        completed = 0
+        scenario_started = time.monotonic()
+        while not stop_requested() and not _should_stop(
+            config, completed, time.monotonic() - scenario_started
+        ):
+            conversations = workload.generate_round(round_offset + completed)
+            window_started = datetime.now().astimezone()
+            started = time.perf_counter()
+            results, operations = runner.run_round(conversations, round_offset + completed)
+            duration = time.perf_counter() - started
+            resources = _sample_resources(config, runtime)
+            row = reporter.write_latency_window(
+                scenario, global_window, window_started, duration, results, resources,
+                batch_size=config.concurrency.batch_size,
+                concurrency=config.concurrency.max_inflight_per_dp,
+            )
+            failed |= _record_failures(reporter, scenario, global_window, results, operations)
+            if row["request_success_rate"] < config.validation.minimum_success_rate:
+                failed = True
+            if row["byte_validation_accuracy"] < 1 and config.validation.stop_on_mismatch:
+                return True
+            LOG.info(
+                "scenario=%s window=%d requests=%d qps=%.2f hit=%.5f "
+                "match/load/save_p99_ms=%.3f/%.3f/%.3f",
+                scenario, global_window, row["requests"], row["qps"], row["hit_ratio"],
+                row["match_p99_ms"], row["load_p99_ms"], row["save_p99_ms"],
+            )
+            completed += 1
+            global_window += 1
+        round_offset += max(1, completed)
+    (config.features.concurrency, config.concurrency.batch_size,
+     config.concurrency.max_inflight_per_dp) = original
+    return failed
+
+
+_PATH_OPERATIONS = {
+    "gpu_to_cpu_save": {"launch_put"},
+    "cpu_to_gpu_load": {"launch_get"},
+    # FlexKV exposes completion only for the end-to-end GPU/SSD paths.
+    "gpu_to_ssd_save_e2e": {"launch_put"},
+    "ssd_to_gpu_reload_e2e": {"ssd_reload_get"},
+}
+
+
+def _bandwidth_done(config, operations: int, active_s: float, payload_bytes: int) -> bool:
+    target_bytes = config.bandwidth.target_payload_gb * 1e9
+    return (
+        operations >= config.bandwidth.min_operations
+        and active_s >= config.bandwidth.min_duration_seconds
+        and (target_bytes <= 0 or payload_bytes >= target_bytes)
+    )
+
+
+def _run_bandwidth(config, runtime, reporter, stop_requested) -> bool:
+    from .runner import StressRunner
+
+    runner = StressRunner(config, runtime)
+    workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
+    _warmup(config, runner, workload, reporter)
+    failed = False
+    window_id = 0
+    round_id = 0
+    original_ssd_interval = config.cache.force_ssd_reload_interval_rounds
+    levels = sorted({
+        value for value in config.bandwidth.concurrency_levels
+        if value <= config.concurrency.max_inflight_per_dp
+    })
+    if not levels:
+        levels = [config.concurrency.max_inflight_per_dp]
+    paths = [
+        path for path in config.bandwidth.paths
+        if config.features.ssd or "ssd" not in path
+    ]
+    for path in paths:
+        config.cache.force_ssd_reload_interval_rounds = (
+            1 if path == "ssd_to_gpu_reload_e2e" else original_ssd_interval
+        )
+        for concurrency in levels:
+            config.features.concurrency = concurrency > 1
+            config.concurrency.batch_size = concurrency
+            cumulative_ops = 0
+            cumulative_seconds = 0.0
+            cumulative_bytes = 0
+            window_operations = []
+            window_validation_samples = 0
+            window_validation_passes = 0
+            window_seconds = 0.0
+            window_started_at = None
+            window_resources = []
+            empty_rounds = 0
+            first = True
+            while first or not _bandwidth_done(
+                config, cumulative_ops, cumulative_seconds, cumulative_bytes
+            ):
+                first = False
+                if stop_requested():
+                    return failed
+                conversations = workload.generate_round(round_id)
+                started_at = datetime.now().astimezone()
+                if window_started_at is None:
+                    window_started_at = started_at
+                results, operations = runner.run_round(conversations, round_id)
+                selected = [
+                    item for item in operations if item.operation in _PATH_OPERATIONS[path]
+                ]
+                active_s = sum(item.latency_ms for item in selected) / 1000
+                validation_samples = sum(result.validation_sampled for result in results)
+                validation_passes = sum(
+                    result.validation_sampled and result.validation_ok for result in results
+                )
+                resources = _sample_resources(config, runtime)
+                failed |= _record_failures(reporter, path, window_id, results, operations)
+                cumulative_ops += len(selected)
+                cumulative_seconds += active_s
+                cumulative_bytes += sum(item.transfer_bytes for item in selected)
+                window_operations.extend(selected)
+                window_seconds += active_s
+                window_validation_samples += validation_samples
+                window_validation_passes += validation_passes
+                window_resources = resources
+                round_id += 1
+                empty_rounds = 0 if selected else empty_rounds + 1
+                done = _bandwidth_done(
+                    config, cumulative_ops, cumulative_seconds, cumulative_bytes
+                )
+                flush = bool(window_operations) and (
+                    config.bandwidth.window_seconds == 0
+                    or window_seconds >= config.bandwidth.window_seconds
+                    or done
+                )
+                if flush:
+                    reporter.write_bandwidth_window(
+                        path, concurrency, window_id, window_started_at, window_seconds,
+                        window_operations, window_validation_samples,
+                        window_validation_passes, window_resources,
+                    )
+                    window_id += 1
+                    window_operations = []
+                    window_validation_samples = 0
+                    window_validation_passes = 0
+                    window_seconds = 0.0
+                    window_started_at = None
+                    window_resources = []
+                if empty_rounds >= 3:
+                    reporter.write_error(window_id, path, "No timed transfer operation was produced",
+                                         scenario=path)
+                    failed = True
+                    break
+            LOG.info(
+                "path=%s concurrency=%d operations=%d payload_gb=%.3f active_s=%.3f",
+                path, concurrency, cumulative_ops, cumulative_bytes / 1e9, cumulative_seconds,
+            )
+    config.cache.force_ssd_reload_interval_rounds = original_ssd_interval
+    return failed
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="FlexKV bandwidth and latency/hit stress benchmark")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--mode", choices=("bandwidth", "latency_hit"))
+    parser.add_argument("--rounds", type=int, help="Override latency_hit run.rounds")
+    parser.add_argument("--duration", type=float, help="Override latency_hit run.duration_seconds")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--cpu-stub", action="store_true")
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args(argv)
 
@@ -87,6 +301,8 @@ def run(argv=None) -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     config = load_config(args.config)
+    if args.mode:
+        config.run.mode = args.mode
     if args.rounds is not None:
         config.run.rounds = args.rounds
     if args.duration is not None:
@@ -99,95 +315,43 @@ def run(argv=None) -> int:
         print(yaml.safe_dump(config_as_dict(config), sort_keys=False))
         return 0
 
-    # These variables must exist before FlexKV modules read GLOBAL_CONFIG_FROM_ENV.
     os.environ["FLEXKV_ENABLE_LAYERWISE_TRANSFER"] = "1" if config.features.layerwise else "0"
     os.environ.setdefault("FLEXKV_SERVER_RECV_PORT", f"ipc:///tmp/flexkv_stress_server_{os.getpid()}")
 
-    from .runner import FlexKVRuntime, StressRunner
+    from .runner import FlexKVRuntime
 
-    reporter = Reporter(config.output.directory)
+    reporter = Reporter(config)
     (reporter.directory / "effective_config.yaml").write_text(
-        yaml.safe_dump(config_as_dict(config), sort_keys=False)
+        yaml.safe_dump(config_as_dict(config), sort_keys=False), encoding="utf-8"
     )
-    runtime = FlexKVRuntime(config)
-    stop_requested = False
+    runtime = None
+    stopping = False
 
     def request_stop(signum, _frame):
-        nonlocal stop_requested
-        LOG.warning("received signal %s; finishing the current batch", signum)
-        stop_requested = True
+        nonlocal stopping
+        LOG.warning("received signal %s; finishing the current operation", signum)
+        stopping = True
 
     previous_handlers = {
         signum: signal.signal(signum, request_stop)
         for signum in (signal.SIGINT, signal.SIGTERM)
     }
     failed = False
-    started = time.monotonic()
     try:
+        runtime = FlexKVRuntime(config)
         runtime.start()
-        runner = StressRunner(config, runtime)
-        workload = WorkloadGenerator(config.conversation, config.tokens_per_block, config.run.seed)
-        for warmup in range(config.run.warmup_rounds):
-            LOG.info("warmup round %d/%d", warmup + 1, config.run.warmup_rounds)
-            warmup_results, warmup_operations = runner.run_round(
-                workload.generate_round(1_000_000_000 + warmup), -1
-            )
-            if any(not result.success for result in warmup_results) or any(
-                not operation.success for operation in warmup_operations
-            ):
-                raise RuntimeError("warmup failed; inspect FlexKV logs before starting the soak run")
-
-        completed = 0
-        while not stop_requested and not _should_stop(config, completed, time.monotonic() - started):
-            round_started = time.perf_counter()
-            conversations = workload.generate_round(completed)
-            results, operations = runner.run_round(conversations, completed)
-            row = reporter.write_round(completed, round_started, results, operations)
-            for result in results:
-                if not result.success:
-                    reporter.write_error(
-                        completed,
-                        "turn",
-                        f"hit_delta={result.hit_delta_tokens}, validation_ok={result.validation_ok}",
-                        result.conversation_id,
-                        result.turn_id,
-                    )
-            for operation in operations:
-                if not operation.success:
-                    reporter.write_error(completed, operation.operation, operation.error or "operation failed")
-            ssd_bytes = _directory_bytes(config.cache.ssd_cache_dir) if config.features.ssd else 0
-            for worker in runtime.workers:
-                memory = worker.request({"operation": "memory"})
-                reporter.write_resource(completed, worker.device_id, {
-                    "allocated_bytes": memory.get("allocated_bytes", 0),
-                    "reserved_bytes": memory.get("reserved_bytes", 0),
-                    "max_allocated_bytes": memory.get("max_allocated_bytes", 0),
-                    "rss_bytes": memory.get("rss_bytes", 0),
-                    "ssd_bytes": ssd_bytes,
-                })
-            if completed % config.run.log_every_rounds == 0:
-                LOG.info(
-                    "round=%d turns=%d success=%.5f qps=%.2f hit_ratio=%.5f "
-                    "hit_delta=%d p99_ms=%.2f samples=%d sample_failures=%d",
-                    completed, row["turns"], row["success_rate"], row["qps"], row["hit_ratio"],
-                    row["hit_delta_tokens"], row["latency_p99_ms"], row["validation_samples"],
-                    row["validation_failures"],
-                )
-            if row["success_rate"] < config.validation.minimum_success_rate:
-                failed = True
-            if any(not operation.success for operation in operations):
-                failed = True
-            if row["validation_failures"]:
-                failed = True
-                if config.validation.stop_on_mismatch:
-                    break
-            completed += 1
+        stop_requested = lambda: stopping
+        if config.run.mode == "latency_hit":
+            failed = _run_latency_hit(config, runtime, reporter, stop_requested)
+        else:
+            failed = _run_bandwidth(config, runtime, reporter, stop_requested)
     except Exception as exc:
         failed = True
         reporter.write_error(-1, "runtime", f"{type(exc).__name__}: {exc}")
         LOG.exception("benchmark failed")
     finally:
-        runtime.close()
+        if runtime is not None:
+            runtime.close()
         reporter.close()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)

--- a/benchmarks/flexkv_stress/metrics.py
+++ b/benchmarks/flexkv_stress/metrics.py
@@ -253,11 +253,7 @@ class Reporter:
     def _backend_name(self) -> str:
         if self.config.features.cpu_stub:
             return "cpu_stub"
-        try:
-            import torch
-            return "rocm" if getattr(torch.version, "hip", None) else "cuda"
-        except Exception:
-            return "cuda"
+        return "cuda"
 
     def write_error(self, window_id: int, operation: str, error: str,
                     conversation_id: int = -1, turn_id: int = -1,

--- a/benchmarks/flexkv_stress/metrics.py
+++ b/benchmarks/flexkv_stress/metrics.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+import csv
+import math
+import time
+
+
+@dataclass
+class OperationResult:
+    operation: str
+    success: bool
+    latency_ms: float
+    tokens: int = 0
+    hit_tokens: int = 0
+    error: str = ""
+
+
+@dataclass
+class TurnResult:
+    round_id: int
+    conversation_id: int
+    turn_id: int
+    added_input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    expected_hit_tokens: int
+    actual_hit_tokens: int
+    hit_delta_tokens: int
+    put_unmatched_tokens: int
+    match_ms: float
+    get_ms: float
+    put_ms: float
+    success: bool
+    validation_sampled: bool = False
+    validation_ok: bool = True
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(fraction * len(ordered)) - 1))
+    return float(ordered[index])
+
+
+class CsvFile:
+    def __init__(self, path: Path, fields: list[str]):
+        self.handle = path.open("w", newline="", encoding="utf-8")
+        self.writer = csv.DictWriter(self.handle, fieldnames=fields, extrasaction="ignore")
+        self.writer.writeheader()
+
+    def write(self, row: dict[str, Any]) -> None:
+        self.writer.writerow(row)
+        self.handle.flush()
+
+    def close(self) -> None:
+        self.handle.close()
+
+
+class Reporter:
+    TURN_FIELDS = list(TurnResult.__dataclass_fields__)
+    ROUND_FIELDS = [
+        "round_id", "elapsed_seconds", "turns", "successes", "failures", "success_rate",
+        "qps", "latency_p50_ms", "latency_p95_ms", "latency_p99_ms", "expected_hit_tokens",
+        "actual_hit_tokens", "hit_ratio", "hit_delta_tokens", "validation_samples",
+        "validation_failures",
+    ]
+    ERROR_FIELDS = ["time", "round_id", "conversation_id", "turn_id", "operation", "error"]
+    OP_FIELDS = ["round_id", "operation", "calls", "successes", "failures", "p50_ms", "p95_ms", "p99_ms"]
+    RESOURCE_FIELDS = [
+        "time", "round_id", "device_id", "allocated_bytes", "reserved_bytes",
+        "max_allocated_bytes", "rss_bytes", "ssd_bytes",
+    ]
+    VALIDATION_FIELDS = ["round_id", "conversation_id", "turn_id", "ok"]
+
+    def __init__(self, output_dir: str | Path):
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        base = Path(output_dir).resolve()
+        self.directory = base / timestamp
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.turns = CsvFile(self.directory / "turns.csv", self.TURN_FIELDS)
+        self.rounds = CsvFile(self.directory / "rounds.csv", self.ROUND_FIELDS)
+        self.windows = CsvFile(self.directory / "windows.csv", self.ROUND_FIELDS)
+        self.errors = CsvFile(self.directory / "errors.csv", self.ERROR_FIELDS)
+        self.operations = CsvFile(self.directory / "operations.csv", self.OP_FIELDS)
+        self.resources = CsvFile(self.directory / "resources.csv", self.RESOURCE_FIELDS)
+        self.validation = CsvFile(self.directory / "validation_samples.csv", self.VALIDATION_FIELDS)
+        self.all_rounds: list[dict[str, Any]] = []
+
+    def write_error(self, round_id: int, operation: str, error: str,
+                    conversation_id: int = -1, turn_id: int = -1) -> None:
+        self.errors.write({
+            "time": time.time(), "round_id": round_id, "conversation_id": conversation_id,
+            "turn_id": turn_id, "operation": operation, "error": error,
+        })
+
+    def write_round(self, round_id: int, started_at: float, results: list[TurnResult],
+                    operations: list[OperationResult]) -> dict[str, Any]:
+        for result in results:
+            self.turns.write(asdict(result))
+            if result.validation_sampled:
+                self.validation.write({
+                    "round_id": result.round_id,
+                    "conversation_id": result.conversation_id,
+                    "turn_id": result.turn_id,
+                    "ok": result.validation_ok,
+                })
+        elapsed = max(time.perf_counter() - started_at, 1e-9)
+        successes = sum(result.success for result in results)
+        expected = sum(result.expected_hit_tokens for result in results)
+        actual = sum(result.actual_hit_tokens for result in results)
+        latencies = [op.latency_ms for op in operations]
+        validation_samples = sum(result.validation_sampled for result in results)
+        validation_failures = sum(result.validation_sampled and not result.validation_ok for result in results)
+        row = {
+            "round_id": round_id,
+            "elapsed_seconds": elapsed,
+            "turns": len(results),
+            "successes": successes,
+            "failures": len(results) - successes,
+            "success_rate": successes / len(results) if results else 1.0,
+            "qps": len(results) / elapsed,
+            "latency_p50_ms": percentile(latencies, 0.50),
+            "latency_p95_ms": percentile(latencies, 0.95),
+            "latency_p99_ms": percentile(latencies, 0.99),
+            "expected_hit_tokens": expected,
+            "actual_hit_tokens": actual,
+            "hit_ratio": actual / sum(result.total_tokens for result in results) if results else 0.0,
+            "hit_delta_tokens": actual - expected,
+            "validation_samples": validation_samples,
+            "validation_failures": validation_failures,
+        }
+        self.rounds.write(row)
+        self.windows.write(row)
+        self.all_rounds.append(row)
+        grouped: dict[str, list[OperationResult]] = defaultdict(list)
+        for op in operations:
+            grouped[op.operation].append(op)
+        for name, items in grouped.items():
+            values = [item.latency_ms for item in items]
+            ok = sum(item.success for item in items)
+            self.operations.write({
+                "round_id": round_id, "operation": name, "calls": len(items), "successes": ok,
+                "failures": len(items) - ok, "p50_ms": percentile(values, 0.50),
+                "p95_ms": percentile(values, 0.95), "p99_ms": percentile(values, 0.99),
+            })
+        return row
+
+    def write_resource(self, round_id: int, device_id: int, values: dict[str, int]) -> None:
+        self.resources.write({"time": time.time(), "round_id": round_id, "device_id": device_id, **values})
+
+    def close(self) -> None:
+        summary_fields = ["rounds", "turns", "successes", "failures", "success_rate", "validation_failures"]
+        total_turns = sum(int(row["turns"]) for row in self.all_rounds)
+        successes = sum(int(row["successes"]) for row in self.all_rounds)
+        validation_failures = sum(int(row["validation_failures"]) for row in self.all_rounds)
+        summary = CsvFile(self.directory / "summary.csv", summary_fields)
+        summary.write({
+            "rounds": len(self.all_rounds), "turns": total_turns, "successes": successes,
+            "failures": total_turns - successes,
+            "success_rate": successes / total_turns if total_turns else 1.0,
+            "validation_failures": validation_failures,
+        })
+        summary.close()
+        for output in (
+            self.turns, self.rounds, self.windows, self.errors, self.operations,
+            self.resources, self.validation,
+        ):
+            output.close()

--- a/benchmarks/flexkv_stress/metrics.py
+++ b/benchmarks/flexkv_stress/metrics.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from collections import defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
+from xml.sax.saxutils import escape
 import csv
+import json
 import math
+import os
 import time
+
+
+SCHEMA_VERSION = "1.0"
+DECIMAL_GB = 1_000_000_000
 
 
 @dataclass
@@ -16,6 +23,7 @@ class OperationResult:
     latency_ms: float
     tokens: int = 0
     hit_tokens: int = 0
+    transfer_bytes: int = 0
     error: str = ""
 
 
@@ -37,9 +45,11 @@ class TurnResult:
     success: bool
     validation_sampled: bool = False
     validation_ok: bool = True
+    query_tokens: int = 0
 
 
 def percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile retained for callers and small unit tests."""
     if not values:
         return 0.0
     ordered = sorted(values)
@@ -47,127 +57,561 @@ def percentile(values: list[float], fraction: float) -> float:
     return float(ordered[index])
 
 
+def decimal_gb(byte_count: int | float) -> float:
+    return float(byte_count) / DECIMAL_GB
+
+
+def throughput_gb_s(byte_count: int | float, seconds: float) -> float:
+    return decimal_gb(byte_count) / seconds if byte_count > 0 and seconds > 0 else 0.0
+
+
+class LogHistogram:
+    """Fixed-size, mergeable logarithmic histogram for long-running latency data."""
+
+    def __init__(self, lowest_ms: float = 0.001, ratio: float = 1.01, bins: int = 4096):
+        self.lowest_ms = lowest_ms
+        self.ratio = ratio
+        self.bins = [0] * bins
+        self.count = 0
+
+    def record(self, value_ms: float) -> None:
+        value = max(0.0, float(value_ms))
+        if value <= self.lowest_ms:
+            index = 0
+        else:
+            index = int(math.log(value / self.lowest_ms, self.ratio)) + 1
+            index = min(len(self.bins) - 1, max(0, index))
+        self.bins[index] += 1
+        self.count += 1
+
+    def merge(self, other: "LogHistogram") -> None:
+        if (self.lowest_ms, self.ratio, len(self.bins)) != (
+            other.lowest_ms, other.ratio, len(other.bins)
+        ):
+            raise ValueError("Cannot merge histograms with different geometries")
+        for index, count in enumerate(other.bins):
+            self.bins[index] += count
+        self.count += other.count
+
+    def percentile(self, fraction: float) -> float:
+        if not self.count:
+            return 0.0
+        target = max(1, math.ceil(self.count * fraction))
+        seen = 0
+        for index, count in enumerate(self.bins):
+            seen += count
+            if seen >= target:
+                if index == 0:
+                    return self.lowest_ms
+                return self.lowest_ms * self.ratio ** (index - 1)
+        return self.lowest_ms * self.ratio ** (len(self.bins) - 2)
+
+
 class CsvFile:
     def __init__(self, path: Path, fields: list[str]):
+        path.parent.mkdir(parents=True, exist_ok=True)
         self.handle = path.open("w", newline="", encoding="utf-8")
         self.writer = csv.DictWriter(self.handle, fieldnames=fields, extrasaction="ignore")
         self.writer.writeheader()
 
     def write(self, row: dict[str, Any]) -> None:
-        self.writer.writerow(row)
+        self.writer.writerow({
+            key: str(value).lower() if isinstance(value, bool) else value
+            for key, value in row.items()
+        })
         self.handle.flush()
 
     def close(self) -> None:
         self.handle.close()
 
 
+LATENCY_FIELDS = [
+    "run_id", "mode", "scenario", "backend", "performance_valid", "model",
+    "architecture", "composite_tp", "kv_tp", "cp", "dp", "gpu_count",
+    "page_tokens", "main_page_gb", "cpu_cache_gb", "ssd_cache_gb", "layerwise",
+    "ssd_enabled", "swa", "conversations_per_round", "turns_min", "turns_max",
+    "system_prompt_blocks", "first_input_blocks", "added_input_blocks", "output_blocks",
+    "partial_block_tokens", "shared_system_prompt", "read_after_put",
+    "batch_size", "concurrency", "requests", "qps",
+    "match_p50_ms", "match_p95_ms", "match_p99_ms",
+    "load_p50_ms", "load_p95_ms", "load_p99_ms",
+    "save_p50_ms", "save_p95_ms", "save_p99_ms",
+    "hit_ratio", "hit_exact_rate", "hit_token_accuracy", "request_success_rate",
+    "byte_validation_accuracy", "gpu_memory_gb", "rss_gb", "ssd_used_gb",
+]
+
+BANDWIDTH_FIELDS = [
+    "run_id", "mode", "scenario", "backend", "performance_valid", "model",
+    "architecture", "composite_tp", "kv_tp", "cp", "dp", "gpu_count",
+    "page_tokens", "main_page_gb", "cpu_cache_gb", "ssd_cache_gb", "layerwise",
+    "ssd_enabled", "swa", "conversations_per_round", "turns_min", "turns_max",
+    "system_prompt_blocks", "first_input_blocks", "added_input_blocks", "output_blocks",
+    "partial_block_tokens", "shared_system_prompt", "read_after_put",
+    "batch_size", "concurrency",
+    "payload_gb", "operations", "duration_s", "throughput_gb_s",
+    "latency_p50_ms", "latency_p95_ms", "latency_p99_ms",
+    "operation_success_rate", "byte_validation_accuracy", "gpu_memory_gb",
+    "rss_gb", "ssd_used_gb",
+]
+
+WINDOW_FIELDS = ["window_id", "window_started_at", "window_duration_s"]
+ERROR_FIELDS = ["time", "scenario", "window_id", "operation", "error"]
+
+
+def _rounded(value: float) -> float:
+    return round(float(value), 9)
+
+
+def _resource_values(resources: list[dict[str, int]], cpu_stub: bool) -> tuple[float, float, float]:
+    if not resources:
+        return 0.0, 0.0, 0.0
+    gpu = sum(item.get("allocated_bytes", 0) for item in resources)
+    # CPU stub workers share one process; accelerator workers are separate processes.
+    rss_values = [item.get("rss_bytes", 0) for item in resources]
+    rss = max(rss_values, default=0) if cpu_stub else sum(rss_values)
+    ssd = max((item.get("ssd_bytes", 0) for item in resources), default=0)
+    return _rounded(decimal_gb(gpu)), _rounded(decimal_gb(rss)), _rounded(decimal_gb(ssd))
+
+
+class _LatencyAggregate:
+    def __init__(self, batch_size: int, concurrency: int):
+        self.batch_size = batch_size
+        self.concurrency = concurrency
+        self.requests = self.successes = 0
+        self.query_tokens = self.actual = self.absolute_delta = self.exact = 0
+        self.validation_samples = self.validation_passes = 0
+        self.duration_s = 0.0
+        self.latency = {name: LogHistogram() for name in ("match", "load", "save")}
+        self.gpu = self.rss = self.ssd = 0.0
+
+    def add(self, results: list[TurnResult], duration_s: float, resources: tuple[float, float, float],
+            tolerance_tokens: int) -> None:
+        self.duration_s += duration_s
+        self.requests += len(results)
+        self.successes += sum(result.success for result in results)
+        for result in results:
+            query = result.query_tokens or result.total_tokens
+            self.query_tokens += query
+            self.actual += result.actual_hit_tokens
+            self.absolute_delta += abs(result.actual_hit_tokens - result.expected_hit_tokens)
+            self.exact += abs(result.hit_delta_tokens) <= tolerance_tokens
+            self.validation_samples += int(result.validation_sampled)
+            self.validation_passes += int(result.validation_sampled and result.validation_ok)
+            self.latency["match"].record(result.match_ms)
+            self.latency["load"].record(result.get_ms)
+            self.latency["save"].record(result.put_ms)
+        self.gpu = max(self.gpu, resources[0])
+        self.rss = max(self.rss, resources[1])
+        self.ssd = max(self.ssd, resources[2])
+
+
+class _BandwidthAggregate:
+    def __init__(self, concurrency: int):
+        self.concurrency = concurrency
+        self.payload_bytes = self.operations = self.successes = 0
+        self.validation_samples = self.validation_passes = 0
+        self.duration_s = 0.0
+        self.latency = LogHistogram()
+        self.gpu = self.rss = self.ssd = 0.0
+
+    def add(self, operations: list[OperationResult], duration_s: float,
+            validation_samples: int, validation_passes: int,
+            resources: tuple[float, float, float]) -> None:
+        self.payload_bytes += sum(item.transfer_bytes for item in operations)
+        self.operations += len(operations)
+        self.successes += sum(item.success for item in operations)
+        self.validation_samples += validation_samples
+        self.validation_passes += validation_passes
+        self.duration_s += duration_s
+        for item in operations:
+            self.latency.record(item.latency_ms)
+        self.gpu = max(self.gpu, resources[0])
+        self.rss = max(self.rss, resources[1])
+        self.ssd = max(self.ssd, resources[2])
+
+
 class Reporter:
-    TURN_FIELDS = list(TurnResult.__dataclass_fields__)
-    ROUND_FIELDS = [
-        "round_id", "elapsed_seconds", "turns", "successes", "failures", "success_rate",
-        "qps", "latency_p50_ms", "latency_p95_ms", "latency_p99_ms", "expected_hit_tokens",
-        "actual_hit_tokens", "hit_ratio", "hit_delta_tokens", "validation_samples",
-        "validation_failures",
-    ]
-    ERROR_FIELDS = ["time", "round_id", "conversation_id", "turn_id", "operation", "error"]
-    OP_FIELDS = ["round_id", "operation", "calls", "successes", "failures", "p50_ms", "p95_ms", "p99_ms"]
-    RESOURCE_FIELDS = [
-        "time", "round_id", "device_id", "allocated_bytes", "reserved_bytes",
-        "max_allocated_bytes", "rss_bytes", "ssd_bytes",
-    ]
-    VALIDATION_FIELDS = ["round_id", "conversation_id", "turn_id", "ok"]
+    """Mode-aware stable CSV/JSON/SVG reporter with bounded-memory histograms."""
 
-    def __init__(self, output_dir: str | Path):
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        base = Path(output_dir).resolve()
-        self.directory = base / timestamp
-        self.directory.mkdir(parents=True, exist_ok=True)
-        self.turns = CsvFile(self.directory / "turns.csv", self.TURN_FIELDS)
-        self.rounds = CsvFile(self.directory / "rounds.csv", self.ROUND_FIELDS)
-        self.windows = CsvFile(self.directory / "windows.csv", self.ROUND_FIELDS)
-        self.errors = CsvFile(self.directory / "errors.csv", self.ERROR_FIELDS)
-        self.operations = CsvFile(self.directory / "operations.csv", self.OP_FIELDS)
-        self.resources = CsvFile(self.directory / "resources.csv", self.RESOURCE_FIELDS)
-        self.validation = CsvFile(self.directory / "validation_samples.csv", self.VALIDATION_FIELDS)
-        self.all_rounds: list[dict[str, Any]] = []
+    def __init__(self, config, output_dir: str | Path | None = None):
+        self.config = config
+        self.started_at = datetime.now().astimezone()
+        self._started_monotonic = time.monotonic()
+        timestamp = self.started_at.strftime("%Y%m%d_%H%M%S")
+        self.run_id = f"{timestamp}_{os.getpid()}"
+        base = Path(output_dir or config.output.directory).resolve()
+        self.directory = base / self.run_id
+        self.directory.mkdir(parents=True, exist_ok=False)
+        self.mode = config.run.mode
+        self.backend = self._backend_name()
+        self.performance_valid = not config.features.cpu_stub
+        self.windows: list[dict[str, Any]] = []
+        self.latency_aggregates: dict[str, _LatencyAggregate] = {}
+        self.bandwidth_aggregates: dict[tuple[str, int], _BandwidthAggregate] = {}
+        self.errors: CsvFile | None = None
+        self.error_count = 0
 
-    def write_error(self, round_id: int, operation: str, error: str,
-                    conversation_id: int = -1, turn_id: int = -1) -> None:
+    def _backend_name(self) -> str:
+        if self.config.features.cpu_stub:
+            return "cpu_stub"
+        try:
+            import torch
+            return "rocm" if getattr(torch.version, "hip", None) else "cuda"
+        except Exception:
+            return "cuda"
+
+    def write_error(self, window_id: int, operation: str, error: str,
+                    conversation_id: int = -1, turn_id: int = -1,
+                    scenario: str = "") -> None:
+        del conversation_id, turn_id
+        if self.errors is None:
+            self.errors = CsvFile(self.directory / "errors.csv", ERROR_FIELDS)
+        self.error_count += 1
         self.errors.write({
-            "time": time.time(), "round_id": round_id, "conversation_id": conversation_id,
-            "turn_id": turn_id, "operation": operation, "error": error,
+            "time": datetime.now().astimezone().isoformat(), "scenario": scenario,
+            "window_id": window_id, "operation": operation, "error": error,
         })
 
-    def write_round(self, round_id: int, started_at: float, results: list[TurnResult],
-                    operations: list[OperationResult]) -> dict[str, Any]:
-        for result in results:
-            self.turns.write(asdict(result))
-            if result.validation_sampled:
-                self.validation.write({
-                    "round_id": result.round_id,
-                    "conversation_id": result.conversation_id,
-                    "turn_id": result.turn_id,
-                    "ok": result.validation_ok,
-                })
-        elapsed = max(time.perf_counter() - started_at, 1e-9)
-        successes = sum(result.success for result in results)
-        expected = sum(result.expected_hit_tokens for result in results)
-        actual = sum(result.actual_hit_tokens for result in results)
-        latencies = [op.latency_ms for op in operations]
-        validation_samples = sum(result.validation_sampled for result in results)
-        validation_failures = sum(result.validation_sampled and not result.validation_ok for result in results)
-        row = {
-            "round_id": round_id,
-            "elapsed_seconds": elapsed,
-            "turns": len(results),
-            "successes": successes,
-            "failures": len(results) - successes,
-            "success_rate": successes / len(results) if results else 1.0,
-            "qps": len(results) / elapsed,
-            "latency_p50_ms": percentile(latencies, 0.50),
-            "latency_p95_ms": percentile(latencies, 0.95),
-            "latency_p99_ms": percentile(latencies, 0.99),
-            "expected_hit_tokens": expected,
-            "actual_hit_tokens": actual,
-            "hit_ratio": actual / sum(result.total_tokens for result in results) if results else 0.0,
-            "hit_delta_tokens": actual - expected,
-            "validation_samples": validation_samples,
-            "validation_failures": validation_failures,
+    def _cache_gb(self, tier: str) -> float:
+        count = getattr(self.config.cache, f"num_{tier}_blocks")
+        configured = getattr(self.config.cache, f"{tier}_cache_gb")
+        return _rounded(decimal_gb(count * self.config.bytes_per_block) if count else configured)
+
+    def _common(self, scenario: str) -> dict[str, Any]:
+        config = self.config
+        def csv_value(value: Any) -> Any:
+            return json.dumps(value, separators=(",", ":")) if isinstance(value, (list, dict)) else value
+
+        return {
+            "run_id": self.run_id, "mode": self.mode, "scenario": scenario,
+            "backend": self.backend, "performance_valid": self.performance_valid,
+            "model": config.preset.name, "architecture": config.preset.architecture,
+            "composite_tp": config.model.tp_size, "kv_tp": config.kv_tp_size,
+            "cp": config.model.cp_size, "dp": config.model.dp_size,
+            "gpu_count": config.required_gpus, "page_tokens": config.tokens_per_block,
+            "main_page_gb": _rounded(decimal_gb(config.bytes_per_block)),
+            "cpu_cache_gb": self._cache_gb("cpu"), "ssd_cache_gb": self._cache_gb("ssd"),
+            "layerwise": config.features.layerwise, "ssd_enabled": config.features.ssd,
+            "swa": config.features.swa,
+            "conversations_per_round": config.conversation.conversations_per_round,
+            "turns_min": config.conversation.turns_min,
+            "turns_max": config.conversation.turns_max,
+            "system_prompt_blocks": config.conversation.system_prompt_blocks,
+            "first_input_blocks": csv_value(config.conversation.first_input_blocks),
+            "added_input_blocks": csv_value(config.conversation.added_input_blocks),
+            "output_blocks": csv_value(config.conversation.output_blocks),
+            "partial_block_tokens": config.conversation.partial_block_tokens,
+            "shared_system_prompt": config.conversation.shared_system_prompt,
+            "read_after_put": config.conversation.read_after_put,
         }
-        self.rounds.write(row)
-        self.windows.write(row)
-        self.all_rounds.append(row)
-        grouped: dict[str, list[OperationResult]] = defaultdict(list)
-        for op in operations:
-            grouped[op.operation].append(op)
-        for name, items in grouped.items():
-            values = [item.latency_ms for item in items]
-            ok = sum(item.success for item in items)
-            self.operations.write({
-                "round_id": round_id, "operation": name, "calls": len(items), "successes": ok,
-                "failures": len(items) - ok, "p50_ms": percentile(values, 0.50),
-                "p95_ms": percentile(values, 0.95), "p99_ms": percentile(values, 0.99),
-            })
+
+    @staticmethod
+    def _latency_values(histograms: dict[str, LogHistogram]) -> dict[str, float]:
+        result: dict[str, float] = {}
+        for name, histogram in histograms.items():
+            for label, fraction in (("p50", .50), ("p95", .95), ("p99", .99)):
+                result[f"{name}_{label}_ms"] = _rounded(histogram.percentile(fraction))
+        return result
+
+    def _latency_row(self, scenario: str, aggregate: _LatencyAggregate) -> dict[str, Any]:
+        requests = aggregate.requests
+        query_tokens = aggregate.query_tokens
+        row = {
+            **self._common(scenario), "batch_size": aggregate.batch_size,
+            "concurrency": aggregate.concurrency, "requests": requests,
+            "qps": _rounded(requests / aggregate.duration_s if aggregate.duration_s else 0),
+            **self._latency_values(aggregate.latency),
+            "hit_ratio": _rounded(aggregate.actual / query_tokens if query_tokens else 0),
+            "hit_exact_rate": _rounded(aggregate.exact / requests if requests else 1),
+            "hit_token_accuracy": _rounded(
+                max(0.0, 1 - aggregate.absolute_delta / query_tokens) if query_tokens else 1
+            ),
+            "request_success_rate": _rounded(aggregate.successes / requests if requests else 1),
+            "byte_validation_accuracy": _rounded(
+                aggregate.validation_passes / aggregate.validation_samples
+                if aggregate.validation_samples else 1
+            ),
+            "gpu_memory_gb": aggregate.gpu, "rss_gb": aggregate.rss,
+            "ssd_used_gb": aggregate.ssd,
+        }
         return row
 
-    def write_resource(self, round_id: int, device_id: int, values: dict[str, int]) -> None:
-        self.resources.write({"time": time.time(), "round_id": round_id, "device_id": device_id, **values})
+    def write_latency_window(self, scenario: str, window_id: int, started_at: datetime,
+                             duration_s: float, results: list[TurnResult],
+                             resources: list[dict[str, int]] | None = None,
+                             batch_size: int | None = None,
+                             concurrency: int | None = None) -> dict[str, Any]:
+        batch = batch_size or (1 if scenario == "unloaded" else self.config.concurrency.batch_size)
+        inflight = concurrency or (1 if scenario == "unloaded" else self.config.concurrency.max_inflight_per_dp)
+        aggregate = self.latency_aggregates.setdefault(scenario, _LatencyAggregate(batch, inflight))
+        window = _LatencyAggregate(batch, inflight)
+        values = _resource_values(resources or [], self.config.features.cpu_stub)
+        tolerance = self.config.validation.hit_tolerance_blocks * self.config.tokens_per_block
+        window.add(results, max(duration_s, 1e-9), values, tolerance)
+        aggregate.add(results, max(duration_s, 1e-9), values, tolerance)
+        row = {
+            **self._latency_row(scenario, window), "window_id": window_id,
+            "window_started_at": started_at.isoformat(),
+            "window_duration_s": _rounded(duration_s),
+        }
+        self.windows.append(row)
+        return row
+
+    def _bandwidth_row(self, scenario: str, aggregate: _BandwidthAggregate) -> dict[str, Any]:
+        common = self._common(scenario)
+        row = {key: common[key] for key in BANDWIDTH_FIELDS if key in common}
+        row.update({
+            "batch_size": aggregate.concurrency, "concurrency": aggregate.concurrency,
+            "payload_gb": _rounded(decimal_gb(aggregate.payload_bytes)),
+            "operations": aggregate.operations, "duration_s": _rounded(aggregate.duration_s),
+            "throughput_gb_s": _rounded(throughput_gb_s(
+                aggregate.payload_bytes, aggregate.duration_s
+            )),
+            "latency_p50_ms": _rounded(aggregate.latency.percentile(.50)),
+            "latency_p95_ms": _rounded(aggregate.latency.percentile(.95)),
+            "latency_p99_ms": _rounded(aggregate.latency.percentile(.99)),
+            "operation_success_rate": _rounded(
+                aggregate.successes / aggregate.operations if aggregate.operations else 1
+            ),
+            "byte_validation_accuracy": _rounded(
+                aggregate.validation_passes / aggregate.validation_samples
+                if aggregate.validation_samples else 1
+            ),
+            "gpu_memory_gb": aggregate.gpu, "rss_gb": aggregate.rss,
+            "ssd_used_gb": aggregate.ssd,
+        })
+        return row
+
+    def write_bandwidth_window(self, scenario: str, concurrency: int, window_id: int,
+                               started_at: datetime, duration_s: float,
+                               operations: list[OperationResult], validation_samples: int,
+                               validation_passes: int,
+                               resources: list[dict[str, int]] | None = None) -> dict[str, Any]:
+        key = (scenario, concurrency)
+        aggregate = self.bandwidth_aggregates.setdefault(key, _BandwidthAggregate(concurrency))
+        window = _BandwidthAggregate(concurrency)
+        values = _resource_values(resources or [], self.config.features.cpu_stub)
+        active_s = max(duration_s, 1e-9)
+        window.add(operations, active_s, validation_samples, validation_passes, values)
+        aggregate.add(operations, active_s, validation_samples, validation_passes, values)
+        row = {
+            **self._bandwidth_row(scenario, window), "window_id": window_id,
+            "window_started_at": started_at.isoformat(),
+            "window_duration_s": _rounded(duration_s),
+        }
+        self.windows.append(row)
+        return row
+
+    def _summary_rows(self) -> list[dict[str, Any]]:
+        if self.mode == "latency_hit":
+            order = {"unloaded": 0, "loaded": 1}
+            return [
+                self._latency_row(name, aggregate)
+                for name, aggregate in sorted(
+                    self.latency_aggregates.items(), key=lambda item: order.get(item[0], 99)
+                )
+            ]
+        return [
+            self._bandwidth_row(name, aggregate)
+            for (name, _), aggregate in sorted(
+                self.bandwidth_aggregates.items(),
+                key=lambda item: (
+                    self.config.bandwidth.paths.index(item[0][0]), item[0][1]
+                ),
+            )
+        ]
+
+    def _json(self, rows: list[dict[str, Any]]) -> dict[str, Any]:
+        config = self.config
+        run = {
+            "run_id": self.run_id, "mode": self.mode, "backend": self.backend,
+            "performance_valid": self.performance_valid,
+            "started_at": self.started_at.isoformat(),
+            "duration_s": _rounded(time.monotonic() - self._started_monotonic),
+        }
+        model = {
+            "preset": config.preset.name, "architecture": config.preset.architecture,
+            "page_tokens": config.tokens_per_block,
+            "main_page_gb": _rounded(decimal_gb(config.bytes_per_block)),
+            "swa_page_gb": _rounded(decimal_gb(config.swa_bytes_per_block)),
+        }
+        topology = {
+            "composite_tp": config.model.tp_size, "kv_tp": config.kv_tp_size,
+            "cp": config.model.cp_size, "dp": config.model.dp_size,
+            "gpu_count": config.required_gpus,
+        }
+        cache = {
+            "cpu_gb": self._cache_gb("cpu"), "ssd_gb": self._cache_gb("ssd"),
+            "ssd_enabled": config.features.ssd, "layerwise": config.features.layerwise,
+            "swa_enabled": config.features.swa,
+        }
+        workload = {
+            "conversations_per_round": config.conversation.conversations_per_round,
+            "turns_min": config.conversation.turns_min,
+            "turns_max": config.conversation.turns_max,
+            "system_prompt_blocks": config.conversation.system_prompt_blocks,
+            "first_input_blocks": config.conversation.first_input_blocks,
+            "input_blocks": config.conversation.added_input_blocks,
+            "output_blocks": config.conversation.output_blocks,
+            "partial_block_tokens": config.conversation.partial_block_tokens,
+            "shared_system_prompt": config.conversation.shared_system_prompt,
+            "read_after_put": config.conversation.read_after_put,
+        }
+        scenarios = []
+        if self.mode == "latency_hit":
+            for row in rows:
+                scenarios.append({
+                    "name": row["scenario"], "batch_size": row["batch_size"],
+                    "concurrency": row["concurrency"], "requests": row["requests"],
+                    "qps": row["qps"],
+                    "latency_ms": {
+                        name: {label: row[f"{name}_{label}_ms"] for label in ("p50", "p95", "p99")}
+                        for name in ("match", "load", "save")
+                    },
+                    "hit": {"ratio": row["hit_ratio"], "exact_rate": row["hit_exact_rate"],
+                            "token_accuracy": row["hit_token_accuracy"]},
+                    "correctness": {
+                        "request_success_rate": row["request_success_rate"],
+                        "byte_validation_accuracy": row["byte_validation_accuracy"],
+                        "validation_samples": self.latency_aggregates[row["scenario"]].validation_samples,
+                    },
+                    "resources_gb": {"gpu_memory": row["gpu_memory_gb"], "rss": row["rss_gb"],
+                                     "ssd_used": row["ssd_used_gb"]},
+                })
+        else:
+            for row in rows:
+                scenarios.append({
+                    "name": row["scenario"], "concurrency": row["concurrency"],
+                    "payload_gb": row["payload_gb"], "operations": row["operations"],
+                    "duration_s": row["duration_s"], "throughput_gb_s": row["throughput_gb_s"],
+                    "latency_ms": {label: row[f"latency_{label}_ms"] for label in ("p50", "p95", "p99")},
+                    "correctness": {
+                        "operation_success_rate": row["operation_success_rate"],
+                        "byte_validation_accuracy": row["byte_validation_accuracy"],
+                    },
+                    "resources_gb": {"gpu_memory": row["gpu_memory_gb"], "rss": row["rss_gb"],
+                                     "ssd_used": row["ssd_used_gb"]},
+                })
+        return {"schema_version": SCHEMA_VERSION, "run": run, "model": model,
+                "topology": topology, "cache": cache, "workload": workload,
+                "scenarios": scenarios}
+
+    def _write_svg(self, rows: list[dict[str, Any]]) -> None:
+        title = (
+            f"FlexKV Stress — {self.config.preset.name} — {self.mode} — {self.backend} — "
+            f"TP/CP/DP {self.config.model.tp_size}/{self.config.model.cp_size}/{self.config.model.dp_size}"
+        )
+        if self.mode == "bandwidth":
+            panels = ["Throughput (GB/s)", "Operation latency p50/p95/p99 (ms)",
+                      "Success and byte validation accuracy", "GPU / RSS / SSD usage (GB)"]
+        else:
+            panels = ["Match / load / save latency p50/p95/p99 (ms)", "QPS",
+                      "Hit and byte accuracy", "GPU / RSS / SSD usage (GB)"]
+        parts = [
+            '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820">',
+            '<rect width="1200" height="820" fill="#0b1220"/>',
+            f'<text x="40" y="38" fill="#f8fafc" font-size="22">{escape(title)}</text>',
+        ]
+        if not self.performance_valid:
+            parts.append('<text id="cpu-stub-watermark" x="600" y="70" text-anchor="middle" '
+                         'fill="#ff5a5f" font-size="20" font-weight="bold">'
+                         'CPU STUB — PERFORMANCE NUMBERS ARE NOT VALID</text>')
+        colors = ["#38bdf8", "#fb7185", "#a3e635", "#fbbf24", "#c084fc"]
+        stable_peaks: set[str] = set()
+        if self.mode == "bandwidth":
+            by_path: dict[str, list[dict[str, Any]]] = {}
+            for row in rows:
+                if row["operation_success_rate"] == 1 and row["byte_validation_accuracy"] == 1:
+                    by_path.setdefault(str(row["scenario"]), []).append(row)
+            for path, candidates in by_path.items():
+                best = max(candidates, key=lambda item: item["throughput_gb_s"])
+                stable_peaks.add(f'{path}@{best["concurrency"]}:throughput_gb_s')
+        for panel_id, panel_title in enumerate(panels):
+            x = 35 + (panel_id % 2) * 580
+            y = 90 + (panel_id // 2) * 350
+            parts.extend([
+                f'<g id="panel-{panel_id + 1}" data-panel="{escape(panel_title)}">',
+                f'<rect x="{x}" y="{y}" width="550" height="320" rx="8" fill="#111c2e" stroke="#334155"/>',
+                f'<text x="{x + 18}" y="{y + 28}" fill="#e2e8f0" font-size="16">{escape(panel_title)}</text>',
+                f'<line class="x-axis" x1="{x + 55}" y1="{y + 275}" x2="{x + 525}" y2="{y + 275}" stroke="#64748b"/>',
+                f'<line class="y-axis" x1="{x + 55}" y1="{y + 55}" x2="{x + 55}" y2="{y + 275}" stroke="#64748b"/>',
+            ])
+            values: list[tuple[str, float]] = []
+            if self.mode == "bandwidth":
+                fields = [
+                    ("throughput_gb_s",),
+                    ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms"),
+                    ("operation_success_rate", "byte_validation_accuracy"),
+                    ("gpu_memory_gb", "rss_gb", "ssd_used_gb"),
+                ][panel_id]
+            else:
+                fields = [
+                    tuple(f"{operation}_{quantile}_ms" for operation in ("match", "load", "save")
+                          for quantile in ("p50", "p95", "p99")),
+                    ("qps",),
+                    ("hit_ratio", "hit_exact_rate", "hit_token_accuracy", "byte_validation_accuracy"),
+                    ("gpu_memory_gb", "rss_gb", "ssd_used_gb"),
+                ][panel_id]
+            plot_rows = self.windows if panel_id == 3 and self.windows else rows
+            for row in plot_rows:
+                base = (f'{row["scenario"]}@{row["concurrency"]}'
+                        if self.mode == "bandwidth" else str(row["scenario"]))
+                if panel_id == 3 and "window_id" in row:
+                    base += f'#window-{row["window_id"]}'
+                values.extend((f"{base}:{field}", float(row[field])) for field in fields)
+            positive = [(label, value) for label, value in values if value > 0]
+            maximum = max((value for _, value in positive), default=1.0)
+            points = []
+            point_records: list[tuple[str, str]] = []
+            for index, (label, value) in enumerate(positive):
+                px = x + 75 + index * (430 / max(1, len(positive) - 1))
+                py = y + 270 - 200 * value / maximum
+                points.append(f"{px:.1f},{py:.1f}")
+                point_records.append((label, points[-1]))
+                peak = label in stable_peaks
+                bar_panel = (
+                    (self.mode == "bandwidth" and panel_id in (1, 2))
+                    or (self.mode == "latency_hit" and panel_id in (0, 1, 2))
+                )
+                if bar_panel:
+                    parts.append(f'<rect class="grouped-bar" data-series="{escape(label)}" '
+                                 f'x="{px - 3:.1f}" y="{py:.1f}" width="6" '
+                                 f'height="{max(0.0, y + 275 - py):.1f}" '
+                                 f'fill="{colors[index % len(colors)]}" opacity="0.55"/>')
+                parts.append(f'<circle data-series="{escape(label)}" '
+                             f'class="{"highest-stable-bandwidth" if peak else "data-point"}" '
+                             f'cx="{px:.1f}" cy="{py:.1f}" r="{8 if peak else 5}" '
+                             f'fill="{colors[index % len(colors)]}"/>')
+                parts.append(f'<text x="{px:.1f}" y="{py - 9:.1f}" text-anchor="middle" fill="#cbd5e1" '
+                             f'font-size="10">{value:.3g}</text>')
+            if points and self.mode == "bandwidth" and panel_id == 0:
+                for path in self.config.bandwidth.paths:
+                    path_points = [point for label, point in point_records if label.startswith(path + "@")]
+                    if path_points:
+                        parts.append(f'<polyline data-series="{escape(path)}" '
+                                     f'points="{" ".join(path_points)}" fill="none" '
+                                     'stroke="#38bdf8" stroke-width="2"/>')
+            elif points:
+                parts.append(f'<polyline data-series="{panel_id + 1}" points="{" ".join(points)}" '
+                             'fill="none" stroke="#38bdf8" stroke-width="2"/>')
+            parts.append('</g>')
+        parts.append('</svg>')
+        (self.directory / "charts.svg").write_text("\n".join(parts) + "\n", encoding="utf-8")
 
     def close(self) -> None:
-        summary_fields = ["rounds", "turns", "successes", "failures", "success_rate", "validation_failures"]
-        total_turns = sum(int(row["turns"]) for row in self.all_rounds)
-        successes = sum(int(row["successes"]) for row in self.all_rounds)
-        validation_failures = sum(int(row["validation_failures"]) for row in self.all_rounds)
-        summary = CsvFile(self.directory / "summary.csv", summary_fields)
-        summary.write({
-            "rounds": len(self.all_rounds), "turns": total_turns, "successes": successes,
-            "failures": total_turns - successes,
-            "success_rate": successes / total_turns if total_turns else 1.0,
-            "validation_failures": validation_failures,
-        })
+        rows = self._summary_rows()
+        fields = LATENCY_FIELDS if self.mode == "latency_hit" else BANDWIDTH_FIELDS
+        summary = CsvFile(self.directory / "summary.csv", fields)
+        for row in rows:
+            summary.write(row)
         summary.close()
-        for output in (
-            self.turns, self.rounds, self.windows, self.errors, self.operations,
-            self.resources, self.validation,
-        ):
-            output.close()
+        metrics = CsvFile(self.directory / "metrics.csv", WINDOW_FIELDS + fields)
+        for row in self.windows:
+            metrics.write(row)
+        metrics.close()
+        (self.directory / "summary.json").write_text(
+            json.dumps(self._json(rows), indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        self._write_svg(rows)
+        if self.errors is not None:
+            self.errors.close()

--- a/benchmarks/flexkv_stress/metrics.py
+++ b/benchmarks/flexkv_stress/metrics.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
-from xml.sax.saxutils import escape
 import csv
 import json
 import math
@@ -231,7 +230,7 @@ class _BandwidthAggregate:
 
 
 class Reporter:
-    """Mode-aware stable CSV/JSON/SVG reporter with bounded-memory histograms."""
+    """Mode-aware stable CSV/JSON reporter with bounded-memory histograms."""
 
     def __init__(self, config, output_dir: str | Path | None = None):
         self.config = config
@@ -496,108 +495,6 @@ class Reporter:
                 "topology": topology, "cache": cache, "workload": workload,
                 "scenarios": scenarios}
 
-    def _write_svg(self, rows: list[dict[str, Any]]) -> None:
-        title = (
-            f"FlexKV Stress — {self.config.preset.name} — {self.mode} — {self.backend} — "
-            f"TP/CP/DP {self.config.model.tp_size}/{self.config.model.cp_size}/{self.config.model.dp_size}"
-        )
-        if self.mode == "bandwidth":
-            panels = ["Throughput (GB/s)", "Operation latency p50/p95/p99 (ms)",
-                      "Success and byte validation accuracy", "GPU / RSS / SSD usage (GB)"]
-        else:
-            panels = ["Match / load / save latency p50/p95/p99 (ms)", "QPS",
-                      "Hit and byte accuracy", "GPU / RSS / SSD usage (GB)"]
-        parts = [
-            '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820">',
-            '<rect width="1200" height="820" fill="#0b1220"/>',
-            f'<text x="40" y="38" fill="#f8fafc" font-size="22">{escape(title)}</text>',
-        ]
-        if not self.performance_valid:
-            parts.append('<text id="cpu-stub-watermark" x="600" y="70" text-anchor="middle" '
-                         'fill="#ff5a5f" font-size="20" font-weight="bold">'
-                         'CPU STUB — PERFORMANCE NUMBERS ARE NOT VALID</text>')
-        colors = ["#38bdf8", "#fb7185", "#a3e635", "#fbbf24", "#c084fc"]
-        stable_peaks: set[str] = set()
-        if self.mode == "bandwidth":
-            by_path: dict[str, list[dict[str, Any]]] = {}
-            for row in rows:
-                if row["operation_success_rate"] == 1 and row["byte_validation_accuracy"] == 1:
-                    by_path.setdefault(str(row["scenario"]), []).append(row)
-            for path, candidates in by_path.items():
-                best = max(candidates, key=lambda item: item["throughput_gb_s"])
-                stable_peaks.add(f'{path}@{best["concurrency"]}:throughput_gb_s')
-        for panel_id, panel_title in enumerate(panels):
-            x = 35 + (panel_id % 2) * 580
-            y = 90 + (panel_id // 2) * 350
-            parts.extend([
-                f'<g id="panel-{panel_id + 1}" data-panel="{escape(panel_title)}">',
-                f'<rect x="{x}" y="{y}" width="550" height="320" rx="8" fill="#111c2e" stroke="#334155"/>',
-                f'<text x="{x + 18}" y="{y + 28}" fill="#e2e8f0" font-size="16">{escape(panel_title)}</text>',
-                f'<line class="x-axis" x1="{x + 55}" y1="{y + 275}" x2="{x + 525}" y2="{y + 275}" stroke="#64748b"/>',
-                f'<line class="y-axis" x1="{x + 55}" y1="{y + 55}" x2="{x + 55}" y2="{y + 275}" stroke="#64748b"/>',
-            ])
-            values: list[tuple[str, float]] = []
-            if self.mode == "bandwidth":
-                fields = [
-                    ("throughput_gb_s",),
-                    ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms"),
-                    ("operation_success_rate", "byte_validation_accuracy"),
-                    ("gpu_memory_gb", "rss_gb", "ssd_used_gb"),
-                ][panel_id]
-            else:
-                fields = [
-                    tuple(f"{operation}_{quantile}_ms" for operation in ("match", "load", "save")
-                          for quantile in ("p50", "p95", "p99")),
-                    ("qps",),
-                    ("hit_ratio", "hit_exact_rate", "hit_token_accuracy", "byte_validation_accuracy"),
-                    ("gpu_memory_gb", "rss_gb", "ssd_used_gb"),
-                ][panel_id]
-            plot_rows = self.windows if panel_id == 3 and self.windows else rows
-            for row in plot_rows:
-                base = (f'{row["scenario"]}@{row["concurrency"]}'
-                        if self.mode == "bandwidth" else str(row["scenario"]))
-                if panel_id == 3 and "window_id" in row:
-                    base += f'#window-{row["window_id"]}'
-                values.extend((f"{base}:{field}", float(row[field])) for field in fields)
-            positive = [(label, value) for label, value in values if value > 0]
-            maximum = max((value for _, value in positive), default=1.0)
-            points = []
-            point_records: list[tuple[str, str]] = []
-            for index, (label, value) in enumerate(positive):
-                px = x + 75 + index * (430 / max(1, len(positive) - 1))
-                py = y + 270 - 200 * value / maximum
-                points.append(f"{px:.1f},{py:.1f}")
-                point_records.append((label, points[-1]))
-                peak = label in stable_peaks
-                bar_panel = (
-                    (self.mode == "bandwidth" and panel_id in (1, 2))
-                    or (self.mode == "latency_hit" and panel_id in (0, 1, 2))
-                )
-                if bar_panel:
-                    parts.append(f'<rect class="grouped-bar" data-series="{escape(label)}" '
-                                 f'x="{px - 3:.1f}" y="{py:.1f}" width="6" '
-                                 f'height="{max(0.0, y + 275 - py):.1f}" '
-                                 f'fill="{colors[index % len(colors)]}" opacity="0.55"/>')
-                parts.append(f'<circle data-series="{escape(label)}" '
-                             f'class="{"highest-stable-bandwidth" if peak else "data-point"}" '
-                             f'cx="{px:.1f}" cy="{py:.1f}" r="{8 if peak else 5}" '
-                             f'fill="{colors[index % len(colors)]}"/>')
-                parts.append(f'<text x="{px:.1f}" y="{py - 9:.1f}" text-anchor="middle" fill="#cbd5e1" '
-                             f'font-size="10">{value:.3g}</text>')
-            if points and self.mode == "bandwidth" and panel_id == 0:
-                for path in self.config.bandwidth.paths:
-                    path_points = [point for label, point in point_records if label.startswith(path + "@")]
-                    if path_points:
-                        parts.append(f'<polyline data-series="{escape(path)}" '
-                                     f'points="{" ".join(path_points)}" fill="none" '
-                                     'stroke="#38bdf8" stroke-width="2"/>')
-            elif points:
-                parts.append(f'<polyline data-series="{panel_id + 1}" points="{" ".join(points)}" '
-                             'fill="none" stroke="#38bdf8" stroke-width="2"/>')
-            parts.append('</g>')
-        parts.append('</svg>')
-        (self.directory / "charts.svg").write_text("\n".join(parts) + "\n", encoding="utf-8")
-
     def close(self) -> None:
         rows = self._summary_rows()
         fields = LATENCY_FIELDS if self.mode == "latency_hit" else BANDWIDTH_FIELDS
@@ -612,6 +509,5 @@ class Reporter:
         (self.directory / "summary.json").write_text(
             json.dumps(self._json(rows), indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
         )
-        self._write_svg(rows)
         if self.errors is not None:
             self.errors.close()

--- a/benchmarks/flexkv_stress/models.py
+++ b/benchmarks/flexkv_stress/models.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+import json
+
+
+DSV4_PRO_RATIOS = [
+    128, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
+    128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
+    128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
+    128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 0,
+]
+
+DSV4_FLASH_RATIOS = [
+    0, 0, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+    4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+    4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0,
+]
+
+GLM52_INDEXER_TYPES = [
+    "full", "full", "full",
+    *[kind for _ in range(18) for kind in ("shared", "shared", "shared", "full")],
+    "shared", "shared", "shared",
+]
+
+
+@dataclass(frozen=True)
+class LayerGroup:
+    name: str
+    layer_indices: tuple[int, ...]
+    num_kv_heads: int
+    head_size: int
+    dtype: str
+    compress_ratio: int = 1
+    sliding_window: int | None = None
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layer_indices)
+
+
+@dataclass(frozen=True)
+class ModelPreset:
+    name: str
+    architecture: str
+    num_layers: int
+    num_kv_heads: int
+    head_size: int
+    dtype: str
+    use_mla: bool
+    tokens_per_block: int
+    groups: tuple[LayerGroup, ...]
+    swa_enabled: bool = False
+    swa_head_size: int = 0
+    swa_num_layers: int = 0
+    metadata: dict[str, Any] | None = None
+
+
+def _dsv4(name: str, ratios: list[int], num_layers: int | None = None) -> ModelPreset:
+    layer_count = num_layers or len(ratios)
+    c4 = tuple(i for i, ratio in enumerate(ratios[:layer_count]) if ratio == 4)
+    c128 = tuple(i for i, ratio in enumerate(ratios[:layer_count]) if ratio == 128)
+    groups = (
+        LayerGroup("c4", c4, 1, 585, "uint8", compress_ratio=4),
+        LayerGroup("c128", c128, 1, 864, "uint8", compress_ratio=128),
+        LayerGroup("c4_indexer", c4, 1, 132, "uint8", compress_ratio=4),
+    )
+    return ModelPreset(
+        name=name,
+        architecture="DeepseekV4ForCausalLM",
+        num_layers=layer_count,
+        num_kv_heads=1,
+        head_size=585,
+        dtype="uint8",
+        use_mla=True,
+        tokens_per_block=256,
+        groups=groups,
+        swa_enabled=True,
+        swa_head_size=585,
+        swa_num_layers=layer_count,
+        metadata={"compress_ratios": list(ratios), "logical_swa_window": 128},
+    )
+
+
+def _glm(name: str, indexer_types: list[str] | None = None) -> ModelPreset:
+    num_layers = 78
+    groups: list[LayerGroup] = [
+        LayerGroup("main", tuple(range(num_layers)), 1, 576, "bfloat16"),
+    ]
+    if indexer_types is None:
+        groups.append(LayerGroup("indexer", tuple(range(num_layers)), 1, 132, "uint8"))
+    else:
+        if len(indexer_types) != num_layers:
+            raise ValueError(f"{name}: expected {num_layers} indexer types, got {len(indexer_types)}")
+        for kind in ("full", "shared"):
+            layers = tuple(i for i, value in enumerate(indexer_types) if value == kind)
+            groups.append(LayerGroup(f"indexer_{kind}", layers, 1, 132, "uint8"))
+    return ModelPreset(
+        name=name,
+        architecture="GlmMoeDsaForCausalLM",
+        num_layers=num_layers,
+        num_kv_heads=1,
+        head_size=576,
+        dtype="bfloat16",
+        use_mla=True,
+        tokens_per_block=64,
+        groups=tuple(groups),
+        metadata={
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64,
+            "index_head_dim": 128,
+            "indexer_types": indexer_types,
+        },
+    )
+
+
+PRESETS = {
+    "dsv4": _dsv4("dsv4_pro", DSV4_PRO_RATIOS),
+    "dsv4_pro": _dsv4("dsv4_pro", DSV4_PRO_RATIOS),
+    "dsv4_flash": _dsv4("dsv4_flash", DSV4_FLASH_RATIOS, num_layers=43),
+    "glm5": _glm("glm5"),
+    "glm5_2": _glm("glm5_2", GLM52_INDEXER_TYPES),
+    "glm5.2": _glm("glm5_2", GLM52_INDEXER_TYPES),
+}
+
+
+def get_preset(name: str) -> ModelPreset:
+    try:
+        return PRESETS[name.lower()]
+    except KeyError as exc:
+        raise ValueError(f"Unknown model preset {name!r}; choose from {sorted(PRESETS)}") from exc
+
+
+def _groups_from_hf(data: dict[str, Any], fallback: ModelPreset) -> tuple[LayerGroup, ...]:
+    architecture = (data.get("architectures") or [fallback.architecture])[0]
+    if architecture == "DeepseekV4ForCausalLM":
+        ratios = data.get("compress_ratios")
+        if not ratios:
+            raise ValueError("DeepSeek-V4 config.json is missing compress_ratios")
+        return _dsv4(fallback.name, [int(v) for v in ratios]).groups
+    if architecture == "GlmMoeDsaForCausalLM":
+        types = data.get("indexer_types")
+        return _glm(fallback.name, list(types) if types else None).groups
+    return fallback.groups
+
+
+def update_from_hf_config(preset: ModelPreset, config_path: str | Path) -> ModelPreset:
+    data = json.loads(Path(config_path).read_text())
+    architecture = (data.get("architectures") or [preset.architecture])[0]
+    groups = _groups_from_hf(data, preset)
+    num_layers = int(data.get("num_hidden_layers", preset.num_layers))
+    return replace(
+        preset,
+        architecture=architecture,
+        num_layers=num_layers,
+        groups=groups,
+        metadata={**(preset.metadata or {}), **data},
+    )
+
+
+def group_bytes_per_block(group: LayerGroup, tokens_per_block: int, kv_dim: int) -> int:
+    if tokens_per_block % group.compress_ratio:
+        raise ValueError(
+            f"tokens_per_block={tokens_per_block} is not divisible by "
+            f"{group.name}.compress_ratio={group.compress_ratio}"
+        )
+    dtype_bytes = {"uint8": 1, "int8": 1, "float16": 2, "bfloat16": 2, "float32": 4}
+    try:
+        itemsize = dtype_bytes[group.dtype]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported preset dtype {group.dtype!r}") from exc
+    return (
+        group.num_layers
+        * kv_dim
+        * (tokens_per_block // group.compress_ratio)
+        * group.num_kv_heads
+        * group.head_size
+        * itemsize
+    )
+
+
+def model_bytes_per_block(preset: ModelPreset, tokens_per_block: int | None = None) -> int:
+    tokens = tokens_per_block or preset.tokens_per_block
+    kv_dim = 1 if preset.use_mla else 2
+    return sum(group_bytes_per_block(group, tokens, kv_dim) for group in preset.groups)

--- a/benchmarks/flexkv_stress/run.sh
+++ b/benchmarks/flexkv_stress/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 CONFIG_YAML [--rounds N] [--duration SECONDS] [--dry-run]" >&2
+  exit 2
+fi
+
+CONFIG="$1"
+shift
+cd "${REPO_ROOT}"
+exec python3 -m benchmarks.flexkv_stress.main --config "${CONFIG}" "$@"

--- a/benchmarks/flexkv_stress/runner.py
+++ b/benchmarks/flexkv_stress/runner.py
@@ -48,7 +48,7 @@ def build_flexkv_configs(config):
         head_size=config.preset.head_size,
         use_mla=config.preset.use_mla,
         dtype=torch_dtype(config.model.dtype or config.preset.dtype),
-        tp_size=config.model.tp_size,
+        tp_size=config.kv_tp_size,
         dp_size=config.model.dp_size,
         cp_size=config.model.cp_size,
         layer_groups=groups,
@@ -143,7 +143,9 @@ class FlexKVRuntime:
             raise RuntimeError("No CUDA/ROCm device is available; use --dry-run in this environment")
         if torch.cuda.device_count() < self.config.required_gpus:
             raise RuntimeError(
-                f"Need {self.config.required_gpus} GPUs for TP×DP×CP, found {torch.cuda.device_count()}"
+                f"Need {self.config.required_gpus} GPUs for composite-TP×DP "
+                f"(kv_tp={self.config.kv_tp_size}, cp={self.config.model.cp_size}), "
+                f"found {torch.cuda.device_count()}"
             )
         base_socket = os.environ.setdefault(
             "FLEXKV_LAYERWISE_EVENTFD_SOCKET",
@@ -159,7 +161,7 @@ class FlexKVRuntime:
         self.model_config, self.cache_config = build_flexkv_configs(self.config)
 
         if self.config.features.layerwise:
-            effective_size = self.config.model.tp_size * self.config.model.cp_size
+            effective_size = self.config.workers_per_dp
             for dp_rank in range(self.config.model.dp_size):
                 group = EventfdGroup(
                     _socket_path(base_socket, dp_rank, self.config.model.dp_size),
@@ -214,22 +216,46 @@ class ManagerDriver:
         self.eventfds = eventfds
         self.oracle = PrefixOracle(config.tokens_per_block, oracle_capacity_blocks)
         self.slots = SlotAllocator(config.model.gpu_blocks_per_rank, config.tokens_per_block)
-        self.swa_slots = SlotAllocator(config.cache.swa_num_slots, 1)
+        self.swa_slots = SlotAllocator(config.cache.swa_num_slots, config.tokens_per_block)
         self.counter_id = 0
         self.last_stored: tuple[object, list[int]] | None = None
 
     def _operation(self, operations: list[OperationResult], name: str, started: float,
-                   success: bool, tokens: int = 0, hit_tokens: int = 0, error: str = "") -> None:
+                   success: bool, tokens: int = 0, hit_tokens: int = 0,
+                   transfer_bytes: int = 0, error: str = "") -> None:
         operations.append(OperationResult(
             name, success, (time.perf_counter() - started) * 1000,
-            tokens=tokens, hit_tokens=hit_tokens, error=error,
+            tokens=tokens, hit_tokens=hit_tokens,
+            transfer_bytes=transfer_bytes, error=error,
         ))
+
+    def _swa_mapping(self):
+        blocks, slots = self.swa_slots.allocate(self.config.tokens_per_block)
+        return blocks.tolist(), slots
+
+    def _launch_bytes(self, pending: list[_Launch]) -> int:
+        import numpy as np
+
+        tpb = self.config.tokens_per_block
+        main_blocks = sum(
+            len(np.unique(np.asarray(item.slots, dtype=np.int64).reshape(-1) // tpb))
+            for item in pending
+        )
+        swa_blocks = sum(
+            len(np.unique(np.asarray(item.swa_slots, dtype=np.int64).reshape(-1) // tpb))
+            for item in pending if item.swa_slots is not None
+        )
+        return (
+            main_blocks * self.config.bytes_per_block
+            + swa_blocks * self.config.swa_bytes_per_block
+        )
 
     def _launch(self, pending: list[_Launch], operation: str,
                 operations: list[OperationResult], layerwise: bool = False) -> bool:
         if not pending:
             return True
         started = time.perf_counter()
+        transfer_bytes = self._launch_bytes(pending)
         try:
             as_batch = len(pending) > 1 or layerwise
             returned = self.manager.launch(
@@ -253,10 +279,16 @@ class ManagerDriver:
                 values = self.eventfds.read_counter(self.counter_id) if self.eventfds else []
                 success = success and (not values or all(sum(rank) > 0 for rank in values))
                 self.counter_id = (self.counter_id + 1) % 3
-            self._operation(operations, operation, started, success)
+            self._operation(
+                operations, operation, started, success,
+                transfer_bytes=transfer_bytes,
+            )
             return success
         except Exception as exc:
-            self._operation(operations, operation, started, False, error=str(exc))
+            self._operation(
+                operations, operation, started, False,
+                transfer_bytes=transfer_bytes, error=str(exc),
+            )
             return False
 
     def _match_get(self, tokens, operations: list[OperationResult]):
@@ -304,8 +336,7 @@ class ManagerDriver:
                 blocks, slots = self.slots.allocate(actual)
                 swa_mapping = None
                 if self.config.features.swa:
-                    swa_block, _ = self.swa_slots.allocate(1)
-                    swa_mapping = np.asarray(swa_block, dtype=np.int64)
+                    _swa_blocks, swa_mapping = self._swa_mapping()
                 get_pending.append(_Launch(task_id, slots, swa_mapping))
             states.append(state)
         get_started = time.perf_counter()
@@ -330,14 +361,13 @@ class ManagerDriver:
             swa_mapping = None
             swa_blocks = []
             if self.config.features.swa:
-                swa_block, _ = self.swa_slots.allocate(1)
-                swa_blocks = [int(swa_block[0])]
-                swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+                swa_blocks, swa_mapping = self._swa_mapping()
             command_dp(self.workers, self.dp_rank, {
                 "operation": "seed", "block_ids": blocks.tolist(), "patterns": patterns,
-                "swa_block_ids": swa_blocks,
+                "swa_block_ids": swa_blocks, "swa_patterns": patterns[-1:],
             })
             started = time.perf_counter()
+            state["save_started"] = started
             try:
                 result = self.manager.put_match(np.asarray(tokens, dtype=np.int64))
                 if result is None:
@@ -352,12 +382,11 @@ class ManagerDriver:
             except Exception as exc:
                 state["put_ok"] = False
                 self._operation(operations, "put_match", started, False, aligned, error=str(exc))
-        put_started = time.perf_counter()
         put_ok = self._launch(put_pending, "launch_put", operations)
-        put_ms = (time.perf_counter() - put_started) * 1000
         for state, tokens, _patterns in put_metadata:
             state["put_ok"] = state["put_ok"] and put_ok
-            state["put_ms"] = put_ms
+            # Service save latency starts at put_match and ends after launch_put/wait.
+            state["put_ms"] = (time.perf_counter() - state["save_started"]) * 1000
             if state["put_ok"]:
                 self.oracle.put(tokens)
                 self.last_stored = (tokens, _patterns)
@@ -376,9 +405,7 @@ class ManagerDriver:
                 swa_mapping = None
                 swa_blocks = []
                 if self.config.features.swa:
-                    swa_block, _ = self.swa_slots.allocate(1)
-                    swa_blocks = [int(swa_block[0])]
-                    swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+                    swa_blocks, swa_mapping = self._swa_mapping()
                 if state["sample"]:
                     command_dp(self.workers, self.dp_rank, {
                         "operation": "zero", "block_ids": blocks.tolist(),
@@ -399,7 +426,7 @@ class ManagerDriver:
                         "operation": "verify",
                         "block_ids": blocks[:self.config.validation.sampled_blocks_per_request],
                         "patterns": patterns[:self.config.validation.sampled_blocks_per_request],
-                        "swa_block_ids": swa_blocks,
+                        "swa_block_ids": swa_blocks, "swa_patterns": patterns[-1:],
                         "max_layers": self.config.validation.sampled_layers_per_group,
                         "max_bytes": self.config.validation.bytes_per_sample,
                     })
@@ -429,8 +456,10 @@ class ManagerDriver:
                 hit_delta_tokens=state["actual"] - state["expected"],
                 put_unmatched_tokens=state["put_unmatched"],
                 match_ms=state["match_ms"], get_ms=state["get_ms"], put_ms=state["put_ms"],
-                success=success, validation_sampled=state["sample"],
+                success=success,
+                validation_sampled=state["sample"] and self.config.conversation.read_after_put,
                 validation_ok=state["validation_ok"],
+                query_tokens=len(turn.get_tokens),
             ))
         return results, operations
 
@@ -455,7 +484,10 @@ class ManagerDriver:
                 getattr(value.status, "name", str(value.status)) == "SUCCESS"
                 for value in put_response.values()
             )
-            self._operation(operations, "put_async", started, put_ok, tokens=length)
+            self._operation(
+                operations, "put_async", started, put_ok, tokens=length,
+                transfer_bytes=(length // self.config.tokens_per_block) * self.config.bytes_per_block,
+            )
         except Exception as exc:
             self._operation(operations, "put_async", started, False, tokens=length, error=str(exc))
             return operations
@@ -474,7 +506,11 @@ class ManagerDriver:
                 getattr(value.status, "name", str(value.status)) == "SUCCESS"
                 for value in get_response.values()
             )
-            self._operation(operations, "get_async", started, get_ok, tokens=length, hit_tokens=length)
+            self._operation(
+                operations, "get_async", started, get_ok, tokens=length,
+                hit_tokens=length,
+                transfer_bytes=(length // self.config.tokens_per_block) * self.config.bytes_per_block,
+            )
             if get_ok:
                 verified = command_dp(self.workers, self.dp_rank, {
                     "operation": "verify", "block_ids": target_blocks.tolist(), "patterns": patterns,
@@ -507,9 +543,7 @@ class ManagerDriver:
             swa_mapping = None
             swa_blocks = []
             if self.config.features.swa:
-                swa_block, _ = self.swa_slots.allocate(1)
-                swa_blocks = [int(swa_block[0])]
-                swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+                swa_blocks, swa_mapping = self._swa_mapping()
             command_dp(self.workers, self.dp_rank, {
                 "operation": "zero", "block_ids": blocks.tolist(),
                 "swa_block_ids": swa_blocks,
@@ -526,7 +560,7 @@ class ManagerDriver:
                     "operation": "verify",
                     "block_ids": blocks[:self.config.validation.sampled_blocks_per_request].tolist(),
                     "patterns": patterns[:self.config.validation.sampled_blocks_per_request],
-                    "swa_block_ids": swa_blocks,
+                    "swa_block_ids": swa_blocks, "swa_patterns": patterns[-1:],
                     "max_layers": self.config.validation.sampled_layers_per_group,
                     "max_bytes": self.config.validation.bytes_per_sample,
                 })

--- a/benchmarks/flexkv_stress/runner.py
+++ b/benchmarks/flexkv_stress/runner.py
@@ -463,6 +463,50 @@ class ManagerDriver:
             ))
         return results, operations
 
+    def warm_shared_prefix(self, tokens) -> list[OperationResult]:
+        """Commit a shared prefix (e.g. the shared system prompt) as its own
+        sequence so a trailing SWA snapshot lands on its block boundary.
+
+        Real serving warms a shared prompt this way (its first commit becomes a
+        reusable prefix). Without it, a prefix that is only ever an interior span
+        of longer PUTs has no SWA snapshot at its boundary, so an ``swa_aware``
+        GET matching just that prefix finds swa_hit=0 and cannot reuse it — even
+        though the Full-KV bytes are cached. Mirrors ``execute_batch``'s PUT path
+        and records the same commit in the oracle so expected==actual.
+        """
+        import numpy as np
+        operations: list[OperationResult] = []
+        aligned = align_down(len(tokens), self.config.tokens_per_block)
+        if aligned == 0:
+            return operations
+        tokens = tuple(tokens[:aligned])
+        blocks, slots = self.slots.allocate(aligned)
+        patterns = _block_patterns(tokens, self.config.tokens_per_block)
+        swa_mapping = None
+        swa_blocks = []
+        if self.config.features.swa:
+            swa_blocks, swa_mapping = self._swa_mapping()
+        command_dp(self.workers, self.dp_rank, {
+            "operation": "seed", "block_ids": blocks.tolist(), "patterns": patterns,
+            "swa_block_ids": swa_blocks, "swa_patterns": patterns[-1:],
+        })
+        started = time.perf_counter()
+        try:
+            result = self.manager.put_match(np.asarray(tokens, dtype=np.int64))
+            if result is None:
+                raise RuntimeError("put_match returned None")
+            task_id, unmatched = result
+            unmatched = np.asarray(unmatched, dtype=bool)
+            self._operation(operations, "put_match", started, True, aligned, 0)
+            put_pending = []
+            if unmatched.any():
+                put_pending.append(_Launch(task_id, slots[unmatched], swa_mapping))
+            if self._launch(put_pending, "launch_put", operations):
+                self.oracle.put(tokens)
+        except Exception as exc:
+            self._operation(operations, "put_match", started, False, aligned, error=str(exc))
+        return operations
+
     def async_probe(self, round_id: int) -> list[OperationResult]:
         """Exercise KVManager's direct put/get APIs with a small unique sequence."""
         import numpy as np
@@ -592,6 +636,17 @@ class StressRunner:
             for dp_rank in range(config.model.dp_size)
         ]
         self.rng = random.Random(config.run.seed ^ 0xF1E5)
+
+    def warm_shared_prefix(self, tokens) -> list[OperationResult]:
+        """Warm a shared prefix on every DP driver so cross-conversation SWA
+        reuse finds a snapshot at the prefix boundary. No-op when there is no
+        shared prefix (``shared_system_prompt=False`` -> empty tokens)."""
+        operations: list[OperationResult] = []
+        if not tokens:
+            return operations
+        for driver in self.drivers:
+            operations.extend(driver.warm_shared_prefix(tokens))
+        return operations
 
     def _sample_keys(self, turns: list[Turn]) -> set[tuple[int, int]]:
         sampled = {

--- a/benchmarks/flexkv_stress/runner.py
+++ b/benchmarks/flexkv_stress/runner.py
@@ -136,11 +136,11 @@ class FlexKVRuntime:
                 manager.start()
             logging.getLogger("flexkv_stress").warning(
                 "CPU stub mode: exercising stress control flow and PyTorch byte copies; "
-                "CUDA/ROCm IPC, native transfers, SSD, and eventfd signaling are not under test"
+                "CUDA IPC, native transfers, SSD, and eventfd signaling are not under test"
             )
             return
         if not torch.cuda.is_available():
-            raise RuntimeError("No CUDA/ROCm device is available; use --dry-run in this environment")
+            raise RuntimeError("No CUDA device is available; use --dry-run in this environment")
         if torch.cuda.device_count() < self.config.required_gpus:
             raise RuntimeError(
                 f"Need {self.config.required_gpus} GPUs for composite-TP×DP "

--- a/benchmarks/flexkv_stress/runner.py
+++ b/benchmarks/flexkv_stress/runner.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+import logging
+import os
+from pathlib import Path
+import random
+import time
+import zlib
+
+from .eventfd import EventfdGroup
+from .gpu_worker import GpuWorker, command_dp, start_gpu_workers
+from .metrics import OperationResult, TurnResult
+from .workload import PrefixOracle, SlotAllocator, Turn, align_down
+
+
+def _block_patterns(tokens, tokens_per_block: int) -> list[int]:
+    import numpy as np
+    values = np.asarray(tokens, dtype=np.int64)
+    patterns = []
+    for start in range(0, len(values), tokens_per_block):
+        patterns.append(zlib.crc32(values[start:start + tokens_per_block].tobytes()) & 0x7FFFFFFF)
+    return patterns
+
+
+def build_flexkv_configs(config):
+    import torch
+    from flexkv.common.config import CacheConfig, LayerGroupSpec, ModelConfig, SWAPoolConfig
+
+    from .device import torch_dtype
+
+    groups = [
+        LayerGroupSpec(
+            num_layers=group.num_layers,
+            num_kv_heads=group.num_kv_heads,
+            head_size=group.head_size,
+            layer_indices=list(group.layer_indices),
+            sliding_window=group.sliding_window,
+            dtype=torch_dtype(group.dtype),
+            compress_ratio=group.compress_ratio,
+        )
+        for group in config.preset.groups
+    ]
+    model = ModelConfig(
+        num_layers=config.preset.num_layers,
+        num_kv_heads=config.preset.num_kv_heads,
+        head_size=config.preset.head_size,
+        use_mla=config.preset.use_mla,
+        dtype=torch_dtype(config.model.dtype or config.preset.dtype),
+        tp_size=config.model.tp_size,
+        dp_size=config.model.dp_size,
+        cp_size=config.model.cp_size,
+        layer_groups=groups,
+    )
+    cpu_blocks = config.cache.num_cpu_blocks or max(
+        1, int(config.cache.cpu_cache_gb * 1024**3 / config.bytes_per_block)
+    )
+    ssd_blocks = config.cache.num_ssd_blocks
+    if not ssd_blocks and config.cache.ssd_cache_gb > 0:
+        ssd_blocks = max(1, int(config.cache.ssd_cache_gb * 1024**3 / config.bytes_per_block))
+    if ssd_blocks and config.cache.ssd_cache_dir:
+        devices = len(config.cache.ssd_cache_dir)
+        ssd_blocks = ((ssd_blocks + devices - 1) // devices) * devices
+    for directory in config.cache.ssd_cache_dir:
+        Path(directory).mkdir(parents=True, exist_ok=True)
+    swa = None
+    if config.features.swa:
+        swa = SWAPoolConfig(
+            enabled=True,
+            num_slots=config.cache.swa_num_slots,
+            num_ssd_slots=config.cache.swa_ssd_slots if config.features.ssd else 0,
+            num_swa_layers=config.preset.swa_num_layers,
+            bytes_per_token_per_layer=config.preset.swa_head_size,
+        )
+    cache = CacheConfig(
+        tokens_per_block=config.tokens_per_block,
+        eviction_policy=config.cache.eviction_policy,
+        enable_cpu=True,
+        enable_ssd=config.features.ssd,
+        enable_gds=config.cache.enable_gds,
+        num_cpu_blocks=cpu_blocks,
+        num_ssd_blocks=ssd_blocks,
+        ssd_cache_dir=config.cache.ssd_cache_dir,
+        swa=swa,
+        enable_swa_transfer=config.features.swa,
+    )
+    return model, cache
+
+
+def _socket_path(base: str, dp_rank: int, dp_size: int) -> str:
+    if dp_size == 1:
+        return base
+    root, extension = os.path.splitext(base)
+    return f"{root}_dp{dp_rank}{extension}"
+
+
+class FlexKVRuntime:
+    def __init__(self, config):
+        self.config = config
+        self.managers = []
+        self.workers: list[GpuWorker] = []
+        self.eventfds: dict[int, EventfdGroup] = {}
+        self.model_config = None
+        self.cache_config = None
+
+    def start(self) -> None:
+        import torch
+        if self.config.features.cpu_stub:
+            from types import SimpleNamespace
+
+            from .cpu_stub import CpuStubManager, start_cpu_workers
+
+            cpu_blocks = self.config.cache.num_cpu_blocks or max(
+                1,
+                int(self.config.cache.cpu_cache_gb * 1024**3 / self.config.bytes_per_block),
+            )
+            self.model_config = None
+            self.cache_config = SimpleNamespace(
+                num_cpu_blocks=cpu_blocks,
+                num_ssd_blocks=0,
+            )
+            self.workers = start_cpu_workers(self.config)
+            capacity = max(
+                1,
+                int(
+                    (self.cache_config.num_cpu_blocks + self.cache_config.num_ssd_blocks)
+                    / self.config.model.dp_size
+                ),
+            )
+            self.managers = [
+                CpuStubManager(self.config, dp_rank, self.workers, capacity)
+                for dp_rank in range(self.config.model.dp_size)
+            ]
+            for manager in self.managers:
+                manager.start()
+            logging.getLogger("flexkv_stress").warning(
+                "CPU stub mode: exercising stress control flow and PyTorch byte copies; "
+                "CUDA/ROCm IPC, native transfers, SSD, and eventfd signaling are not under test"
+            )
+            return
+        if not torch.cuda.is_available():
+            raise RuntimeError("No CUDA/ROCm device is available; use --dry-run in this environment")
+        if torch.cuda.device_count() < self.config.required_gpus:
+            raise RuntimeError(
+                f"Need {self.config.required_gpus} GPUs for TP×DP×CP, found {torch.cuda.device_count()}"
+            )
+        base_socket = os.environ.setdefault(
+            "FLEXKV_LAYERWISE_EVENTFD_SOCKET",
+            f"/tmp/flexkv_stress_eventfd_{os.getpid()}.sock",
+        )
+        os.environ["FLEXKV_ENABLE_LAYERWISE_TRANSFER"] = "1" if self.config.features.layerwise else "0"
+        os.environ.setdefault("FLEXKV_SERVER_RECV_PORT", f"ipc:///tmp/flexkv_stress_server_{os.getpid()}")
+
+        from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
+        from flexkv.kvmanager import KVManager
+        GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer = self.config.features.layerwise
+        GLOBAL_CONFIG_FROM_ENV.server_recv_port = os.environ["FLEXKV_SERVER_RECV_PORT"]
+        self.model_config, self.cache_config = build_flexkv_configs(self.config)
+
+        if self.config.features.layerwise:
+            effective_size = self.config.model.tp_size * self.config.model.cp_size
+            for dp_rank in range(self.config.model.dp_size):
+                group = EventfdGroup(
+                    _socket_path(base_socket, dp_rank, self.config.model.dp_size),
+                    effective_size,
+                    self.config.preset.num_layers,
+                )
+                group.start()
+                self.eventfds[dp_rank] = group
+
+        for dp_rank in range(self.config.model.dp_size):
+            manager = KVManager(self.model_config, self.cache_config, dp_client_id=dp_rank)
+            manager.start()
+            self.managers.append(manager)
+        self.workers = start_gpu_workers(self.config, self.managers[0].gpu_register_port)
+
+        deadline = time.monotonic() + 180
+        while time.monotonic() < deadline:
+            if all(manager.is_ready() for manager in self.managers):
+                break
+            time.sleep(0.2)
+        else:
+            raise TimeoutError("FlexKV managers did not become ready in 180 seconds")
+        for group in self.eventfds.values():
+            group.wait_ready()
+
+    def close(self) -> None:
+        for manager in reversed(self.managers):
+            try:
+                manager.shutdown()
+            except Exception:
+                pass
+        for worker in self.workers:
+            worker.shutdown()
+        for group in self.eventfds.values():
+            group.close()
+
+
+@dataclass
+class _Launch:
+    task_id: int
+    slots: object
+    swa_slots: object | None = None
+
+
+class ManagerDriver:
+    def __init__(self, config, dp_rank: int, manager, workers: list[GpuWorker], eventfds=None,
+                 oracle_capacity_blocks: int = 0):
+        self.config = config
+        self.dp_rank = dp_rank
+        self.manager = manager
+        self.workers = workers
+        self.eventfds = eventfds
+        self.oracle = PrefixOracle(config.tokens_per_block, oracle_capacity_blocks)
+        self.slots = SlotAllocator(config.model.gpu_blocks_per_rank, config.tokens_per_block)
+        self.swa_slots = SlotAllocator(config.cache.swa_num_slots, 1)
+        self.counter_id = 0
+        self.last_stored: tuple[object, list[int]] | None = None
+
+    def _operation(self, operations: list[OperationResult], name: str, started: float,
+                   success: bool, tokens: int = 0, hit_tokens: int = 0, error: str = "") -> None:
+        operations.append(OperationResult(
+            name, success, (time.perf_counter() - started) * 1000,
+            tokens=tokens, hit_tokens=hit_tokens, error=error,
+        ))
+
+    def _launch(self, pending: list[_Launch], operation: str,
+                operations: list[OperationResult], layerwise: bool = False) -> bool:
+        if not pending:
+            return True
+        started = time.perf_counter()
+        try:
+            as_batch = len(pending) > 1 or layerwise
+            returned = self.manager.launch(
+                task_ids=[item.task_id for item in pending],
+                slot_mappings=[item.slots for item in pending],
+                swa_slot_mappings=[item.swa_slots for item in pending] if self.config.features.swa else None,
+                as_batch=as_batch,
+                layerwise_transfer=layerwise,
+                counter_id=self.counter_id,
+            )
+            responses = self.manager.wait(
+                returned,
+                timeout=self.config.concurrency.request_timeout_seconds,
+                completely=True,
+            )
+            success = bool(responses) and all(
+                getattr(response.status, "name", str(response.status)) == "SUCCESS"
+                for response in responses.values()
+            )
+            if layerwise:
+                values = self.eventfds.read_counter(self.counter_id) if self.eventfds else []
+                success = success and (not values or all(sum(rank) > 0 for rank in values))
+                self.counter_id = (self.counter_id + 1) % 3
+            self._operation(operations, operation, started, success)
+            return success
+        except Exception as exc:
+            self._operation(operations, operation, started, False, error=str(exc))
+            return False
+
+    def _match_get(self, tokens, operations: list[OperationResult]):
+        import numpy as np
+        started = time.perf_counter()
+        try:
+            result = self.manager.get_match(
+                np.asarray(tokens, dtype=np.int64),
+                swa_aware=self.config.features.swa,
+            )
+            if result is None:
+                raise RuntimeError("get_match returned None")
+            task_id, mask = result
+            hit_tokens = int(mask.sum())
+            self._operation(operations, "get_match", started, True, len(tokens), hit_tokens)
+            return task_id, mask, hit_tokens
+        except Exception as exc:
+            self._operation(operations, "get_match", started, False, len(tokens), error=str(exc))
+            return -1, None, 0
+
+    def execute_batch(self, turns: list[Turn], round_id: int,
+                      sample_keys: set[tuple[int, int]]) -> tuple[list[TurnResult], list[OperationResult]]:
+        import numpy as np
+        operations: list[OperationResult] = []
+        states = []
+
+        # GET the prefix available before this turn, matching SGLang's load phase.
+        get_pending = []
+        for turn in turns:
+            expected = self.oracle.match(turn.get_tokens)
+            task_id, mask, actual = self._match_get(turn.get_tokens, operations)
+            state = {
+                "turn": turn, "expected": expected, "actual": actual,
+                "match_ok": (
+                    task_id >= 0
+                    and abs(actual - expected)
+                    <= self.config.validation.hit_tolerance_blocks * self.config.tokens_per_block
+                ),
+                "get_ok": True, "put_ok": True, "put_unmatched": 0,
+                "match_ms": operations[-1].latency_ms, "get_ms": 0.0, "put_ms": 0.0,
+                "sample": (turn.conversation_id, turn.turn_id) in sample_keys,
+                "validation_ok": True,
+            }
+            if task_id >= 0 and actual:
+                blocks, slots = self.slots.allocate(actual)
+                swa_mapping = None
+                if self.config.features.swa:
+                    swa_block, _ = self.swa_slots.allocate(1)
+                    swa_mapping = np.asarray(swa_block, dtype=np.int64)
+                get_pending.append(_Launch(task_id, slots, swa_mapping))
+            states.append(state)
+        get_started = time.perf_counter()
+        get_ok = self._launch(
+            get_pending, "launch_get", operations,
+            layerwise=self.config.features.layerwise,
+        )
+        get_ms = (time.perf_counter() - get_started) * 1000
+        for state in states:
+            state["get_ok"] = get_ok
+            state["get_ms"] = get_ms
+
+        # Simulate inference writes, then PUT only the unmatched slots.
+        put_pending = []
+        put_metadata = []
+        for state in states:
+            turn = state["turn"]
+            aligned = align_down(len(turn.put_tokens), self.config.tokens_per_block)
+            tokens = turn.put_tokens[:aligned]
+            blocks, slots = self.slots.allocate(aligned)
+            patterns = _block_patterns(tokens, self.config.tokens_per_block)
+            swa_mapping = None
+            swa_blocks = []
+            if self.config.features.swa:
+                swa_block, _ = self.swa_slots.allocate(1)
+                swa_blocks = [int(swa_block[0])]
+                swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+            command_dp(self.workers, self.dp_rank, {
+                "operation": "seed", "block_ids": blocks.tolist(), "patterns": patterns,
+                "swa_block_ids": swa_blocks,
+            })
+            started = time.perf_counter()
+            try:
+                result = self.manager.put_match(np.asarray(tokens, dtype=np.int64))
+                if result is None:
+                    raise RuntimeError("put_match returned None")
+                task_id, unmatched = result
+                unmatched = np.asarray(unmatched, dtype=bool)
+                state["put_unmatched"] = int(unmatched.sum())
+                self._operation(operations, "put_match", started, True, aligned, 0)
+                if unmatched.any():
+                    put_pending.append(_Launch(task_id, slots[unmatched], swa_mapping))
+                put_metadata.append((state, tokens, patterns))
+            except Exception as exc:
+                state["put_ok"] = False
+                self._operation(operations, "put_match", started, False, aligned, error=str(exc))
+        put_started = time.perf_counter()
+        put_ok = self._launch(put_pending, "launch_put", operations)
+        put_ms = (time.perf_counter() - put_started) * 1000
+        for state, tokens, _patterns in put_metadata:
+            state["put_ok"] = state["put_ok"] and put_ok
+            state["put_ms"] = put_ms
+            if state["put_ok"]:
+                self.oracle.put(tokens)
+                self.last_stored = (tokens, _patterns)
+
+        # Immediate read-back catches transfer corruption; sampling controls byte verification.
+        if self.config.conversation.read_after_put:
+            read_pending = []
+            read_metadata = []
+            for state, tokens, patterns in put_metadata:
+                task_id, _mask, actual = self._match_get(tokens, operations)
+                if task_id < 0 or actual == 0:
+                    state["get_ok"] = False
+                    continue
+                blocks, slots = self.slots.allocate(actual)
+                actual_patterns = patterns[:len(blocks)]
+                swa_mapping = None
+                swa_blocks = []
+                if self.config.features.swa:
+                    swa_block, _ = self.swa_slots.allocate(1)
+                    swa_blocks = [int(swa_block[0])]
+                    swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+                if state["sample"]:
+                    command_dp(self.workers, self.dp_rank, {
+                        "operation": "zero", "block_ids": blocks.tolist(),
+                        "swa_block_ids": swa_blocks,
+                        "max_layers": self.config.validation.sampled_layers_per_group,
+                    })
+                read_pending.append(_Launch(task_id, slots, swa_mapping))
+                read_metadata.append((state, blocks.tolist(), actual_patterns, swa_blocks))
+            read_ok = self._launch(
+                read_pending, "launch_readback", operations,
+                layerwise=self.config.features.layerwise,
+            )
+            for state, blocks, patterns, swa_blocks in read_metadata:
+                state["get_ok"] = state["get_ok"] and read_ok
+                if state["sample"] and read_ok:
+                    verify_started = time.perf_counter()
+                    responses = command_dp(self.workers, self.dp_rank, {
+                        "operation": "verify",
+                        "block_ids": blocks[:self.config.validation.sampled_blocks_per_request],
+                        "patterns": patterns[:self.config.validation.sampled_blocks_per_request],
+                        "swa_block_ids": swa_blocks,
+                        "max_layers": self.config.validation.sampled_layers_per_group,
+                        "max_bytes": self.config.validation.bytes_per_sample,
+                    })
+                    state["validation_ok"] = all(response.get("ok", False) for response in responses)
+                    errors = [error for response in responses for error in response.get("errors", [])]
+                    self._operation(
+                        operations,
+                        "validate_readback",
+                        verify_started,
+                        state["validation_ok"],
+                        error="; ".join(errors[:5]),
+                    )
+
+        results = []
+        for state in states:
+            turn = state["turn"]
+            success = state["match_ok"] and state["get_ok"] and state["put_ok"] and state["validation_ok"]
+            results.append(TurnResult(
+                round_id=round_id,
+                conversation_id=turn.conversation_id,
+                turn_id=turn.turn_id,
+                added_input_tokens=turn.added_input_tokens,
+                output_tokens=turn.output_tokens,
+                total_tokens=len(turn.put_tokens),
+                expected_hit_tokens=state["expected"],
+                actual_hit_tokens=state["actual"],
+                hit_delta_tokens=state["actual"] - state["expected"],
+                put_unmatched_tokens=state["put_unmatched"],
+                match_ms=state["match_ms"], get_ms=state["get_ms"], put_ms=state["put_ms"],
+                success=success, validation_sampled=state["sample"],
+                validation_ok=state["validation_ok"],
+            ))
+        return results, operations
+
+    def async_probe(self, round_id: int) -> list[OperationResult]:
+        """Exercise KVManager's direct put/get APIs with a small unique sequence."""
+        import numpy as np
+        operations: list[OperationResult] = []
+        length = self.config.tokens_per_block * 2
+        tokens = np.arange(length, dtype=np.int64) + (round_id + 1) * 10_000_000 + self.dp_rank * 100_000
+        patterns = _block_patterns(tokens, self.config.tokens_per_block)
+        source_blocks, source_slots = self.slots.allocate(length)
+        command_dp(self.workers, self.dp_rank, {
+            "operation": "seed", "block_ids": source_blocks.tolist(), "patterns": patterns,
+        })
+        started = time.perf_counter()
+        try:
+            put_task = self.manager.put_async(tokens, source_slots)
+            put_response = self.manager.wait(
+                put_task, timeout=self.config.concurrency.request_timeout_seconds, completely=True
+            )
+            put_ok = bool(put_response) and all(
+                getattr(value.status, "name", str(value.status)) == "SUCCESS"
+                for value in put_response.values()
+            )
+            self._operation(operations, "put_async", started, put_ok, tokens=length)
+        except Exception as exc:
+            self._operation(operations, "put_async", started, False, tokens=length, error=str(exc))
+            return operations
+
+        target_blocks, target_slots = self.slots.allocate(length)
+        command_dp(self.workers, self.dp_rank, {
+            "operation": "zero", "block_ids": target_blocks.tolist(),
+        })
+        started = time.perf_counter()
+        try:
+            get_task = self.manager.get_async(tokens, target_slots)
+            get_response = self.manager.wait(
+                get_task, timeout=self.config.concurrency.request_timeout_seconds, completely=True
+            )
+            get_ok = bool(get_response) and all(
+                getattr(value.status, "name", str(value.status)) == "SUCCESS"
+                for value in get_response.values()
+            )
+            self._operation(operations, "get_async", started, get_ok, tokens=length, hit_tokens=length)
+            if get_ok:
+                verified = command_dp(self.workers, self.dp_rank, {
+                    "operation": "verify", "block_ids": target_blocks.tolist(), "patterns": patterns,
+                    "max_layers": self.config.validation.sampled_layers_per_group,
+                    "max_bytes": self.config.validation.bytes_per_sample,
+                })
+                if not all(response.get("ok", False) for response in verified):
+                    operations[-1].success = False
+                    errors = [error for response in verified for error in response.get("errors", [])]
+                    operations[-1].error = "async GET byte verification failed: " + "; ".join(errors[:5])
+        except Exception as exc:
+            self._operation(operations, "get_async", started, False, tokens=length, error=str(exc))
+        return operations
+
+    def ssd_probe(self) -> list[OperationResult]:
+        """Force a direct-mode CPU miss and verify SSD -> CPU -> GPU reload."""
+        import numpy as np
+        operations: list[OperationResult] = []
+        if self.last_stored is None:
+            return operations
+        tokens, patterns = self.last_stored
+        started = time.perf_counter()
+        try:
+            self.manager._clear_cpu_cache()
+            self._operation(operations, "clear_cpu_for_ssd_probe", started, True)
+            task_id, _mask, actual = self._match_get(tokens, operations)
+            if task_id < 0 or actual != len(tokens):
+                raise RuntimeError(f"SSD probe expected {len(tokens)} hit tokens, got {actual}")
+            blocks, slots = self.slots.allocate(actual)
+            swa_mapping = None
+            swa_blocks = []
+            if self.config.features.swa:
+                swa_block, _ = self.swa_slots.allocate(1)
+                swa_blocks = [int(swa_block[0])]
+                swa_mapping = np.asarray(swa_blocks, dtype=np.int64)
+            command_dp(self.workers, self.dp_rank, {
+                "operation": "zero", "block_ids": blocks.tolist(),
+                "swa_block_ids": swa_blocks,
+                "max_layers": self.config.validation.sampled_layers_per_group,
+            })
+            ok = self._launch(
+                [_Launch(task_id, slots, swa_mapping)],
+                "ssd_reload_get",
+                operations,
+                layerwise=self.config.features.layerwise,
+            )
+            if ok:
+                responses = command_dp(self.workers, self.dp_rank, {
+                    "operation": "verify",
+                    "block_ids": blocks[:self.config.validation.sampled_blocks_per_request].tolist(),
+                    "patterns": patterns[:self.config.validation.sampled_blocks_per_request],
+                    "swa_block_ids": swa_blocks,
+                    "max_layers": self.config.validation.sampled_layers_per_group,
+                    "max_bytes": self.config.validation.bytes_per_sample,
+                })
+                if not all(response.get("ok", False) for response in responses):
+                    operations[-1].success = False
+                    errors = [error for response in responses for error in response.get("errors", [])]
+                    operations[-1].error = "SSD reload byte verification failed: " + "; ".join(errors[:5])
+        except Exception as exc:
+            self._operation(operations, "ssd_probe", started, False, error=str(exc))
+        return operations
+
+
+class StressRunner:
+    def __init__(self, config, runtime: FlexKVRuntime):
+        self.config = config
+        self.runtime = runtime
+        self.drivers = [
+            ManagerDriver(
+                config, dp_rank, runtime.managers[dp_rank], runtime.workers,
+                runtime.eventfds.get(dp_rank),
+                max(
+                    1,
+                    int(
+                        (runtime.cache_config.num_cpu_blocks + runtime.cache_config.num_ssd_blocks)
+                        / config.model.dp_size
+                    ),
+                ),
+            )
+            for dp_rank in range(config.model.dp_size)
+        ]
+        self.rng = random.Random(config.run.seed ^ 0xF1E5)
+
+    def _sample_keys(self, turns: list[Turn]) -> set[tuple[int, int]]:
+        sampled = {
+            (turn.conversation_id, turn.turn_id)
+            for turn in turns if self.rng.random() < self.config.validation.sample_rate
+        }
+        needed = min(self.config.validation.min_samples_per_round, len(turns)) - len(sampled)
+        if needed > 0:
+            remaining = [turn for turn in turns if (turn.conversation_id, turn.turn_id) not in sampled]
+            for turn in self.rng.sample(remaining, needed):
+                sampled.add((turn.conversation_id, turn.turn_id))
+        return sampled
+
+    def run_round(self, conversations, round_id: int) -> tuple[list[TurnResult], list[OperationResult]]:
+        all_turns = [turn for conversation in conversations for turn in conversation.turns]
+        sample_keys = self._sample_keys(all_turns)
+        results: list[TurnResult] = []
+        operations: list[OperationResult] = []
+        max_turns = max((len(conversation.turns) for conversation in conversations), default=0)
+        for turn_id in range(max_turns):
+            by_dp = [[] for _ in self.drivers]
+            for conversation in conversations:
+                if turn_id < len(conversation.turns):
+                    dp_rank = conversation.conversation_id % len(self.drivers)
+                    by_dp[dp_rank].append(conversation.turns[turn_id])
+
+            def run_dp(dp_rank: int):
+                dp_results, dp_operations = [], []
+                batch_size = (
+                    min(self.config.concurrency.batch_size, self.config.concurrency.max_inflight_per_dp)
+                    if self.config.features.concurrency else 1
+                )
+                for start in range(0, len(by_dp[dp_rank]), batch_size):
+                    batch = by_dp[dp_rank][start:start + batch_size]
+                    batch_started = time.perf_counter()
+                    batch_results, batch_operations = self.drivers[dp_rank].execute_batch(
+                        batch, round_id, sample_keys
+                    )
+                    dp_results.extend(batch_results)
+                    dp_operations.extend(batch_operations)
+                    if self.config.concurrency.target_qps > 0:
+                        target_seconds = len(batch) / self.config.concurrency.target_qps
+                        time.sleep(max(0, target_seconds - (time.perf_counter() - batch_started)))
+                return dp_results, dp_operations
+
+            active = [rank for rank, turns in enumerate(by_dp) if turns]
+            if self.config.features.concurrency and len(active) > 1:
+                with ThreadPoolExecutor(max_workers=len(active)) as executor:
+                    futures = [executor.submit(run_dp, rank) for rank in active]
+                    for future in futures:
+                        batch_results, batch_operations = future.result()
+                        results.extend(batch_results)
+                        operations.extend(batch_operations)
+            else:
+                for rank in active:
+                    batch_results, batch_operations = run_dp(rank)
+                    results.extend(batch_results)
+                    operations.extend(batch_operations)
+        interval = self.config.features.async_api_probe_interval_rounds
+        if (
+            interval > 0
+            and round_id % interval == 0
+            and not self.config.features.swa
+            and not self.config.features.layerwise
+        ):
+            for driver in self.drivers:
+                operations.extend(driver.async_probe(round_id))
+        ssd_interval = self.config.cache.force_ssd_reload_interval_rounds
+        if (
+            self.config.features.ssd
+            and self.config.model.dp_size == 1
+            and ssd_interval > 0
+            and round_id % ssd_interval == 0
+        ):
+            operations.extend(self.drivers[0].ssd_probe())
+        return results, operations

--- a/benchmarks/flexkv_stress/workload.py
+++ b/benchmarks/flexkv_stress/workload.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import deque
+import hashlib
+import random
+from typing import Any, Iterable
+
+
+def sample_blocks(spec: Any, turn_id: int, rng: random.Random) -> int:
+    if isinstance(spec, int):
+        return spec
+    if isinstance(spec, list):
+        if not spec:
+            return 0
+        if len(spec) == 2:
+            return rng.randint(int(spec[0]), int(spec[1]))
+        return int(spec[turn_id % len(spec)])
+    if isinstance(spec, dict):
+        mode = spec.get("mode", "fixed")
+        if mode == "fixed":
+            return int(spec.get("value", spec.get("blocks", 0)))
+        if mode == "range":
+            low, high = spec.get("values", spec.get("blocks"))
+            return rng.randint(int(low), int(high))
+        if mode == "list":
+            values = spec.get("values", spec.get("blocks"))
+            return int(values[turn_id % len(values)])
+    raise ValueError(f"Unsupported block length spec: {spec!r}")
+
+
+def align_down(value: int, alignment: int) -> int:
+    return value // alignment * alignment
+
+
+@dataclass
+class Turn:
+    conversation_id: int
+    turn_id: int
+    get_tokens: tuple[int, ...]
+    put_tokens: tuple[int, ...]
+    added_input_tokens: int
+    output_tokens: int
+    expected_hit_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return len(self.put_tokens)
+
+
+@dataclass
+class Conversation:
+    conversation_id: int
+    history: list[int]
+    committed_prefix_tokens: int = 0
+    turns: list[Turn] = field(default_factory=list)
+
+
+class WorkloadGenerator:
+    def __init__(self, config, tokens_per_block: int, seed: int):
+        self.config = config
+        self.tokens_per_block = tokens_per_block
+        self.rng = random.Random(seed)
+        shared_count = config.system_prompt_blocks * tokens_per_block
+        self.shared_system = self._tokens(shared_count, salt=0) if config.shared_system_prompt else ()
+
+    def _tokens(self, count: int, salt: int) -> tuple[int, ...]:
+        # Keep token IDs deterministic while making unrelated conversations distinct.
+        return tuple(self.rng.randrange(1, 2**30) ^ salt for _ in range(count))
+
+    def _new_conversation(self, conversation_id: int) -> Conversation:
+        if self.config.shared_system_prompt:
+            system = list(self.shared_system)
+        else:
+            count = self.config.system_prompt_blocks * self.tokens_per_block
+            system = list(self._tokens(count, salt=conversation_id << 8))
+        return Conversation(conversation_id=conversation_id, history=system)
+
+    def generate_round(self, round_id: int) -> list[Conversation]:
+        conversations = []
+        base_id = round_id * self.config.conversations_per_round
+        for offset in range(self.config.conversations_per_round):
+            conv = self._new_conversation(base_id + offset)
+            num_turns = self.rng.randint(self.config.turns_min, self.config.turns_max)
+            for turn_id in range(num_turns):
+                input_spec = self.config.first_input_blocks if turn_id == 0 else self.config.added_input_blocks
+                input_blocks = sample_blocks(input_spec, turn_id, self.rng)
+                output_blocks = sample_blocks(self.config.output_blocks, turn_id, self.rng)
+                partial = self.config.partial_block_tokens if turn_id == 0 else 0
+                added_count = input_blocks * self.tokens_per_block + partial
+                output_count = output_blocks * self.tokens_per_block
+                added = self._tokens(added_count, salt=(conv.conversation_id << 12) ^ turn_id)
+                output = self._tokens(output_count, salt=(conv.conversation_id << 12) ^ turn_id ^ 0xA5)
+                get_tokens = tuple(conv.history) + added
+                put_tokens = get_tokens + output
+                conv.turns.append(Turn(
+                    conversation_id=conv.conversation_id,
+                    turn_id=turn_id,
+                    get_tokens=get_tokens,
+                    put_tokens=put_tokens,
+                    added_input_tokens=added_count,
+                    output_tokens=output_count,
+                    expected_hit_tokens=conv.committed_prefix_tokens,
+                ))
+                conv.history[:] = put_tokens
+                conv.committed_prefix_tokens = align_down(len(put_tokens), self.tokens_per_block)
+            conversations.append(conv)
+        return conversations
+
+
+class SlotAllocator:
+    def __init__(self, num_blocks: int, tokens_per_block: int):
+        self.num_blocks = num_blocks
+        self.tokens_per_block = tokens_per_block
+        self.cursor = 0
+
+    def allocate(self, num_tokens: int):
+        import numpy as np
+        num_blocks = (num_tokens + self.tokens_per_block - 1) // self.tokens_per_block
+        if num_blocks > self.num_blocks:
+            raise ValueError(
+                f"Request needs {num_blocks} GPU blocks, pool only has {self.num_blocks}"
+            )
+        blocks = (np.arange(num_blocks, dtype=np.int64) + self.cursor) % self.num_blocks
+        self.cursor = int((self.cursor + num_blocks) % self.num_blocks)
+        slots = (
+            blocks[:, None] * self.tokens_per_block
+            + np.arange(self.tokens_per_block, dtype=np.int64)[None, :]
+        ).reshape(-1)
+        return blocks, slots[:num_tokens]
+
+
+class PrefixOracle:
+    """Block-prefix trie for sequences successfully committed through PUT."""
+
+    @dataclass
+    class _Node:
+        children: dict[int, "PrefixOracle._Node"] = field(default_factory=dict)
+        references: int = 0
+
+    def __init__(self, tokens_per_block: int, capacity_blocks: int = 0):
+        self.tokens_per_block = tokens_per_block
+        self.capacity_blocks = capacity_blocks
+        self.root = self._Node()
+        self.sequences: deque[tuple[int, ...]] = deque()
+        self.logical_blocks = 0
+
+    def _keys(self, tokens: Iterable[int]) -> tuple[int, ...]:
+        import numpy as np
+        values = np.asarray(tuple(tokens), dtype=np.int64)
+        aligned = align_down(len(values), self.tokens_per_block)
+        keys = []
+        for start in range(0, aligned, self.tokens_per_block):
+            digest = hashlib.blake2b(
+                values[start:start + self.tokens_per_block].tobytes(), digest_size=8
+            ).digest()
+            keys.append(int.from_bytes(digest, "little"))
+        return tuple(keys)
+
+    def match(self, tokens: Iterable[int]) -> int:
+        node = self.root
+        matched = 0
+        for key in self._keys(tokens):
+            node = node.children.get(key)
+            if node is None:
+                break
+            matched += 1
+        return matched * self.tokens_per_block
+
+    def put(self, tokens: Iterable[int]) -> None:
+        keys = self._keys(tokens)
+        if not keys:
+            return
+        node = self.root
+        node.references += 1
+        for key in keys:
+            node = node.children.setdefault(key, self._Node())
+            node.references += 1
+        self.sequences.append(keys)
+        self.logical_blocks += len(keys)
+        while self.capacity_blocks and self.logical_blocks > self.capacity_blocks and self.sequences:
+            self._remove(self.sequences.popleft())
+
+    def _remove(self, keys: tuple[int, ...]) -> None:
+        node = self.root
+        path = []
+        node.references -= 1
+        for key in keys:
+            child = node.children.get(key)
+            if child is None:
+                return
+            path.append((node, key, child))
+            child.references -= 1
+            node = child
+        for parent, key, child in reversed(path):
+            if child.references == 0:
+                del parent.children[key]
+            else:
+                break
+        self.logical_blocks -= len(keys)

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -16,14 +16,18 @@ class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * 64)]
 
 
-# Load CUDA runtime library
-try:
-    cudart = ctypes.CDLL("libcudart.so")
-except:
-    try:
-        cudart = ctypes.CDLL("libcudart.so.12")
-    except:
-        cudart = ctypes.CDLL("libcudart.so.11")
+# PyTorch exposes ROCm devices through the torch.cuda API, but ROCm hosts do
+# not ship libcudart.  PyTorch reduction IPC works on both backends; direct
+# CUDA IPC remains an NVIDIA-only fallback.
+IS_ROCM = getattr(torch.version, "hip", None) is not None
+cudart = None
+if not IS_ROCM:
+    for _library in ("libcudart.so", "libcudart.so.12", "libcudart.so.11"):
+        try:
+            cudart = ctypes.CDLL(_library)
+            break
+        except OSError:
+            continue
 
 # CUDA IPC handle size (64 bytes on Linux)
 CUDA_IPC_HANDLE_SIZE = 64
@@ -94,6 +98,9 @@ class TensorSharedHandle:
         if not tensor.is_cuda:
             raise ValueError("Only support CUDA tensor sharing")
 
+        if force_direct_ipc and IS_ROCM:
+            raise RuntimeError("Direct CUDA IPC is not available on ROCm; use PyTorch IPC")
+
         if not force_direct_ipc:
             ## Try PyTorch's built-in method first
             try:
@@ -116,6 +123,12 @@ class TensorSharedHandle:
             except RuntimeError as e:
                 flexkv_logger.warning(f"PyTorch CUDA IPC export failed: {e}")
                 flexkv_logger.info("Attempting direct CUDA IPC export...")
+
+        if cudart is None:
+            backend = "ROCm" if IS_ROCM else "CUDA"
+            raise RuntimeError(
+                f"PyTorch {backend} IPC export failed and direct CUDA IPC is unavailable"
+            )
 
         try:
             ## Try direct CUDA IPC export
@@ -144,6 +157,8 @@ class TensorSharedHandle:
         tensor_dtype: Optional[Union[torch.dtype, str]],
         offset: int = 0,
     ) -> None:
+        if IS_ROCM:
+            raise RuntimeError("External direct CUDA IPC handles are not supported on ROCm")
         if ipc_handle is None:
             raise ValueError("ipc_handle is required when constructing from external handle")
         if tensor_shape is None:
@@ -338,6 +353,8 @@ class TensorSharedHandle:
         """
         Use CUDA IPC API to export the tensor's IPC handle
         """
+        if cudart is None:
+            raise RuntimeError("Direct CUDA IPC requires the NVIDIA CUDA runtime")
         # Get device pointer
         data_ptr = tensor.data_ptr()
         device = tensor.device
@@ -390,6 +407,8 @@ class TensorSharedHandle:
             device: Target CUDA device
             offset: Offset in bytes from the base pointer (for memory pool allocations)
         """
+        if cudart is None:
+            raise RuntimeError("Direct CUDA IPC requires the NVIDIA CUDA runtime")
         # Ensure CUDA is initialized in this process
         if not torch.cuda.is_initialized():
             flexkv_logger.info("Initializing CUDA in subprocess")

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -16,18 +16,14 @@ class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * 64)]
 
 
-# PyTorch exposes ROCm devices through the torch.cuda API, but ROCm hosts do
-# not ship libcudart.  PyTorch reduction IPC works on both backends; direct
-# CUDA IPC remains an NVIDIA-only fallback.
-IS_ROCM = getattr(torch.version, "hip", None) is not None
-cudart = None
-if not IS_ROCM:
-    for _library in ("libcudart.so", "libcudart.so.12", "libcudart.so.11"):
-        try:
-            cudart = ctypes.CDLL(_library)
-            break
-        except OSError:
-            continue
+# Load CUDA runtime library
+try:
+    cudart = ctypes.CDLL("libcudart.so")
+except:
+    try:
+        cudart = ctypes.CDLL("libcudart.so.12")
+    except:
+        cudart = ctypes.CDLL("libcudart.so.11")
 
 # CUDA IPC handle size (64 bytes on Linux)
 CUDA_IPC_HANDLE_SIZE = 64
@@ -98,9 +94,6 @@ class TensorSharedHandle:
         if not tensor.is_cuda:
             raise ValueError("Only support CUDA tensor sharing")
 
-        if force_direct_ipc and IS_ROCM:
-            raise RuntimeError("Direct CUDA IPC is not available on ROCm; use PyTorch IPC")
-
         if not force_direct_ipc:
             ## Try PyTorch's built-in method first
             try:
@@ -123,12 +116,6 @@ class TensorSharedHandle:
             except RuntimeError as e:
                 flexkv_logger.warning(f"PyTorch CUDA IPC export failed: {e}")
                 flexkv_logger.info("Attempting direct CUDA IPC export...")
-
-        if cudart is None:
-            backend = "ROCm" if IS_ROCM else "CUDA"
-            raise RuntimeError(
-                f"PyTorch {backend} IPC export failed and direct CUDA IPC is unavailable"
-            )
 
         try:
             ## Try direct CUDA IPC export
@@ -157,8 +144,6 @@ class TensorSharedHandle:
         tensor_dtype: Optional[Union[torch.dtype, str]],
         offset: int = 0,
     ) -> None:
-        if IS_ROCM:
-            raise RuntimeError("External direct CUDA IPC handles are not supported on ROCm")
         if ipc_handle is None:
             raise ValueError("ipc_handle is required when constructing from external handle")
         if tensor_shape is None:
@@ -353,8 +338,6 @@ class TensorSharedHandle:
         """
         Use CUDA IPC API to export the tensor's IPC handle
         """
-        if cudart is None:
-            raise RuntimeError("Direct CUDA IPC requires the NVIDIA CUDA runtime")
         # Get device pointer
         data_ptr = tensor.data_ptr()
         device = tensor.device
@@ -407,8 +390,6 @@ class TensorSharedHandle:
             device: Target CUDA device
             offset: Offset in bytes from the base pointer (for memory pool allocations)
         """
-        if cudart is None:
-            raise RuntimeError("Direct CUDA IPC requires the NVIDIA CUDA runtime")
         # Ensure CUDA is initialized in this process
         if not torch.cuda.is_initialized():
             flexkv_logger.info("Initializing CUDA in subprocess")

--- a/tests/test_flexkv_stress_unit.py
+++ b/tests/test_flexkv_stress_unit.py
@@ -12,7 +12,6 @@ import numpy as np
 import torch
 
 from benchmarks.flexkv_stress.config import ConversationConfig, load_config
-from benchmarks.flexkv_stress.device import DeviceBackend
 from benchmarks.flexkv_stress.main import _should_stop
 from benchmarks.flexkv_stress.metrics import (
     LogHistogram, OperationResult, Reporter, TurnResult, decimal_gb, percentile,
@@ -260,18 +259,6 @@ class MetricsAndDeviceTests(unittest.TestCase):
             self.assertNotIn("hit_ratio", row)
             summary = json.loads((output / "summary.json").read_text())
             self.assertEqual(summary["scenarios"][0]["throughput_gb_s"], 1)
-
-    def test_backend_detection(self):
-        fake_rocm = type("Torch", (), {"version": type("Version", (), {"hip": "6.0"})()})()
-        fake_cuda = type("Torch", (), {"version": type("Version", (), {"hip": None})()})()
-        self.assertEqual(DeviceBackend.detect(fake_rocm).name, "rocm")
-        self.assertEqual(DeviceBackend.detect(fake_cuda).name, "cuda")
-
-    def test_memory_handle_gates_direct_cuda_ipc(self):
-        source = (ROOT / "flexkv" / "common" / "memory_handle.py").read_text()
-        self.assertIn("IS_ROCM = getattr(torch.version, \"hip\", None) is not None", source)
-        self.assertIn("Direct CUDA IPC is not available on ROCm", source)
-
 
 class RunnerLogicTests(unittest.TestCase):
     class FakeManager:

--- a/tests/test_flexkv_stress_unit.py
+++ b/tests/test_flexkv_stress_unit.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
-from xml.etree import ElementTree
 
 import numpy as np
 import torch
@@ -226,7 +225,7 @@ class MetricsAndDeviceTests(unittest.TestCase):
             )
             output = reporter.directory
             reporter.close()
-            for name in ("summary.csv", "metrics.csv", "summary.json", "charts.svg"):
+            for name in ("summary.csv", "metrics.csv", "summary.json"):
                 self.assertTrue((output / name).exists(), name)
             self.assertFalse((output / "errors.csv").exists())
             with (output / "summary.json").open() as handle:
@@ -240,10 +239,6 @@ class MetricsAndDeviceTests(unittest.TestCase):
                 row = next(csv.DictReader(handle))
             self.assertEqual(float(row["hit_ratio"]), summary["scenarios"][0]["hit"]["ratio"])
             self.assertNotIn("transfer_bytes", row)
-            root = ElementTree.parse(output / "charts.svg").getroot()
-            text = "".join(root.itertext())
-            self.assertIn("CPU STUB — PERFORMANCE NUMBERS ARE NOT VALID", text)
-            self.assertEqual(len([node for node in root.iter() if node.attrib.get("id", "").startswith("panel-")]), 4)
 
     def test_bandwidth_reporter_uses_mode_specific_schema(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -265,10 +260,6 @@ class MetricsAndDeviceTests(unittest.TestCase):
             self.assertNotIn("hit_ratio", row)
             summary = json.loads((output / "summary.json").read_text())
             self.assertEqual(summary["scenarios"][0]["throughput_gb_s"], 1)
-            root = ElementTree.parse(output / "charts.svg").getroot()
-            self.assertTrue(any(
-                node.attrib.get("class") == "highest-stable-bandwidth" for node in root.iter()
-            ))
 
     def test_backend_detection(self):
         fake_rocm = type("Torch", (), {"version": type("Version", (), {"hip": "6.0"})()})()

--- a/tests/test_flexkv_stress_unit.py
+++ b/tests/test_flexkv_stress_unit.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from benchmarks.flexkv_stress.config import ConversationConfig, load_config
+from benchmarks.flexkv_stress.device import DeviceBackend
+from benchmarks.flexkv_stress.main import _should_stop
+from benchmarks.flexkv_stress.metrics import OperationResult, Reporter, TurnResult, percentile
+from benchmarks.flexkv_stress.models import (
+    DSV4_FLASH_RATIOS,
+    GLM52_INDEXER_TYPES,
+    get_preset,
+    model_bytes_per_block,
+    update_from_hf_config,
+)
+from benchmarks.flexkv_stress.workload import PrefixOracle, SlotAllocator, WorkloadGenerator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_DIR = ROOT / "benchmarks" / "flexkv_stress" / "configs"
+
+
+class ModelPresetTests(unittest.TestCase):
+    def test_model_presets_have_valid_physical_groups(self):
+        expected_layers = {
+            "dsv4_pro": 61,
+            "dsv4_flash": 43,
+            "glm5": 78,
+            "glm5_2": 78,
+        }
+        for name, count in expected_layers.items():
+            with self.subTest(name=name):
+                preset = get_preset(name)
+                self.assertEqual(preset.num_layers, count)
+                self.assertGreater(model_bytes_per_block(preset), 0)
+                for group in preset.groups:
+                    self.assertTrue(group.layer_indices)
+                    self.assertLess(max(group.layer_indices), count)
+                    self.assertEqual(preset.tokens_per_block % group.compress_ratio, 0)
+
+    def test_dsv4_geometry(self):
+        preset = get_preset("dsv4_pro")
+        groups = {group.name: group for group in preset.groups}
+        self.assertEqual(groups["c4"].head_size, 585)
+        self.assertEqual(groups["c128"].head_size, 864)
+        self.assertEqual(groups["c4_indexer"].head_size, 132)
+        self.assertEqual(groups["c4"].layer_indices, groups["c4_indexer"].layer_indices)
+
+    def test_glm52_indexer_partition(self):
+        self.assertEqual(len(GLM52_INDEXER_TYPES), 78)
+        preset = get_preset("glm5_2")
+        groups = {group.name: group for group in preset.groups}
+        combined = set(groups["indexer_full"].layer_indices) | set(groups["indexer_shared"].layer_indices)
+        self.assertEqual(combined, set(range(78)))
+        self.assertFalse(set(groups["indexer_full"].layer_indices) & set(groups["indexer_shared"].layer_indices))
+
+    def test_hf_config_refreshes_dsv4_service_layer_count(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(json.dumps({
+                "architectures": ["DeepseekV4ForCausalLM"],
+                "num_hidden_layers": 43,
+                "compress_ratios": DSV4_FLASH_RATIOS,
+            }))
+            preset = update_from_hf_config(get_preset("dsv4_flash"), path)
+            self.assertEqual(preset.num_layers, 43)
+            self.assertLess(max(layer for group in preset.groups for layer in group.layer_indices), 43)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_all_example_configs_load(self):
+        for path in sorted(CONFIG_DIR.glob("*.yaml")):
+            with self.subTest(path=path.name):
+                config = load_config(path)
+                self.assertGreater(config.required_gpus, 0)
+                self.assertGreater(config.bytes_per_block, 0)
+
+    def test_explicit_layer_group_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.yaml"
+            path.write_text("""
+model:
+  preset: glm5
+  layer_groups:
+    - name: tiny
+      layers: [0, 1]
+      head_size: 64
+      dtype: uint8
+cache: {num_cpu_blocks: 8}
+run: {rounds: 1}
+""")
+            config = load_config(path)
+            self.assertEqual(config.preset.groups[0].layer_indices, (0, 1))
+
+    def test_stop_conditions(self):
+        config = load_config(CONFIG_DIR / "glm5.yaml")
+        config.run.rounds = 10
+        config.run.duration_seconds = 100
+        config.run.stop_when = "either"
+        self.assertTrue(_should_stop(config, 10, 1))
+        config.run.stop_when = "both"
+        self.assertFalse(_should_stop(config, 10, 1))
+        self.assertTrue(_should_stop(config, 10, 100))
+
+
+class WorkloadTests(unittest.TestCase):
+    def test_multiturn_lengths_and_oracle(self):
+        cfg = ConversationConfig(
+            conversations_per_round=1,
+            turns_min=2,
+            turns_max=2,
+            system_prompt_blocks=2,
+            first_input_blocks=1,
+            added_input_blocks=1,
+            output_blocks=1,
+        )
+        conversation = WorkloadGenerator(cfg, 16, seed=7).generate_round(0)[0]
+        first, second = conversation.turns
+        self.assertEqual(first.added_input_tokens, 16)
+        self.assertEqual(first.output_tokens, 16)
+        self.assertEqual(second.expected_hit_tokens, len(first.put_tokens))
+        oracle = PrefixOracle(16)
+        self.assertEqual(oracle.match(first.get_tokens), 0)
+        oracle.put(first.put_tokens)
+        self.assertEqual(oracle.match(second.get_tokens), len(first.put_tokens))
+
+    def test_shared_system_prompt_hits_across_conversations(self):
+        cfg = ConversationConfig(
+            conversations_per_round=2,
+            turns_min=1,
+            turns_max=1,
+            system_prompt_blocks=2,
+            first_input_blocks=1,
+            output_blocks=1,
+        )
+        conversations = WorkloadGenerator(cfg, 8, seed=9).generate_round(0)
+        oracle = PrefixOracle(8)
+        oracle.put(conversations[0].turns[0].put_tokens)
+        self.assertEqual(oracle.match(conversations[1].turns[0].get_tokens), 16)
+
+    def test_oracle_drops_old_sequences_at_capacity(self):
+        oracle = PrefixOracle(2, capacity_blocks=2)
+        oracle.put([1, 2])
+        oracle.put([3, 4])
+        self.assertEqual(oracle.match([1, 2]), 2)
+        oracle.put([5, 6])
+        self.assertEqual(oracle.match([1, 2]), 0)
+        self.assertEqual(oracle.match([5, 6]), 2)
+
+    def test_slot_allocator_wraps_by_block(self):
+        allocator = SlotAllocator(4, 8)
+        blocks, slots = allocator.allocate(10)
+        self.assertEqual(blocks.tolist(), [0, 1])
+        self.assertEqual(slots.tolist(), list(range(10)))
+        blocks, _ = allocator.allocate(24)
+        self.assertEqual(blocks.tolist(), [2, 3, 0])
+
+
+class MetricsAndDeviceTests(unittest.TestCase):
+    def test_percentile(self):
+        self.assertEqual(percentile([1, 2, 3, 4], 0.50), 2)
+        self.assertEqual(percentile([1, 2, 3, 4], 0.99), 4)
+
+    def test_reporter_writes_csvs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            reporter = Reporter(directory)
+            result = TurnResult(0, 1, 0, 16, 16, 32, 0, 0, 0, 32, 1, 2, 3, True, True, True)
+            reporter.write_round(0, __import__("time").perf_counter(), [result], [OperationResult("put", True, 1)])
+            output = reporter.directory
+            reporter.close()
+            for name in (
+                "rounds.csv", "windows.csv", "turns.csv", "operations.csv",
+                "validation_samples.csv", "resources.csv", "errors.csv", "summary.csv",
+            ):
+                self.assertTrue((output / name).exists(), name)
+            with (output / "summary.csv").open() as handle:
+                summary = next(csv.DictReader(handle))
+            self.assertEqual(summary["turns"], "1")
+
+    def test_backend_detection(self):
+        fake_rocm = type("Torch", (), {"version": type("Version", (), {"hip": "6.0"})()})()
+        fake_cuda = type("Torch", (), {"version": type("Version", (), {"hip": None})()})()
+        self.assertEqual(DeviceBackend.detect(fake_rocm).name, "rocm")
+        self.assertEqual(DeviceBackend.detect(fake_cuda).name, "cuda")
+
+    def test_memory_handle_gates_direct_cuda_ipc(self):
+        source = (ROOT / "flexkv" / "common" / "memory_handle.py").read_text()
+        self.assertIn("IS_ROCM = getattr(torch.version, \"hip\", None) is not None", source)
+        self.assertIn("Direct CUDA IPC is not available on ROCm", source)
+
+
+class RunnerLogicTests(unittest.TestCase):
+    class FakeManager:
+        class Status:
+            name = "SUCCESS"
+
+        class Response:
+            def __init__(self):
+                self.status = RunnerLogicTests.FakeManager.Status()
+
+        def __init__(self):
+            self.sequences = []
+            self.tasks = {}
+            self.next_task = 1
+
+        def _match(self, tokens):
+            best = 0
+            for stored in self.sequences:
+                common = 0
+                for left, right in zip(tokens, stored):
+                    if left != right:
+                        break
+                    common += 1
+                best = max(best, common)
+            return best
+
+        def get_match(self, tokens, swa_aware=False):
+            task = self.next_task
+            self.next_task += 1
+            hit = self._match(tokens)
+            mask = np.zeros(len(tokens), dtype=np.int64)
+            mask[:hit] = 1
+            self.tasks[task] = ("get", tuple(tokens))
+            return task, mask
+
+        def put_match(self, tokens):
+            task = self.next_task
+            self.next_task += 1
+            hit = self._match(tokens)
+            mask = np.ones(len(tokens), dtype=np.int64)
+            mask[:hit] = 0
+            self.tasks[task] = ("put", tuple(tokens))
+            return task, mask
+
+        def launch(self, task_ids, slot_mappings, **kwargs):
+            for task in task_ids:
+                operation, tokens = self.tasks[task]
+                if operation == "put":
+                    self.sequences.append(tokens)
+            return [10_000 + task_ids[0]] if kwargs.get("as_batch") else list(task_ids)
+
+        def wait(self, task_ids, **kwargs):
+            return {task: self.Response() for task in task_ids}
+
+    def test_manager_driver_multiturn_flow(self):
+        from benchmarks.flexkv_stress.runner import ManagerDriver
+
+        config = load_config(CONFIG_DIR / "glm5.yaml")
+        config.features.layerwise = False
+        config.features.swa = False
+        config.features.ssd = False
+        config.features.concurrency = False
+        config.model.gpu_blocks_per_rank = 256
+        conversation_cfg = ConversationConfig(
+            conversations_per_round=1,
+            turns_min=2,
+            turns_max=2,
+            system_prompt_blocks=1,
+            first_input_blocks=1,
+            added_input_blocks=1,
+            output_blocks=1,
+        )
+        turns = WorkloadGenerator(conversation_cfg, config.tokens_per_block, 11).generate_round(0)[0].turns
+        driver = ManagerDriver(config, 0, self.FakeManager(), workers=[])
+        fake_command = lambda *_args, **_kwargs: [{"ok": True}]
+        with patch("benchmarks.flexkv_stress.runner.command_dp", fake_command):
+            first, _ = driver.execute_batch([turns[0]], 0, set())
+            second, _ = driver.execute_batch([turns[1]], 0, set())
+        self.assertTrue(first[0].success)
+        self.assertTrue(second[0].success)
+        self.assertEqual(second[0].actual_hit_tokens, second[0].expected_hit_tokens)
+
+    def test_cpu_stub_copies_real_torch_blocks(self):
+        from benchmarks.flexkv_stress.cpu_stub import CpuStubManager, start_cpu_workers
+
+        config = load_config(CONFIG_DIR / "cpu_stub.yaml")
+        workers = start_cpu_workers(config)
+        manager = CpuStubManager(config, 0, workers, config.cache.num_cpu_blocks // 2)
+        tokens = np.arange(config.tokens_per_block * 2, dtype=np.int64)
+        slots = np.arange(config.tokens_per_block * 2, dtype=np.int64)
+        source = [worker for worker in workers if worker.dp_rank == 0]
+        for worker in source:
+            for group in worker.tensors_per_group:
+                for tensor in group:
+                    tensor[0].fill_(11 + worker.effective_rank)
+                    tensor[1].fill_(22 + worker.effective_rank)
+        put_task, put_mask = manager.put_match(tokens)
+        manager.launch([put_task], [slots[put_mask]])
+        for worker in source:
+            for group in worker.tensors_per_group:
+                for tensor in group:
+                    tensor[0].zero_()
+                    tensor[1].zero_()
+        get_task, get_mask = manager.get_match(tokens)
+        self.assertEqual(int(get_mask.sum()), len(tokens))
+        manager.launch([get_task], [slots])
+        for worker in source:
+            for group in worker.tensors_per_group:
+                for tensor in group:
+                    self.assertTrue(bool(torch.all(tensor[0] == 11 + worker.effective_rank)))
+                    self.assertTrue(bool(torch.all(tensor[1] == 22 + worker.effective_rank)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flexkv_stress_unit.py
+++ b/tests/test_flexkv_stress_unit.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-import csv
 import json
+import csv
+from dataclasses import replace
 from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
+from xml.etree import ElementTree
 
 import numpy as np
 import torch
@@ -13,7 +15,10 @@ import torch
 from benchmarks.flexkv_stress.config import ConversationConfig, load_config
 from benchmarks.flexkv_stress.device import DeviceBackend
 from benchmarks.flexkv_stress.main import _should_stop
-from benchmarks.flexkv_stress.metrics import OperationResult, Reporter, TurnResult, percentile
+from benchmarks.flexkv_stress.metrics import (
+    LogHistogram, OperationResult, Reporter, TurnResult, decimal_gb, percentile,
+    throughput_gb_s,
+)
 from benchmarks.flexkv_stress.models import (
     DSV4_FLASH_RATIOS,
     GLM52_INDEXER_TYPES,
@@ -110,6 +115,29 @@ run: {rounds: 1}
         self.assertFalse(_should_stop(config, 10, 1))
         self.assertTrue(_should_stop(config, 10, 100))
 
+    def test_composite_tp_cp_overlap_matches_sglang_topology(self):
+        config = load_config(CONFIG_DIR / "glm5_cpu_smoke.yaml")
+        self.assertEqual(config.model.tp_size, 4)
+        self.assertEqual(config.model.cp_size, 2)
+        self.assertEqual(config.kv_tp_size, 2)
+        self.assertEqual(config.workers_per_dp, 4)
+        self.assertEqual(config.required_gpus, 4)
+        self.assertEqual(config.bytes_per_block, config.bytes_per_gpu_block * 2)
+        self.assertEqual(
+            [config.worker_ranks(rank) for rank in range(config.workers_per_dp)],
+            [(0, 0), (1, 0), (0, 1), (1, 1)],
+        )
+
+    def test_composite_tp_must_be_divisible_by_cp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "invalid.yaml"
+            path.write_text("""
+model: {preset: glm5, tp_size: 3, cp_size: 2}
+run: {rounds: 1}
+""")
+            with self.assertRaisesRegex(ValueError, "must be divisible"):
+                load_config(path)
+
 
 class WorkloadTests(unittest.TestCase):
     def test_multiturn_lengths_and_oracle(self):
@@ -169,21 +197,78 @@ class MetricsAndDeviceTests(unittest.TestCase):
         self.assertEqual(percentile([1, 2, 3, 4], 0.50), 2)
         self.assertEqual(percentile([1, 2, 3, 4], 0.99), 4)
 
-    def test_reporter_writes_csvs(self):
+    def test_log_histogram_is_mergeable(self):
+        left, right = LogHistogram(), LogHistogram()
+        for value in (1, 2):
+            left.record(value)
+        for value in (3, 4):
+            right.record(value)
+        left.merge(right)
+        self.assertEqual(left.count, 4)
+        self.assertGreaterEqual(left.percentile(.99), 3.9)
+
+    def test_decimal_gb_and_bandwidth_units(self):
+        self.assertEqual(decimal_gb(1_000_000_000), 1)
+        self.assertEqual(throughput_gb_s(2_000_000_000, 2), 1)
+
+    def test_latency_reporter_writes_stable_artifacts(self):
         with tempfile.TemporaryDirectory() as directory:
-            reporter = Reporter(directory)
-            result = TurnResult(0, 1, 0, 16, 16, 32, 0, 0, 0, 32, 1, 2, 3, True, True, True)
-            reporter.write_round(0, __import__("time").perf_counter(), [result], [OperationResult("put", True, 1)])
+            config = load_config(CONFIG_DIR / "glm5_cpu_smoke.yaml")
+            config.output.directory = directory
+            reporter = Reporter(config)
+            result = TurnResult(
+                0, 1, 0, 16, 16, 32, 12, 8, -4, 24,
+                1, 2, 3, True, True, True, query_tokens=16,
+            )
+            reporter.write_latency_window(
+                "unloaded", 0, __import__("datetime").datetime.now().astimezone(),
+                1, [result], [], batch_size=1, concurrency=1,
+            )
             output = reporter.directory
             reporter.close()
-            for name in (
-                "rounds.csv", "windows.csv", "turns.csv", "operations.csv",
-                "validation_samples.csv", "resources.csv", "errors.csv", "summary.csv",
-            ):
+            for name in ("summary.csv", "metrics.csv", "summary.json", "charts.svg"):
                 self.assertTrue((output / name).exists(), name)
+            self.assertFalse((output / "errors.csv").exists())
+            with (output / "summary.json").open() as handle:
+                summary = json.load(handle)
+            self.assertEqual(summary["schema_version"], "1.0")
+            self.assertFalse(summary["run"]["performance_valid"])
+            self.assertEqual(summary["scenarios"][0]["hit"]["ratio"], .5)
+            self.assertEqual(summary["scenarios"][0]["hit"]["exact_rate"], 0)
+            self.assertEqual(summary["scenarios"][0]["hit"]["token_accuracy"], .75)
             with (output / "summary.csv").open() as handle:
-                summary = next(csv.DictReader(handle))
-            self.assertEqual(summary["turns"], "1")
+                row = next(csv.DictReader(handle))
+            self.assertEqual(float(row["hit_ratio"]), summary["scenarios"][0]["hit"]["ratio"])
+            self.assertNotIn("transfer_bytes", row)
+            root = ElementTree.parse(output / "charts.svg").getroot()
+            text = "".join(root.itertext())
+            self.assertIn("CPU STUB — PERFORMANCE NUMBERS ARE NOT VALID", text)
+            self.assertEqual(len([node for node in root.iter() if node.attrib.get("id", "").startswith("panel-")]), 4)
+
+    def test_bandwidth_reporter_uses_mode_specific_schema(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = load_config(CONFIG_DIR / "glm5_cpu_smoke.yaml")
+            config.run.mode = "bandwidth"
+            config.output.directory = directory
+            reporter = Reporter(config)
+            reporter.write_bandwidth_window(
+                "cpu_to_gpu_load", 2, 0,
+                __import__("datetime").datetime.now().astimezone(), 2,
+                [OperationResult("launch_get", True, 10, transfer_bytes=2_000_000_000)],
+                1, 1, [],
+            )
+            output = reporter.directory
+            reporter.close()
+            with (output / "summary.csv").open() as handle:
+                row = next(csv.DictReader(handle))
+            self.assertEqual(float(row["throughput_gb_s"]), 1)
+            self.assertNotIn("hit_ratio", row)
+            summary = json.loads((output / "summary.json").read_text())
+            self.assertEqual(summary["scenarios"][0]["throughput_gb_s"], 1)
+            root = ElementTree.parse(output / "charts.svg").getroot()
+            self.assertTrue(any(
+                node.attrib.get("class") == "highest-stable-bandwidth" for node in root.iter()
+            ))
 
     def test_backend_detection(self):
         fake_rocm = type("Torch", (), {"version": type("Version", (), {"hip": "6.0"})()})()
@@ -272,11 +357,86 @@ class RunnerLogicTests(unittest.TestCase):
         driver = ManagerDriver(config, 0, self.FakeManager(), workers=[])
         fake_command = lambda *_args, **_kwargs: [{"ok": True}]
         with patch("benchmarks.flexkv_stress.runner.command_dp", fake_command):
-            first, _ = driver.execute_batch([turns[0]], 0, set())
-            second, _ = driver.execute_batch([turns[1]], 0, set())
+            first, first_operations = driver.execute_batch([turns[0]], 0, set())
+            second, second_operations = driver.execute_batch([turns[1]], 0, set())
         self.assertTrue(first[0].success)
         self.assertTrue(second[0].success)
         self.assertEqual(second[0].actual_hit_tokens, second[0].expected_hit_tokens)
+        put_match = next(item for item in first_operations if item.operation == "put_match")
+        launch_get = next(item for item in second_operations if item.operation == "launch_get")
+        self.assertGreaterEqual(first[0].put_ms, put_match.latency_ms)
+        self.assertGreaterEqual(second[0].get_ms, launch_get.latency_ms)
+
+    def test_swa_mapping_uses_token_slots_and_rotates_pages(self):
+        from benchmarks.flexkv_stress.runner import ManagerDriver
+
+        config = load_config(CONFIG_DIR / "dsv4_pro.yaml")
+        driver = ManagerDriver(config, 0, self.FakeManager(), workers=[])
+        first_blocks, first_mapping = driver._swa_mapping()
+        second_blocks, second_mapping = driver._swa_mapping()
+        self.assertEqual(first_blocks, [0])
+        self.assertEqual(second_blocks, [1])
+        self.assertEqual(len(first_mapping), config.tokens_per_block)
+        self.assertEqual(int(second_mapping[0] // config.tokens_per_block), 1)
+
+    def test_swa_validation_uses_terminal_pattern_when_main_is_sampled(self):
+        from benchmarks.flexkv_stress.cpu_stub import CpuTorchWorker
+
+        config = load_config(CONFIG_DIR / "cpu_stub.yaml")
+        config.features.swa = True
+        config.cache.swa_num_slots = 2
+        config.preset = replace(
+            config.preset,
+            swa_enabled=True,
+            swa_num_layers=1,
+            swa_head_size=2,
+        )
+        worker = CpuTorchWorker(config, dp_rank=0, effective_rank=0, device_id=0)
+        worker.request({
+            "operation": "seed",
+            "block_ids": [0],
+            "patterns": [11],
+            "swa_block_ids": [0],
+            "swa_patterns": [99],
+        })
+        response = worker.request({
+            "operation": "verify",
+            "block_ids": [0],
+            "patterns": [11],
+            "swa_block_ids": [0],
+            "swa_patterns": [99],
+            "max_layers": 1,
+            "max_bytes": 8,
+        })
+        self.assertTrue(response["ok"], response["errors"])
+
+    def test_cp_workers_hold_full_duplicate_kv_for_each_kv_tp_rank(self):
+        from benchmarks.flexkv_stress.cpu_stub import start_cpu_workers
+        from benchmarks.flexkv_stress.gpu_worker import command_dp
+
+        config = load_config(CONFIG_DIR / "glm5_cpu_smoke.yaml")
+        workers = start_cpu_workers(config)
+        self.assertEqual(len(workers), 4)
+        self.assertEqual(
+            [(worker.kv_tp_rank, worker.cp_rank) for worker in workers],
+            [(0, 0), (1, 0), (0, 1), (1, 1)],
+        )
+        command_dp(workers, 0, {
+            "operation": "seed", "block_ids": [0], "patterns": [1234],
+        })
+        for group_index in range(len(workers[0].tensors_per_group)):
+            self.assertTrue(torch.equal(
+                workers[0].tensors_per_group[group_index][0][0],
+                workers[2].tensors_per_group[group_index][0][0],
+            ))
+            self.assertTrue(torch.equal(
+                workers[1].tensors_per_group[group_index][0][0],
+                workers[3].tensors_per_group[group_index][0][0],
+            ))
+            self.assertFalse(torch.equal(
+                workers[0].tensors_per_group[group_index][0][0],
+                workers[1].tensors_per_group[group_index][0][0],
+            ))
 
     def test_cpu_stub_copies_real_torch_blocks(self):
         from benchmarks.flexkv_stress.cpu_stub import CpuStubManager, start_cpu_workers


### PR DESCRIPTION
## Summary

- add a long-running FlexKV stress benchmark for latency, cache-hit correctness, and transfer bandwidth
- support composite TP/CP rank mapping, layerwise execution, SWA slot mapping, SSD reload paths, and CPU-only stub validation
- add deterministic multi-turn synthetic workloads, prefix-oracle checks, byte-pattern readback, structured metrics, and model-specific smoke configurations
- document the benchmark design, measurement boundaries, and operating instructions

## Why

FlexKV needs a repeatable workload that exercises prefix matching and KV movement across GPU, CPU, and SSD without requiring model inference. The benchmark also needs to validate cache-hit accounting and transferred bytes while covering the current DSV4 and GLM5 cache layouts.

## Impact

The new benchmark is isolated under `benchmarks/flexkv_stress`. It does not alter production cache behavior. CPU stub mode allows correctness and configuration checks without accelerator hardware; GPU runs remain available for real transfer and endurance measurements.

## Validation

- `python -m pytest tests/test_flexkv_stress_unit.py -q` — 25 passed, 11 subtests passed
- DSV4 CPU smoke configuration dry-run
- GLM5 CPU smoke configuration dry-run
- `git diff --check`
