### PR TITLE
Add Mooncake Store backend support and SGLang compatibility aliases

### DIFF
--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -389,6 +389,9 @@ class GlobalCacheEngine:
         self.eviction_policy = GLOBAL_CONFIG_FROM_ENV.eviction_policy
         self.protected_threshold = GLOBAL_CONFIG_FROM_ENV.slru_protected_threshold
 
+        self.use_mooncake_store_backend = cache_config.use_mooncake_store_backend
+
+        
         # Initialize metrics collector for cache engine monitoring (before creating CacheEngines)
         self._metrics_collector = get_global_collector()
         if self._metrics_collector is None:
@@ -467,7 +470,20 @@ class GlobalCacheEngine:
                 )
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
         if cache_config.enable_remote:
-            if cache_config.enable_kv_sharing:
+            if self.use_mooncake_store_backend:
+                # mooncake-store: global distributed KV cache pool.
+                # The engine does not manage local block IDs; it resolves blocks
+                # by content-hash keys via MooncakeStoreClient.batch_exists().
+                from flexkv.external.mooncake_store_utils import (
+                    MooncakeStoreCacheEngine,
+                )
+                # PP rank/size already populated on cache_config by
+                # update_default_config_from_user_config (single injection
+                # point sourced from RankInfo). Just consume it.
+                self.remote_cache_engine = MooncakeStoreCacheEngine(
+                    cache_config=cache_config,
+                )
+            elif cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
                 self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta)
             elif self.index_accel:
@@ -603,8 +619,19 @@ class GlobalCacheEngine:
             )
 
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
-        return_mask[block_start_idx* self.tokens_per_block:
-                    (block_start_idx + num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
+
+        if temp_cache_strategy.ignore_gpu and temp_cache_strategy.ignore_gds:
+            prefetch_blocks = 0
+            for op in transfer_graph._op_map.values():
+                if op.transfer_type == TransferType.REMOTE2H:
+                    prefetch_blocks += len(op.src_block_ids)
+            if prefetch_blocks > 0:
+                return_mask[block_start_idx * self.tokens_per_block:
+                            (block_start_idx + prefetch_blocks) * self.tokens_per_block] = True
+        else:
+
+            return_mask[block_start_idx* self.tokens_per_block:
+                        (block_start_idx + num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
 
         # if layer_num // layer_granularity != 1:
         #     transfer_graph, finished_ops_ids = convert_read_graph_to_layer_wise_graph(transfer_graph=transfer_graph,
@@ -668,7 +695,7 @@ class GlobalCacheEngine:
             :ssd_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
         remote_matched_blocks = remote_matched_result.physical_blocks[
             :remote_matched_result.num_ready_matched_blocks][block_mask_start:block_mask_end]
-        shared_pcfs_read = self.cache_config.enable_kv_sharing and self.index_accel
+        shared_pcfs_read = self.cache_config.enable_kv_sharing and self.index_accel and not self.use_mooncake_store_backend
         remote_file_nodeids = None
         if shared_pcfs_read:
             remote_file_nodeids = remote_matched_result.block_node_ids
@@ -759,6 +786,17 @@ class GlobalCacheEngine:
 
         op_remote2h = None
         if fragment3_num_blocks > 0:
+            # For mooncake-store, pass content-hash keys so the transfer worker
+            # can address blocks by hash instead of file offset.
+            if self.use_mooncake_store_backend:
+                mooncacke_block_hashes = sequence_meta.block_hashes[
+                    block_mask_start + fragment12_num_blocks:
+                    block_mask_start + fragment12_num_blocks + fragment3_num_blocks
+                ]
+                assert len(mooncacke_block_hashes) == len(fragment3_remote_blocks)
+
+            else:
+                mooncacke_block_hashes = None
             op_remote2h = TransferOp(
                 graph_id = transfer_graph.graph_id,
                 transfer_type = TransferType.REMOTE2H,
@@ -766,6 +804,7 @@ class GlobalCacheEngine:
                 dst_block_ids = fragment123_cpu_blocks[-fragment3_num_blocks:],
                 src_block_node_ids = fragment3_remote_file_nodeids,
                 dp_client_id = dp_client_id,
+                mooncake_store_block_hashes = mooncacke_block_hashes,
             )
             transfer_graph.add_transfer_op(op_remote2h)
 
@@ -1266,12 +1305,21 @@ class GlobalCacheEngine:
                                                        fragment12_cpu_blocks])
             else:
                 fragment3_cpu_blocks = fragment12_cpu_blocks[-fragment3_num_blocks:]
+            if self.use_mooncake_store_backend:
+                mooncacke_block_hashes = sequence_meta.block_hashes[
+                    block_mask_start + len(remote_matched_blocks):
+                    block_mask_start + len(remote_matched_blocks) + fragment3_num_blocks
+                ]
+                assert len(mooncacke_block_hashes) == len(fragment3_cpu_blocks)
+            else:
+                mooncacke_block_hashes = None
             op_h2remote = TransferOp(
                 graph_id = transfer_graph.graph_id,
                 transfer_type = TransferType.H2REMOTE,
                 src_block_ids = fragment3_cpu_blocks,
                 dst_block_ids = fragment3_remote_blocks,
                 dp_client_id = dp_client_id,
+                mooncake_store_block_hashes = mooncacke_block_hashes,
             )
             transfer_graph.add_transfer_op(op_h2remote)
             transfer_graph.add_dependency(op_h2remote.op_id, op_d2h.op_id)

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -288,8 +288,6 @@ class RedisNodeInfo:
                 "uuid": self.uuid,
                 "status": "active",
                 "timestamp": str(int(time.time())),
-                "pp_rank": str(getattr(self, 'pp_rank', 0)),
-                "pp_size": str(getattr(self, 'pp_size', 1)),
             })
 
             # Set TTL so the key auto-expires if the process crashes

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -623,20 +623,17 @@ def update_default_config_from_user_config(rank_info: RankInfo,
             f"[CacheConfig] GB->blocks conversion (with indexer): "
             f"main_block_size={main_block_size_in_bytes} B, "
             f"indexer_block_size={indexer_block_size_in_bytes} B, "
-            f"total_block_size={block_size_in_bytes} B"
+            f"total_block_size={block_size_in_bytes} B; "
+            f"cpu_cache_gb={user_config.cpu_cache_gb} -> num_cpu_blocks={cache_config.num_cpu_blocks}, "
+            f"ssd_cache_gb={user_config.ssd_cache_gb} -> num_ssd_blocks={cache_config.num_ssd_blocks}"
         )
     else:
         flexkv_logger.info(
             f"[CacheConfig] GB->blocks conversion: "
-            f"block_size={block_size_in_bytes} B"
+            f"block_size={block_size_in_bytes} B; "
+            f"cpu_cache_gb={user_config.cpu_cache_gb} -> num_cpu_blocks={cache_config.num_cpu_blocks}, "
+            f"ssd_cache_gb={user_config.ssd_cache_gb} -> num_ssd_blocks={cache_config.num_ssd_blocks}"
         )
-
-    flexkv_logger.info(
-        f"[CacheConfig] GB->blocks conversion: "
-        f"block_size={block_size_in_bytes} B; "
-        f"cpu_cache_gb={user_config.cpu_cache_gb} -> num_cpu_blocks={cache_config.num_cpu_blocks}, "
-        f"ssd_cache_gb={user_config.ssd_cache_gb} -> num_ssd_blocks={cache_config.num_ssd_blocks}"
-    )
 
     cache_config.ssd_cache_dir = user_config.ssd_cache_dir
     cache_config.enable_ssd = user_config.ssd_cache_gb > 0

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -40,14 +40,8 @@ class ModelConfig:
     # ------------------------------------------------------------------
     # Attention-level parallel configs
     # ------------------------------------------------------------------
-    # enable_dp_attention: whether DP-attention is enabled (sglang
-    # ``--enable-dp-attention`` or TRT-LLM ``enable_attention_dp``).
-    # When True, the physical TP group is split into
-    # attn_tp × attn_cp × attn_dp.
-    enable_dp_attention: bool = False
-
-    # attn_cp_size: context-parallel size (global).
-    attn_cp_size: int = 1
+    # cp_size: context-parallel size (global), default 1.
+    cp_size: int = 1
 
     # ------------------------------------------------------------------
     # Topology configs (global)
@@ -94,16 +88,11 @@ class ModelConfig:
                 f"[ModelConfig] cannot derive gpus_per_node: "
                 f"total_gpus={self.total_gpus} not divisible by nnodes={self.nnodes}"
             )
-        if self.nnodes_per_tp_group > 2:
+        if self.nnodes_per_pp_rank > 2:
             raise ValueError(
                 f"[ModelConfig] only support 2-nodes TP for now, but got "
-                f"nnodes_per_tp_group={self.nnodes_per_tp_group} "
+                f"nnodes_per_pp_rank={self.nnodes_per_pp_rank} "
                 f"(tp_size={self.tp_size}, gpus_per_node={self.gpus_per_node})"
-            )
-        if self.tp_size % self.nnodes_per_tp_group != 0:
-            raise ValueError(
-                f"[ModelConfig] tp_size={self.tp_size} not divisible by "
-                f"nnodes_per_tp_group={self.nnodes_per_tp_group}"
             )
         if self.instance_num < 1:
             raise ValueError(
@@ -119,8 +108,8 @@ class ModelConfig:
             raise AttributeError(
                 f"ModelConfig is frozen — cannot set '{name}'. "
                 f"All primitive fields must be set during post_init_from_*(), "
-                f"after which freeze() is called.  Derived fields (attn_tp_size, "
-                f"tp_size_per_node) are @property "
+                f"after which freeze() is called.  Derived fields (effective_tp_size, "
+                f"tp_size_per_node, cp_size_per_node, nnodes_per_pp_rank) are @property "
                 f"and cannot be set at all."
             )
         object.__setattr__(self, name, value)
@@ -130,8 +119,10 @@ class ModelConfig:
     # ------------------------------------------------------------------
     @property
     def total_gpus(self) -> int:
-        """Total GPUs across all nodes for one FlexKV instance."""
-        return self.dp_size * self.tp_size * self.pp_size
+        """Total GPU worker registration slots across all nodes for one FlexKV instance.
+
+        Unified formula: dp_size × tp_size × cp_size × pp_size."""
+        return self.dp_size * self.tp_size * self.cp_size * self.pp_size
 
     @property
     def total_clients(self) -> int:
@@ -140,7 +131,7 @@ class ModelConfig:
 
     @property
     def gpus_per_node(self) -> int:
-        """Total GPUs on this node (across all DP, PP stages and TP groups)."""
+        """GPU worker registration slots on this node (across all DP shards, PP stages and TP groups)."""
         return self.total_gpus // self.nnodes
 
     @property
@@ -149,57 +140,34 @@ class ModelConfig:
         return max(self.nnodes // self.pp_size, 1)
 
     @property
-    def nnodes_per_tp_group(self) -> int:
-        """Number of nodes spanned by one TP group."""
-        return self.nnodes_per_pp_rank
-
-    @property
     def tp_size_per_node(self) -> int:
         """Number of TP ranks on this node within one TP group."""
-        flexkv_logger.info(f"[Config] TP size per node: {self.tp_size} // {self.nnodes_per_tp_group}")
-        return self.tp_size // self.nnodes_per_tp_group
+        return max(1, self.tp_size // self.nnodes_per_pp_rank)
 
     @property
-    def attn_dp_size(self) -> int:
-        """Attention-level DP size (= dp_size when enable_dp_attention else 1)."""
-        return max(1, self.dp_size) if self.enable_dp_attention else 1
+    def cp_size_per_node(self) -> int:
+        """CP size on this node for a single PP stage.
 
-    @property
-    def attn_tp_size(self) -> int:
-        """Attention-level TP size derived from tp / attn_dp / attn_cp."""
-        attn_dp = self.attn_dp_size
-        cp = max(1, self.attn_cp_size)
-        return max(1, max(1, self.tp_size) // (attn_dp * cp))
-
-    @property
-    def attn_tp_size_per_node(self) -> int:
-        """Attention-level TP size per node."""
-        flexkv_logger.info(f"[Config] Attention-level TP size per node: {self.attn_tp_size} // {self.nnodes_per_tp_group}")
-        return self.attn_tp_size // self.nnodes_per_tp_group
-
-    @property
-    def attn_cp_size_per_node(self) -> int:
-        """Attention-level CP size on this node for a single pp stage. """
-        flexkv_logger.info(f"[Config] Attention-level CP size per node: {self.attn_cp_size} // {self.nnodes_per_pp_rank}")
-        return max(1, self.attn_cp_size // self.nnodes_per_pp_rank)
+        Used for multi-node scenarios where the CP group spans multiple nodes.
+        """
+        return max(1, self.cp_size // self.nnodes_per_pp_rank)
 
     @property
     def effective_tp_size(self) -> int:
-        """Effective tp-group size used for *data-plane* CPU slicing."""
-        return max(1, self.attn_tp_size) * max(1, self.attn_cp_size)
+        """Number of CPU block slices = tp_size × cp_size."""
+        return max(1, self.tp_size) * max(1, self.cp_size)
 
     @property
     def effective_tp_size_per_node(self) -> int:
         """Per-node counterpart of :pyattr:`effective_tp_size`."""
-        flexkv_logger.info(f"[Config] Effective tp-group size per node: {self.attn_tp_size_per_node} * {self.attn_cp_size_per_node}")
-        return self.attn_tp_size_per_node * self.attn_cp_size_per_node
+        return self.tp_size_per_node * self.cp_size_per_node
 
     @property
     def num_kv_heads_per_node(self) -> int:
         """Number of KV heads visible to a single node."""
         if self.use_mla:
             return self.num_kv_heads
-        return self.num_kv_heads * self.tp_size_per_node // max(1, self.attn_tp_size)
+        return self.num_kv_heads * self.tp_size_per_node // max(1, self.tp_size)
 
     @property
     def kv_dim(self) -> int:
@@ -222,7 +190,8 @@ class ModelConfig:
             f", head_size={self.head_size}, use_mla={self.use_mla}"
             f", dtype={self.dtype}"
             f", tp_size={self.tp_size}, pp_size={self.pp_size}, dp_size={self.dp_size}"
-            f", attn_cp_size={self.attn_cp_size}"
+            f", cp_size={self.cp_size}"
+            f", total_gpus={self.total_gpus}"
             f", nnodes={self.nnodes}, master_host={self.master_host!r}"
             f", instance_num={self.instance_num}"
         )
@@ -234,11 +203,12 @@ class RankInfo:
     tp_rank: int = 0
     pp_rank: int = 0
     dp_rank: int = 0
-    attn_cp_rank: int = 0
+    cp_rank: int = 0
     node_rank: int = 0
     instance_id: int = 0
     pp_start_layer: int = 0
     pp_end_layer: int = -1
+    local_rank: int = -1
     @property
     def tp_rank_per_node(self) -> int:
         """TP rank index within the local node (within one TP group)."""
@@ -257,17 +227,19 @@ class RankInfo:
         return self.instance_id * self.model_config.dp_size + self.dp_rank
 
     @property
-    def attn_tp_rank(self) -> int:
-        """Attention-level TP rank derived from tp_rank / attn_tp_size."""
-        return self.tp_rank % max(1, self.model_config.attn_tp_size)
-
-    @property
     def effective_tp_rank(self) -> int:
-        """Effective tp-rank in the *data-plane* segmentation space."""
+        """Effective tp-rank in the *data-plane* segmentation space.
+
+        For MLA models, every CP rank holds the same KV pages (the MLA latent
+        is not split along the sequence axis from a KV perspective), so
+        ``cp_rank`` must NOT participate in slice indexing — otherwise a CP rank
+        would write to a non-existent CPU slice and corrupt block accounting.
+        For non-MLA models, CP shards along the sequence dimension and each
+        ``(cp_rank, tp_rank)`` pair owns a unique slice.
+        """
         if self.model_config.use_mla:
-            return self.attn_tp_rank
-        attn_tp_size = max(1, self.model_config.attn_tp_size)
-        return self.attn_cp_rank * attn_tp_size + self.attn_tp_rank
+            return self.tp_rank
+        return self.cp_rank * max(1, self.model_config.tp_size) + self.tp_rank
 
     @property
     def pp_size_per_node(self) -> int:
@@ -279,25 +251,6 @@ class RankInfo:
     def pp_rank_per_node(self) -> int:
         """This rank's PP index *within* its node."""
         return self.pp_rank % self.pp_size_per_node
-
-    @property
-    def dp_size_per_node(self) -> int:
-        """Number of DP replicas co-located on a single node."""
-        model_config = self.model_config
-        return model_config.gpus_per_node // (self.pp_size_per_node * model_config.tp_size_per_node)
-
-    @property
-    def dp_rank_per_node(self) -> int:
-        """This rank's DP index *within* its node (non-DP-attention layout)."""
-        return self.dp_rank % self.dp_size_per_node
-
-    @property
-    def local_rank(self) -> int:
-        model_config = self.model_config
-        if model_config.enable_dp_attention:
-            return self.pp_rank_per_node * model_config.tp_size_per_node + self.tp_rank_per_node
-        return (self.dp_rank_per_node * self.pp_size_per_node + self.pp_rank_per_node) \
-               * model_config.tp_size_per_node + self.tp_rank_per_node
 
     @property
     def num_layers_per_pp_stage(self) -> int:
@@ -319,8 +272,9 @@ class RankInfo:
         """
         return (
             f"RankInfo(tp_rank={self.tp_rank}, pp_rank={self.pp_rank}"
-            f", dp_rank={self.dp_rank}, attn_cp_rank={self.attn_cp_rank}"
+            f", dp_rank={self.dp_rank}, cp_rank={self.cp_rank}"
             f", node_rank={self.node_rank}, instance_id={self.instance_id}"
+            f", local_rank={self.local_rank}, effective_tp_rank={self.effective_tp_rank}"
         )
 
 
@@ -676,6 +630,13 @@ def update_default_config_from_user_config(rank_info: RankInfo,
             f"[CacheConfig] GB->blocks conversion: "
             f"block_size={block_size_in_bytes} B"
         )
+
+    flexkv_logger.info(
+        f"[CacheConfig] GB->blocks conversion: "
+        f"block_size={block_size_in_bytes} B; "
+        f"cpu_cache_gb={user_config.cpu_cache_gb} -> num_cpu_blocks={cache_config.num_cpu_blocks}, "
+        f"ssd_cache_gb={user_config.ssd_cache_gb} -> num_ssd_blocks={cache_config.num_ssd_blocks}"
+    )
 
     cache_config.ssd_cache_dir = user_config.ssd_cache_dir
     cache_config.enable_ssd = user_config.ssd_cache_gb > 0

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -11,7 +11,7 @@ import torch
 
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.debug import flexkv_logger
-
+from flexkv.external.mooncake_store_keys import PoolSpec, PoolKind
 
 @dataclass
 class IndexerCacheConfig:
@@ -156,6 +156,7 @@ class ModelConfig:
     @property
     def tp_size_per_node(self) -> int:
         """Number of TP ranks on this node within one TP group."""
+        flexkv_logger.info(f"[Config] TP size per node: {self.tp_size} // {self.nnodes_per_tp_group}")
         return self.tp_size // self.nnodes_per_tp_group
 
     @property
@@ -173,11 +174,13 @@ class ModelConfig:
     @property
     def attn_tp_size_per_node(self) -> int:
         """Attention-level TP size per node."""
+        flexkv_logger.info(f"[Config] Attention-level TP size per node: {self.attn_tp_size} // {self.nnodes_per_tp_group}")
         return self.attn_tp_size // self.nnodes_per_tp_group
 
     @property
     def attn_cp_size_per_node(self) -> int:
         """Attention-level CP size on this node for a single pp stage. """
+        flexkv_logger.info(f"[Config] Attention-level CP size per node: {self.attn_cp_size} // {self.nnodes_per_pp_rank}")
         return max(1, self.attn_cp_size // self.nnodes_per_pp_rank)
 
     @property
@@ -188,6 +191,7 @@ class ModelConfig:
     @property
     def effective_tp_size_per_node(self) -> int:
         """Per-node counterpart of :pyattr:`effective_tp_size`."""
+        flexkv_logger.info(f"[Config] Effective tp-group size per node: {self.attn_tp_size_per_node} * {self.attn_cp_size_per_node}")
         return self.attn_tp_size_per_node * self.attn_cp_size_per_node
 
     @property
@@ -389,10 +393,33 @@ class CacheConfig:
     # Mooncake transfer engine config path (serialized via pickle to survive spawn subprocesses)
     mooncake_config_path: Optional[str] = None
 
+    # Mooncake-store distributed KV cache backend
+    # When True, mooncake-store replaces the CFS/PCFS remote backend.
+    # The store manages a global pool of CPU memory pinned for RDMA zero-copy.
+    use_mooncake_store_backend: bool = False
+    mooncake_store_config_path: Optional[str] = None  # Path to mooncake-store JSON config file
+    # PP isolation knobs: mooncake keys are partitioned by the *node-local*
+    # CPU pool layer range (see ``build_key``). pp_rank/pp_size identify
+    # the stage in cross-node deployments; node_layer_start/end describe
+    # which model-layer range this node's CPU pool covers; total_layers
+    # is the full model layer count.  Defaults are safe (no suffix) for
+    # PP==1 single-node case.
+    mooncake_store_pp_rank: int = 0
+    mooncake_store_pp_size: int = 1
+    mooncake_store_node_layer_start: int = 0
+    mooncake_store_node_layer_end: int = 0
+    mooncake_store_total_layers: int = 0
+
     def __post_init__(self):
         self.enable_kv_sharing = self.enable_p2p_cpu or \
             self.enable_p2p_ssd or self.enable_3rd_remote
         self.enable_remote = self.enable_3rd_remote
+        self.use_mooncake_store_backend = self.use_mooncake_store_backend or bool(os.getenv('FLEXKV_USE_MOONCAKE_STORE_BACKEND', 0))
+        if self.use_mooncake_store_backend:
+            if self.mooncake_store_config_path is None:
+                self.mooncake_store_config_path = os.getenv('FLEXKV_MOONCAKE_STORE_CONFIG_PATH', None)
+                if self.mooncake_store_config_path is None:
+                    raise ValueError(f"Mooncake store config file path not found in cache config or environment variable MOONCAKE_STORE_CONFIG_PATH")
 
     def __str__(self) -> str:
         return (
@@ -406,6 +433,16 @@ class CacheConfig:
             f", num_cpu_blocks={self.num_cpu_blocks}"
             f", num_ssd_blocks={self.num_ssd_blocks})"
         )
+    def enable_pool_specs(self) -> List[PoolSpec]:
+        """Return the pool specs that are actually active in this run.
+        The main KV pool is always present. Side-cars are appended in a
+        deterministic order so all components (worker creation, match
+        joint query, key-prefix builders) see the same list.
+        """
+        specs = [PoolSpec(PoolKind.KV)]
+        if self.indexer is not None:
+            specs.append(PoolSpec(PoolKind.INDEXER))
+        return specs
 
 GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     # Multi-instance configuration
@@ -419,6 +456,9 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     cpp_metrics_port=int(os.getenv('FLEXKV_CPP_METRICS_PORT', 8081)),
     ## Port for Python metrics HTTP server (default: 8080)
     py_metrics_port=int(os.getenv('FLEXKV_PY_METRICS_PORT', 8080)),
+
+    use_mooncake_store_backend=bool(int(os.getenv('FLEXKV_USE_MOONCAKE_STORE_BACKEND', 0))),
+    mooncake_store_config_path=os.getenv('FLEXKV_MOONCAKE_STORE_CONFIG_PATH', None),
 
     # Server-client mode configuration
     server_client_mode=bool(int(os.getenv('FLEXKV_SERVER_CLIENT_MODE', 0))),
@@ -490,6 +530,16 @@ class UserConfig:
     enable_p2p_ssd: bool = False
     enable_3rd_remote: bool = False
 
+    # Mooncake-store backend (distributed global KV cache pool)
+    use_mooncake_store_backend: bool = False
+    mooncake_store_config_path: Optional[str] = None  # Path to mooncake-store JSON config file
+    # PP isolation knobs (see CacheConfig for the suffix policy details).
+    mooncake_store_pp_rank: int = 0
+    mooncake_store_pp_size: int = 1
+    mooncake_store_node_layer_start: int = 0
+    mooncake_store_node_layer_end: int = 0
+    mooncake_store_total_layers: int = 0
+
     # distributed zmq configs
     local_zmq_ip: Optional[str] = None
     local_zmq_port: Optional[int] = None
@@ -558,8 +608,18 @@ def convert_to_block_num(size_in_GB: float, block_size_in_bytes: int) -> int:
 def update_default_config_from_user_config(rank_info: RankInfo,
                                            cache_config: CacheConfig,
                                            user_config: UserConfig) -> None:
+    # Block size (bytes) used to translate cpu_cache_gb / ssd_cache_gb
+    # into block counts. On single-node PP the CPU pool covers all PP stages
+    # on the node, so size each block with the full model layer count.
+    # Cross-node PP keeps rank-local PP-stage sizing.
+    if int(rank_info.model_config.nnodes) == 1:
+        layers_per_block = int(rank_info.model_config.num_layers)
+    else:
+        layers_per_block = int(rank_info.num_layers_per_pp_stage)
     main_block_size_in_bytes = (
-        rank_info.token_size_in_bytes_per_pp_stage * cache_config.tokens_per_block
+        layers_per_block
+        * rank_info.model_config.bytes_per_token_per_layer
+        * cache_config.tokens_per_block
     )
     indexer_block_size_in_bytes = 0
     if cache_config.indexer is not None:
@@ -574,7 +634,7 @@ def update_default_config_from_user_config(rank_info: RankInfo,
             * indexer_cfg.dtype.itemsize
         )
         indexer_block_size_in_bytes = (
-            rank_info.num_layers_per_pp_stage
+            layers_per_block
             * indexer_bytes_per_token_per_layer
         )
     block_size_in_bytes = main_block_size_in_bytes + indexer_block_size_in_bytes
@@ -628,11 +688,46 @@ def update_default_config_from_user_config(rank_info: RankInfo,
     cache_config.enable_p2p_ssd = user_config.enable_p2p_ssd
     cache_config.enable_3rd_remote = user_config.enable_3rd_remote
 
+    # Propagate mooncake-store backend settings
+    cache_config.use_mooncake_store_backend = user_config.use_mooncake_store_backend
+    cache_config.mooncake_store_config_path = user_config.mooncake_store_config_path
+
+    # PP isolation: forward this rank's pp_rank / pp_size onto cache_config
+    # for cross-node PP key suffix.  total_layers (full model layer count)
+    # also flows through here.  node_layer_start/end describe the per-node
+    # CPU pool layer range and are NOT known yet at this point ��� they get
+    # populated later by transfer_manager once all GPU registrations have
+    # arrived (gpu_pp_start_layer_mapping is complete).  See
+    # transfer_manager.py around the node_min_pp_start_layer block.
+    cache_config.mooncake_store_pp_rank = int(rank_info.pp_rank)
+    cache_config.mooncake_store_pp_size = int(rank_info.model_config.pp_size)
+    cache_config.mooncake_store_total_layers = int(rank_info.model_config.num_layers)
+
+    # Single-node deployment: the per-node CPU pool always covers the FULL
+    # model layer set regardless of pp_size, so we can resolve
+    # node_layer_start/end up-front here.  This is critical for the match
+    # path: GlobalCacheEngine creates MooncakeStoreCacheEngine in the parent
+    # process at construction time and snapshots these fields, so any later
+    # write-back from the TransferManager subprocess never reaches the
+    # parent.  Pre-populating here keeps the match path consistent with the
+    # worker (subprocess) path for single-node deployments.
+    #
+    # Cross-node PP is the only case where a node holds *part* of the model:
+    # leave node_layer_start/end at their defaults (0, 0) so transfer_manager
+    # later overwrites them inside the subprocess.  Match-side correctness
+    # for that case is a separate concern (the parent process still snapshots
+    # 0/0 and falls into the cross-node branch by sticking the
+    # _pp_rank_<i>_of_<N> suffix, which is the right behavior for cross-node
+    # PP).
+    if int(rank_info.model_config.nnodes) == 1:
+        cache_config.mooncake_store_node_layer_start = 0
+        cache_config.mooncake_store_node_layer_end = int(rank_info.model_config.num_layers)
+
     # Update derived flags after setting p2p and remote configs
     cache_config.enable_kv_sharing = (cache_config.enable_p2p_cpu or
                                       cache_config.enable_p2p_ssd or
                                       cache_config.enable_3rd_remote)
-    cache_config.enable_remote = cache_config.enable_3rd_remote
+    cache_config.enable_remote = cache_config.enable_3rd_remote or cache_config.use_mooncake_store_backend
 
     if cache_config.num_ssd_blocks % len(cache_config.ssd_cache_dir) != 0:
         cache_config.num_ssd_blocks = \
@@ -642,7 +737,8 @@ def update_default_config_from_user_config(rank_info: RankInfo,
 
     if not cache_config.enable_cpu:
         raise ValueError("enable_cpu must be True")
-    if cache_config.enable_remote and not cache_config.enable_ssd:
+    if (cache_config.enable_remote and not cache_config.enable_ssd
+            and not cache_config.use_mooncake_store_backend):
         raise ValueError("enable_ssd must be True if enable_remote is True")
     if not cache_config.enable_cpu and not cache_config.enable_gds:
         raise ValueError("enable_gds must be True if enable_cpu is False")
@@ -653,7 +749,7 @@ def update_default_config_from_user_config(rank_info: RankInfo,
             "enable_kv_sharing and enable_gds cannot be used at the same time"
         )
 
-    if cache_config.enable_remote:
+    if cache_config.enable_remote and not cache_config.use_mooncake_store_backend:
         if cache_config.remote_cache_path is None:
             if cache_config.remote_file_prefix is None:
                 raise ValueError(

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -153,6 +153,16 @@ class ModelConfig:
         return max(1, self.cp_size // self.nnodes_per_pp_rank)
 
     @property
+    def attn_tp_size(self) -> int:
+        """Compatibility alias for integrations that still use attn_* names."""
+        return self.tp_size
+
+    @property
+    def attn_cp_size(self) -> int:
+        """Compatibility alias for integrations that still use attn_* names."""
+        return self.cp_size
+
+    @property
     def effective_tp_size(self) -> int:
         """Number of CPU block slices = tp_size × cp_size."""
         return max(1, self.tp_size) * max(1, self.cp_size)
@@ -213,6 +223,16 @@ class RankInfo:
     def tp_rank_per_node(self) -> int:
         """TP rank index within the local node (within one TP group)."""
         return self.tp_rank % self.model_config.tp_size_per_node
+
+    @property
+    def attn_tp_rank(self) -> int:
+        """Compatibility alias for integrations that still use attn_* names."""
+        return self.tp_rank
+
+    @property
+    def attn_cp_rank(self) -> int:
+        """Compatibility alias for integrations that still use attn_* names."""
+        return self.cp_rank
 
     @property
     def dp_client_id(self) -> int:

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -107,6 +107,9 @@ class TransferOp:
     # used for distributed cpu and ssd
     src_block_node_ids: Optional[np.ndarray] = None
     pending_count: int = 0
+    # Block content hashes for mooncake-store key-based addressing.
+    # Each element corresponds to one block in src_block_ids / dst_block_ids.
+    mooncake_store_block_hashes: Optional[np.ndarray] = None
 
     def __post_init__(self) -> None:
         if self.transfer_type != TransferType.VIRTUAL and \
@@ -407,6 +410,46 @@ def _merge_ops(ops: List[TransferOp], transfer_type: TransferType,
     return merged_op
 
 
+
+def _merge_remote2h_ops(ops, transfer_type, graph, callbacks, op_callback_dict):
+    """REMOTE2H/H2REMOTE merge support — preserves the extra fields that the
+    plain ``_merge_ops`` would drop:
+      * ``mooncake_store_block_hashes`` (used by mooncake-store worker to
+        build per-block keys via build_key)
+      * ``src_block_node_ids``           (used by PCFS / multi-host workers)
+
+    The merge is a straight concatenation, mirroring the SIMM-branch design.
+    """
+    if not ops:
+        return None
+    src_blocks = np.concatenate([op.src_block_ids for op in ops])
+    dst_blocks = np.concatenate([op.dst_block_ids for op in ops])
+    mooncake_hashes = None
+    if all(op.mooncake_store_block_hashes is not None for op in ops):
+        mooncake_hashes = np.concatenate(
+            [op.mooncake_store_block_hashes for op in ops]
+        )
+    src_node_ids = None
+    if all(getattr(op, "src_block_node_ids", None) is not None for op in ops):
+        src_node_ids = np.concatenate([op.src_block_node_ids for op in ops])
+
+    merged_op = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=transfer_type,
+        src_block_ids=src_blocks,
+        dst_block_ids=dst_blocks,
+        dp_client_id=ops[0].dp_client_id,
+        src_block_node_ids=src_node_ids,
+        mooncake_store_block_hashes=mooncake_hashes,
+    )
+    if callbacks:
+        if len(callbacks) == 1:
+            op_callback_dict[merged_op.op_id] = callbacks[0]
+        else:
+            op_callback_dict[merged_op.op_id] = _make_combined_callback(callbacks)
+    return merged_op
+
+
 def merge_to_batch_graph(batch_id: int,
                          transfer_graphs: List[TransferOpGraph],
                          task_end_op_ids: List[int],
@@ -441,8 +484,11 @@ def merge_to_batch_graph(batch_id: int,
 
     ops_by_type: Dict[TransferType, List[TransferOp]] = {}
     callbacks_by_type: Dict[TransferType, List[Callable]] = {}
+    # REMOTE2H/H2REMOTE merge support: both directions of the
+    # mooncake-store sidecar pool participate in the batch.
     supported_types = {TransferType.DISK2H, TransferType.H2D,
-                       TransferType.D2H, TransferType.H2DISK}
+                       TransferType.D2H, TransferType.H2DISK,
+                       TransferType.REMOTE2H, TransferType.H2REMOTE}
 
     for tt in supported_types:
         ops_by_type[tt] = []
@@ -455,7 +501,7 @@ def merge_to_batch_graph(batch_id: int,
             if op.transfer_type not in supported_types:
                 raise NotImplementedError(
                     f"Batch merge does not support transfer type: {op.transfer_type}. "
-                    f"Only DISK2H, H2D, D2H, and H2DISK are supported."
+                    f"Only DISK2H, H2D, D2H, H2DISK, REMOTE2H, and H2REMOTE are supported."
                 )
             ops_by_type[op.transfer_type].append(op)
             if op.op_id in op_callback_dict:
@@ -463,13 +509,28 @@ def merge_to_batch_graph(batch_id: int,
 
     new_op_callback_dict: Dict[int, Callable] = {}
 
-    # GET path: DISK2H -> H2D
+    # GET path: REMOTE2H (optional) + DISK2H (optional) -> H2D
     merged_disk2h_op = _merge_ops(ops_by_type[TransferType.DISK2H], TransferType.DISK2H,
                                   merged_graph, callbacks_by_type[TransferType.DISK2H], new_op_callback_dict)
     merged_h2d_op = _merge_ops(ops_by_type[TransferType.H2D], TransferType.H2D,
                                merged_graph, callbacks_by_type[TransferType.H2D], new_op_callback_dict)
+    # REMOTE2H needs the specialised merger to keep mooncake hashes /
+    # node ids. The op is not yet attached to the graph; caller branches
+    # below decide when to add it.
+    merged_remote2h_op = _merge_remote2h_ops(
+        ops_by_type[TransferType.REMOTE2H], TransferType.REMOTE2H,
+        merged_graph, callbacks_by_type[TransferType.REMOTE2H], new_op_callback_dict,
+    )
 
     if layerwise_transfer:
+        # REMOTE2H/H2REMOTE merge support (layerwise path): REMOTE2H is an
+        # *external* pre-stage to the C++ layerwise pipeline. We attach
+        # it as a standalone graph node and make the LayerwiseTransferOp
+        # depend on it. This keeps the C++ fused worker unchanged while
+        # guaranteeing that the mooncake prefix is in CPU buffer before
+        # the first layer fires its eventfd.
+        if merged_remote2h_op is not None:
+            merged_graph.add_transfer_op(merged_remote2h_op)
         if merged_h2d_op is not None:
             layerwise_transfer_op = LayerwiseTransferOp(
                 graph_id=merged_graph.graph_id,
@@ -489,6 +550,12 @@ def merge_to_batch_graph(batch_id: int,
                 indexer_dst_block_ids=merged_h2d_op.dst_block_ids.copy(),
             )
             merged_graph.add_transfer_op(layerwise_transfer_op)
+            # REMOTE2H/H2REMOTE merge support: gate the layerwise op on
+            # the REMOTE2H prefetch finishing (CPU buffer fully populated).
+            if merged_remote2h_op is not None:
+                merged_graph.add_dependency(
+                    layerwise_transfer_op.op_id, merged_remote2h_op.op_id,
+                )
         batch_end_op_id = -1
         new_op_callback_dict.clear()
     else:
@@ -498,24 +565,50 @@ def merge_to_batch_graph(batch_id: int,
             merged_graph.add_transfer_op(merged_h2d_op)
         if merged_disk2h_op is not None and merged_h2d_op is not None:
             merged_graph.add_dependency(merged_h2d_op.op_id, merged_disk2h_op.op_id)
+        # REMOTE2H/H2REMOTE merge support (non-layerwise GET): attach
+        # REMOTE2H and gate H2D on it (mirrors the SIMM-branch design).
+        if merged_remote2h_op is not None:
+            merged_graph.add_transfer_op(merged_remote2h_op)
+            if merged_h2d_op is not None:
+                merged_graph.add_dependency(
+                    merged_h2d_op.op_id, merged_remote2h_op.op_id,
+                )
 
         # PUT path: D2H -> H2DISK
         merged_d2h_op = _merge_ops(ops_by_type[TransferType.D2H], TransferType.D2H,
                                    merged_graph, callbacks_by_type[TransferType.D2H], new_op_callback_dict)
         merged_h2disk_op = _merge_ops(ops_by_type[TransferType.H2DISK], TransferType.H2DISK,
                                       merged_graph, callbacks_by_type[TransferType.H2DISK], new_op_callback_dict)
+        # REMOTE2H/H2REMOTE merge support (PUT path): merge H2REMOTE with
+        # the specialised merger to preserve mooncake hashes.
+        merged_h2remote_op = _merge_remote2h_ops(
+            ops_by_type[TransferType.H2REMOTE], TransferType.H2REMOTE,
+            merged_graph, callbacks_by_type[TransferType.H2REMOTE], new_op_callback_dict,
+        )
         if merged_d2h_op is not None:
             merged_graph.add_transfer_op(merged_d2h_op)
         if merged_h2disk_op is not None:
             merged_graph.add_transfer_op(merged_h2disk_op)
         if merged_d2h_op is not None and merged_h2disk_op is not None:
             merged_graph.add_dependency(merged_h2disk_op.op_id, merged_d2h_op.op_id)
+        if merged_h2remote_op is not None:
+            merged_graph.add_transfer_op(merged_h2remote_op)
+            if merged_d2h_op is not None:
+                merged_graph.add_dependency(
+                    merged_h2remote_op.op_id, merged_d2h_op.op_id,
+                )
 
-        # batch_end_op_id: GET: H2D > DISK2H; PUT: H2DISK > D2H
+        # batch_end_op_id (REMOTE2H/H2REMOTE merge support):
+        #   GET: H2D > REMOTE2H > DISK2H
+        #   PUT: H2REMOTE > H2DISK > D2H
         if merged_h2d_op is not None:
             batch_end_op_id = merged_h2d_op.op_id
+        elif merged_remote2h_op is not None:
+            batch_end_op_id = merged_remote2h_op.op_id
         elif merged_disk2h_op is not None:
             batch_end_op_id = merged_disk2h_op.op_id
+        elif merged_h2remote_op is not None:
+            batch_end_op_id = merged_h2remote_op.op_id
         elif merged_h2disk_op is not None:
             batch_end_op_id = merged_h2disk_op.op_id
         elif merged_d2h_op is not None:

--- a/flexkv/external/__init__.py
+++ b/flexkv/external/__init__.py
@@ -1,0 +1,14 @@
+# External backend adapters for FlexKV.
+# Currently provides the mooncake-store distributed KV cache backend.
+from flexkv.external.mooncake_store_utils import (
+    MooncakeStoreConfig,
+    MooncakeStoreClient,
+    MooncakeStoreCacheEngine,
+)
+
+__all__ = ["MooncakeStoreConfig", "MooncakeStoreClient", "MooncakeStoreCacheEngine"]
+def __getattr__(name):
+    if name in __all__:
+        from . import mooncake_store_utils as _m
+        return getattr(_m, name)
+    raise AttributeError(name)

--- a/flexkv/external/mooncake_store_keys.py
+++ b/flexkv/external/mooncake_store_keys.py
@@ -1,0 +1,74 @@
+"""
+mooncake_store_keys.py
+----------------------
+Single source of truth for Mooncake-store key suffixes used across the
+FlexKV ↔ mooncake-store integration.
+
+Two suffixes are defined:
+
+* ``KV_SUFFIX``       – full KV-cache blocks (default FlexKV traffic).
+* ``INDEXER_SUFFIX``  – DSA indexer side-car blocks (one per main KV
+  block, identical block-id namespace, separate Mooncake worker).
+
+A helper ``build_key(block_hash, suffix)`` is provided to make the
+key-construction explicit at call sites.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Dict
+
+
+class PoolKind(str, Enum):
+    KV = "FlexKV"
+    INDEXER = "FlexKV_indexer"
+    SWA = "FlexKV_swa"
+
+@dataclass(frozen=True)
+class PoolSpec:
+    kind: PoolKind
+    required_for_hit: bool = True
+
+def build_key(
+    block_hash: Union[int, str],
+    kind: PoolKind,
+    pp_rank: int = 0,
+    pp_size: int = 1,
+    node_layer_start: int = 0,
+    node_layer_end: int = 0,
+    total_layers: int = 0,
+) -> str:
+    """Build a Mooncake-store key from a block hash and a pool kind.
+
+    Key suffix policy (driven by the *node-local* CPU pool layer range):
+
+    * Single-node deployment (any ``pp_size``): the per-node CPU pool covers
+      the *full* model layer set, so the on-the-wire block is bitwise
+      identical to a PP=1 deployment's block. No suffix is appended,
+      letting single-node PP=1 / PP=2 / PP=4 instances share keys and
+      hit each other's cache.
+
+    * Cross-node PP (node only holds part of the model): suffix is
+      ``_pp_rank_<i>_of_<N>`` so that different PP topologies (e.g.
+      2-node PP=2 vs 4-node PP=4) do NOT alias each other ��� their
+      per-node layer slices have different lengths and would yield
+      bitwise-incompatible blocks under the same key.
+
+    Determination of "single-node" is done from the *layer range* the
+    node's CPU pool covers, not from ``pp_size`` directly, because
+    single-node PP>1 deployments still get a full-model CPU pool
+    (see PR #171 / ``num_layers_on_node`` in ``transfer_manager.py``).
+    """
+    base = f"{block_hash}_{kind.value}"
+    # Case 1: node CPU pool covers the entire model -> no suffix.
+    # ``total_layers == 0`` defends pre-PR call sites that didn't pass
+    # the new fields; in that case fall through to the legacy logic.
+    if total_layers > 0 and (node_layer_end - node_layer_start) == total_layers:
+        return base
+    # Case 2: cross-node PP -> per-stage suffix carrying the topology.
+    if pp_size > 1:
+        return f"{base}_pp_rank_{pp_rank}_of_{pp_size}"
+    return base

--- a/flexkv/external/mooncake_store_utils.py
+++ b/flexkv/external/mooncake_store_utils.py
@@ -106,11 +106,15 @@ class MooncakeStoreConfig:
             )
         with open(file_path, "r") as f:
             config = json.load(f)
-
+            
         global_segment_size = (
             override_global_segment_size
             if override_global_segment_size is not None
-            else config["global_segment_size"]
+            else config["global_segment_size"] * 1024 * 1024 * 1024
+        )
+        flexkv_logger.info(
+            "[MooncakeStoreConfig] global_segment_size for mooncake store is: %d GB",
+            global_segment_size / 1024 / 1024 / 1024,
         )
 
         return cls(

--- a/flexkv/external/mooncake_store_utils.py
+++ b/flexkv/external/mooncake_store_utils.py
@@ -1,0 +1,647 @@
+"""
+mooncake_store_utils.py
+-----------------------
+Adapter layer that connects FlexKV to the mooncake-store distributed KV
+cache pool (``mooncake.store.MooncakeDistributedStore``).
+
+Three public objects are exposed:
+
+* ``MooncakeStoreConfig``  – plain config dataclass (mirrors ``CacheConfig``
+  mooncake-store fields so the worker needs only one argument).
+* ``MooncakeStoreClient`` – thin wrapper around
+  ``MooncakeDistributedStore`` with FlexKV-friendly helpers.
+* ``MooncakeStoreCacheEngine`` – presents a ``match()`` / ``insert()``
+  interface compatible with ``CacheEngineAccel`` so it can be used as
+  ``remote_cache_engine`` inside the ``KVCacheManager`` factory.
+"""
+
+from __future__ import annotations
+
+from gc import enable
+import os
+from dataclasses import dataclass, field
+from typing import Optional, Set, Union, Any, List, TYPE_CHECKING
+
+import time
+import json
+import torch
+import requests
+import uuid
+import numpy as np
+
+from flexkv.common.block import SequenceMeta
+from flexkv.common.debug import flexkv_logger
+from flexkv.common.type import MatchResultAccel
+
+# from flexkv.common.config import CacheConfig
+from flexkv.external.mooncake_store_keys import build_key
+
+if TYPE_CHECKING:
+    from flexkv.common.config import CacheConfig
+
+DEFAULT_LOCAL_BUFFER_SIZE = 16 * 1024 * 1024  # 16 MB
+SETUP_TIMEOUT = 600
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MooncakeStoreConfig:
+    """All settings required to initialise a ``MooncakeDistributedStore``."""
+
+    master_addr: str = (
+        ""  # Address of the Mooncake master / etcd endpoint, e.g. "192.168.1.1:2379".
+    )
+
+    metadata_server: str = (
+        "P2PHANDSHAKE"  # Metadata server type string passed to the store SDK.
+    )
+
+    protocol: str = "rdma"  # Transport protocol: "rdma" or "tcp".
+
+    device_name: str = (
+        ""  # RDMA device name, e.g. "mlx5_0". Empty string means auto-select.
+    )
+
+    local_hostname: str = ""  # Local IP or hostname for RDMA buffer registration.
+
+    global_segment_size: int = (
+        256 * 1024 * 1024 * 1024
+    )  # Size (bytes) of the memory segment registered with the store. Default 256 GiB.
+
+    enable_ssd_offload: bool = False  # Enable SSD offload.
+
+    ssd_offload_path: Optional[str] = None  # SSD offload path.
+    
+    master_metrics_port: int = 9003  # Master metrics port.
+
+    @classmethod
+    def from_file(
+        cls, cache_config, override_global_segment_size: Optional[int] = None
+    ) -> "MooncakeStoreConfig":
+        """Load MooncakeStoreConfig from JSON file.
+
+        Parameters
+        ----------
+        cache_config:
+            FlexKV CacheConfig instance (used to locate the config file path).
+        override_global_segment_size:
+            If provided, overrides the ``global_segment_size`` from the JSON file.
+            Use ``0`` to create a *pure-client* instance that does NOT contribute
+            any segment to the cluster pool.  This is useful for sidecar workers
+            (e.g. indexer) which only need to read/write data into pre-registered
+            buffers and do not need their own storage segment.
+        """
+        file_path = getattr(cache_config, "mooncake_store_config_path", None)
+        if file_path is None:
+            file_path = os.getenv("FLEXKV_MOONCAKE_STORE_CONFIG_PATH", None)
+            if file_path is None:
+                raise ValueError(
+                    f"Mooncake store config file path not found in cache config or environment variable MOONCAKE_STORE_CONFIG_PATH"
+                )
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(
+                f"Mooncake store config file not found: {file_path}"
+            )
+        with open(file_path, "r") as f:
+            config = json.load(f)
+
+        global_segment_size = (
+            override_global_segment_size
+            if override_global_segment_size is not None
+            else config["global_segment_size"]
+        )
+
+        return cls(
+            master_addr=config["master_addr"],
+            metadata_server=config["metadata_server"],
+            protocol=config["protocol"],
+            device_name=config["device_name"],
+            local_hostname=config["local_hostname"],
+            global_segment_size=global_segment_size,
+            enable_ssd_offload=config["enable_ssd_offload"],
+            ssd_offload_path=config["ssd_offload_path"],
+            master_metrics_port=config["master_metrics_port"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class MooncakeStoreClient:
+    """
+    Thin wrapper around ``mooncake.store.MooncakeDistributedStore`` that adds
+    FlexKV-specific helpers (register_buffer, batch_put, batch_get, batch_exists).
+
+    The underlying store object is lazily created on first use to allow
+    pickling of the config across process boundaries.
+    """
+
+    def __init__(self, config: MooncakeStoreConfig, query_only: bool = False) -> None:
+        self._config = config
+        self._store = None  # created lazily in setup()
+        self._is_setup = False
+        self._query_only = query_only
+        self.setup()
+        print("client setup done")
+        if not self._query_only:
+            self.check_server()
+            print("client check server done")
+        if not self._query_only:
+            # only warm up when not in query only mode
+            self.warm_up()
+
+    def setup(self) -> None:
+        """Initialise the underlying MooncakeDistributedStore.
+
+        Must be called once in the worker process *before* any put/get.
+        Importing ``mooncake.store`` is deferred here so that processes that
+        do not use the backend are not affected by the import cost.
+        """
+        if self._is_setup:
+            return
+        try:
+            from mooncake.store import MooncakeDistributedStore  # type: ignore[import]
+        except ImportError as exc:
+            raise ImportError(
+                "mooncake-store Python SDK not found. "
+                "Install it with: pip install mooncake-store"
+            ) from exc
+
+        cfg = self._config
+        protocol = "rpc_only" if self._query_only else cfg.protocol
+        global_segment_size = 0 if self._query_only else cfg.global_segment_size
+        local_segment_size = 0 if self._query_only else DEFAULT_LOCAL_BUFFER_SIZE
+        self._store = MooncakeDistributedStore()
+        ret_code = self._store.setup(
+            cfg.local_hostname,  # 1: client_hostname
+            cfg.metadata_server,  # 2: metadata_server
+            global_segment_size,  # 3: global_segment_size
+            local_segment_size,  # 4: local_buffer_size (16 MB SDK buffer)
+            protocol,  # 5: protocol
+            cfg.device_name,  # 6: device_name
+            cfg.master_addr,  # 7: master_server_address
+            # cfg.enable_ssd_offload,       # 8: enable ssd offload
+            # cfg.ssd_offload_path,         # 9: ssd offload path
+        )
+        if ret_code:
+            raise RuntimeError(
+                f"[MooncakeStoreClient] MooncakeDistributedStore.setup() failed "
+                f"with error code: {ret_code}"
+            )
+        self._is_setup = True
+        flexkv_logger.info(
+            "[MooncakeStoreClient] Store initialised: "
+            f"master_addr={cfg.master_addr}, protocol={protocol}"
+        )
+
+    def check_server(self) -> None:
+        master_server_ip = self._config.master_addr.split(":")[0]
+        segments_url = f"http://{master_server_ip}:{self._config.master_metrics_port}/get_all_segments"
+        # Segment providers mount their own pool; only pure clients must wait for
+        # an existing segment to show up in the master metrics endpoint.
+        require_existing_segments = self._config.global_segment_size == 0
+
+        start_time = time.perf_counter()
+        check_result = False
+        while time.perf_counter() - start_time < SETUP_TIMEOUT:
+            try:
+                check_segments_resp = requests.get(segments_url, timeout=3)
+            except Exception:
+                flexkv_logger.info(
+                    "[MooncakeStoreClient] waiting mooncake store server started, cost_time: %.2f seconds.",
+                    time.perf_counter() - start_time,
+                )
+                time.sleep(3)
+                continue
+
+            if require_existing_segments and check_segments_resp.text == "":
+                flexkv_logger.info(
+                    "[MooncakeStoreClient] waiting mooncake store server started, cost_time: %.2f seconds.",
+                    time.perf_counter() - start_time,
+                )
+                time.sleep(3)
+                continue
+
+            flexkv_logger.info(
+                "[MooncakeStoreClient] Mooncake store server started successfully."
+            )
+            check_result = True
+            break
+
+        if not check_result:
+            flexkv_logger.error(
+                "[MooncakeStoreClient] Launch mooncake store server timeout"
+            )
+            raise ValueError(
+                "[MooncakeStoreClient] Launch mooncake store server timeout"
+            )
+
+    def warm_up(self):
+        flexkv_logger.info(
+            "[MooncakeStoreClient] Warmup the mooncake store server by writing a 4KB warmup value to the store."
+        )
+        warmup_key = "flexkv_mooncake_store_warmup_key" + uuid.uuid4().hex
+        warmup_value = bytes(4 * 1024)  # 4 KB
+        # Retry logic to handle Transfer Engine startup race condition
+        max_retries = 10
+        retry_delay = 1.0  # seconds
+        for attempt in range(max_retries):
+            ret = self._store.put(warmup_key, warmup_value)
+            if ret == 0:
+                break
+            flexkv_logger.warning(
+                f"[MooncakeStoreClient] Warmup put failed (attempt {attempt + 1}/{max_retries}), "
+                f"ret={ret}, retrying in {retry_delay}s..."
+            )
+            time.sleep(retry_delay)
+        else:
+            raise RuntimeError(
+                f"[MooncakeStoreClient] Warmup put failed after {max_retries} attempts, "
+                "Transfer Engine might not be ready"
+            )
+
+        assert (
+            self._store.is_exist(warmup_key) == 1
+        ), "[MooncakeStoreClient] Warmup put failed"
+        assert (
+            self._store.get(warmup_key) == warmup_value
+        ), "[MooncakeStoreClient] Warmup get failed"
+
+    def register_buffer(
+        self,
+        tensor_or_ptr: "Union[torch.Tensor, int]",  # ensure the params type
+        size: int = 0,
+    ) -> None:
+        """Register a pinned CPU tensor (or raw ptr + size) with the store for zero-copy RDMA.
+
+        Parameters
+        ----------
+        tensor_or_ptr:
+            Either a ``torch.Tensor`` (ptr and size are derived automatically)
+            or a raw integer pointer (``size`` must be provided).
+        size:
+            Byte size of the region.  Ignored when ``tensor_or_ptr`` is a tensor.
+        """
+        self._ensure_setup()
+        # TODO: we should ensure the tensor is BLOCKFIRST aligned
+        # assert
+        if isinstance(tensor_or_ptr, torch.Tensor):
+            ptr: int = tensor_or_ptr.data_ptr()
+            size = tensor_or_ptr.numel() * tensor_or_ptr.element_size()
+        else:
+            ptr = int(tensor_or_ptr)
+        ret_code = self._store.register_buffer(ptr, size)
+        if ret_code != 0:
+            flexkv_logger.error(
+                f"[MooncakeStoreClient] register_buffer failed with error code: {ret_code}"
+            )
+            raise RuntimeError(
+                f"[MooncakeStoreClient] register_buffer failed "
+                f"with error code: {ret_code}"
+            )
+        flexkv_logger.info(
+            f"[MooncakeStoreClient] Registered buffer ptr=0x{ptr:x} size={size}"
+        )
+
+    def unregister_buffer(self, buffer_or_ptr: Union[torch.Tensor, int]) -> None:
+        """Unregister a buffer from the store."""
+        self._ensure_setup()
+        if isinstance(buffer_or_ptr, torch.Tensor):
+            ptr = buffer_or_ptr.data_ptr()
+        else:
+            ptr = int(buffer_or_ptr)
+        ret_code = self._store.unregister_buffer(ptr)
+        if ret_code != 0:
+            flexkv_logger.error(
+                f"[MooncakeStoreClient] unregister_buffer failed with error code: {ret_code}"
+            )
+            raise RuntimeError(
+                f"[MooncakeStoreClient] unregister_buffer failed "
+                f"with error code: {ret_code}"
+            )
+        flexkv_logger.info(f"[MooncakeStoreClient] Unregistered buffer ptr=0x{ptr:x}")
+
+    def put(self, key: str, buffer_ptr: int, buffer_size: int) -> bool:
+        """Write a KV block to the store."""
+        self._ensure_setup()
+        assert (
+            buffer_ptr is not None and buffer_size is not None
+        ), "[MooncakeStoreClient] buffer_ptr and buffer_size must be provided"
+        exist_result = self.batch_exists([key])
+        if exist_result == 1:
+            flexkv_logger.info(
+                f"[MooncakeStoreClient] key {key} already exists, skip put"
+            )
+            return True
+        ret_code = self._store.batch_put_from([key], [buffer_ptr], [buffer_size])
+
+        return ret_code == 0
+
+    def batch_put(
+        self,
+        key_strs: list[str],
+        buffer_ptrs: list[int],
+        buffer_sizes: list[int],
+    ) -> List[bool]:
+        assert buffer_ptrs is not None and buffer_sizes is not None
+        assert len(key_strs) == len(buffer_ptrs) == len(buffer_sizes)
+
+        exist_results = self.batch_exists_impl(key_strs)
+
+        set_keys = []
+        set_buffer_ptrs = []
+        set_buffer_sizes = []
+        set_indices = []
+        set_results = [-1] * len(key_strs)
+        total_size = 0
+        for i in range(len(key_strs)):
+            if exist_results[i] != 1:
+                set_keys.append(key_strs[i])
+                set_buffer_ptrs.append(buffer_ptrs[i])
+                set_buffer_sizes.append(buffer_sizes[i])
+                set_indices.append(i)
+                total_size += buffer_sizes[i]
+            else:
+                set_results[i] = 0
+
+        if len(set_keys) > 0:
+            start_time = time.perf_counter()
+            put_results = self.zero_copy_put_impl(
+                set_keys, set_buffer_ptrs, set_buffer_sizes
+            )
+            end_time = time.perf_counter()
+            flexkv_logger.info(
+                f"[MooncakeStoreClient] batch_put: "
+                f"{len(set_keys)} keys put in {end_time - start_time:.2f} seconds"
+            )
+            for i in range(len(set_indices)):
+                set_results[set_indices[i]] = put_results[i]
+        return self._check_success(set_results, is_set_operate=True)
+
+    def get(self, key: str, buffer_ptr: int, buffer_size: int) -> bool:
+        """Read a KV block from the store."""
+        self._ensure_setup()
+        assert buffer_ptr is not None and buffer_size is not None
+        ret_code = self._store.batch_get_into([key], [buffer_ptr], [buffer_size])
+        return ret_code[0] >= 0
+
+    def batch_get(
+        self,
+        key_strs: list[str],
+        buffer_ptrs: list[int],
+        buffer_sizes: list[int],
+    ) -> List[bool]:
+        """Read multiple KV blocks from the store in one call."""
+        self._ensure_setup()
+        get_results = self.zero_copy_get_impl(key_strs, buffer_ptrs, buffer_sizes)
+        return self._check_success(get_results, is_set_operate=False)
+
+    def batch_exists(self, keys_strs: list[str]) -> int:
+        """
+        Check existence of multiple keys in the store.
+        Returns:
+            int: longest prefix of keys that exist in the store.
+        """
+        self._ensure_setup()
+        exit_results = self.batch_exists_impl(keys_strs)
+        flexkv_logger.info(f"[MooncakeStoreClient] batch_exists: {exit_results}")
+        for i in range(len(keys_strs)):
+            if exit_results[i] != 1:
+                return i
+
+        return len(keys_strs)
+
+    def exists(self, key: str) -> bool:
+        """Check existence of a key in the store."""
+        self._ensure_setup()
+        result = self._store._batch_exist([key])
+        return result[0] == 1
+
+    def zero_copy_put_impl(
+        self, keys_strs: list[str], buffer_ptrs: list[int], buffer_sizes: list[int]
+    ) -> List[int]:
+        """Write multiple KV blocks to the store in one call."""
+        return self._store.batch_put_from(keys_strs, buffer_ptrs, buffer_sizes)
+
+    def zero_copy_get_impl(
+        self, keys_strs: list[str], buffer_ptrs: list[int], buffer_sizes: list[int]
+    ) -> List[int]:
+        """Read multiple KV blocks from the store in one call."""
+        return self._store.batch_get_into(keys_strs, buffer_ptrs, buffer_sizes)
+
+    def batch_exists_impl(self, keys_strs: list[str]) -> List[int]:
+        """Check existence of multiple keys in the store.
+        Returns:
+            List[int]: per-key raw status codes from the SDK.
+                1  = key exists,
+                0  = key not found,
+                -1 = store error.
+        """
+        return self._store.batch_is_exist(keys_strs)
+
+    def _check_success(self, results: List[int], is_set_operate: bool) -> List[bool]:
+        # put: success when return == 0; get: success when return > 0 (bytes read)
+        return [k_res == 0 if is_set_operate else k_res > 0 for k_res in results]
+
+    def _ensure_setup(self) -> None:
+        if not self._is_setup:
+            raise RuntimeError(
+                "MooncakeStoreClient.setup() must be called before any I/O. "
+                "Call setup() inside the worker process after forking."
+            )
+
+    def clear(self) -> None:
+        """Clear the store."""
+        self._ensure_setup()
+        self._store.remove_all()
+
+
+# ---------------------------------------------------------------------------
+# Cache engine
+# ---------------------------------------------------------------------------
+
+
+class _MooncakeStoreDummyNode:
+    """Placeholder node for MooncakeStoreCacheEngine.insert(); unlock/set_ready are no-ops."""
+
+    def size(self) -> int:
+        return 0
+
+
+class MooncakeStoreCacheEngine:
+    """
+    Presents the same ``match()`` / ``insert()`` interface as
+    ``CacheEngineAccel`` so that it can be dropped in as
+    ``KVCacheManager.remote_cache_engine``.
+
+    """
+
+    # Special sentinel returned in matched_pos so the GET path can branch.
+    MATCHED_POS = "global"
+
+    def __init__(
+        self,
+        cache_config: CacheConfig,
+    ) -> None:
+        self.tokens_per_block = cache_config.tokens_per_block
+        # PP isolation + layer-range key suffix; see ``build_key`` docstring.
+        # Single source of truth = cache_config (filled by
+        # update_default_config_from_user_config + transfer_manager).
+        self.pp_rank = int(getattr(cache_config, "mooncake_store_pp_rank", 0) or 0)
+        self.pp_size = int(getattr(cache_config, "mooncake_store_pp_size", 1) or 1)
+        self.node_layer_start = int(
+            getattr(cache_config, "mooncake_store_node_layer_start", 0) or 0
+        )
+        self.node_layer_end = int(
+            getattr(cache_config, "mooncake_store_node_layer_end", 0) or 0
+        )
+        self.total_layers = int(
+            getattr(cache_config, "mooncake_store_total_layers", 0) or 0
+        )
+        self.pool_specs = cache_config.enable_pool_specs()
+        self.hit_pool_specs = [s for s in self.pool_specs if s.required_for_hit]
+
+        mooncake_store_config = MooncakeStoreConfig.from_file(cache_config)
+        if mooncake_store_config is None:
+            raise ValueError(
+                f"[MooncakeStoreCacheEngine] MooncakeStoreConfig is not found in cache config"
+            )
+        self.mooncake_store_client = MooncakeStoreClient(
+            mooncake_store_config, query_only=True
+        )
+
+        flexkv_logger.info(
+            f"[MooncakeStoreCacheEngine] pools={[s.kind.value for s in self.pool_specs]}, "
+            f"hit_required={[s.kind.value for s in self.hit_pool_specs]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface (matches CacheEngineAccel)
+    # ------------------------------------------------------------------
+
+    def match(self, sequence_meta: SequenceMeta) -> MatchResultAccel:
+        """Query the mooncake-store for which prefix of *sequence_meta* is cached.
+
+        Generic N-pool joint-existence check driven by
+        ``cache_config.enable_pool_specs()``:
+
+        * **Single-pool** (only KV): longest prefix where ``"<hash>_FlexKV"``
+          exists in the store.
+        * **Multi-pool** (KV + indexer / SWA / GDN / ...): one RPC asks for
+          ``"<hash>_<pool>"`` for every (pool, block) pair, then we take the
+          longest prefix where **all** pools whose ``required_for_hit`` is
+          True exist simultaneously. This guarantees that every block
+          returned as ``hit`` has a well-formed full set of side-cars on
+          the remote side, which is the contract layerwise H2D relies on.
+
+        The returned ``MatchResultAccel`` has:
+        * ``matched_pos="global"``
+        * ``physical_blocks=np.arange(num_matched)``  (dummy; keys are used)
+        * ``num_matched_blocks`` = longest prefix present in the store
+        * ``num_ready_matched_blocks`` = same as num_matched_blocks
+        """
+        n_blocks = sequence_meta.num_blocks
+        if n_blocks == 0:
+            return MatchResultAccel(
+                num_ready_matched_blocks=0,
+                num_matched_blocks=0,
+                last_ready_node=None,
+                last_node=None,
+                last_node_matched_length=0,
+                physical_blocks=np.arange(0, dtype=np.int64),
+                matched_pos=self.MATCHED_POS,
+            )
+
+        block_hashes = [str(sequence_meta.block_hashes[i]) for i in range(n_blocks)]
+        spec_counts = len(self.hit_pool_specs)
+
+        # Pack all (pool, block) pairs into one flat key list for a single RPC.
+        # Layout: [pool0_block0, pool0_block1, ..., pool1_block0, pool1_block1, ...]
+        all_keys: List[str] = []
+        for spec in self.hit_pool_specs:
+            all_keys.extend(
+                build_key(
+                    h,
+                    spec.kind,
+                    pp_rank=self.pp_rank,
+                    pp_size=self.pp_size,
+                    node_layer_start=self.node_layer_start,
+                    node_layer_end=self.node_layer_end,
+                    total_layers=self.total_layers,
+                )
+                for h in block_hashes
+            )
+        flexkv_logger.info(f"[MooncakeStoreCacheEngine] match: all_keys: {all_keys}")
+        if spec_counts == 1:
+            # Fast path: existing batch_exists already does prefix scan internally.
+            matched_length = self.mooncake_store_client.batch_exists(all_keys)
+        else:
+            raw = self.mooncake_store_client.batch_exists_impl(all_keys)
+            matched_length = 0
+            for i in range(n_blocks):
+                ok = all(raw[p * n_blocks + i] == 1 for p in range(spec_counts))
+                if ok:
+                    matched_length += 1
+                else:
+                    break
+
+        return MatchResultAccel(
+            num_ready_matched_blocks=matched_length,
+            num_matched_blocks=matched_length,
+            last_ready_node=None,
+            last_node=None,
+            last_node_matched_length=matched_length,
+            physical_blocks=np.arange(matched_length, dtype=np.int64),
+            matched_pos=self.MATCHED_POS,
+        )
+
+    def insert(
+        self,
+        sequence_meta: SequenceMeta,
+        physical_block_ids,
+        num_insert_blocks: int = -1,
+        is_ready: bool = True,
+        match_result: Optional[MatchResultAccel] = None,
+    ) -> _MooncakeStoreDummyNode:
+        """No-op. Writes to mooncake-store are performed by the transfer worker."""
+        return _MooncakeStoreDummyNode()
+
+    def reset(self) -> None:
+        """No-op. The store manages its own state."""
+        pass
+
+    def start(self) -> None:
+        """Start the cache engine."""
+        pass
+
+    def stop(self) -> None:
+        """Stop the cache engine."""
+        pass
+
+    def lock_node(self, node: Any) -> None:
+        pass
+
+    def unlock(self, node: Any) -> None:
+        pass
+
+    def set_ready(self, node: Any, ready: bool, ready_length: int) -> None:
+        pass
+
+    def insert_and_publish(self, node: Any) -> bool:
+        return True
+
+    # TAKE is skipped as the real index is managed by simm itself
+    def take(
+        self,
+        num_required_blocks: int,
+        protected_node: Optional[Any] = None,
+        strict: bool = True,
+    ) -> np.ndarray:
+        return np.zeros(num_required_blocks, dtype=np.int64)
+
+    def recycle(self, block_ids: np.ndarray) -> None:
+        pass

--- a/flexkv/external/mooncake_store_utils.py
+++ b/flexkv/external/mooncake_store_utils.py
@@ -355,7 +355,7 @@ class MooncakeStoreClient:
         assert len(key_strs) == len(buffer_ptrs) == len(buffer_sizes)
 
         exist_results = self.batch_exists_impl(key_strs)
-
+        flexkv_logger.info(f"[MooncakeStoreClient] batch_put exist_results: {exist_results}")
         set_keys = []
         set_buffer_ptrs = []
         set_buffer_sizes = []
@@ -412,7 +412,7 @@ class MooncakeStoreClient:
         """
         self._ensure_setup()
         exit_results = self.batch_exists_impl(keys_strs)
-        flexkv_logger.info(f"[MooncakeStoreClient] batch_exists: {exit_results}")
+        flexkv_logger.info(f"[MooncakeStoreClient] batch_exists, exit_results: {exit_results}")
         for i in range(len(keys_strs)):
             if exit_results[i] != 1:
                 return i
@@ -585,6 +585,7 @@ class MooncakeStoreCacheEngine:
             matched_length = self.mooncake_store_client.batch_exists(all_keys)
         else:
             raw = self.mooncake_store_client.batch_exists_impl(all_keys)
+            flexkv_logger.info(f"[MooncakeStoreCacheEngine] match: exist_results: {raw}")
             matched_length = 0
             for i in range(n_blocks):
                 ok = all(raw[p * n_blocks + i] == 1 for p in range(spec_counts))

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -137,6 +137,7 @@ class FlexKVConfig:
             logger.info(f"[FlexKV] Using kv_cache_dtype from framework config: '{framework_dtype_str}' -> {resolved}")
             return
 
+        # --- Priority 3: fallback ---
         self.model_config.dtype = fallback_dtype
         logger.warning(
             f"[FlexKV] No kv_cache_dtype from user/framework config, "
@@ -151,33 +152,42 @@ class FlexKVConfig:
         indexer_head_size: Optional[int] = None,
         indexer_dtype: Optional[torch.dtype] = None,
     ) -> None:
-        """Detect sparse-attention indexer config (DSv4 / NSA).
+        """Detect and configure indexer from HuggingFace model config.
 
-        NOTE: kept on this branch because mooncake-store integration needs
-        IndexerCacheConfig to size the dedicated indexer CPU pool. The
-        layerwise-rebase upstream comment claimed this method conflicts with
-        ``layer_groups``-based heterogeneous KV, but on the mooncake branch
-        we use ``IndexerCacheConfig`` directly (multi-pool path).
+        All three frameworks store the indexer K cache in an FP8-quantized
+        layout with ``quant_block_size = 128`` (hardcoded in each):
+
+        - vLLM (``DeepseekV32IndexerCache`` / ``deepseek_v4_attention.py``):
+            head_dim = index_head_dim + index_head_dim // 128 * 4, dtype=uint8
+        - TRT-LLM (``DSACacheManager``, ``dsa.py``):
+            per_token_size = index_head_dim + index_head_dim // 128 * 4
+        - sglang (``NSATokenToKVPool``, ``memory_pool.py``):
+            index_k_with_scale_buffer_dtype = torch.uint8  (class constant)
+            shape: page_size * (index_head_dim + index_head_dim // 128 * 4)
+
+        Formula:
+            head_size = tpb * (index_head_dim + index_head_dim // 128 * 4)
+            dtype     = torch.uint8
+
+        where ``+ index_head_dim // 128 * 4`` is the per-block FP32 scale
+        overhead (4 bytes per 128-element block).
         """
         if hf_config is None:
             return
 
         try:
-            qk_rope_head_dim = getattr(hf_config, 'qk_rope_head_dim', None)
-            if qk_rope_head_dim is None or qk_rope_head_dim <= 0:
-                return
+            if indexer_head_size is not None and indexer_head_size > 0:
+                head_size = indexer_head_size
+            else:
+                index_head_dim = getattr(hf_config, 'index_head_dim', None)
+                if index_head_dim is None or index_head_dim <= 0:
+                    # This model has no sparse attention indexer — skip.
+                    return
 
-            index_head_dim = getattr(hf_config, 'index_head_dim', None)
-            if index_head_dim is not None and index_head_dim > 0:
                 quant_block_size = 128
                 head_size = self.cache_config.tokens_per_block * (
                     index_head_dim + index_head_dim // quant_block_size * 4
                 )
-            else:
-                head_size = qk_rope_head_dim
-
-            if indexer_head_size is not None and indexer_head_size > 0:
-                head_size = indexer_head_size
 
             dtype = indexer_dtype if indexer_dtype is not None else torch.uint8
 
@@ -303,14 +313,24 @@ class FlexKVConfig:
             # authoritative physical device index.
             local_rank=int(os.environ.get('LOCAL_RANK', -1)),
         )
+        # Detect indexer config from HuggingFace model config.
+        # vLLM exposes hf_config via vllm_config.model_config.hf_config.
+        hf_config = getattr(vllm_config.model_config, 'hf_config', None)
+        self._detect_indexer_config_from_hf(hf_config)
+
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
         self.server_recv_port = GLOBAL_CONFIG_FROM_ENV.server_recv_port
         self.gpu_register_port = self.server_recv_port + "_gpu_register"
 
-        hf_config = getattr(vllm_config.model_config, 'hf_config', None)
-        self._detect_indexer_config_from_hf(hf_config, source="vllm")
-
         logger.info(f"[FlexKV vllm] {self.model_config}, {rank_info}")
+
+
+        if self.cache_config.indexer is not None:
+            logger.info(
+                f"[FlexKV vLLM] Indexer config detected: "
+                f"head_size={self.cache_config.indexer.head_size}, "
+                f"dtype={self.cache_config.indexer.dtype}"
+            )
 
         # Freeze model_config — no further mutations allowed
         self.model_config.freeze()
@@ -495,10 +515,11 @@ class FlexKVConfig:
             # via torch.cuda.set_device(gpu_id) before this point.
             local_rank=torch.cuda.current_device(),
         )
-        update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
-
         hf_config = getattr(sglang_config, 'hf_config', None)
-        self._detect_indexer_config_from_hf(hf_config, source="sglang")
+
+        self._detect_indexer_config_from_hf(hf_config)
+
+        update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
         if self.cache_config.indexer is not None:
             logger.info(
@@ -582,7 +603,7 @@ class FlexKVConfig:
                     self.model_config.head_size = hf_config.hidden_size // hf_config.num_attention_heads
                     self.model_config.num_kv_heads = hf_config.num_attention_heads
 
-            self._detect_indexer_config_from_hf(hf_config, source="TRT-LLM")
+            self._detect_indexer_config_from_hf(hf_config)
         except Exception as e:
             flexkv_logger.error(f"Failed to load config from {model_path}: {e}")
 
@@ -627,6 +648,13 @@ class FlexKVConfig:
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
         logger.info(f"[FlexKV TRT-LLM] {self.model_config}, {rank_info}")
+
+        if self.cache_config.indexer is not None:
+            logger.info(
+                f"[FlexKV TRT-LLM] Indexer config detected: "
+                f"head_size={self.cache_config.indexer.head_size}, "
+                f"dtype={self.cache_config.indexer.dtype}"
+            )
 
         # Freeze model_config — no further mutations allowed
         self.model_config.freeze()

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -140,15 +140,25 @@ class FlexKVConfig:
         self.model_config.dtype = fallback_dtype
         logger.warning(
             f"[FlexKV] No kv_cache_dtype from user/framework config, "
-            f"falling back to {fallback_dtype}."
+            f"falling back to {fallback_dtype}. "
+            f"Set FLEXKV_KV_CACHE_DTYPE env var or pass --kv-cache-dtype to be explicit."
         )
 
     def _detect_indexer_config_from_hf(
         self,
         hf_config,
+        source: str = "",
         indexer_head_size: Optional[int] = None,
         indexer_dtype: Optional[torch.dtype] = None,
     ) -> None:
+        """Detect sparse-attention indexer config (DSv4 / NSA).
+
+        NOTE: kept on this branch because mooncake-store integration needs
+        IndexerCacheConfig to size the dedicated indexer CPU pool. The
+        layerwise-rebase upstream comment claimed this method conflicts with
+        ``layer_groups``-based heterogeneous KV, but on the mooncake branch
+        we use ``IndexerCacheConfig`` directly (multi-pool path).
+        """
         if hf_config is None:
             return
 
@@ -176,12 +186,13 @@ class FlexKVConfig:
                 num_kv_heads=1,
                 dtype=dtype,
             )
+            source_label = f" ({source})" if source else ""
             logger.info(
-                f"Detected sparse attention indexer config: "
+                f"Detected sparse attention indexer config{source_label}: "
                 f"head_size={head_size}, dtype={dtype}, "
                 f"tokens_per_block={self.cache_config.tokens_per_block}")
         except Exception as e:
-            logger.debug(f"Could not detect indexer config: {e}")
+            logger.debug(f"Could not detect indexer config ({source}): {e}")
 
     @classmethod
     def from_env(cls) -> 'FlexKVConfig':
@@ -203,9 +214,11 @@ class FlexKVConfig:
         self,
         vllm_config: "VllmConfig",
         ) -> RankInfo:
-        tp_rank = getattr(vllm_config.parallel_config, 'tensor_parallel_rank', 0)
-        dp_rank = getattr(vllm_config.parallel_config, 'data_parallel_rank', 0)
-        node_rank = getattr(vllm_config.parallel_config, 'node_rank', 0)
+        parallel_config = vllm_config.parallel_config
+        tp_rank = int(getattr(parallel_config, 'tensor_parallel_rank', 0))
+        pp_rank = int(getattr(parallel_config, 'pipeline_parallel_rank', 0))
+        dp_rank = int(getattr(parallel_config, 'data_parallel_rank', 0))
+        node_rank = int(getattr(parallel_config, 'node_rank', 0))
         self.cache_config.tokens_per_block = vllm_config.cache_config.block_size
 
         self.model_config.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
@@ -217,6 +230,7 @@ class FlexKVConfig:
         )
         is_mla = vllm_config.model_config.is_deepseek_mla
         self.model_config.use_mla = is_mla
+        self._hf_text_config = getattr(vllm_config.model_config, 'hf_text_config', None)
 
         # NVFP4: vLLM stores the packed fp4 data + fp8 block scales in a single
         # uint8 tensor whose per-head last dim is head_size//2 + head_size//16.
@@ -245,12 +259,14 @@ class FlexKVConfig:
                 "skipping the nvfp4 head_size fold. If vLLM rejects this "
                 "config, use fp8/fp8_ds_mla for MLA instead."
             )
-        self.model_config.tp_size = vllm_config.parallel_config.tensor_parallel_size
-        self.model_config.dp_size = vllm_config.parallel_config.data_parallel_size
-        self.model_config.pp_size = vllm_config.parallel_config.pipeline_parallel_size
-        self.model_config.nnodes = max(1, getattr(vllm_config.parallel_config, 'nnodes', 1))
+        self.model_config.tp_size = int(parallel_config.tensor_parallel_size)
+        self.model_config.dp_size = int(parallel_config.data_parallel_size)
+        self.model_config.pp_size = int(parallel_config.pipeline_parallel_size)
+        # vLLM CP (context parallel) support: read cp_size from parallel_config.
+        # Falls back to 1 if the attribute is not present (older vLLM versions).
+        self.model_config.cp_size = max(1, int(getattr(parallel_config, 'context_parallel_size', 1)))
+        self.model_config.nnodes = max(1, int(getattr(parallel_config, 'nnodes', 1)))
 
-        pp_rank = getattr(vllm_config.parallel_config, 'pipeline_parallel_rank', 0)
 
         if self.model_config.pp_size > 1:
             from vllm.distributed.utils import get_pp_indices as vllm_get_pp_indices
@@ -282,13 +298,17 @@ class FlexKVConfig:
             instance_id=instance_id,
             pp_start_layer=pp_start_layer,
             pp_end_layer=pp_end_layer,
+            # vLLM sets LOCAL_RANK env var (= rank % gpus_per_node) before
+            # launching each worker process.  Use it directly as the
+            # authoritative physical device index.
+            local_rank=int(os.environ.get('LOCAL_RANK', -1)),
         )
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
         self.server_recv_port = GLOBAL_CONFIG_FROM_ENV.server_recv_port
         self.gpu_register_port = self.server_recv_port + "_gpu_register"
 
         hf_config = getattr(vllm_config.model_config, 'hf_config', None)
-        self._detect_indexer_config_from_hf(hf_config)
+        self._detect_indexer_config_from_hf(hf_config, source="vllm")
 
         logger.info(f"[FlexKV vllm] {self.model_config}, {rank_info}")
 
@@ -322,19 +342,41 @@ class FlexKVConfig:
             page_size: KV block size (tokens per block) used by sglang
             tp_rank: physical tensor parallel rank (runtime, from process group)
             pp_rank: pipeline parallel rank (runtime, from process group)
-            dp_rank: data parallel rank (runtime, from process group)
-            attn_cp_rank: attention-level context parallel rank (runtime)
+            dp_rank: logical DP shard index for this worker.
+                - plain DP (``enable_dp_attention=False``): the regular
+                  ``dp_rank`` passed to the scheduler process (0, 1, …).
+                - DP Attention (``enable_dp_attention=True``): the
+                  ``attn_dp_rank`` derived from ``tp_rank`` via
+                  ``compute_dp_attention_world_info`` (already converted
+                  by the sglang scheduler before calling this method).
+                In both cases this value is stored directly as
+                ``RankInfo.dp_rank`` and ``ModelConfig.dp_size`` is set
+                to the true ``sglang_dp_size`` so that
+                ``dp_client_id = instance_id * dp_size + dp_rank`` is
+                globally unique across all DP shards and instances.
+            attn_cp_rank: sglang's ``attn_cp_rank`` — attention-level context
+                parallel rank within the CP group.
         """
+        # sglang uses attn_cp_rank; map to FlexKV's generic cp_rank here so
+        # the rest of the function and all downstream code stays framework-agnostic.
+        cp_rank = attn_cp_rank
         # Extract parallelism params from server_args
-        tp_size = server_args.tp_size
-        pp_size = server_args.pp_size
-        dp_size = server_args.dp_size
+        sglang_tp_size = int(server_args.tp_size)  # raw sglang tp_size (composite)
+        pp_size = int(server_args.pp_size)
+        sglang_dp_size = int(server_args.dp_size if server_args.dp_size is not None else 1)
         nnodes = server_args.nnodes
         node_rank = server_args.node_rank
-        enable_dp_attention = server_args.enable_dp_attention
-        attn_cp_size = getattr(server_args, 'attn_cp_size', 1)
+        enable_dp_attention = bool(server_args.enable_dp_attention)
+        attn_cp_size = int(getattr(server_args, 'attn_cp_size', 1))
         kv_cache_dtype = getattr(server_args, 'kv_cache_dtype', None)
+
         dp_rank = 0 if dp_rank is None else int(dp_rank)
+        cp_rank = 0 if cp_rank is None else int(cp_rank)
+
+        attn_dp_size = sglang_dp_size if enable_dp_attention else 1
+        attn_tp_size = max(1, sglang_tp_size // (attn_dp_size * attn_cp_size))
+        # attn_tp_rank: derived from physical tp_rank
+        attn_tp_rank = int(tp_rank) % attn_tp_size
 
         # cache config: use page_size as tokens_per_block so that FlexKV's
         # CPU radix tree manages blocks at page granularity, ensuring that
@@ -360,8 +402,8 @@ class FlexKVConfig:
                     self.model_config.num_kv_heads = int(getattr(sglang_config, "num_key_value_heads", 0))
             elif hasattr(sglang_config, "get_num_kv_heads"):
                 try:
-                    per_rank = int(sglang_config.get_num_kv_heads(tp_size))
-                    self.model_config.num_kv_heads = per_rank * tp_size
+                    per_rank = int(sglang_config.get_num_kv_heads(sglang_tp_size))
+                    self.model_config.num_kv_heads = per_rank * sglang_tp_size
                 except Exception:
                     self.model_config.num_kv_heads = int(getattr(sglang_config, "num_key_value_heads", 0))
             else:
@@ -396,8 +438,25 @@ class FlexKVConfig:
 
         self.model_config.use_mla = use_mla
 
-        self.model_config.tp_size = int(tp_size)
-        self.model_config.dp_size = int(dp_size if dp_size is not None else 1)
+        # Fill FlexKV parallel config.
+        #
+        # model_config.tp_size = attn_tp_size (innermost TP dimension).
+        #   - plain DP:       attn_tp_size == sglang_tp_size  (dp is orthogonal)
+        #   - DP Attention:   attn_tp_size == sglang_tp_size / (dp_size * cp_size)
+        #
+        # model_config.dp_size = sglang_dp_size in BOTH modes.
+        #   - plain DP:       each dp shard is an independent process; dp_size
+        #                     is the true number of DP shards so that dp_client_id
+        #                     = instance_id * dp_size + dp_rank is globally unique.
+        #   - DP Attention:   attn_dp_size == sglang_dp_size; same formula applies.
+        #
+        # FlexKV does not distinguish between "plain DP" and "DP Attention" —
+        # both are represented as dp_size > 1 with each shard owning its own
+        # KVManager (identified by dp_client_id).  The difference is only in
+        # how sglang derives dp_rank (scheduler arg vs attn_dp_rank from tp_rank).
+        self.model_config.tp_size = int(attn_tp_size)
+        self.model_config.dp_size = int(sglang_dp_size)
+        self.model_config.cp_size = int(attn_cp_size)
         self.model_config.pp_size = int(pp_size)
 
         if pp_size > 1:
@@ -408,8 +467,6 @@ class FlexKVConfig:
         else:
             pp_start_layer = 0
             pp_end_layer = self.model_config.num_layers
-        self.model_config.enable_dp_attention = bool(enable_dp_attention)
-        self.model_config.attn_cp_size = int(attn_cp_size)
         self.model_config.nnodes = max(1, int(nnodes))
         _dist_init_addr = getattr(server_args, 'dist_init_addr', None)
         if _dist_init_addr and int(nnodes) > 1:
@@ -425,19 +482,23 @@ class FlexKVConfig:
 
         rank_info = RankInfo(
             model_config=self.model_config,
-            tp_rank=tp_rank,
+            tp_rank=attn_tp_rank,   # sglang attn_tp_rank = tp_rank % attn_tp_size
             pp_rank=pp_rank,
-            dp_rank=dp_rank,
-            attn_cp_rank=attn_cp_rank,
+            dp_rank=dp_rank,        # sglang attn_dp_rank (already computed by scheduler)
+            cp_rank=cp_rank,        # sglang attn_cp_rank
             node_rank=node_rank,
             instance_id=instance_id,
             pp_start_layer=pp_start_layer,
             pp_end_layer=pp_end_layer,
+            # Use torch.cuda.current_device()
+            # which reflects the physical GPU index set by sglang's worker launcher
+            # via torch.cuda.set_device(gpu_id) before this point.
+            local_rank=torch.cuda.current_device(),
         )
         update_default_config_from_user_config(rank_info, self.cache_config, self.user_config)
 
         hf_config = getattr(sglang_config, 'hf_config', None)
-        self._detect_indexer_config_from_hf(hf_config)
+        self._detect_indexer_config_from_hf(hf_config, source="sglang")
 
         if self.cache_config.indexer is not None:
             logger.info(
@@ -458,44 +519,44 @@ class FlexKVConfig:
         self,
         config,
     ) -> RankInfo:
-        tp_rank = config.mapping.tp_rank
-        dp_rank = getattr(config.mapping, 'dp_rank', 0)
-        node_rank = config.mapping.node_rank
+        mapping = config.mapping
+        tp_rank = mapping.tp_rank
+        node_rank = mapping.node_rank
         self.cache_config.tokens_per_block = config.tokens_per_block
-        # Convert dtype string to torch.dtype
-        dtype_str = config.pytorch_backend_config.kv_cache_dtype
-        flexkv_logger.info(f"[FlexKVConfig] dtype_str from TRT config: {dtype_str}")
+        # Resolve KV cache dtype via unified priority logic.
+        _pytorch_backend = getattr(config, 'pytorch_backend_config', None)
+        trt_dtype_str = getattr(_pytorch_backend, 'kv_cache_dtype', 'auto') if _pytorch_backend else 'auto'
+        self._resolve_dtype(
+            framework_dtype_str=trt_dtype_str if isinstance(trt_dtype_str, str) else None,
+            fallback_dtype=torch.bfloat16,
+        )
 
-        if dtype_str == "auto":
-            self._resolve_dtype(
-                framework_dtype_str=None,
-                fallback_dtype=torch.bfloat16,
-            )
-        elif isinstance(dtype_str, str):
-            self.model_config.dtype = self._parse_dtype_str(dtype_str)
-        else:
-            self.model_config.dtype = dtype_str
         # NVFP4 packed head_size fold is only implemented/verified for vLLM.
         _warn_nvfp4_unsupported_framework(
             self.user_config.kv_cache_dtype
             if self.user_config.kv_cache_dtype is not None
-            else (dtype_str if isinstance(dtype_str, str) else None),
+            else (trt_dtype_str if isinstance(trt_dtype_str, str) else None),
             framework="trtllm",
         )
 
-        # Set model config (parallel configs part)
-        if config.mapping.enable_attention_dp:
+        # Set model config (parallel configs part).
+        enable_attention_dp = bool(getattr(mapping, 'enable_attention_dp', False))
+        if enable_attention_dp:
             self.model_config.tp_size = 1
-            self.model_config.dp_size = config.mapping.tp_size
-            dp_rank = config.mapping.rank
+            self.model_config.dp_size = int(mapping.tp_size)
+            dp_rank = int(mapping.tp_rank)
         else:
-            self.model_config.tp_size = config.mapping.tp_size
-            self.model_config.dp_size = 1
+            self.model_config.tp_size = int(mapping.tp_size)
+            self.model_config.dp_size = int(getattr(mapping, 'dp_size', 1))
             dp_rank = 0
-        self.model_config.pp_size = getattr(config.mapping, 'pp_size', 1)
-        pp_rank = getattr(config.mapping, 'pp_rank', 0)
+        pp_rank = int(getattr(mapping, 'pp_rank', 0))
+        # TRT-LLM CP size: read from mapping.cp_size (available in TRT-LLM >= 0.15).
+        # Falls back to 1 if not present.
+        self.model_config.cp_size = max(1, int(getattr(mapping, 'cp_size', 1)))
+        # TRT-LLM CP rank: read from mapping.cp_rank.
+        cp_rank = int(getattr(mapping, 'cp_rank', 0))
 
-        self.model_config.nnodes = max(1, getattr(config.mapping, 'nnodes', 1))
+        self.model_config.nnodes = max(1, getattr(mapping, 'nnodes', 1))
         # self.model_config (model configs part)
         try:
             model_path = getattr(config, 'hf_model_dir', None)
@@ -521,12 +582,12 @@ class FlexKVConfig:
                     self.model_config.head_size = hf_config.hidden_size // hf_config.num_attention_heads
                     self.model_config.num_kv_heads = hf_config.num_attention_heads
 
-            self._detect_indexer_config_from_hf(hf_config)
+            self._detect_indexer_config_from_hf(hf_config, source="TRT-LLM")
         except Exception as e:
             flexkv_logger.error(f"Failed to load config from {model_path}: {e}")
 
         if self.model_config.pp_size > 1:
-            layers_range = config.mapping.pp_layers(self.model_config.num_layers)
+            layers_range = mapping.pp_layers(self.model_config.num_layers)
             pp_start_layer = layers_range[0]
             pp_end_layer = layers_range[-1] + 1
         else:
@@ -549,16 +610,17 @@ class FlexKVConfig:
         self.model_config.master_ports = tuple(
             os.getenv("FLEXKV_MASTER_PORTS", "5556,5557,5558").split(",")
         )
-
         rank_info = RankInfo(
             model_config=self.model_config,
             tp_rank=tp_rank,
             pp_rank=pp_rank,
             dp_rank=dp_rank,
+            cp_rank=cp_rank,
             node_rank=node_rank,
             instance_id=instance_id,
             pp_start_layer=pp_start_layer,
             pp_end_layer=pp_end_layer,
+            local_rank=mapping.local_rank,
         )
 
         # Update cache config with user config after model config is initialized

--- a/flexkv/integration/tensorrt_llm/trtllm_adapter.py
+++ b/flexkv/integration/tensorrt_llm/trtllm_adapter.py
@@ -527,6 +527,7 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
             flexkv_config.gpu_register_port,
             dp_client_id=rank_info.dp_client_id,
             pp_rank=rank_info.pp_rank,
+            pp_start_layer=rank_info.pp_start_layer,
             device_id=rank_info.local_rank,
         )
         flexkv_logger.info("Finish init FlexKVWorkerConnector")
@@ -644,4 +645,3 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
         """Cleanup on deletion."""
         if hasattr(self, 'remote_process') and self.remote_process is not None:
             self.shutdown()
-

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -712,6 +712,7 @@ class FlexKVWorkerConnector:
             flexkv_config.gpu_register_port,
             dp_client_id=rank_info.dp_client_id,
             pp_rank=rank_info.pp_rank,
+            pp_start_layer=rank_info.pp_start_layer,
             device_id=rank_info.local_rank,
         )
         logger.info("Finish init FlexKVWorkerConnector")

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -240,7 +240,15 @@ class KVManager:
 
     def prefetch_async(self,
                        token_ids: np.ndarray,
-                       namespace: Optional[List[str]] = None) -> int:
+                       namespace: Optional[List[str]] = None) -> Tuple[int, int]:
+        """Schedule a prefix-match + async load.
+
+        Returns ``(task_id, actual_prefetch_tokens)``:
+        - ``task_id`` >= 0 if a prefetch task was successfully launched, < 0 otherwise.
+        - ``actual_prefetch_tokens`` is the number of tokens that the underlying
+          KV task engine already knows it can serve from external storage.
+
+        """
         if isinstance(token_ids, torch.Tensor):
             token_ids = token_ids.numpy()
         if self.server_client_mode:

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -245,12 +245,14 @@ class KVManager:
             token_ids = token_ids.numpy()
         if self.server_client_mode:
             task_id = self.dp_client.prefetch_async(token_ids, namespace=namespace)
+            return task_id, 0
         else:
-            task_id = self.kv_task_engine.prefetch_async(
+            task_id, actual_prefetch_tokens = self.kv_task_engine.prefetch_async(
                 token_ids,
                 namespace=namespace,
             )
-        return task_id
+            flexkv_logger.info(f"[FlexKV] prefetch: task_id={task_id}, actual_prefetch_tokens={actual_prefetch_tokens}")
+        return task_id, actual_prefetch_tokens
 
     def launch(self,
                task_ids: Union[int, List[int]],

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -746,13 +746,19 @@ class KVTaskEngine(KVTaskManager):
                        token_ids: np.ndarray,
                        dp_client_id: int = 0,
                        task_id: int = -1,
-                       namespace: Optional[List[str]] = None) -> int:
+                       namespace: Optional[List[str]] = None) -> Tuple[int, int]:
         if task_id == -1:
             task_id = self._gen_task_id()
         nvtx.push_range(f"prefetch match: task_id={task_id}", color=get_nvtx_default_color())
         self.create_prefetch_task(task_id, token_ids, dp_client_id=dp_client_id, namespace=namespace)
         self._process_empty_graph(task_id)
         nvtx.pop_range()
+        task = self.tasks[task_id]
+        actual_prefetch_tokens = 0
+        if task is not None and task.return_mask is not None:
+            actual_prefetch_tokens = int(np.sum(task.return_mask))
+        else:
+            flexkv_logger.warning(f"prefetch task {task_id} returned None")
         # trace prefetch async request
         self.tracer.trace_request(
             request_type="PREFETCH_ASYNC",
@@ -763,7 +769,7 @@ class KVTaskEngine(KVTaskManager):
             dp_client_id=dp_client_id
         )
         self._launch_task(task_id)
-        return task_id
+        return task_id, actual_prefetch_tokens
 
     def merge_to_batch_kvtask(self,
                               batch_id: int,

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -102,7 +102,11 @@ class KVTaskManager:
                  ):
         if not cache_config.enable_cpu:
             raise ValueError("enable_cpu must be True")
-        if cache_config.enable_remote and not cache_config.enable_ssd:
+        if (
+            cache_config.enable_remote
+            and not cache_config.enable_ssd
+            and not cache_config.use_mooncake_store_backend
+        ):
             raise ValueError("enable_ssd must be True if enable_remote is True")
         if not cache_config.enable_cpu and not cache_config.enable_gds:
             raise ValueError("enable_gds must be True if enable_cpu is False")

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -255,6 +255,7 @@ class KVTPClient:
         dp_client_id: int,
         device_id: int,
         pp_rank: int = 0,
+        pp_start_layer: int = 0,
     ):
         """A TP-level GPU registration client."""
         # Init inter-process communication
@@ -265,12 +266,13 @@ class KVTPClient:
 
         self.dp_client_id = dp_client_id
         self.pp_rank = pp_rank
+        self.pp_start_layer = pp_start_layer
         self.device_id = device_id
 
         flexkv_logger.info(
             f"KVTPClient {device_id} Initialized! "
             f"(gpu_register_port={gpu_register_port}, "
-            f"dp_client_id={dp_client_id}, pp_rank={pp_rank})")
+            f"dp_client_id={dp_client_id}, pp_rank={pp_rank}, pp_start_layer={pp_start_layer})")
 
     def set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
         """Send set_slot_mapping message to TransferManagerOnRemote via existing ZMQ channel.
@@ -328,6 +330,7 @@ class KVTPClient:
         register_req = RegisterTPClientRequest(
             dp_client_id=self.dp_client_id,
             pp_rank=self.pp_rank,
+            pp_start_layer=self.pp_start_layer,
             device_id=device_id,
             handles=handles,
             gpu_layout=kv_layout,

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -20,6 +20,7 @@ class RegisterDPClientRequest:
 class RegisterTPClientRequest:
     dp_client_id: int
     pp_rank: int
+    pp_start_layer: int
     device_id: int
     handles: List[TensorSharedHandle]
     gpu_layout: KVCacheLayout

--- a/flexkv/storage/allocator.py
+++ b/flexkv/storage/allocator.py
@@ -102,7 +102,11 @@ class CPUAllocator(BaseStorageAllocator):
         total_size = layout.get_total_elements()
         pin_memory = kwargs.get('pin_memory', False)
         # although the kv layout may have multiple dimensions, we only have one-dim CPU tensor
-        flexkv_logger.info(f"CPU allocate total_size: {dtype.itemsize * total_size/1024/1024/1024} GB")
+        flexkv_logger.info(
+            f"CPU allocate total_size: "
+            f"{total_size * dtype.itemsize / 1024 / 1024 / 1024:.4f} GB "
+            f"(elements={total_size}, dtype={dtype})"
+        )
         physical_tensor = torch.empty(
                             size=(total_size,),
                             dtype=dtype,

--- a/flexkv/storage/allocator.py
+++ b/flexkv/storage/allocator.py
@@ -100,13 +100,14 @@ class CPUAllocator(BaseStorageAllocator):
                  dtype: torch.dtype,
                  **kwargs: Any) -> StorageHandle:
         total_size = layout.get_total_elements()
+        pin_memory = kwargs.get('pin_memory', False)
         # although the kv layout may have multiple dimensions, we only have one-dim CPU tensor
         flexkv_logger.info(f"CPU allocate total_size: {dtype.itemsize * total_size/1024/1024/1024} GB")
         physical_tensor = torch.empty(
                             size=(total_size,),
                             dtype=dtype,
                             device="cpu",
-                            pin_memory=False,
+                            pin_memory=pin_memory,
                         )
         return StorageHandle(
             handle_type=AccessHandleType.TENSOR,

--- a/flexkv/storage/storage_engine.py
+++ b/flexkv/storage/storage_engine.py
@@ -46,6 +46,7 @@ class StorageEngine:
                 head_size=self._model_config.head_size,
                 is_mla=self._model_config.use_mla
             )
+            flexkv_logger.info(f"[StorageEngine] CPU layout: {self._cpu_layout}")
             self.allocate(
                 device_type=DeviceType.CPU,
                 layout=self._cpu_layout,
@@ -110,47 +111,66 @@ class StorageEngine:
                 )
 
         if self._cache_config.enable_remote:
-            if not GLOBAL_CONFIG_FROM_ENV.remote_layout_type == self._cpu_layout.type:
-                raise ValueError(f"Remote layout type must be the same as CPU layout type: {self._cpu_layout.type}")
-            self._remote_layout: Optional[KVCacheLayout] = KVCacheLayout(
-                type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
-                num_layer=num_layers_per_pp_stage,
-                num_block=self._cache_config.num_remote_blocks,
-                tokens_per_block=self._cache_config.tokens_per_block,
-                num_head=self._model_config.num_kv_heads_per_node,
-                head_size=self._model_config.head_size,
-                is_mla=self._model_config.use_mla
-            )
-            self.allocate(
-                device_type=DeviceType.REMOTE,
-                layout=self._remote_layout,
-                dtype=self._model_config.dtype,
-                file_path=self._cache_config.remote_cache_path,
-                remote_config_custom = self._cache_config.remote_config_custom
-            )
-            if self._indexer_config is not None:
-                indexer_remote_layout = KVCacheLayout(
+            use_mooncake_store = self._cache_config.use_mooncake_store_backend
+            if use_mooncake_store:
+                # No separate contributed region: hot CPU buffer is registered with
+                # mooncake-store directly (synchronous PUSH semantics, no staging needed).
+                # print(f"!!!!!! num_remote_blocks: {self._cache_config.num_remote_blocks}")
+                # self._remote_layout = KVCacheLayout(
+                #     type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
+                #     num_layer=num_layers_per_pp_stage,
+                #     num_block=self._cache_config.num_remote_blocks,
+                #     tokens_per_block=self._cache_config.tokens_per_block,
+                #     num_head=self._model_config.num_kv_heads_per_node,
+                #     head_size=self._model_config.head_size,
+                #     is_mla=self._model_config.use_mla
+                # )
+                flexkv_logger.info(
+                    "[StorageEngine] mooncake-store backend: hot CPU buffer will be "
+                    "registered directly (no separate contributed region)."
+                )
+            else:
+                if not GLOBAL_CONFIG_FROM_ENV.remote_layout_type == self._cpu_layout.type:
+                    raise ValueError(f"Remote layout type must be the same as CPU layout type: {self._cpu_layout.type}")
+                self._remote_layout: Optional[KVCacheLayout] = KVCacheLayout(
                     type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
                     num_layer=num_layers_per_pp_stage,
                     num_block=self._cache_config.num_remote_blocks,
-                    tokens_per_block=1,
-                    num_head=self._indexer_config.num_kv_heads,
-                    head_size=self._indexer_config.head_size,
-                    is_mla=True
+                    tokens_per_block=self._cache_config.tokens_per_block,
+                    num_head=self._model_config.num_kv_heads_per_node,
+                    head_size=self._model_config.head_size,
+                    is_mla=self._model_config.use_mla
                 )
-                indexer_remote_path = self._cache_config.remote_cache_path
-                if isinstance(indexer_remote_path, str):
-                    indexer_remote_path = indexer_remote_path + "_indexer"
-                elif isinstance(indexer_remote_path, list):
-                    indexer_remote_path = [p + "_indexer" for p in indexer_remote_path]
                 self.allocate(
                     device_type=DeviceType.REMOTE,
-                    layout=indexer_remote_layout,
-                    dtype=self._indexer_config.dtype,
-                    file_path=indexer_remote_path,
-                    remote_config_custom=self._cache_config.remote_config_custom,
-                    is_indexer=True,
+                    layout=self._remote_layout,
+                    dtype=self._model_config.dtype,
+                    file_path=self._cache_config.remote_cache_path,
+                    remote_config_custom = self._cache_config.remote_config_custom
                 )
+                if self._indexer_config is not None:
+                    indexer_remote_layout = KVCacheLayout(
+                        type=GLOBAL_CONFIG_FROM_ENV.remote_layout_type,
+                        num_layer=num_layers_per_pp_stage,
+                        num_block=self._cache_config.num_remote_blocks,
+                        tokens_per_block=1,
+                        num_head=self._indexer_config.num_kv_heads,
+                        head_size=self._indexer_config.head_size,
+                        is_mla=True
+                    )
+                    indexer_remote_path = self._cache_config.remote_cache_path
+                    if isinstance(indexer_remote_path, str):
+                        indexer_remote_path = indexer_remote_path + "_indexer"
+                    elif isinstance(indexer_remote_path, list):
+                        indexer_remote_path = [p + "_indexer" for p in indexer_remote_path]
+                    self.allocate(
+                        device_type=DeviceType.REMOTE,
+                        layout=indexer_remote_layout,
+                        dtype=self._indexer_config.dtype,
+                        file_path=indexer_remote_path,
+                        remote_config_custom=self._cache_config.remote_config_custom,
+                        is_indexer=True,
+                    )
 
     @property
     def _has_indexer(self) -> bool:

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -412,7 +412,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
 
                 try:
                     with conn:
-                        # Receive 16-byte metadata: tp_rank_per_node, tp_size_per_node,
+                        # Receive 16-byte metadata: effective_tp_rank, effective_tp_size_per_node,
                         # num_layers, num_counters
                         metadata = conn.recv(16)
                         if len(metadata) < 16:
@@ -421,7 +421,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                                 f"expected 16 bytes, got {len(metadata)}")
                             continue
 
-                        rank_key, tp_size_per_node_recv, recv_num_layers, recv_num_counters = \
+                        rank_key, effective_tp_size_per_node_recv, recv_num_layers, recv_num_counters = \
                             struct.unpack("iiii", metadata[:16])
 
                         if not all_rank_eventfds:
@@ -429,8 +429,8 @@ class LayerwiseTransferWorker(TransferWorkerBase):
 
                         flexkv_logger.debug(
                             f"[LayerwiseWorker] Connection {conn_idx}: "
-                            f"tp_rank_per_node={rank_key}, "
-                            f"tp_size_per_node={tp_size_per_node_recv}, "
+                            f"effective_tp_rank={rank_key}, "
+                            f"effective_tp_size_per_node={effective_tp_size_per_node_recv}, "
                             f"num_layers={recv_num_layers}, "
                             f"num_counters={recv_num_counters}")
 
@@ -450,7 +450,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                         except Exception:
                             pass
                         flexkv_logger.info(
-                            f"[LayerwiseWorker] Received all eventfds from tp_rank_per_node={rank_key} "
+                            f"[LayerwiseWorker] Received all eventfds from effective_tp_rank={rank_key} "
                             f"on {socket_path}")
                 except Exception as e:
                     # Send NACK so client knows to retry

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -80,6 +80,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                  h2d_cta_num: int = 4,
                  d2h_cta_num: int = 4,
                  enable_eventfd: bool = True,
+                 start_layer_id: int = 0,
                  indexer_gpu_blocks: Optional[List[List[TensorSharedHandle]]] = None,
                  indexer_cpu_blocks: Optional[Union[torch.Tensor, HugePageTensorHandle]] = None,
                  indexer_gpu_kv_layouts: Optional[List[KVCacheLayout]] = None,
@@ -149,14 +150,16 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                            f"{cpu_blocks.numel() * cpu_blocks.element_size() / (1024 ** 3):.2f} GB")
         cudaHostRegister(cpu_blocks)
         flexkv_logger.debug("[LayerwiseWorker] CPU memory pinned successfully")
-        self.cpu_blocks = cpu_blocks
 
         self.cpu_chunk_size_in_bytes = cpu_kv_layout.get_chunk_size() * self.dtype.itemsize
         self.cpu_block_stride_in_bytes = cpu_kv_layout.get_block_stride() * self.dtype.itemsize
         # Full CPU strides (for SSD->CPU, which transfers all TP ranks' data)
         self.cpu_kv_stride_in_bytes = cpu_kv_layout.get_kv_stride() * self.dtype.itemsize
         self.cpu_layer_stride_in_bytes = cpu_kv_layout.get_layer_stride() * self.dtype.itemsize
+
         # TP-divided CPU strides (for CPU->GPU, each rank reads its own portion)
+        # Must be computed BEFORE the cpu_blocks offset below, because the offset
+        # must use the same (post-div_head) stride that the C++ H2D kernel uses.
         if cpu_kv_layout.type == KVCacheLayoutType.BLOCKFIRST and not self.is_mla:
             cpu_kv_layout_tp = cpu_kv_layout.div_head(self.tp_group_size)
         else:
@@ -164,6 +167,29 @@ class LayerwiseTransferWorker(TransferWorkerBase):
         self.cpu_tp_stride_in_bytes = self.cpu_block_stride_in_bytes // self.tp_group_size
         self.h2d_cpu_kv_stride_in_bytes = cpu_kv_layout_tp.get_kv_stride() * self.dtype.itemsize
         self.h2d_cpu_layer_stride_in_bytes = cpu_kv_layout_tp.get_layer_stride() * self.dtype.itemsize
+
+        # Offset cpu_blocks by start_layer_id so that the C++ kernel always uses
+        # layer_id=0 on the GPU side (GPU tensor is PP-stage-local, 0-indexed)
+        # while writing to the correct slice of the shared per-node CPU pool.
+        # The CPU pool covers all PP stages on this node; each PP stage's worker
+        # advances the base pointer by (start_layer_id * cpu_layer_stride) bytes.
+        # Must use the post-div_head h2d_cpu_layer_stride_in_bytes here, because
+        # the C++ H2D kernel uses that same stride for layer-wise addressing.
+        self.start_layer_id = start_layer_id
+        if start_layer_id > 0:
+            layer_offset_elems = start_layer_id * (self.h2d_cpu_layer_stride_in_bytes // self.dtype.itemsize)
+            cpu_blocks = cpu_blocks.flatten()[layer_offset_elems:]
+            flexkv_logger.debug(
+                f"[LayerwiseWorker] worker_id={worker_id}: "
+                f"start_layer_id={start_layer_id}, num_layers={self.num_layers}, "
+                f"cpu_ptr_offset={start_layer_id * self.h2d_cpu_layer_stride_in_bytes} bytes"
+            )
+        else:
+            flexkv_logger.debug(
+                f"[LayerwiseWorker] worker_id={worker_id}: "
+                f"start_layer_id=0, num_layers={self.num_layers} (no cpu_ptr offset)"
+            )
+        self.cpu_blocks = cpu_blocks
 
         self.use_ce_transfer_h2d = use_ce_transfer_h2d
         self.use_ce_transfer_d2h = use_ce_transfer_d2h

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -40,6 +40,7 @@ from flexkv.transfer.worker import (
     tpGDSTransferWorker,
     NixlTransferWorker,
     PEER2CPUTransferWorker,
+    MooncakeStoreTransferWorker,
 )
 from flexkv.transfer.compression import build_compressors
 from flexkv.transfer.layerwise import (
@@ -48,6 +49,7 @@ from flexkv.transfer.layerwise import (
 )
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.ring_buffer import SharedOpPool
+from flexkv.external.mooncake_store_keys import PoolKind
 
 
 def register_op_to_buffer(op: TransferOp, pin_buffer: SharedOpPool) -> None:
@@ -95,6 +97,7 @@ class TransferEngine:
         cpu_handle: Optional[StorageHandle] = None,
         ssd_handle: Optional[StorageHandle] = None,
         remote_handle: Optional[StorageHandle] = None,
+        worker_key_to_start_layer_id: Optional[Dict[WorkerKey, int]] = None,
         indexer_gpu_handles: Optional[Dict[WorkerKey, List[StorageHandle]]] = None,
         indexer_cpu_handle: Optional[StorageHandle] = None,
         indexer_ssd_handle: Optional[StorageHandle] = None,
@@ -109,12 +112,22 @@ class TransferEngine:
             cpu_handle: CPU handle
             ssd_handle: Optional SSD handle
             remote_handle: Optional remote handle
+            worker_key_to_start_layer_id: Optional mapping from WorkerKey to the
+                CPU-pool-local start_layer_id (global pp_start_layer minus the minimum
+                pp_start_layer on this node). Required for single-node PP>1 deployments
+                where multiple PP stages share one TransferManager and CPU pool.
         """
         self.model_config: ModelConfig = model_config
         self.cache_config: CacheConfig = cache_config
 
         first_handles = next(iter(gpu_handles.values()))
         self._num_layers_for_local_pp_stage = first_handles[0].kv_layout.num_layer
+
+        # start_layer_id per WorkerKey: defaults to 0 for all keys if not provided
+        self._worker_key_to_start_layer_id: Dict[WorkerKey, int] = (
+            worker_key_to_start_layer_id if worker_key_to_start_layer_id is not None
+            else {wk: 0 for wk in gpu_handles.keys()}
+        )
 
         # Use spawn context for CUDA compatibility
         self.mp_ctx = mp.get_context('spawn')
@@ -172,6 +185,10 @@ class TransferEngine:
 
         assert self._cpu_handle is not None
         _enable_layerwise = GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer
+        # PP isolation note: pp_rank/pp_size flow through cache_config
+        # (populated by update_default_config_from_user_config from
+        # RankInfo). Workers read from cache_config; we don't need to
+        # derive a node-local _local_pp_rank here anymore.
         # Use num_gpu_groups to support multi-instance mode
         # Use gpu_device_id from StorageHandle for correct CUDA device selection
         
@@ -189,6 +206,7 @@ class TransferEngine:
                         cpu_kv_layout=self._cpu_handle.kv_layout,
                         dtype=gpu_handles[0].dtype,
                         gpu_device_id=gpu_handles[0].gpu_device_id,
+                        start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -198,6 +216,7 @@ class TransferEngine:
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
             else:
+                flexkv_logger.info(f"[TransferEngine] self._cpu_handle.kv_layout: {self._cpu_handle.kv_layout}")
                 self.h2d_workers = {
                     worker_key: tpGPUCPUTransferWorker.create_worker(
                         mp_ctx=self.mp_ctx,
@@ -209,6 +228,7 @@ class TransferEngine:
                         cpu_kv_layout=self._cpu_handle.kv_layout,
                         dtype=gpu_handles[0].dtype,
                         tp_group_size=self.model_config.effective_tp_size_per_node,
+                        start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                         use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                         use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                         transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -232,6 +252,7 @@ class TransferEngine:
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     dtype=gpu_handles[0].dtype,
                     gpu_device_id=gpu_handles[0].gpu_device_id,
+                    start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -252,6 +273,7 @@ class TransferEngine:
                     cpu_kv_layout=self._cpu_handle.kv_layout,
                     dtype=gpu_handles[0].dtype,
                     tp_group_size=self.model_config.effective_tp_size_per_node,
+                    start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                     use_ce_transfer_h2d=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_h2d,
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     transfer_num_cta_h2d=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
@@ -321,6 +343,26 @@ class TransferEngine:
             )
             self._worker_map[TransferType.H2REMOTE] = self.remotecpu_write_worker
             self._worker_map[TransferType.REMOTE2H] = self.remotecpu_read_worker
+        elif (getattr(self.cache_config, 'use_mooncake_store_backend', False) 
+              and self._cpu_handle is not None):
+            # mooncake-store backend: no _remote_handle (StorageEngine skips RemoteAllocator),
+            # but we still need workers for H2REMOTE and REMOTE2H.
+  
+            self.mooncake_store_worker: WorkerHandle = MooncakeStoreTransferWorker.create_worker(
+                mp_ctx=self.mp_ctx,
+                finished_ops_queue=self.finished_ops_queue,
+                op_buffer_tensor=self.pin_buffer.get_buffer(),
+                cpu_blocks=self._cpu_handle.get_worker_tensor(),
+                cpu_kv_layout=self._cpu_handle.kv_layout,
+                dtype=self._cpu_handle.dtype,
+                cache_config=self.cache_config,
+                pool_kind=PoolKind.KV,
+            )
+     
+            self._worker_map[TransferType.H2REMOTE] = self.mooncake_store_worker
+            self._worker_map[TransferType.REMOTE2H] = self.mooncake_store_worker
+            flexkv_logger.info("[TransferEngine] mooncake-store workers created for H2REMOTE/REMOTE2H")
+
         if self.cache_config.enable_gds:
             assert self._ssd_handle is not None
             if self.cache_config.enable_nixl:
@@ -363,6 +405,7 @@ class TransferEngine:
                         ssd_kv_layout=self._ssd_handle.kv_layout,
                         dtype=self._ssd_handle.dtype,
                         gpu_device_id=gpu_handles[0].gpu_device_id,
+                        start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                     )
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
@@ -379,6 +422,7 @@ class TransferEngine:
                         ssd_kv_layout=self._ssd_handle.kv_layout,
                         dtype=self._ssd_handle.dtype,
                         tp_group_size=self.model_config.effective_tp_size_per_node,
+                        start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                     )
                     for worker_key, gpu_handles in self.gpu_handle_groups.items()
                 }
@@ -425,6 +469,7 @@ class TransferEngine:
                     use_ce_transfer_d2h=GLOBAL_CONFIG_FROM_ENV.use_ce_transfer_d2h,
                     h2d_cta_num=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_h2d,
                     d2h_cta_num=GLOBAL_CONFIG_FROM_ENV.transfer_num_cta_d2h,
+                    start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                     indexer_gpu_blocks=[h.get_tensor_handle_list() for h in idx_handles] if idx_handles else None,
                     indexer_cpu_blocks=self._indexer_cpu_handle.get_worker_tensor() if idx_handles else None,
                     indexer_gpu_kv_layouts=[h.kv_layout for h in idx_handles] if idx_handles else None,
@@ -621,6 +666,27 @@ class TransferEngine:
                 self._indexer_worker_map[TransferType.H2REMOTE] = self._indexer_h2remote_worker
                 self._indexer_worker_map[TransferType.REMOTE2H] = self._indexer_remote2h_worker
                 flexkv_logger.info("TransferEngine: indexer Remote workers initialized")
+            elif (getattr(self.cache_config, 'use_mooncake_store_backend', False)
+                  and self._indexer_cpu_handle is not None):
+                # mooncake-store backend for indexer.
+                self._indexer_mooncake_store_worker: WorkerHandle = MooncakeStoreTransferWorker.create_worker(
+                    mp_ctx=self.mp_ctx,
+                    finished_ops_queue=self._indexer_finished_ops_queue,
+                    op_buffer_tensor=self.pin_buffer.get_buffer(),
+                    cpu_blocks=self._indexer_cpu_handle.get_worker_tensor(),
+                    cpu_kv_layout=self._indexer_cpu_handle.kv_layout,
+                    dtype=self._indexer_cpu_handle.dtype,
+                    cache_config=self.cache_config,
+                    pool_kind=PoolKind.INDEXER,
+                    override_global_segment_size=0,
+                )
+                self._indexer_worker_map[TransferType.H2REMOTE] = self._indexer_mooncake_store_worker
+                self._indexer_worker_map[TransferType.REMOTE2H] = self._indexer_mooncake_store_worker
+                flexkv_logger.info(
+                    f"[TransferEngine] indexer mooncake-store worker initialized "
+                    f"(pool_kind={PoolKind.INDEXER.name}/'{PoolKind.INDEXER.value}', "
+                    f"global_segment_size=0 / pure-client mode)"
+                )
             if self.cache_config.enable_gds and self._indexer_ssd_handle is not None:
                 if self.model_config.effective_tp_size_per_node == 1:
                     self._indexer_gds_workers: Dict[WorkerKey, WorkerHandle] = {
@@ -635,6 +701,7 @@ class TransferEngine:
                             ssd_kv_layout=self._indexer_ssd_handle.kv_layout,
                             dtype=self._indexer_ssd_handle.dtype,
                             gpu_device_id=indexer_gpu_handles_list[0].gpu_device_id,
+                            start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                         )
                         for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     }
@@ -651,6 +718,7 @@ class TransferEngine:
                             ssd_kv_layout=self._indexer_ssd_handle.kv_layout,
                             dtype=self._indexer_ssd_handle.dtype,
                             tp_group_size=self.model_config.effective_tp_size_per_node,
+                            start_layer_id=self._worker_key_to_start_layer_id.get(worker_key, 0),
                         )
                         for worker_key, indexer_gpu_handles_list in self._indexer_gpu_handles.items()
                     }
@@ -996,6 +1064,14 @@ class TransferEngine:
                             src_block_ids=op.src_block_ids.copy(),
                             dst_block_ids=op.dst_block_ids.copy(),
                             dp_client_id=op.dp_client_id,
+                            # Forward mooncake-store block hashes so that the
+                            # indexer worker can build the same per-block keys
+                            # (with its own suffix) for batch_put / batch_get.
+                            mooncake_store_block_hashes=(
+                                op.mooncake_store_block_hashes.copy()
+                                if op.mooncake_store_block_hashes is not None
+                                else None
+                            ),
                         )
                         register_op_to_buffer(indexer_replica, self.pin_buffer)
                         self._child_id_to_child[indexer_replica.op_id] = indexer_replica
@@ -1018,6 +1094,14 @@ class TransferEngine:
                         src_block_ids=op.src_block_ids.copy(),
                         dst_block_ids=op.dst_block_ids.copy(),
                         dp_client_id=op.dp_client_id,
+                        # Forward mooncake-store block hashes so that the
+                        # indexer worker can build the same per-block keys
+                        # (with its own suffix) for batch_put / batch_get.
+                        mooncake_store_block_hashes=(
+                            op.mooncake_store_block_hashes.copy()
+                            if op.mooncake_store_block_hashes is not None
+                            else None
+                        ),
                     )
                     register_op_to_buffer(indexer_op, self.pin_buffer)
                     self._child_id_to_child[indexer_op.op_id] = indexer_op

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -515,6 +515,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         # the tp dim should always be right after the block dim
         # on both blockfirst layout and layerfirst layout
         if cpu_kv_layout.type == KVCacheLayoutType.BLOCKFIRST and not self.is_mla:
+            flexkv_logger.info(f"[tpGPUCPUTransferWorker] div_head tp_group_size: {self.tp_group_size}")
             cpu_kv_layout = cpu_kv_layout.div_head(self.tp_group_size)
 
         self.cpu_layer_stride_in_bytes = cpu_kv_layout.get_layer_stride() * self.dtype.itemsize

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -18,6 +18,7 @@ import zmq
 import json
 
 from flexkv import c_ext
+from flexkv.external.mooncake_store_keys import PoolKind
 
 from flexkv.c_ext import transfer_kv_blocks, transfer_kv_blocks_ssd, TPTransferThreadGroup
 
@@ -46,6 +47,7 @@ from flexkv.transfer.compression.common.strategy import (
 from flexkv.transfer.worker_op import WorkerTransferOp, WorkerLayerwiseTransferOp
 
 from flexkv.mooncakeEngineWrapper import MoonCakeTransferEngineWrapper
+from flexkv.external.mooncake_store_keys import build_key
 from flexkv.transfer.zmqHelper import NotifyMsg, NotifyStatus, SSDZMQServer, SSDZMQClient
 from flexkv.cache.redis_meta import RedisMeta
 from flexkv.transfer.utils import (
@@ -304,6 +306,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                  cpu_kv_layout: KVCacheLayout,
                  dtype: torch.dtype,
                  gpu_device_id: int,
+                 start_layer_id: int = 0,
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
                  transfer_num_cta_h2d: int = 4,
@@ -328,8 +331,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         self.kv_dim = gpu_kv_layout.kv_dim
 
         self.num_layers = gpu_kv_layout.num_layer
-
-        # a chunk can be located by layer_id * layer_stride + kv_id * kv_stride + block_id * block_stride
+        self.start_layer_id = start_layer_id
         self.chunk_size_in_bytes = gpu_kv_layout.get_chunk_size() * self.dtype.itemsize
         self.gpu_kv_stride_in_bytes = gpu_kv_layout.get_kv_stride() * self.dtype.itemsize
         self.gpu_block_stride_in_bytes = gpu_kv_layout.get_block_stride() * self.dtype.itemsize
@@ -338,6 +340,32 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         self.cpu_layer_stride_in_bytes = cpu_kv_layout.get_layer_stride() * self.dtype.itemsize
         self.cpu_kv_stride_in_bytes = cpu_kv_layout.get_kv_stride() * self.dtype.itemsize
         self.cpu_block_stride_in_bytes = cpu_kv_layout.get_block_stride() * self.dtype.itemsize
+
+        assert start_layer_id + self.num_layers <= cpu_kv_layout.num_layer, (
+            f"GPUCPUTransferWorker: start_layer_id({start_layer_id}) + "
+            f"num_layers({self.num_layers}) exceeds cpu pool size({cpu_kv_layout.num_layer}). "
+            f"Single-node PP>1 deployment requires cpu pool to cover all PP stages."
+        )
+        # Offset cpu_tensor by start_layer_id so that the C++ kernel always uses
+        # layer_id=0 on the GPU side (GPU tensor is PP-stage-local, 0-indexed)
+        # while writing to the correct slice of the shared per-node CPU pool.
+        # The CPU pool covers all PP stages on this node; each PP stage's worker
+        # advances the base pointer by (start_layer_id * cpu_layer_stride) bytes.
+        if start_layer_id > 0:
+            layer_offset_elems = start_layer_id * (self.cpu_layer_stride_in_bytes // self.dtype.itemsize)
+            self.cpu_tensor = cpu_blocks.flatten()[layer_offset_elems:]
+            flexkv_logger.debug(
+                f"[GPUCPUTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id={start_layer_id}, num_layers={self.num_layers}, "
+                f"cpu_pool_total_layers={cpu_kv_layout.num_layer}, "
+                f"cpu_ptr_offset={start_layer_id * self.cpu_layer_stride_in_bytes} bytes"
+            )
+        else:
+            self.cpu_tensor = cpu_blocks
+            flexkv_logger.debug(
+                f"[GPUCPUTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id=0, num_layers={self.num_layers} (no cpu_ptr offset)"
+            )
 
         if len(self.gpu_blocks) == 1:
             self.gpu_block_type_ = 1
@@ -402,7 +430,8 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             self.cpu_layer_stride_in_bytes,
             self.cpu_block_stride_in_bytes,
             self.chunk_size_in_bytes,
-            0,
+            0,              # start_layer_id=0: GPU tensor is PP-stage-local (0-indexed);
+                            # CPU pool offset is baked into self.cpu_tensor pointer.
             self.num_layers,
             transfer_num_cta,
             transfer_type == TransferType.H2D,
@@ -440,6 +469,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
                  cpu_kv_layout: KVCacheLayout,
                  dtype: torch.dtype,
                  tp_group_size: int,
+                 start_layer_id: int = 0,
                  use_ce_transfer_h2d: bool = False,
                  use_ce_transfer_d2h: bool = False,
                  transfer_num_cta_h2d: int = 4,
@@ -468,7 +498,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         cudaHostRegister(cpu_blocks)
 
         self.num_layers = gpu_kv_layouts[0].num_layer
-        # here the chunk size doesn't include the layer info
+        self.start_layer_id = start_layer_id
         self.gpu_chunk_sizes_in_bytes = [gpu_kv_layout.get_chunk_size() * self.dtype.itemsize \
                                 for gpu_kv_layout in gpu_kv_layouts]
         self.gpu_kv_strides_in_bytes = [gpu_kv_layout.get_kv_stride() * self.dtype.itemsize \
@@ -509,6 +539,27 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             for j in range(len(self.gpu_blocks[i]))
         ]
         cpu_blocks_ptr = cpu_blocks.data_ptr()
+        # Offset cpu_blocks_ptr by start_layer_id so that the C++ kernel always uses
+        # layer_id=0 on the GPU side (GPU tensor is PP-stage-local, 0-indexed)
+        # while writing to the correct slice of the shared per-node CPU pool.
+        # The CPU pool covers all PP stages on this node; each PP stage's worker
+        # advances the base pointer by (start_layer_id * cpu_layer_stride) bytes.
+        # Must use the post-div_head cpu_layer_stride_in_bytes here, because the
+        # C++ kernel uses the same stride for layer-wise addressing inside the block.
+        # (cpu_block_stride = num_layer * cpu_layer_stride_in_bytes in BLOCKFIRST layout
+        #  after div_head, so both strides are consistent.)
+        if start_layer_id > 0:
+            cpu_blocks_ptr += start_layer_id * self.cpu_layer_stride_in_bytes
+            flexkv_logger.debug(
+                f"[tpGPUCPUTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id={start_layer_id}, num_layers={self.num_layers}, "
+                f"cpu_ptr_offset={start_layer_id * self.cpu_layer_stride_in_bytes} bytes"
+            )
+        else:
+            flexkv_logger.debug(
+                f"[tpGPUCPUTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id=0, num_layers={self.num_layers} (no cpu_ptr offset)"
+            )
         gpu_device_ids = [self.gpu_blocks[i][0].device.index for i in range(self.num_gpus)]
         num_tensors_per_gpu = len(self.gpu_blocks[0])
 
@@ -570,7 +621,8 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             transfer_num_cta,
             transfer_type == TransferType.H2D,
             use_ce_transfer,
-            0,
+            0,              # layer_id=0: GPU tensor is PP-stage-local (0-indexed);
+                            # CPU pool offset is baked into cpu_blocks_ptr.
             self.num_layers,
             self.is_mla,
             self.mla_d2h_mode,  # Pass MLA D2H mode to C++
@@ -922,6 +974,7 @@ class GDSTransferWorker(TransferWorkerBase):
         ssd_kv_layout: KVCacheLayout,
         dtype: torch.dtype,
         gpu_device_id: int = 0,
+        start_layer_id: int = 0,
     ) -> None:
         """
         Initialize GDS Transfer Worker
@@ -966,6 +1019,21 @@ class GDSTransferWorker(TransferWorkerBase):
 
         # Layout information
         self.num_layers = gpu_kv_layout.num_layer
+        self.start_layer_id = start_layer_id
+        # Offset the SSD-side layer_id_list by start_layer_id at transfer time so that
+        # the C++ GDS kernel seeks to the correct slice of the shared per-node SSD pool.
+        # GPU side is PP-stage-local (0-indexed); the SSD pool covers all PP stages on this node.
+        if start_layer_id > 0:
+            flexkv_logger.debug(
+                f"[GDSTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id={start_layer_id}, num_layers={self.num_layers}, "
+                f"ssd_seek_offset will be applied at transfer time"
+            )
+        else:
+            flexkv_logger.debug(
+                f"[GDSTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id=0, num_layers={self.num_layers} (no SSD seek offset)"
+            )
         gpu_kv_layout_per_layer = gpu_kv_layout.div_layer(self.num_layers)
         ssd_kv_layout_per_file = ssd_kv_layout.div_block(self.num_files, padding=True)
 
@@ -1024,8 +1092,21 @@ class GDSTransferWorker(TransferWorkerBase):
         if len(ssd_block_id_list) == 0:
             return
 
-        # Process transfer for each layer
-        layer_id_list = torch.arange(0, self.num_layers, dtype=torch.int32)
+        # Offset the SSD-side layer_id_list by start_layer_id so that the C++ GDS
+        # kernel seeks to the correct slice of the shared per-node SSD pool.
+        # GPU side is PP-stage-local (0-indexed); the SSD pool covers all PP stages
+        # on this node, so layer_id_list[0] = start_layer_id encodes the SSD seek offset
+        # (start_layer_id * ssd_layer_stride bytes).
+        layer_id_list = torch.arange(self.start_layer_id, self.start_layer_id + self.num_layers, dtype=torch.int32)
+        if self.start_layer_id > 0:
+            flexkv_logger.debug(
+                f"[GDSTransferWorker] SSD layer_id_list starts at {self.start_layer_id} "
+                f"(ssd_seek_offset={self.start_layer_id * self.ssd_layer_stride_in_bytes} bytes)"
+            )
+        else:
+            flexkv_logger.debug(
+                f"[GDSTransferWorker] start_layer_id=0, num_layers={self.num_layers} (no SSD seek offset)"
+            )
 
         # Determine if this is a read operation
         is_read = (transfer_type == TransferType.DISK2D)
@@ -1097,6 +1178,7 @@ class tpGDSTransferWorker(TransferWorkerBase):
         ssd_kv_layout: KVCacheLayout,
         dtype: torch.dtype,
         tp_group_size: int,
+        start_layer_id: int = 0,
     ) -> None:
         """
         Initialize TP GDS Transfer Worker
@@ -1138,6 +1220,21 @@ class tpGDSTransferWorker(TransferWorkerBase):
 
         # Layout information
         self.num_layers = gpu_kv_layouts[0].num_layer
+        self.start_layer_id = start_layer_id
+        # start_layer_id is passed directly to the C++ tp_group_transfer kernel as the
+        # SSD-side layer seek offset (start_layer_id * ssd_layer_stride bytes).
+        # GPU side is PP-stage-local (0-indexed); the SSD pool covers all PP stages on this node.
+        if start_layer_id > 0:
+            flexkv_logger.debug(
+                f"[tpGDSTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id={start_layer_id}, num_layers={self.num_layers}, "
+                f"ssd_seek_offset will be computed at transfer time"
+            )
+        else:
+            flexkv_logger.debug(
+                f"[tpGDSTransferWorker] worker_id={worker_id}: "
+                f"start_layer_id=0, num_layers={self.num_layers} (no SSD seek offset)"
+            )
         ssd_kv_layout_per_file = ssd_kv_layout.div_block(self.num_files, padding=True)
         self.ssd_chunk_size_in_bytes = ssd_kv_layout_per_file.get_chunk_size() * self.dtype.itemsize
         self.ssd_block_stride_in_bytes = ssd_kv_layout_per_file.get_block_stride() * self.dtype.itemsize
@@ -1219,6 +1316,11 @@ class tpGDSTransferWorker(TransferWorkerBase):
         if len(gpu_block_id_list) == 0:
             return
 
+        # start_layer_id is passed directly to the C++ tp_group_transfer kernel,
+        # which uses it as the SSD-side layer seek offset (start_layer_id * ssd_layer_stride).
+        # GPU side is PP-stage-local (0-indexed); the SSD pool covers all PP stages
+        # on this node. This is equivalent to the layer_id_list offset used in
+        # GDSTransferWorker, but expressed as a scalar parameter to the TP kernel.
         self.tp_gds_transfer_thread_group.tp_group_transfer(
             gpu_block_id_list,
             ssd_block_id_list,
@@ -1228,7 +1330,7 @@ class tpGDSTransferWorker(TransferWorkerBase):
             self.ssd_tp_stride_in_bytes,
             self.num_blocks_per_file,
             is_read,
-            0,
+            self.start_layer_id,
             self.num_layers,
             self.is_mla,
         )
@@ -2479,3 +2581,191 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
             flexkv_logger.info(f"Fetched node {node_id} meta from Redis.")
 
         return self.node_metas[node_id]
+
+
+# ---------------------------------------------------------------------------
+# MooncakeStoreTransferWorker
+# ---------------------------------------------------------------------------
+
+class MooncakeStoreTransferWorker(TransferWorkerBase):
+    """
+    Transfer worker that uses mooncake-store for remote KV cache I/O.
+
+    Transfer semantics
+    * **H2REMOTE (PUT)**: build (key, ptr, size) triples that point directly
+      into the hot-CPU buffer and call ``batch_put``.
+
+    * **REMOTE2H (GET)**: call ``batch_get`` directly with pointers into the
+      hot-CPU buffer.
+
+    Addressing
+    Key format: ``"{block_hash}_{kind.value}"`` — one key per block (all layers are stored
+    together as a single contiguous slab under one key for each kind).
+    """
+
+    def __init__(
+        self,
+        worker_id: int,
+        transfer_conn: Connection,
+        finished_ops_queue: MPQueue,
+        op_buffer_tensor: torch.Tensor,
+        cpu_blocks: Union[List[torch.Tensor], torch.Tensor],
+        cpu_kv_layout: "KVCacheLayout",
+        dtype: torch.dtype,
+        cache_config: "CacheConfig",
+        pool_kind: PoolKind = PoolKind.KV,
+        override_global_segment_size: Optional[int] = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        cpu_blocks:
+            Hot-CPU KV cache tensor (flat, from
+            ``StorageHandle.get_worker_tensor()``).
+        cpu_kv_layout:
+            KVCacheLayout for the hot-CPU slab.
+        dtype:
+            Element dtype of the KV tensors.
+        cache_config:
+            CacheConfig used to load MooncakeStoreConfig via
+            ``MooncakeStoreConfig.from_file()``.
+        suffix_str:
+            String appended to each key for namespace isolation. The main KV
+            worker uses the default ``"FlexKV"``; sidecar workers (e.g. indexer)
+            should use a distinct value (e.g. ``"FlexKV_indexer"``) to keep
+            their objects separate in the global Mooncake namespace.
+        override_global_segment_size:
+            If set, overrides the ``global_segment_size`` from the JSON config.
+            Pass ``0`` to create a *pure-client* worker that does NOT contribute
+            its own segment to the cluster pool. Use this for sidecar workers
+            (e.g. indexer) so we do not waste memory on duplicate segments.
+        """
+        super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
+        # Single source of truth: cache_config carries PP / layer-range info
+        # populated by update_default_config_from_user_config (pp_rank/pp_size/
+        # total_layers) plus transfer_manager (node_layer_start/end after the
+        # GPU registration phase).  Defaults keep pp_size==1 callers untouched.
+        self.pp_rank = int(getattr(cache_config, 'mooncake_store_pp_rank', 0) or 0)
+        self.pp_size = int(getattr(cache_config, 'mooncake_store_pp_size', 1) or 1)
+        self.node_layer_start = int(getattr(cache_config, 'mooncake_store_node_layer_start', 0) or 0)
+        self.node_layer_end = int(getattr(cache_config, 'mooncake_store_node_layer_end', 0) or 0)
+        self.total_layers = int(getattr(cache_config, 'mooncake_store_total_layers', 0) or 0)
+
+        self.suffix_str = pool_kind.value
+        self.pool_kind = pool_kind
+        # ---- Hot CPU region ------------------------------------------------
+        cpu_blocks: torch.Tensor = materialize_worker_tensor(cpu_blocks)
+        flexkv_logger.info(
+            f"Pinning CPU Memory: "
+            f"{cpu_blocks.numel() * cpu_blocks.element_size() / (1024 ** 3):.2f} GB"
+        )
+        cudaHostRegister(cpu_blocks)
+        self.cpu_layer_ptrs = self._get_layer_ptrs(cpu_blocks)
+
+        self.num_layers: int = cpu_kv_layout.num_layer
+        self.num_cpu_blocks: int = cpu_kv_layout.num_block
+        self.block_size =cpu_kv_layout.get_chunk_size()
+        self.dtype: torch.dtype = dtype
+
+        self.cpu_kv_layout = cpu_kv_layout
+        assert self.cpu_kv_layout.type == KVCacheLayoutType.BLOCKFIRST
+
+        self.is_mla: bool = cpu_kv_layout.is_mla
+        self.kv_dim = 2 if not self.is_mla else 1
+
+        self.cpu_blocks = cpu_blocks
+        self.cache_config = cache_config
+        self._cpu_buffer = cpu_blocks[0] if isinstance(cpu_blocks, (list, tuple)) else cpu_blocks
+        cpu_memory_size = self.cpu_kv_layout.get_total_elements() * self.dtype.itemsize
+
+
+        # ---- mooncake-store client -----------------------------------------
+        from flexkv.external.mooncake_store_utils import MooncakeStoreClient, MooncakeStoreConfig
+        store_config = MooncakeStoreConfig.from_file(
+            self.cache_config,
+            override_global_segment_size=override_global_segment_size,
+        )
+        self.mooncake_client = MooncakeStoreClient(store_config)
+
+        # Register hot CPU buffer directly for mooncake-store access.
+        self.mooncake_client.register_buffer(self._cpu_buffer)
+        flexkv_logger.info(
+            f"[MooncakeStoreTransferWorker:{self.suffix_str}] Registered hot CPU buffer "
+            f"ptr=0x{self._cpu_buffer.data_ptr():x} "
+            f"size={self._cpu_buffer.numel() * self._cpu_buffer.element_size()} B "
+            f"({self.num_cpu_blocks} blocks x {self.num_layers} layers), "
+            f"global_segment_size={store_config.global_segment_size}"
+        )
+
+    # ------------------------------------------------------------------
+    # TransferWorkerBase interface
+    # ------------------------------------------------------------------
+
+    def _transfer_impl(
+        self,
+        cpu_ptrs: List[int],
+        block_sizes: List[int],
+        keys: List[str],
+        transfer_type: TransferType,
+    ) -> None:
+        if transfer_type == TransferType.H2REMOTE:
+            put_ok = self.mooncake_client.batch_put(keys, cpu_ptrs, block_sizes)
+            if os.environ.get("FLEXKV_DEBUG_MOONCAKE_STORE", "0"):
+                flexkv_logger.info(f"[MooncakeStoreTransferWorker] H2REMOTE transfer keys: {keys}, ok={sum(put_ok)}, fail={len(keys) - sum(put_ok)}")
+        elif transfer_type == TransferType.REMOTE2H:
+            get_ok = self.mooncake_client.batch_get(keys, cpu_ptrs, block_sizes)
+            if os.environ.get("FLEXKV_DEBUG_MOONCAKE_STORE", "0"):
+                flexkv_logger.info(f"[MooncakeStoreTransferWorker] REMOTE2H transfer keys: {keys}, ok={sum(get_ok)}, fail={len(keys) - sum(get_ok)}")
+        else:
+            raise ValueError(f"[MooncakeStoreTransferWorker] Invalid transfer type: {transfer_type} for mooncake-store transfer worker. "
+                             "Only H2REMOTE and REMOTE2H are supported.")
+
+    def launch_transfer(self, transfer_op: "WorkerTransferOp") -> bool:  # type: ignore[override]
+        cpu_ptrs, block_sizes, keys = self._preprocess(transfer_op)
+        transfer_type = transfer_op.transfer_type
+        start_time = time.time()
+        self._transfer_impl(cpu_ptrs, block_sizes, keys, transfer_type)
+        end_time = time.time()
+
+
+        transfer_size = sum(block_sizes)
+        self._log_transfer_performance(transfer_op, transfer_size, start_time, end_time)
+        return True
+
+    # ------------------------------------------------------------------
+    # internal helper functions
+    # ------------------------------------------------------------------
+
+    def _preprocess(self, transfer_op: "WorkerTransferOp") -> Tuple[List[int], List[int], List[str]]:
+        # REMOTE2H: fill CPU (dst); H2REMOTE: read from CPU (src)
+        cpu_block_ids = (
+            transfer_op.dst_block_ids 
+            if transfer_op.transfer_type == TransferType.REMOTE2H 
+            else transfer_op.src_block_ids
+        )
+        assert transfer_op.mooncake_store_block_hashes is not None
+        elements_per_block = self.cpu_kv_layout.get_elements_per_block()
+
+        block_size_bytes = elements_per_block * self.dtype.itemsize
+        cpu_ptrs = []
+        block_sizes = []
+        keys = []
+        base_ptr = self._cpu_buffer.data_ptr()
+        for i, blk_id in enumerate(cpu_block_ids):
+            cpu_ptr = base_ptr + blk_id * block_size_bytes
+            key = build_key(
+                transfer_op.mooncake_store_block_hashes[i],
+                self.pool_kind,
+                pp_rank=self.pp_rank,
+                pp_size=self.pp_size,
+                node_layer_start=self.node_layer_start,
+                node_layer_end=self.node_layer_end,
+                total_layers=self.total_layers,
+            )
+            cpu_ptrs.append(cpu_ptr)
+            block_sizes.append(block_size_bytes)
+            keys.append(key)
+        return cpu_ptrs, block_sizes, keys
+
+    def _postprocess(self, transfer_op: "WorkerTransferOp") -> None:
+        pass

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1,6 +1,9 @@
 import contextlib
 import os
 import copy
+import sys
+import faulthandler
+
 import torch.multiprocessing as mp
 import threading
 import time
@@ -138,6 +141,8 @@ class TransferWorkerBase(ABC):
     @classmethod
     def _worker_process(cls, worker_id: int, transfer_conn: Connection, finished_ops_queue: MPQueue,
                         op_buffer_tensor: torch.Tensor, ready_event: Any, *args: Any, **kwargs: Any) -> None:
+        # Enable faulthandler in worker subprocess to capture segfault/SIGBUS stack traces.
+        faulthandler.enable(file=sys.stderr, all_threads=True)
         # Note: MPI initialization prevention is handled by create_safe_process
         # Environment variables are set before this function is called
         worker = cls(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor, *args, **kwargs)
@@ -1196,7 +1201,9 @@ class tpGDSTransferWorker(TransferWorkerBase):
             dtype: Data type
             tp_group_size: Effective tp-group size on this node
                 (``effective_tp_size_per_node`` =
-                ``attn_tp_size_per_node × attn_cp_size_per_node``).
+                ``tp_size_per_node × cp_size_per_node``).
+            layer_groups: Optional per-group KV layouts for heterogeneous models
+                (Gemma4 multi-shape, DSA/NSA indexer-as-group).
         """
         # Initialize base class first
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)

--- a/flexkv/transfer/worker_op.py
+++ b/flexkv/transfer/worker_op.py
@@ -17,6 +17,8 @@ class WorkerTransferOp:
     src_block_ids: np.ndarray
     dst_block_ids: np.ndarray
     src_block_node_ids: Optional[np.ndarray]
+    # Block content hashes for mooncake-store key-based addressing.
+    mooncake_store_block_hashes: Optional[np.ndarray]
 
     def __init__(self, transfer_op: TransferOp):
         self.transfer_op_id = transfer_op.op_id
@@ -27,8 +29,14 @@ class WorkerTransferOp:
         self.valid_block_num = transfer_op.valid_block_num
         # Always preserve optional src_block_node_ids from TransferOp
         self.src_block_node_ids = transfer_op.src_block_node_ids
+        # Preserve block_hashes for mooncake-store key-based transfer
+        self.mooncake_store_block_hashes = transfer_op.mooncake_store_block_hashes
 
         if self.src_slot_id == -1 or self.dst_slot_id == -1:
+            self.src_block_ids = transfer_op.src_block_ids
+            self.dst_block_ids = transfer_op.dst_block_ids
+        elif transfer_op.mooncake_store_block_hashes is not None:
+            # mooncake-store backend needs CPU block ids to compute ptrs
             self.src_block_ids = transfer_op.src_block_ids
             self.dst_block_ids = transfer_op.dst_block_ids
         else:

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -46,6 +46,7 @@ class TransferManager:
         self.all_gpu_layouts: Dict[int, KVCacheLayout] = {}
         self.all_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> gpu_blocks
         self.gpu_worker_key_mapping: Dict[int, WorkerKey] = {}
+        self.gpu_pp_start_layer_mapping: Dict[int, int] = {}  # device_id -> pp_start_layer
 
         # Indexer GPU registration data
         self.all_indexer_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> indexer_gpu_blocks
@@ -73,6 +74,7 @@ class TransferManager:
                     dp_client_id=req.dp_client_id,
                     pp_rank=req.pp_rank,
                 )
+                self.gpu_pp_start_layer_mapping[device_id] = req.pp_start_layer
                 # Store indexer GPU data if present
                 if req.indexer_handles is not None:
                     self.all_indexer_gpu_blocks[device_id] = req.indexer_handles
@@ -137,11 +139,59 @@ class TransferManager:
             f"Expected {self.expected_gpus} GPU layouts, got {len(self.all_gpu_layouts)}"
         assert len(self.all_gpu_blocks) == self.expected_gpus, \
             f"Expected {self.expected_gpus} GPU blocks, got {len(self.all_gpu_blocks)}"
-        num_layers_per_pp_stage = next(iter(self.all_gpu_layouts.values())).num_layer
+
+        # Compute total layers on this node: sum up num_layer for each distinct pp_rank.
+        # In single-node PP>1 deployments, multiple pp_ranks share this TransferManager,
+        # so the CPU pool must cover all their layer ranges, not just one pp_stage.
+        pp_rank_to_num_layers: Dict[int, int] = {}
+        for device_id, layout in self.all_gpu_layouts.items():
+            worker_key = self.gpu_worker_key_mapping[device_id]
+            pp_rank = worker_key.pp_rank
+            if pp_rank not in pp_rank_to_num_layers:
+                pp_rank_to_num_layers[pp_rank] = layout.num_layer
+        num_layers_on_node = sum(pp_rank_to_num_layers.values())
+        flexkv_logger.info(
+            f"CPU pool num_layers_on_node={num_layers_on_node} "
+            f"(pp_rank_to_num_layers={pp_rank_to_num_layers})")
+
+        # Build per-WorkerKey start_layer_id mapping for TransferEngine.
+        # gpu_pp_start_layer_mapping stores the *global* layer offset computed by
+        # get_pp_indices (e.g. pp_rank=1 on a 32-layer model with PP=2 gives 16).
+        # The CPU pool on this node is indexed from 0, so we subtract the minimum
+        # global pp_start_layer seen on this node to get the CPU-pool-local offset.
+        # Examples:
+        #   single-node PP=2: node_min=0, pp_rank=0 → 0, pp_rank=1 → L/2   ✓
+        #   cross-node PP=2, node-1: node_min=L/2, pp_rank=1 → L/2-L/2=0   ✓
+        node_min_pp_start_layer = min(self.gpu_pp_start_layer_mapping.values(), default=0)
+        worker_key_to_start_layer_id: Dict[WorkerKey, int] = {}
+        for device_id, pp_start_layer in self.gpu_pp_start_layer_mapping.items():
+            worker_key = self.gpu_worker_key_mapping[device_id]
+            if worker_key not in worker_key_to_start_layer_id:
+                worker_key_to_start_layer_id[worker_key] = pp_start_layer - node_min_pp_start_layer
+        flexkv_logger.info(
+            f"worker_key_to_start_layer_id={worker_key_to_start_layer_id} "
+            f"(node_min_pp_start_layer={node_min_pp_start_layer})")
+
+        if self.cache_config.use_mooncake_store_backend:
+            # Mooncake key suffix uses the per-node CPU pool layer range.
+            # Full-model node (single-node PP) -> no suffix; partial node
+            # (cross-node PP) -> _pp_rank_<i>_of_<N> suffix.  See build_key.
+            node_layer_end = node_min_pp_start_layer + num_layers_on_node
+            self.cache_config.mooncake_store_node_layer_start = int(node_min_pp_start_layer)
+            self.cache_config.mooncake_store_node_layer_end = int(node_layer_end)
+            # total_layers usually injected by update_default_config_from_user_config,
+            # but be defensive in case the engine was constructed bare.
+            if int(getattr(self.cache_config, 'mooncake_store_total_layers', 0) or 0) == 0:
+                self.cache_config.mooncake_store_total_layers = int(self.model_config.num_layers)
+            flexkv_logger.info(
+                f"mooncake key range: node_layer_start={node_min_pp_start_layer}, "
+                f"node_layer_end={node_layer_end}, "
+                f"total_layers={self.cache_config.mooncake_store_total_layers}")
+
         self.storage_engine = StorageEngine(
             self.model_config,
             self.cache_config,
-            num_layers_per_pp_stage,
+            num_layers_on_node,
         )
 
         # Register GPU blocks with their global device IDs
@@ -174,9 +224,11 @@ class TransferManager:
             if self.cache_config.enable_cpu else None
         ssd_handle = self.storage_engine.get_storage_handle(DeviceType.SSD) \
             if self.cache_config.enable_ssd else None
+        # mooncake-store backend does not use RemoteAllocator; remote is handled by MooncakeStoreTransferWorker.
+        use_mooncake_store = self.cache_config.use_mooncake_store_backend
         remote_handle = (
             self.storage_engine.get_storage_handle(DeviceType.REMOTE) \
-            if self.cache_config.enable_remote \
+            if self.cache_config.enable_remote and not use_mooncake_store\
             else None
         )
 
@@ -213,6 +265,7 @@ class TransferManager:
             cpu_handle=cpu_handle,
             ssd_handle=ssd_handle,
             remote_handle=remote_handle,
+            worker_key_to_start_layer_id=worker_key_to_start_layer_id,
             indexer_gpu_handles=indexer_gpu_handles,
             indexer_cpu_handle=indexer_cpu_handle,
             indexer_ssd_handle=indexer_ssd_handle,

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -780,16 +780,25 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
                         break
                 except ChildProcessError:
                     break
+
         signal.signal(signal.SIGCHLD, _reap_children)
         try:
-            flexkv_logger.debug(f"_process_worker started, pid={os.getpid()}, "
-                               f"gpu_register_port={gpu_register_port}")
+            flexkv_logger.debug(
+                f"_process_worker started, pid={os.getpid()}, "
+                f"gpu_register_port={gpu_register_port}"
+            )
+            os.environ["MPI4PY_RC_INITIALIZE"] = "false"
+            transfer_manager = TransferManager(
+                model_config, cache_config, gpu_register_port
+            )
+            # Signal parent only after the ZMQ PULL socket is bound so GPU
+            # registration messages are not dropped by early PUSH sends.
             start_event.set()
-            os.environ['MPI4PY_RC_INITIALIZE'] = 'false'
-            transfer_manager = TransferManager(model_config, cache_config, gpu_register_port)
             transfer_manager.initialize_transfer_engine()
             transfer_manager.start()
-            flexkv_logger.debug("TransferEngine started successfully, setting ready_event")
+            flexkv_logger.debug(
+                "TransferEngine started successfully, setting ready_event"
+            )
             ready_event.set()
 
             # Setup selector for event-driven processing (complete zero polling!)
@@ -854,7 +863,7 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
             flexkv_logger.error(f"Failed to initialize transfer manager process: {e}")
         finally:
             # Cleanup selector (only if it was created)
-            if 'sel' in locals():
+            if "sel" in locals():
                 try:
                     sel.close()
                 except Exception as e:

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -149,11 +149,15 @@ class GPUKVCacheVerifier:
         elif isinstance(shared_gpu_blocks[0], TensorSharedHandle):
              self.gpu_blocks = [wrapper.get_tensor() for wrapper in shared_gpu_blocks]
         else:
+            # List[List[torch.Tensor]] or List[List[TensorSharedHandle]]
             imported_gpu_blocks = []
-            for handles_in_one_gpu in shared_gpu_blocks:
+            for items_in_one_gpu in shared_gpu_blocks:
                 blocks_in_one_gpu = []
-                for handle in handles_in_one_gpu:
-                    blocks_in_one_gpu.append(handle.get_tensor())
+                for item in items_in_one_gpu:
+                    if isinstance(item, torch.Tensor):
+                        blocks_in_one_gpu.append(item)
+                    else:
+                        blocks_in_one_gpu.append(item.get_tensor())
                 imported_gpu_blocks.append(blocks_in_one_gpu)
             self.gpu_blocks = imported_gpu_blocks
         self.gpu_block_num = gpu_kv_layout.num_block

--- a/tests/test_mooncake_store_integration.py
+++ b/tests/test_mooncake_store_integration.py
@@ -1,0 +1,477 @@
+# SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for FlexKV + mooncake-store integration:
+  * MooncakeStoreClient: batch_put / batch_get / batch_exists round-trip
+  * MooncakeStoreCacheEngine.match():
+      - single-pool (KV-only) longest-prefix semantics
+      - multi-pool (KV + indexer) joint-existence intersection
+  * End-to-end: put-with-pattern -> match -> get -> verify data
+
+Requires
+--------
+A running mooncake-store cluster reachable from the test host, plus a JSON
+config file describing the local client. Set one of:
+
+    export FLEXKV_MOONCAKE_STORE_CONFIG_PATH=/path/to/mooncake_store.json
+
+The test module is skipped automatically when the SDK is missing or the
+config env-var is not set, so it is safe to run in CI without a cluster.
+
+Running
+-------
+    pytest tests/test_mooncake_store_integration.py -m mooncake -v
+
+Run only mooncake tests (skip when not configured):
+    pytest tests/test_mooncake_store_integration.py -v
+"""
+from __future__ import annotations
+
+import os
+import uuid
+import pytest
+import torch
+import numpy as np
+
+# Skip the entire module if the mooncake-store SDK is not installed.
+pytest.importorskip("mooncake.store", reason="mooncake-store SDK not installed")
+
+from flexkv.common.config import CacheConfig, IndexerCacheConfig
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.common.block import SequenceMeta
+from flexkv.external.mooncake_store_keys import PoolKind, build_key
+from flexkv.common.debug import flexkv_logger
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def _mooncake_configured() -> bool:
+    return bool(os.environ.get("FLEXKV_MOONCAKE_STORE_CONFIG_PATH"))
+
+
+def _config_path() -> str:
+    return os.environ.get("FLEXKV_MOONCAKE_STORE_CONFIG_PATH", "")
+
+
+def _make_cache_config(*, with_indexer: bool = False) -> CacheConfig:
+    """Build a minimal CacheConfig that targets mooncake-store."""
+    indexer = IndexerCacheConfig() if with_indexer else None
+    return CacheConfig(
+        tokens_per_block=16,
+        enable_cpu=True,
+        enable_ssd=False,
+        enable_remote=True,
+        use_mooncake_store_backend=True,
+        mooncake_store_config_path=_config_path(),
+        num_cpu_blocks=64,
+        num_remote_blocks=128,
+        indexer=indexer,
+    )
+
+
+def _make_blockfirst_layout(num_blocks=16, num_layers=1, tokens_per_block=16):
+    return KVCacheLayout(
+        type=KVCacheLayoutType.BLOCKFIRST,
+        num_layer=num_layers,
+        num_block=num_blocks,
+        tokens_per_block=tokens_per_block,
+        num_head=2,
+        head_size=64,
+        is_mla=True,
+    )
+
+
+def _unique_key(prefix: str) -> str:
+    """Avoid collisions between test runs that share a live cluster."""
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def mooncake_client():
+    """Module-scoped MooncakeStoreClient bound to the configured cluster."""
+    if not _mooncake_configured():
+        pytest.skip(
+            "mooncake-store not configured: "
+            "set FLEXKV_MOONCAKE_STORE_CONFIG_PATH to a JSON config file"
+        )
+
+    from flexkv.external.mooncake_store_utils import (
+        MooncakeStoreConfig,
+        MooncakeStoreClient,
+    )
+
+    cache_config = _make_cache_config()
+    cfg = MooncakeStoreConfig.from_file(cache_config)
+    # Read/write client (NOT query_only) so we can call batch_put/get.
+    client = MooncakeStoreClient(cfg, query_only=False)
+    flexkv_logger.info("client setup done")
+    yield client
+    # No explicit teardown: the SDK's underlying store has its own GC.
+
+
+@pytest.fixture
+def buffer_and_keys():
+    """Allocate a small CPU tensor and register it as a Mooncake MR.
+
+    Returns ``(buffer, layout, ptrs, sizes)`` for the caller to populate
+    with KV-style data and then publish via ``batch_put`` etc.
+    """
+    layout = _make_blockfirst_layout(num_blocks=4)
+    dtype = torch.bfloat16
+    elements_per_block = layout.get_elements_per_block()
+    block_size_bytes = elements_per_block * dtype.itemsize
+    total_bytes = layout.num_block * block_size_bytes
+
+    buffer = torch.zeros(total_bytes // dtype.itemsize, dtype=dtype)
+    ptrs = [
+        int(buffer.data_ptr() + i * block_size_bytes)
+        for i in range(layout.num_block)
+    ]
+    sizes = [block_size_bytes] * layout.num_block
+    return buffer, layout, ptrs, sizes
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: low-level client tests (mirrors test_simm_client_query/transfer)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mooncake
+def test_mooncake_client_query(mooncake_client, buffer_and_keys):
+    """batch_put then batch_exists returns the expected longest-prefix length."""
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+    print("register buffer done")
+    # Use 3 of the 4 buffer slots as test keys.
+    keys = [_unique_key(f"query_{i}") for i in range(3)]
+    put_ok = mooncake_client.batch_put(
+        key_strs=keys,
+        buffer_ptrs=ptrs[: len(keys)],
+        buffer_sizes=sizes[: len(keys)],
+    )
+    print("register buffer done")
+
+    assert all(put_ok), f"batch_put failed: {put_ok}"
+
+    # All three should exist -> prefix length == 3.
+    n = mooncake_client.batch_exists(keys)
+    assert n == len(keys), f"expected batch_exists={len(keys)}, got {n}"
+
+    # Inserting a non-existent key in the middle must shrink the prefix.
+    mixed = [keys[0], _unique_key("missing"), keys[2]]
+    n2 = mooncake_client.batch_exists(mixed)
+    assert n2 == 1, f"expected prefix=1 (only first exists), got {n2}"
+
+    mooncake_client.unregister_buffer(buffer)
+
+
+@pytest.mark.mooncake
+def test_mooncake_client_transfer(mooncake_client, buffer_and_keys):
+    """batch_put then batch_get must round-trip the original payload."""
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    elements_per_block = layout.get_elements_per_block()
+    keys = [_unique_key(f"xfer_{i}") for i in range(layout.num_block)]
+
+    # Seed each block with a distinguishable scalar.
+    flat = buffer.view(-1)
+    for i in range(layout.num_block):
+        flat[i * elements_per_block : (i + 1) * elements_per_block] = float(i + 100)
+
+    put_ok = mooncake_client.batch_put(
+        key_strs=keys, buffer_ptrs=ptrs, buffer_sizes=sizes
+    )
+    assert all(put_ok), f"batch_put failed: {put_ok}"
+
+    # Wipe and read back from the cluster.
+    buffer.zero_()
+    get_ok = mooncake_client.batch_get(
+        key_strs=keys, buffer_ptrs=ptrs, buffer_sizes=sizes
+    )
+    assert all(get_ok), f"batch_get failed: {get_ok}"
+
+    for i in range(layout.num_block):
+        actual = flat[i * elements_per_block].item()
+        expected = float(i + 100)
+        assert actual == expected, f"block {i}: expected {expected}, got {actual}"
+
+    mooncake_client.unregister_buffer(buffer)
+
+# ---------------------------------------------------------------------------
+# Layer 2: MooncakeStoreCacheEngine.match() — single-pool (KV-only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mooncake
+def test_match_kv_only_full_hit(mooncake_client, buffer_and_keys):
+    """When all KV keys exist, match() returns num_blocks."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+    assert seq.num_blocks == num_blocks
+
+    # Publish KV blocks under the suffix the worker would actually write.
+    kv_keys = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    put_ok = mooncake_client.batch_put(
+        key_strs=kv_keys, buffer_ptrs=ptrs, buffer_sizes=sizes
+    )
+    assert all(put_ok)
+
+    cache_config = _make_cache_config(with_indexer=False)
+    engine = MooncakeStoreCacheEngine(cache_config)
+
+    result = engine.match(seq)
+    assert result.matched_pos == MooncakeStoreCacheEngine.MATCHED_POS
+    assert result.num_matched_blocks == num_blocks, (
+        f"expected match={num_blocks}, got {result.num_matched_blocks}"
+    )
+    assert result.num_ready_matched_blocks == result.num_matched_blocks
+
+    mooncake_client.unregister_buffer(buffer)
+
+@pytest.mark.mooncake
+def test_match_kv_only_partial_prefix(mooncake_client, buffer_and_keys):
+    """If only the first K KV keys exist, match() returns exactly K."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block  # 4
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+
+    # Only publish the first 2 KV keys.
+    publish = 2
+    kv_keys_full = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    put_ok = mooncake_client.batch_put(
+        key_strs=kv_keys_full[:publish],
+        buffer_ptrs=ptrs[:publish],
+        buffer_sizes=sizes[:publish],
+    )
+    assert all(put_ok)
+
+    cache_config = _make_cache_config(with_indexer=False)
+    engine = MooncakeStoreCacheEngine(cache_config)
+
+    result = engine.match(seq)
+    assert result.num_matched_blocks == publish, (
+        f"expected partial prefix={publish}, got {result.num_matched_blocks}"
+    )
+
+    mooncake_client.unregister_buffer(buffer)
+
+# ---------------------------------------------------------------------------
+# Layer 3: MooncakeStoreCacheEngine.match() — multi-pool (KV + indexer)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mooncake
+def test_match_kv_indexer_joint_full_hit(mooncake_client, buffer_and_keys):
+    """When KV and indexer are BOTH published, match() returns num_blocks."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+
+    kv_keys = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    idx_keys = [build_key(seq.block_hashes[i], PoolKind.INDEXER) for i in range(num_blocks)]
+
+    # We re-use the same buffer slots for both pools; the test only cares
+    # about key-existence, not block content.
+    assert all(mooncake_client.batch_put(kv_keys, ptrs, sizes))
+    assert all(mooncake_client.batch_put(idx_keys, ptrs, sizes))
+
+    cache_config = _make_cache_config(with_indexer=True)
+    engine = MooncakeStoreCacheEngine(cache_config)
+    assert len(engine.hit_pool_specs) == 2  # KV + indexer
+
+    result = engine.match(seq)
+    assert result.num_matched_blocks == num_blocks, (
+        f"joint hit should return {num_blocks}, got {result.num_matched_blocks}"
+    )
+
+    mooncake_client.unregister_buffer(buffer)
+
+@pytest.mark.mooncake
+def test_match_kv_indexer_joint_indexer_missing(mooncake_client, buffer_and_keys):
+    """KV-hit but indexer-miss must NOT count as a hit (prefix truncates)."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block  # 4
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+
+    kv_keys = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    idx_keys = [build_key(seq.block_hashes[i], PoolKind.INDEXER) for i in range(num_blocks)]
+
+    # Publish ALL KV keys, but only the FIRST 2 indexer keys.
+    assert all(mooncake_client.batch_put(kv_keys, ptrs, sizes))
+    publish_idx = 2
+    assert all(
+        mooncake_client.batch_put(
+            idx_keys[:publish_idx], ptrs[:publish_idx], sizes[:publish_idx]
+        )
+    )
+
+    cache_config = _make_cache_config(with_indexer=True)
+    engine = MooncakeStoreCacheEngine(cache_config)
+
+    result = engine.match(seq)
+    # Joint-AND prefix must stop at the first indexer miss.
+    assert result.num_matched_blocks == publish_idx, (
+        f"joint match must truncate at first indexer miss; "
+        f"expected {publish_idx}, got {result.num_matched_blocks}"
+    )
+
+    mooncake_client.unregister_buffer(buffer)
+
+@pytest.mark.mooncake
+def test_match_kv_indexer_joint_kv_missing(mooncake_client, buffer_and_keys):
+    """Symmetric: KV-miss but indexer-hit also truncates."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+
+    kv_keys = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    idx_keys = [build_key(seq.block_hashes[i], PoolKind.INDEXER) for i in range(num_blocks)]
+
+    # Publish only the first KV key, but ALL indexer keys.
+    publish_kv = 1
+    assert all(
+        mooncake_client.batch_put(
+            kv_keys[:publish_kv], ptrs[:publish_kv], sizes[:publish_kv]
+        )
+    )
+    assert all(mooncake_client.batch_put(idx_keys, ptrs, sizes))
+
+    cache_config = _make_cache_config(with_indexer=True)
+    engine = MooncakeStoreCacheEngine(cache_config)
+
+    result = engine.match(seq)
+    assert result.num_matched_blocks == publish_kv, (
+        f"joint match must truncate at first KV miss; "
+        f"expected {publish_kv}, got {result.num_matched_blocks}"
+    )
+
+    mooncake_client.unregister_buffer(buffer)
+
+# ---------------------------------------------------------------------------
+# Layer 4: end-to-end (put pattern -> match -> get -> verify content)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mooncake
+def test_mooncake_e2e_kv_only(mooncake_client, buffer_and_keys):
+    """End-to-end with KV-only pool: write recognisable pattern, match,
+    fetch back, verify byte-for-byte equality."""
+    from flexkv.external.mooncake_store_utils import MooncakeStoreCacheEngine
+
+    buffer, layout, ptrs, sizes = buffer_and_keys
+    mooncake_client.register_buffer(buffer)
+
+    tokens_per_block = layout.tokens_per_block
+    num_blocks = layout.num_block
+    elements_per_block = layout.get_elements_per_block()
+
+    token_ids = np.random.randint(
+        0, 1_000_000, size=num_blocks * tokens_per_block, dtype=np.int64
+    )
+    seq = SequenceMeta(token_ids=token_ids, tokens_per_block=tokens_per_block)
+
+    flat = buffer.view(-1)
+    for i in range(num_blocks):
+        flat[i * elements_per_block : (i + 1) * elements_per_block] = float(200 + i)
+
+    kv_keys = [build_key(seq.block_hashes[i], PoolKind.KV) for i in range(num_blocks)]
+    assert all(mooncake_client.batch_put(kv_keys, ptrs, sizes))
+
+    cache_config = _make_cache_config(with_indexer=False)
+    engine = MooncakeStoreCacheEngine(cache_config)
+
+    result = engine.match(seq)
+    assert result.num_matched_blocks == num_blocks, "all blocks must be matchable"
+
+    # Wipe and pull data back through batch_get.
+    buffer.zero_()
+    assert all(mooncake_client.batch_get(kv_keys, ptrs, sizes))
+    for i in range(num_blocks):
+        assert flat[i * elements_per_block].item() == float(200 + i), (
+            f"block {i} content mismatch after round-trip"
+        )
+
+    mooncake_client.unregister_buffer(buffer)
+
+# ---------------------------------------------------------------------------
+# Layer 5: PoolSpec/CacheConfig wiring sanity (no cluster needed)
+# ---------------------------------------------------------------------------
+
+def test_enable_pool_specs_kv_only_when_indexer_none():
+    """Without indexer, only the KV pool is active."""
+    cfg = CacheConfig(
+        tokens_per_block=16,
+        enable_remote=True,
+        use_mooncake_store_backend=True,
+        mooncake_store_config_path="/tmp/dummy.json",  # not loaded here
+        indexer=None,
+    )
+    specs = cfg.enable_pool_specs()
+    kinds = [s.kind for s in specs]
+    assert kinds == [PoolKind.KV]
+
+
+def test_enable_pool_specs_includes_indexer_when_configured():
+    """Configuring an IndexerCacheConfig must add the INDEXER pool."""
+    cfg = CacheConfig(
+        tokens_per_block=16,
+        enable_remote=True,
+        use_mooncake_store_backend=True,
+        mooncake_store_config_path="/tmp/dummy.json",
+        indexer=IndexerCacheConfig(),
+    )
+    specs = cfg.enable_pool_specs()
+    kinds = [s.kind for s in specs]
+    assert kinds == [PoolKind.KV, PoolKind.INDEXER]
+    assert all(s.required_for_hit for s in specs), (
+        "all current pools must participate in joint-hit"
+    )
+
+
+def test_build_key_format_matches_worker_contract():
+    """Centralised key builder must produce '<hash>_<suffix>' literally."""
+    assert build_key(123, PoolKind.KV) == "123_FlexKV"
+    assert build_key("abc", PoolKind.INDEXER) == "abc_FlexKV_indexer"

--- a/tests/test_transfer_correctness.py
+++ b/tests/test_transfer_correctness.py
@@ -1,0 +1,797 @@
+"""
+FlexKV transfer correctness test suite.
+
+Systematically verifies KV Cache data correctness across all combinations of:
+  - Parallel configurations: PP=2, TP=2, PP+TP, simulated cross-node PP/TP variants
+  - Storage backends: CPU-only, CPU+SSD, GDS, Layerwise CPU-only, Layerwise CPU+SSD
+
+Core verification principle:
+  Fill GPU blocks with deterministic hash values keyed on (layer_id, kv_id, head_id, token_ids),
+  perform a full round-trip transfer, then verify the restored data matches the original hashes.
+  Any routing error (layer offset, head shard offset, etc.) will cause verification failure.
+
+GPU availability strategy:
+  - Prefer real multi-GPU testing when enough physical GPUs are available.
+  - Automatically downgrade to override_device_id simulation on fewer GPUs.
+  - Skip tests that cannot be simulated at all.
+  - Mark simulated tests with [simulated] in the test label.
+
+Extensibility:
+  - Add new storage backends: add an entry to BACKEND_REGISTRY.
+  - Add new parallel configs (e.g. CP): add an entry to PARALLEL_CONFIG_REGISTRY.
+  - Core test logic (_run_transfer_test) requires no modification.
+"""
+
+import os
+import time
+import threading
+import ctypes
+import socket
+import struct
+import traceback
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+import torch
+import multiprocessing as mp
+
+from flexkv.common.config import ModelConfig, CacheConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.common.request import KVResponseStatus
+from flexkv.common.memory_handle import TensorSharedHandle
+from flexkv.kvmanager import KVManager
+from flexkv.server.client import KVTPClient
+
+from common_utils import (
+    generate_request_pair,
+    block_ids_2_slot_mapping,
+    GPUKVCacheVerifier,
+)
+
+# ---------------------------------------------------------------------------
+# Global test constants
+# ---------------------------------------------------------------------------
+NUM_LAYERS_TOTAL  = 4      # total model layers
+NUM_KV_HEADS      = 8      # total KV heads (before TP sharding)
+HEAD_SIZE         = 64
+TOKENS_PER_BLOCK  = 16
+DTYPE             = torch.float16
+NUM_GPU_BLOCKS    = 64
+BLOCK_PER_REQ     = 4
+NUM_REQUESTS      = NUM_GPU_BLOCKS // BLOCK_PER_REQ   # 16 requests
+
+# ---------------------------------------------------------------------------
+# Task 1: Parallel configuration registry & GPU adaptive strategy
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WorkerSpec:
+    """Describes a single logical worker (one PP stage × one TP rank)."""
+    pp_rank: int
+    tp_rank: int
+    pp_start_layer: int   # absolute layer index where this PP stage starts
+    num_layers: int       # number of layers owned by this PP stage
+    num_heads: int        # number of KV heads owned by this TP rank (after sharding)
+    head_offset: int      # global head index offset for this TP rank
+    device_id: int        # physical GPU device id to use for tensor allocation
+    register_device_id: int  # logical device_id used for KVManager registration
+
+
+@dataclass
+class ParallelConfig:
+    """Describes a parallel configuration to be tested."""
+    name: str
+    pp_size: int
+    tp_size: int
+    # Minimum number of physical GPUs needed for a "real" (non-simulated) run.
+    # Set to 1 if even a single GPU suffices for a real run.
+    min_gpus_for_real: int
+    # Whether this config can be simulated via override_device_id when GPUs are insufficient.
+    can_simulate: bool = True
+
+    def total_workers(self) -> int:
+        return self.pp_size * self.tp_size
+
+    def resolve_device_assignment(self, available_gpus: int) -> Tuple[List[WorkerSpec], bool]:
+        """Return (worker_specs, is_simulated).
+
+        Strategy:
+          1. If available_gpus >= min_gpus_for_real → assign workers to distinct GPUs (real).
+          2. Elif can_simulate → assign all workers to GPU 0 via override_device_id (simulated).
+          3. Else → return ([], False) to signal skip.
+        """
+        if available_gpus == 0:
+            return [], False
+
+        layers_per_pp = NUM_LAYERS_TOTAL // self.pp_size
+        heads_per_tp  = NUM_KV_HEADS // self.tp_size
+
+        if available_gpus >= self.min_gpus_for_real:
+            # Real multi-GPU: assign each worker to a distinct GPU (round-robin if needed)
+            is_simulated = False
+            workers = []
+            worker_idx = 0
+            for pp_rank in range(self.pp_size):
+                for tp_rank in range(self.tp_size):
+                    device_id = worker_idx % available_gpus
+                    workers.append(WorkerSpec(
+                        pp_rank=pp_rank,
+                        tp_rank=tp_rank,
+                        pp_start_layer=pp_rank * layers_per_pp,
+                        num_layers=layers_per_pp,
+                        num_heads=heads_per_tp,
+                        head_offset=tp_rank * heads_per_tp,
+                        device_id=device_id,
+                        register_device_id=worker_idx,  # unique logical id
+                    ))
+                    worker_idx += 1
+            return workers, is_simulated
+        elif self.can_simulate:
+            # Simulated: all workers share GPU 0, but use distinct register_device_id
+            is_simulated = True
+            workers = []
+            worker_idx = 0
+            for pp_rank in range(self.pp_size):
+                for tp_rank in range(self.tp_size):
+                    workers.append(WorkerSpec(
+                        pp_rank=pp_rank,
+                        tp_rank=tp_rank,
+                        pp_start_layer=pp_rank * layers_per_pp,
+                        num_layers=layers_per_pp,
+                        num_heads=heads_per_tp,
+                        head_offset=tp_rank * heads_per_tp,
+                        device_id=0,           # all on GPU 0
+                        register_device_id=worker_idx,
+                    ))
+                    worker_idx += 1
+            return workers, is_simulated
+        else:
+            return [], False
+
+
+# Registry of all parallel configurations to test.
+# To add a new config (e.g. CP), simply append a new ParallelConfig here.
+PARALLEL_CONFIG_REGISTRY: List[ParallelConfig] = [
+    ParallelConfig(
+        name="pp2",
+        pp_size=2, tp_size=1,
+        min_gpus_for_real=2,
+        can_simulate=True,
+    ),
+    ParallelConfig(
+        name="tp2",
+        pp_size=1, tp_size=2,
+        min_gpus_for_real=2,
+        can_simulate=True,
+    ),
+    ParallelConfig(
+        name="pp2_tp2",
+        pp_size=2, tp_size=2,
+        min_gpus_for_real=4,
+        can_simulate=True,
+    ),
+    ParallelConfig(
+        name="sim_cross_node_pp2",
+        pp_size=2, tp_size=1,
+        min_gpus_for_real=2,
+        can_simulate=True,
+    ),
+    ParallelConfig(
+        name="sim_cross_node_tp2",
+        pp_size=1, tp_size=2,
+        min_gpus_for_real=2,
+        can_simulate=True,
+    ),
+    ParallelConfig(
+        name="sim_cross_node_pp2_tp2",
+        pp_size=2, tp_size=2,
+        min_gpus_for_real=4,
+        can_simulate=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Task 3: Storage backend registry (CacheConfig factory)
+# ---------------------------------------------------------------------------
+
+class Backend(str, Enum):
+    CPU_ONLY           = "cpu_only"
+    CPU_SSD            = "cpu_ssd"
+    GDS                = "gds"
+    LAYERWISE_CPU_ONLY = "layerwise_cpu_only"
+    LAYERWISE_CPU_SSD  = "layerwise_cpu_ssd"
+
+
+def make_cache_config(backend: Backend) -> Optional[CacheConfig]:
+    """Factory: return a CacheConfig for the given backend, or None if unavailable.
+
+    Returns None when:
+      - backend == GDS and FLEXKV_ENABLE_GDS != "1"
+    The caller should call pytest.skip() when None is returned.
+
+    To add a new backend, add a new branch here — no other code needs changing.
+    """
+    if backend == Backend.CPU_ONLY:
+        return CacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            enable_cpu=True,
+            enable_ssd=False,
+            enable_gds=False,
+            enable_remote=False,
+            num_cpu_blocks=512,
+            num_ssd_blocks=0,
+        )
+    elif backend == Backend.CPU_SSD:
+        return CacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            enable_cpu=True,
+            enable_ssd=True,
+            enable_gds=False,
+            enable_remote=False,
+            num_cpu_blocks=512,   # large enough to hold all blocks without SSD eviction
+            num_ssd_blocks=512,
+            ssd_cache_dir=["/tmp/flexkv_test_ssd_cache"],
+        )
+    elif backend == Backend.GDS:
+        if os.environ.get("FLEXKV_ENABLE_GDS", "0") != "1":
+            return None
+        return CacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            enable_cpu=True,
+            enable_ssd=True,
+            enable_gds=True,
+            enable_remote=False,
+            num_cpu_blocks=256,
+            num_ssd_blocks=512,
+        )
+    elif backend == Backend.LAYERWISE_CPU_ONLY:
+        return CacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            enable_cpu=True,
+            enable_ssd=False,
+            enable_gds=False,
+            enable_remote=False,
+            num_cpu_blocks=512,
+            num_ssd_blocks=0,
+        )
+    elif backend == Backend.LAYERWISE_CPU_SSD:
+        return CacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            enable_cpu=True,
+            enable_ssd=True,
+            enable_gds=False,
+            enable_remote=False,
+            num_cpu_blocks=512,   # large enough to hold all blocks without SSD eviction
+            num_ssd_blocks=512,
+            ssd_cache_dir=["/tmp/flexkv_test_ssd_cache"],
+        )
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def is_layerwise_backend(backend: Backend) -> bool:
+    return backend in (Backend.LAYERWISE_CPU_ONLY, Backend.LAYERWISE_CPU_SSD)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Generic multi-worker registration framework
+# ---------------------------------------------------------------------------
+
+def _worker_process_fn(
+    worker_spec: WorkerSpec,
+    gpu_register_port: str,
+    model_config: ModelConfig,
+    cache_config: CacheConfig,
+    num_gpu_blocks: int,
+    child_conn,
+) -> None:
+    """Subprocess: allocate GPU blocks for one (pp_rank, tp_rank) worker and register to KVManager.
+
+    Sends a list of TensorSharedHandle back through child_conn, then stays alive
+    until the process is terminated by the parent.
+    """
+    try:
+        device_id = worker_spec.device_id
+        kv_dim = 2  # non-MLA
+
+        # Allocate GPU blocks for this worker's layers
+        gpu_blocks = []
+        for _ in range(worker_spec.num_layers):
+            t = torch.zeros(
+                kv_dim,
+                num_gpu_blocks,
+                TOKENS_PER_BLOCK,
+                worker_spec.num_heads,
+                HEAD_SIZE,
+                dtype=DTYPE,
+            ).cuda(device_id)
+            gpu_blocks.append(t)
+
+        gpu_kv_layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=worker_spec.num_layers,
+            num_block=num_gpu_blocks,
+            tokens_per_block=TOKENS_PER_BLOCK,
+            num_head=worker_spec.num_heads,
+            head_size=HEAD_SIZE,
+            is_mla=False,
+        )
+
+        tp_client = KVTPClient(
+            gpu_register_port=gpu_register_port,
+            dp_client_id=0,
+            pp_rank=worker_spec.pp_rank,
+            pp_start_layer=worker_spec.pp_start_layer,
+            device_id=worker_spec.register_device_id,
+        )
+        tp_client.register_to_server(
+            gpu_blocks,
+            gpu_kv_layout,
+            override_device_id=worker_spec.register_device_id,
+        )
+
+        # Send handles back to main process
+        shared = [TensorSharedHandle(t) for t in gpu_blocks]
+        child_conn.send(shared)
+        child_conn.close()
+
+        # Stay alive until terminated
+        while True:
+            time.sleep(1)
+
+    except Exception:
+        traceback.print_exc()
+        try:
+            child_conn.send(None)
+            child_conn.close()
+        except Exception:
+            pass
+
+
+def _shutdown_processes(procs: list) -> None:
+    """Terminate all worker processes gracefully."""
+    for p in procs:
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout=5)
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=2)
+
+
+def _collect_gpu_blocks(
+    pipes: list,
+    workers: List[WorkerSpec],
+    test_label: str,
+) -> List[List[TensorSharedHandle]]:
+    """Collect TensorSharedHandle lists from all worker pipes.
+
+    Returns a flat list indexed by worker index (same order as `workers`).
+    Each element is a list of TensorSharedHandle, one per layer in that worker's PP stage.
+    """
+    all_handles = []
+    for idx, (parent_conn, worker) in enumerate(zip(pipes, workers)):
+        handles = parent_conn.recv()
+        assert handles is not None, (
+            f"[{test_label}] Worker pp_rank={worker.pp_rank} tp_rank={worker.tp_rank} "
+            f"failed to register"
+        )
+        all_handles.append(handles)
+        parent_conn.close()
+    return all_handles
+
+
+def _build_combined_verifier(
+    all_handles: List[List[TensorSharedHandle]],
+    workers: List[WorkerSpec],
+    pp_size: int,
+    tp_size: int,
+) -> GPUKVCacheVerifier:
+    """Build a GPUKVCacheVerifier that covers all PP stages and TP ranks.
+
+    GPUKVCacheVerifier expects:
+      shared_gpu_blocks[tp_rank][layer_local_idx] = tensor
+
+    For PP+TP, we concatenate layers across PP stages for each TP rank:
+      shared_gpu_blocks[tp_rank] = [pp0_layer0, pp0_layer1, ..., pp1_layer0, pp1_layer1, ...]
+
+    The verifier's num_layers = NUM_LAYERS_TOTAL (all layers across all PP stages).
+    The verifier's num_head = heads_per_tp (per TP rank, after sharding).
+    """
+    layers_per_pp = NUM_LAYERS_TOTAL // pp_size
+    heads_per_tp  = NUM_KV_HEADS // tp_size
+
+    # Materialise handles into tensors
+    # worker_tensors[worker_idx][layer_local] = tensor
+    worker_tensors = []
+    for handles in all_handles:
+        worker_tensors.append([h.get_tensor() for h in handles])
+
+    # Build per-TP-rank combined layer list
+    # For tp_rank r: collect layers from all PP stages in order
+    # Shape: blocks_by_tp[tp_rank][layer_global] = torch.Tensor
+    blocks_by_tp: List[List[torch.Tensor]] = []
+    for tp_rank in range(tp_size):
+        layers_for_this_tp = []
+        for pp_rank in range(pp_size):
+            worker_idx = pp_rank * tp_size + tp_rank
+            layers_for_this_tp.extend(worker_tensors[worker_idx])
+        blocks_by_tp.append(layers_for_this_tp)
+
+    full_gpu_layout = KVCacheLayout(
+        type=KVCacheLayoutType.LAYERFIRST,
+        num_layer=NUM_LAYERS_TOTAL,
+        num_block=NUM_GPU_BLOCKS,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        num_head=heads_per_tp,
+        head_size=HEAD_SIZE,
+        is_mla=False,
+    )
+
+    verifier = GPUKVCacheVerifier(
+        shared_gpu_blocks=blocks_by_tp,
+        gpu_kv_layout=full_gpu_layout,
+        tp_size=tp_size,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        dtype=DTYPE,
+        gpu_layout_type=0,  # LAYERFIRST, one tensor per layer
+    )
+    return verifier
+
+
+# ---------------------------------------------------------------------------
+# Mock SGLang eventfd client (needed for layerwise tests)
+# ---------------------------------------------------------------------------
+
+_libc = ctypes.CDLL("libc.so.6", use_errno=True)
+_EFD_SEMAPHORE = 0x1
+
+
+def _sys_eventfd(initval: int = 0, flags: int = 0) -> int:
+    fd = _libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
+    if fd == -1:
+        err = ctypes.get_errno()
+        raise OSError(err, f"eventfd failed: {os.strerror(err)}")
+    return fd
+
+
+def _send_fds_via_scm(sock: socket.socket, fds: list, extra_data: bytes = b"x"):
+    fds_packed = struct.pack(f"{len(fds)}i", *fds)
+    ancdata = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds_packed)]
+    sock.sendmsg([extra_data], ancdata)
+
+
+def _mock_sglang_eventfd_client(
+    socket_path: str,
+    tp_rank: int,
+    tp_size: int,
+    num_layers: int,
+    num_counters: int = 3,
+    max_retries: int = 120,
+    retry_interval: float = 0.5,
+):
+    """Background thread: simulate SGLang sending eventfds to LayerwiseTransferWorker."""
+    created_fds = []
+    try:
+        for _ in range(num_counters * num_layers):
+            created_fds.append(_sys_eventfd(0, _EFD_SEMAPHORE))
+
+        sock = None
+        for _ in range(max_retries):
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                sock.connect(socket_path)
+                break
+            except (FileNotFoundError, ConnectionRefusedError):
+                sock.close()
+                sock = None
+                time.sleep(retry_interval)
+
+        if sock is None:
+            print(f"[MockEventfdClient] FAILED to connect to {socket_path}")
+            return
+
+        metadata = struct.pack("iiii", tp_rank, tp_size, num_layers, num_counters)
+        sock.sendall(metadata)
+
+        fd_idx = 0
+        for counter_id in range(num_counters):
+            fds = created_fds[fd_idx:fd_idx + num_layers]
+            fd_idx += num_layers
+            _send_fds_via_scm(sock, fds, struct.pack("i", counter_id))
+
+        sock.settimeout(30.0)
+        ack = sock.recv(1)
+        if ack and ack[0] == 1:
+            print(f"[MockEventfdClient] Eventfd handshake OK (tp_rank={tp_rank})")
+        sock.close()
+    except Exception as e:
+        print(f"[MockEventfdClient] Error: {e}")
+        traceback.print_exc()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Core transfer test function (supports any parallel config × backend)
+# ---------------------------------------------------------------------------
+
+def _run_transfer_test(
+    parallel_config: ParallelConfig,
+    cache_config: CacheConfig,
+    workers: List[WorkerSpec],
+    is_simulated: bool,
+    layerwise: bool,
+    test_label: str,
+) -> None:
+    """Run a full round-trip transfer test for the given parallel config and backend.
+
+    Steps:
+      1. Start KVManager with the given pp_size / tp_size.
+      2. Spawn one subprocess per worker; each registers its GPU blocks.
+      3. Fill GPU blocks with deterministic hash values.
+      4. PUT all requests.
+      5. Clear GPU blocks to zero.
+      6. GET data back.
+      7. Verify all PP stages × TP ranks match original hash values.
+    """
+    sim_tag = " [simulated]" if is_simulated else ""
+    print(f"\n[{test_label}]{sim_tag} Starting transfer test "
+          f"(pp={parallel_config.pp_size}, tp={parallel_config.tp_size}, "
+          f"backend={'layerwise+' if layerwise else ''}{cache_config})")
+
+    model_config = ModelConfig(
+        num_layers=NUM_LAYERS_TOTAL,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+        use_mla=False,
+        tp_size=parallel_config.tp_size,
+        dp_size=1,
+        pp_size=parallel_config.pp_size,
+    )
+
+    # ---- Layerwise env setup ----
+    orig_layerwise_env  = os.environ.get("FLEXKV_ENABLE_LAYERWISE_TRANSFER")
+    orig_layerwise_flag = GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer
+    if layerwise:
+        os.environ["FLEXKV_ENABLE_LAYERWISE_TRANSFER"] = "1"
+        GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer = True
+
+    procs: List[mp.Process] = []
+    eventfd_threads: List[threading.Thread] = []
+
+    try:
+        kvmanager = KVManager(
+            model_config=model_config,
+            cache_config=cache_config,
+            dp_client_id=0,
+        )
+
+        # Start mock eventfd clients BEFORE kvmanager.start() for layerwise.
+        # FlexKV creates one LayerwiseWorker per pp_rank, each listening on its
+        # own socket (e.g. _pp0.sock, _pp1.sock when pp_size > 1).  Each socket
+        # expects tp_size connections (one per TP rank).  We must mock all of them.
+        if layerwise:
+            base_socket = os.environ.get(
+                "FLEXKV_LAYERWISE_EVENTFD_SOCKET",
+                "/tmp/flexkv_layerwise_eventfd.sock",
+            )
+            layers_per_pp = NUM_LAYERS_TOTAL // parallel_config.pp_size
+            for pp_rank in range(parallel_config.pp_size):
+                # Replicate build_layerwise_eventfd_socket_path logic
+                if parallel_config.pp_size > 1:
+                    root, ext = os.path.splitext(base_socket)
+                    sock_path = f"{root}_pp{pp_rank}{ext}"
+                else:
+                    sock_path = base_socket
+                # Send eventfds for each TP rank on this PP rank's socket
+                for tp_rank in range(parallel_config.tp_size):
+                    t = threading.Thread(
+                        target=_mock_sglang_eventfd_client,
+                        args=(sock_path, tp_rank, parallel_config.tp_size,
+                              layers_per_pp),
+                        daemon=True,
+                    )
+                    t.start()
+                    eventfd_threads.append(t)
+
+        kvmanager.start()
+
+        mp_ctx = mp.get_context("spawn")
+        pipes = []
+
+        for worker in workers:
+            parent_conn, child_conn = mp_ctx.Pipe()
+            pipes.append(parent_conn)
+            p = mp_ctx.Process(
+                target=_worker_process_fn,
+                args=(worker, kvmanager.gpu_register_port,
+                      model_config, cache_config,
+                      NUM_GPU_BLOCKS, child_conn),
+                daemon=True,
+            )
+            procs.append(p)
+            p.start()
+
+        # Collect GPU block handles from all workers
+        all_handles = _collect_gpu_blocks(pipes, workers, test_label)
+
+        # Build combined verifier covering all PP stages × TP ranks
+        verifier = _build_combined_verifier(
+            all_handles, workers,
+            parallel_config.pp_size, parallel_config.tp_size,
+        )
+
+        # Wait for KVManager to be ready
+        for _ in range(60):
+            if kvmanager.is_ready():
+                break
+            time.sleep(1)
+        assert kvmanager.is_ready(), f"[{test_label}] KVManager not ready after 60s"
+
+        # ---- Generate requests ----
+        request_pairs = [
+            generate_request_pair(i, BLOCK_PER_REQ, NUM_GPU_BLOCKS, TOKENS_PER_BLOCK, 1)
+            for i in range(NUM_REQUESTS)
+        ]
+
+        # ---- PUT phase ----
+        print(f"[{test_label}] PUT phase: writing {NUM_REQUESTS} requests...")
+        for token_ids, block_ids, _ in request_pairs:
+            verifier.fill_gpu_blocks(token_ids, block_ids)
+            write_req = kvmanager.put_async(
+                token_ids=token_ids,
+                slot_mapping=block_ids_2_slot_mapping(block_ids, TOKENS_PER_BLOCK),
+                token_mask=None,
+            )
+            results = kvmanager.wait([write_req], completely=True)
+            assert results[write_req].status == KVResponseStatus.SUCCESS, \
+                f"[{test_label}] PUT failed for request"
+            verifier.clear_gpu_blocks(block_ids)
+        print(f"[{test_label}] PUT phase done.")
+
+        # ---- GET phase ----
+        print(f"[{test_label}] GET phase: reading back {NUM_REQUESTS} requests...")
+        total_hit  = 0
+        total_miss = 0
+
+        if layerwise:
+            # Layerwise: batch all GETs together
+            task_ids      = []
+            slot_mappings = []
+            req_info      = []
+            for token_ids, block_ids, _ in request_pairs:
+                task_id, _ = kvmanager.get_match(token_ids=token_ids, token_mask=None)
+                task_ids.append(task_id)
+                slot_mappings.append(block_ids_2_slot_mapping(block_ids, TOKENS_PER_BLOCK))
+                req_info.append((token_ids, block_ids))
+
+            returned_ids = kvmanager.launch(
+                task_ids=task_ids,
+                slot_mappings=slot_mappings,
+                as_batch=True,
+                layerwise_transfer=True,
+            )
+            batch_id = returned_ids[0]
+            batch_results = kvmanager.wait(batch_id, completely=True)
+            kvresponse = batch_results[batch_id]
+            assert kvresponse.status == KVResponseStatus.SUCCESS, \
+                f"[{test_label}] Layerwise batch GET failed: {kvresponse.status}"
+
+            for idx, (token_ids, block_ids) in enumerate(req_info):
+                mask = kvresponse.get_mask(idx)
+                total_hit  += mask.sum().item()
+                total_miss += len(mask) - mask.sum().item()
+                valid_tokens = mask.sum().item() // TOKENS_PER_BLOCK * TOKENS_PER_BLOCK
+                if valid_tokens > 0:
+                    assert verifier.verify_kv_blocks(
+                        token_ids[:valid_tokens],
+                        block_ids[:valid_tokens // TOKENS_PER_BLOCK],
+                    ), f"[{test_label}] Data mismatch after layerwise GET (request {idx})"
+        else:
+            # Non-layerwise: launch each GET individually
+            for token_ids, block_ids, _ in request_pairs:
+                task_id, _ = kvmanager.get_match(token_ids=token_ids, token_mask=None)
+                kvmanager.launch(
+                    task_ids=[task_id],
+                    slot_mappings=[block_ids_2_slot_mapping(block_ids, TOKENS_PER_BLOCK)],
+                )
+                results = kvmanager.wait([task_id], completely=True)
+                kvresponse = results[task_id]
+                assert kvresponse.status == KVResponseStatus.SUCCESS, \
+                    f"[{test_label}] GET failed"
+                total_hit  += kvresponse.return_mask.sum().item()
+                total_miss += len(kvresponse.return_mask) - kvresponse.return_mask.sum().item()
+                valid_tokens = kvresponse.return_mask.sum().item() // TOKENS_PER_BLOCK * TOKENS_PER_BLOCK
+                if valid_tokens > 0:
+                    assert verifier.verify_kv_blocks(
+                        token_ids[:valid_tokens],
+                        block_ids[:valid_tokens // TOKENS_PER_BLOCK],
+                    ), f"[{test_label}] Data mismatch after GET"
+
+        print(f"[{test_label}] GET phase done: hit={total_hit}, miss={total_miss}")
+
+        # When backing store is large enough, expect 0 misses
+        num_cpu = cache_config.num_cpu_blocks
+        num_ssd = cache_config.num_ssd_blocks
+        if (cache_config.enable_cpu and num_cpu >= NUM_GPU_BLOCKS) or \
+           (cache_config.enable_ssd and num_ssd >= NUM_GPU_BLOCKS) or \
+           (cache_config.enable_gds and num_ssd >= NUM_GPU_BLOCKS):
+            assert total_miss == 0, \
+                f"[{test_label}] Expected 0 cache miss, got {total_miss}"
+
+        print(f"[{test_label}] PASSED ✓")
+
+    finally:
+        _shutdown_processes(procs)
+        kvmanager.shutdown()
+        # Restore layerwise env
+        if layerwise:
+            if orig_layerwise_env is None:
+                os.environ.pop("FLEXKV_ENABLE_LAYERWISE_TRANSFER", None)
+            else:
+                os.environ["FLEXKV_ENABLE_LAYERWISE_TRANSFER"] = orig_layerwise_env
+            GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer = orig_layerwise_flag
+            for t in eventfd_threads:
+                t.join(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Parameterized test cases with skip / downgrade logic
+# ---------------------------------------------------------------------------
+
+# Build the full test matrix: (parallel_config, backend)
+# Each combination is a separate pytest test case.
+_TEST_PARAMS = []
+for _pc in PARALLEL_CONFIG_REGISTRY:
+    for _be in Backend:
+        _TEST_PARAMS.append(pytest.param(
+            _pc, _be,
+            id=f"{_pc.name}__{_be.value}",
+        ))
+
+
+@pytest.mark.parametrize("parallel_config,backend", _TEST_PARAMS)
+def test_transfer_correctness(parallel_config: ParallelConfig, backend: Backend):
+    """Parametrized transfer correctness test: parallel_config × storage backend.
+
+    Automatically:
+      - Skips if no CUDA devices are available.
+      - Skips GDS tests when FLEXKV_ENABLE_GDS != "1".
+      - Downgrades to simulated (override_device_id) when physical GPUs are insufficient.
+      - Skips if the config cannot be simulated and GPUs are insufficient.
+    """
+    # --- GPU availability check ---
+    available_gpus = torch.cuda.device_count()
+    if available_gpus == 0:
+        pytest.skip("No CUDA devices available")
+
+    # --- Backend availability check ---
+    cache_config = make_cache_config(backend)
+    if cache_config is None:
+        pytest.skip(f"Backend '{backend.value}' is not available "
+                    f"(set FLEXKV_ENABLE_GDS=1 to enable GDS tests)")
+
+    # --- Resolve device assignment (real multi-GPU vs simulated) ---
+    workers, is_simulated = parallel_config.resolve_device_assignment(available_gpus)
+    if not workers:
+        pytest.skip(
+            f"Parallel config '{parallel_config.name}' requires "
+            f">= {parallel_config.min_gpus_for_real} GPUs for real testing "
+            f"and cannot be simulated. Available: {available_gpus}"
+        )
+
+    sim_tag = " [simulated]" if is_simulated else " [real]"
+    test_label = f"{parallel_config.name}__{backend.value}{sim_tag}"
+
+    layerwise = is_layerwise_backend(backend)
+
+    _run_transfer_test(
+        parallel_config=parallel_config,
+        cache_config=cache_config,
+        workers=workers,
+        is_simulated=is_simulated,
+        layerwise=layerwise,
+        test_label=test_label,
+    )


### PR DESCRIPTION
## Motivation

This PR brings the Mooncake Store integration branch onto the latest FlexKV main branch and adds a small compatibility layer for SGLang FlexKV connector initialization.

The goal is to support FlexKV remote KV cache sharing through Mooncake Store while keeping compatibility with integrations that still read attention-parallel fields using `attn_*` names.

## Modifications

- Merge Mooncake Store remote cache backend support into current FlexKV main.
- Add Mooncake Store key/client utilities for remote KV block lookup and transfer.
- Support Mooncake Store remote mode without requiring SSD cache to be enabled.
- Add compatibility aliases in `ModelConfig`:
  - `attn_tp_size -> tp_size`
  - `attn_cp_size -> cp_size`
- Add compatibility aliases in `RankInfo`:
  - `attn_tp_rank -> tp_rank`
  - `attn_cp_rank -> cp_rank`
- Keep the existing generic `tp/cp` internal topology model unchanged.
- Include transfer correctness and Mooncake Store integration tests from the integration branch.

## Validation

- Verified branch is based on the latest upstream `taco-project/FlexKV:main`.
- Verified syntax with `python3 -m py_compile flexkv/common/config.py`.
- Verified the new `attn_*` compatibility properties are present.
- Tested with SGLang FlexKV PD-disaggregation setup using Mooncake Store backend.