### PR TITLE
Remove engine arg from SWAReadSource.

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -719,6 +719,12 @@ PYBIND11_MODULE(c_ext, m) {
       .def("drain_freed_swa_slots",
            &flexkv::CRadixTreeIndex::drain_freed_swa_slots)
       // ===== SWA node-mount: store-side mount + SWA-only eviction =====
+      .def("mount_swa", &flexkv::CRadixTreeIndex::mount_swa, py::arg("node"),
+           py::arg("slot"))
+      .def("publish_swa", &flexkv::CRadixTreeIndex::publish_swa,
+           py::arg("node"))
+      .def("unmount_swa", &flexkv::CRadixTreeIndex::unmount_swa,
+           py::arg("node"))
       .def("set_swa", &flexkv::CRadixTreeIndex::set_swa, py::arg("node"),
            py::arg("slot"))
       .def("promote_swa", &flexkv::CRadixTreeIndex::promote_swa,
@@ -751,6 +757,7 @@ PYBIND11_MODULE(c_ext, m) {
       .def("lock", &flexkv::CRadixNode::lock)
       .def("unlock", &flexkv::CRadixNode::unlock)
       .def("has_swa", &flexkv::CRadixNode::has_swa)
+      .def("is_swa_readable", &flexkv::CRadixNode::is_swa_readable)
       .def_property_readonly("parent", &flexkv::CRadixNode::get_parent,
                              py::return_value_policy::reference)
       // ===== SWA accessors (node-attached SWA state) =====
@@ -758,6 +765,8 @@ PYBIND11_MODULE(c_ext, m) {
                     &flexkv::CRadixNode::set_swa_host_slot)
       .def_property("swa_tombstone", &flexkv::CRadixNode::get_swa_tombstone,
                     &flexkv::CRadixNode::set_swa_tombstone)
+      .def_property("swa_ready", &flexkv::CRadixNode::swa_ready,
+                    &flexkv::CRadixNode::set_swa_ready)
       .def_property_readonly("swa_lock_ref",
                              &flexkv::CRadixNode::get_swa_lock_ref)
       .def("inc_swa_lock_ref", &flexkv::CRadixNode::inc_swa_lock_ref)

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -220,12 +220,17 @@ void CRadixNode::merge_child() {
   // buffering its slot for release (the slot is being kept, not freed).
   index->record_freed_swa_slot(this); // release parent's old SWA (if any)
   int child_slot = child->get_swa_host_slot();
+  bool child_published = child->swa_ready();
   if (child_slot != -1) {
     index->swa_lru_remove(child); // detach child from SWA-LRU
     child->set_swa_host_slot(-1); // child no longer owns it
     child->set_swa_tombstone(true);
+    child->set_swa_ready(false);
     if (!index->is_root(this)) {
-      index->set_swa(this, child_slot); // remount on the merged node
+      index->mount_swa(this, child_slot);
+      if (child_published) {
+        index->publish_swa(this);
+      }
     } else {
       // root cannot carry SWA; free the slot rather than leak it.
       index->buffer_freed_swa_slot(child_slot);
@@ -610,9 +615,9 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
   auto prefix_blocks_num = 0;
   auto ready_prefix_blocks_num = 0;
   auto last_node_matched_length = 0;
-  // SWA (node-mount): deepest fully-matched ready node carrying a live SWA
-  // slot.
+  // SWA (node-mount): structural mount node + deepest readable SWA hit.
   CRadixNode *last_swa_node = nullptr;
+  CRadixNode *last_swa_hit_node = nullptr;
   int swa_hit_blocks = 0;
   auto physical_blocks_tensor =
       torch::empty({num_blocks}, torch::dtype(torch::kInt64));
@@ -648,14 +653,18 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
           break;
         }
       }
+      // Structural SWA mount: visible for dedup once the whole node matched.
+      if (matched_length == current_node->size() && current_node->has_swa()) {
+        last_swa_node = current_node;
+      }
       if (current_node->is_ready()) {
         last_ready_node = current_node;
         ready_prefix_blocks_num += matched_length;
-        // SWA hit only when the WHOLE node matched (its trailing page is
-        // exposed); a partial match must not claim the node's tail window.
-        if (matched_length == current_node->size() && current_node->has_swa()) {
-          last_swa_node = current_node;
+        // Readable SWA hit only on a full node match (trailing page exposed).
+        if (matched_length == current_node->size() &&
+            current_node->is_swa_readable()) {
           swa_hit_blocks = ready_prefix_blocks_num;
+          last_swa_hit_node = current_node;
         }
       }
       last_node_matched_length = matched_length;
@@ -672,13 +681,15 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
     if (child_hash_opt.has_value() &&
         current_node->lookup_child(child_hash_opt.value())) {
       child_hash = child_hash_opt.value();
+      if (current_node->has_swa()) {
+        last_swa_node = current_node;
+      }
       if (current_node->is_ready()) {
         last_ready_node = current_node;
         ready_prefix_blocks_num += current_node->size();
-        // Whole node matched (we are descending into a child): expose its SWA.
-        if (current_node->has_swa()) {
-          last_swa_node = current_node;
+        if (current_node->is_swa_readable()) {
           swa_hit_blocks = ready_prefix_blocks_num;
+          last_swa_hit_node = current_node;
         }
       }
       prefix_blocks_num += current_node->size();
@@ -718,13 +729,16 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
         matched_length = 0;
       }
 
+      if (matched_length == current_node->size() && current_node->has_swa()) {
+        last_swa_node = current_node;
+      }
       if (current_node->is_ready()) {
         last_ready_node = current_node;
         ready_prefix_blocks_num += matched_length;
-        // Only a full node match exposes the trailing page's SWA.
-        if (matched_length == current_node->size() && current_node->has_swa()) {
-          last_swa_node = current_node;
+        if (matched_length == current_node->size() &&
+            current_node->is_swa_readable()) {
           swa_hit_blocks = ready_prefix_blocks_num;
+          last_swa_hit_node = current_node;
         }
       }
 
@@ -758,12 +772,11 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
   // Read-hit heat update: on a real match (update_cache_info=true), promote the
   // matched SWA node to its SWA-LRU MRU — the SWA peer of the per-node Full-KV
   // update_time() bump above, so a reused SWA copy survives eviction over a
-  // never-reused one. last_swa_node is the deepest fully-matched ready node with
-  // a live SWA slot (or nullptr); promote_swa no-ops on root / no-SWA. A probe
-  // (update_cache_info=false) must NOT touch the SWA-LRU. Mirrors Python
+  // never-reused one. Only a readable SWA hit (swa_hit_blocks>0) is promoted.
+  // A probe (update_cache_info=false) must NOT touch the SWA-LRU. Mirrors Python
   // RadixTreeIndex.match_prefix.
-  if (update_cache_info && last_swa_node != nullptr) {
-    promote_swa(last_swa_node);
+  if (update_cache_info && last_swa_hit_node != nullptr) {
+    promote_swa(last_swa_hit_node);
   }
   return std::make_shared<CMatchResult>(
       ready_prefix_blocks_num, prefix_blocks_num, last_node_matched_length,

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -54,6 +54,7 @@ private:
   int swa_host_slot = -1;          // CPU SWA host pool slot id (-1 = no backup)
   bool swa_tombstone = true;       // true = no SWA data available (default)
   int swa_lock_ref = 0;            // SWA lock reference count
+  bool swa_ready = false;       // true once SWA bytes are published (readable)
   uint64_t swa_last_access_time = 0; // SWA LRU timestamp
   // Intrusive SWA-only LRU doubly-linked list pointers (independent of the
   // Full-KV leaf_list). Nodes carrying a live SWA slot are threaded on the
@@ -153,6 +154,14 @@ public:
 
   // True iff this node carries a live (non-tombstone) SWA slot.
   bool has_swa() { return !swa_tombstone && swa_host_slot >= 0; }
+
+  // True once the mounted SWA slot is published and safe to match / LRU-evict.
+  bool is_swa_ready() { return swa_ready; }
+
+  void set_swa_ready(bool ready) { swa_ready = ready; }
+
+  // Readable SWA: mounted, published, on a ready Full-KV node (data-plane hit).
+  bool is_swa_readable() { return has_swa() && is_ready() && is_swa_ready(); }
 
   // ===== SWA-LRU intrusive list accessors =====
   CRadixNode *get_swa_lru_prev() { return swa_lru_prev; }
@@ -281,10 +290,10 @@ public:
   torch::Tensor block_node_ids;
 
   // ===== SWA (node-mounted) =====
-  // Deepest fully-matched, ready node carrying a live SWA slot, and the
-  // ready-prefix block count ending at that node. This is the SWA hit (longest
-  // reusable trailing-SWA prefix) found in the SAME single forward pass as the
-  // Full-KV match — no backtracking. nullptr / 0 when no SWA on the path.
+  // last_swa_node: deepest fully-matched node with a mounted SWA slot (structural
+  // dedup / coalesce; independent of either ready bit). nullptr when none.
+  // swa_hit_blocks: ready-prefix depth where SWA bytes are readable
+  // (has_swa && is_ready && swa_ready on a full node match); 0 when none.
   CRadixNode *last_swa_node = nullptr;
   int swa_hit_blocks = 0;
 
@@ -505,26 +514,41 @@ public:
     node->set_on_swa_lru(false);
   }
 
-  // Least-recently-used SWA node with swa_lock_ref == 0 (any node, not just
-  // leaves). Returns nullptr when every SWA node is locked / list is empty.
+  // Least-recently-used published SWA node with swa_lock_ref == 0. Pending
+  // mounts (!swa_ready) are not on the SWA-LRU and are skipped here.
   CRadixNode *swa_lru_get_lru_unlocked() {
     CRadixNode *x = swa_lru_tail->get_swa_lru_prev();
-    while (x != swa_lru_head && x->get_swa_lock_ref() > 0) {
+    while (x != swa_lru_head &&
+           (x->get_swa_lock_ref() > 0 || !x->swa_ready())) {
       x = x->get_swa_lru_prev();
     }
     return x != swa_lru_head ? x : nullptr;
   }
 
-  // Mount an SWA slot on node's trailing page (store side). Caller guarantees
-  // node's LAST page is the target window (split first if not — see I0).
-  void set_swa(CRadixNode *node, int slot) {
+  // Mount an SWA slot on node's trailing page without publishing it. The slot is
+  // addressable for in-flight transfers but not matchable until publish_swa().
+  void mount_swa(CRadixNode *node, int slot) {
     assert(node != root);
     int old = node->get_swa_host_slot();
-    // A different existing slot means the caller is overwriting a live SWA
-    // mount. Unmount via record_freed_swa_slot() first instead of hiding it here.
     assert(old == -1 || old == slot);
     node->set_swa_host_slot(slot);
     node->set_swa_tombstone(false);
+    node->set_swa_ready(false);
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    node->set_swa_last_access_time((uint64_t)now.tv_sec * 1000000 +
+                                   (uint64_t)now.tv_usec);
+    // Pending mounts stay off the SWA-LRU until publish_swa().
+  }
+
+  // Publish a previously mounted SWA slot: matchable and on the SWA-LRU.
+  void publish_swa(CRadixNode *node) {
+    assert(node != root);
+    assert(node->has_swa());
+    if (node->swa_ready()) {
+      return;
+    }
+    node->set_swa_ready(true);
     struct timeval now;
     gettimeofday(&now, nullptr);
     node->set_swa_last_access_time((uint64_t)now.tv_sec * 1000000 +
@@ -533,14 +557,22 @@ public:
     swa_enabled_ = true;  // arm the I2 cascade in full-KV evict()
   }
 
+  // Detach and buffer a node's SWA slot (rollback / eviction helper).
+  void unmount_swa(CRadixNode *node) { record_freed_swa_slot(node); }
+
+  // Mount + publish (legacy immediate-publish semantics for tests / compat).
+  void set_swa(CRadixNode *node, int slot) {
+    mount_swa(node, slot);
+    publish_swa(node);
+  }
+
   // Refresh a node's SWA recency on read-hit: splice it to the SWA-LRU MRU.
   // SWA recency lives in the LRU list position (evict_swa walks the list, never
   // reads swa_last_access_time), so a hit that only bumped the timestamp would
   // NOT survive eviction — we must actually move the node. Mirror of the Python
-  // RadixTreeIndex.promote_swa. No-op for root or a node with no live SWA (a
-  // tombstone is not on the SWA-LRU; re-adding it would corrupt the list).
+  // RadixTreeIndex.promote_swa. No-op for root or unpublished SWA.
   void promote_swa(CRadixNode *node) {
-    if (node == root || !node->has_swa()) {
+    if (node == root || !node->is_swa_readable()) {
       return;
     }
     struct timeval now;
@@ -559,6 +591,7 @@ public:
       freed_swa_slots.push_back(slot);
       node->set_swa_host_slot(-1);
       node->set_swa_tombstone(true);
+      node->set_swa_ready(false);
     }
     // Always unlink from the SWA-LRU (idempotent) so a freed/invalidated node
     // is never left threaded on the list.

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -98,11 +98,11 @@ class SWAReadSource:
     host_slot: int = -1
     node: Optional[object] = None
     device_type: Optional[DeviceType] = None
-    engine: Optional[object] = None
 
     @property
     def found(self) -> bool:
-        return self.hit_blocks > 0 and self.host_slot >= 0 and self.node is not None
+        return (self.hit_blocks > 0 and self.host_slot >= 0
+                and self.node is not None and self.device_type is not None)
 
 
 class CacheEngineAccel:
@@ -1135,54 +1135,13 @@ class GlobalCacheEngine:
         op_callback_dict = {}
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
-            swa_empty = np.array([], dtype=np.int64)
-            device_type = swa_read_source.device_type
-            source_engine = swa_read_source.engine
-            source_slot = swa_read_source.host_slot
-            source_node = swa_read_source.node
-            source_engine._pin_swa_node(source_node)
-            staging_slot = -1
-            cpu_swa_slots = np.array([source_slot], dtype=np.int64)
-            ssd_swa_slots = swa_empty
-            remote_swa_slots = swa_empty
-            if device_type != DeviceType.CPU:
-                staging_slot = self.cpu_cache_engine._alloc_swa_slot()
-                if staging_slot < 0:
-                    self._swa_release_load_lock(
-                        node=source_node, engine=source_engine)
-                    swa_h2d_id = None
-                else:
-                    cpu_swa_slots = np.array([staging_slot], dtype=np.int64)
-                    source_slots = np.array([source_slot], dtype=np.int64)
-                    if device_type == DeviceType.SSD:
-                        ssd_swa_slots = source_slots
-                    else:
-                        remote_swa_slots = source_slots
-            else:
-                swa_h2d_id = None
-
-            if staging_slot >= 0 or device_type == DeviceType.CPU:
-                swa_h2d_id = self.swa_cache.build_get_chain(
-                    transfer_graph,
-                    gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
-                    cpu_slot_ids=cpu_swa_slots,
-                    ssd_slot_ids=ssd_swa_slots,
-                    remote_slot_ids=remote_swa_slots,
-                    dp_client_id=dp_client_id,
-                )
-                if swa_h2d_id is None:
-                    self._swa_release_load_lock(
-                        node=source_node,
-                        staging_slot=staging_slot,
-                        engine=source_engine)
-                else:
-                    finished_ops_ids.append(swa_h2d_id)
-                    op_callback_dict[swa_h2d_id] = partial(
-                        self._swa_release_load_lock,
-                        node=source_node,
-                        staging_slot=staging_slot,
-                        engine=source_engine,
-                    )
+            self._append_swa_get_ops(
+                transfer_graph,
+                finished_ops_ids,
+                op_callback_dict,
+                swa_read_source,
+                dp_client_id,
+            )
 
         return GetTransferPlan(
             transfer_graph=transfer_graph,
@@ -1421,51 +1380,13 @@ class GlobalCacheEngine:
 
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
-            swa_empty = np.array([], dtype=np.int64)
-            device_type = swa_read_source.device_type
-            source_engine = swa_read_source.engine ## NOTE: do we need to pass this engine?
-            source_slot = swa_read_source.host_slot
-            source_node = swa_read_source.node
-            source_engine._pin_swa_node(source_node)
-            staging_slot = -1
-            cpu_swa_slots = np.array([source_slot], dtype=np.int64)
-            ssd_swa_slots = swa_empty
-
-            # if device is SSD, we need to allocate a cpu slot for SWA
-            if device_type == DeviceType.SSD:
-                staging_slot = self.cpu_cache_engine._alloc_swa_slot()
-                if staging_slot < 0:
-                    self._swa_release_load_lock(
-                        node=source_node, engine=source_engine)
-                    swa_h2d_id = None
-                else:
-                    cpu_swa_slots = np.array([staging_slot], dtype=np.int64)
-                    ssd_swa_slots = np.array([source_slot], dtype=np.int64)
-            else:
-                swa_h2d_id = None
-
-            if staging_slot >= 0 or device_type == DeviceType.CPU:
-                swa_h2d_id = self.swa_cache.build_get_chain(
-                    transfer_graph,
-                    gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
-                    cpu_slot_ids=cpu_swa_slots,
-                    ssd_slot_ids=ssd_swa_slots,
-                    remote_slot_ids=swa_empty,
-                    dp_client_id=dp_client_id,
-                )
-                if swa_h2d_id is None:
-                    self._swa_release_load_lock(
-                        node=source_node,
-                        staging_slot=staging_slot,
-                        engine=source_engine)
-                else:
-                    finished_ops_ids.append(swa_h2d_id)
-                    op_callback_dict[swa_h2d_id] = partial(
-                        self._swa_release_load_lock,
-                        node=source_node,
-                        staging_slot=staging_slot,
-                        engine=source_engine,
-                    )
+            self._append_swa_get_ops(
+                transfer_graph,
+                finished_ops_ids,
+                op_callback_dict,
+                swa_read_source,
+                dp_client_id,
+            )
         nvtx.end_range(nvtx_range)
         return GetTransferPlan(
             transfer_graph=transfer_graph,
@@ -2159,7 +2080,6 @@ class GlobalCacheEngine:
                 host_slot=source_slot,
                 node=source_node,
                 device_type=device_type,
-                engine=engine,
             )
 
             return usable_end, source
@@ -2173,7 +2093,71 @@ class GlobalCacheEngine:
 
     _SWA_GPU_PLACEHOLDER = np.array([0], dtype=np.int64)
 
-    def _swa_release_load_lock(self, node, staging_slot: int = -1, engine=None) -> None:
+    def _append_swa_get_ops(self,
+                            transfer_graph: TransferOpGraph,
+                            finished_ops_ids: List[int],
+                            op_callback_dict: Dict[int, Callable],
+                            swa_read_source: SWAReadSource,
+                            dp_client_id: int) -> None:
+        """Pin the SWA source node and append SWA GET peer ops to ``transfer_graph``."""
+        assert swa_read_source.found
+        device_type = swa_read_source.device_type
+        source_engine = self.cache_engines[device_type]
+        source_node = swa_read_source.node
+        source_slot = swa_read_source.host_slot
+
+        source_engine._pin_swa_node(source_node)
+        swa_empty = np.array([], dtype=np.int64)
+        staging_slot = -1
+        cpu_swa_slots = np.array([source_slot], dtype=np.int64)
+        ssd_swa_slots = swa_empty
+        remote_swa_slots = swa_empty
+
+        if device_type != DeviceType.CPU:
+            staging_slot = self.cpu_cache_engine._alloc_swa_slot()
+            if staging_slot < 0:
+                self._swa_release_load_lock(
+                    node=source_node, source_device_type=device_type)
+                return
+            cpu_swa_slots = np.array([staging_slot], dtype=np.int64)
+            source_slots = np.array([source_slot], dtype=np.int64)
+            if device_type == DeviceType.SSD:
+                ssd_swa_slots = source_slots
+            else:
+                remote_swa_slots = source_slots
+
+        swa_h2d_id = self.swa_cache.build_get_chain(
+            transfer_graph,
+            gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
+            cpu_slot_ids=cpu_swa_slots,
+            ssd_slot_ids=ssd_swa_slots,
+            remote_slot_ids=remote_swa_slots,
+            dp_client_id=dp_client_id,
+        )
+        if swa_h2d_id is None:
+            self._swa_release_load_lock(
+                node=source_node,
+                staging_slot=staging_slot,
+                source_device_type=device_type,
+            )
+            return
+
+        finished_ops_ids.append(swa_h2d_id)
+        self._append_op_callback(
+            op_callback_dict,
+            swa_h2d_id,
+            partial(
+                self._swa_release_load_lock,
+                node=source_node,
+                staging_slot=staging_slot,
+                source_device_type=device_type,
+            ),
+        )
+
+    def _swa_release_load_lock(self,
+                               node,
+                               staging_slot: int = -1,
+                               source_device_type: Optional[DeviceType] = None) -> None:
         """SWA H2D completion callback: release the source pin and free any
         transient CPU staging slot.
 
@@ -2187,8 +2171,10 @@ class GlobalCacheEngine:
         try:
             if node is not None and getattr(node, "swa_lock_ref", 0) > 0:
                 node.dec_swa_lock_ref()
-                if engine is not None:
-                    engine.index.unlock(node)
+                if source_device_type is not None:
+                    engine = self.cache_engines.get(source_device_type)
+                    if engine is not None:
+                        engine.index.unlock(node)
                 elif hasattr(node, "unlock"):
                     node.unlock()
                 else:

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -576,7 +576,12 @@ class CacheStrategy:
 DEFAULT_CACHE_STRATEGY = CacheStrategy()
 
 CPUONLY_CACHE_STRATEGY = CacheStrategy(ignore_gpu=False, ignore_ssd=True, ignore_remote=True, ignore_gds=True)
+# The GPU-side SWA slot is a size-1 placeholder here (window == one page ==
+# one slot on DSv4). It is rebound late from the request's swa_slot_mapping
+# via TransferOpGraph.set_swa_gpu_blocks() in launch, mirroring the Full-KV
+# GPU late-bind.
 
+_SWA_GPU_PLACEHOLDER = np.array([0], dtype=np.int64)
 class GlobalCacheEngine:
     def __init__(self, cache_config: CacheConfig, model_config: ModelConfig, redis_meta: RedisMeta = None,
                  event_collector: Optional[KVEventCollector] = None):
@@ -2086,20 +2091,19 @@ class GlobalCacheEngine:
 
         return block_mask_start, SWAReadSource()
 
-    # The GPU-side SWA slot is a size-1 placeholder here (window == one page ==
-    # one slot on DSv4). It is rebound late from the request's swa_slot_mapping
-    # via TransferOpGraph.set_swa_gpu_blocks() in launch, mirroring the Full-KV
-    # GPU late-bind.
-
-    _SWA_GPU_PLACEHOLDER = np.array([0], dtype=np.int64)
-
     def _append_swa_get_ops(self,
                             transfer_graph: TransferOpGraph,
                             finished_ops_ids: List[int],
                             op_callback_dict: Dict[int, Callable],
                             swa_read_source: SWAReadSource,
                             dp_client_id: int) -> None:
-        """Pin the SWA source node and append SWA GET peer ops to ``transfer_graph``."""
+        """
+        Pin the SWA source node and append SWA GET peer ops to ``transfer_graph``.
+        Now we only support CPU, SSD and REMOTE as SWA sourc.
+        NOTE:
+        - if device_type is SSD, we need to allocate a cpu slot for SWA
+        - if device_type is REMOTE, we need to allocate a cpu slot for SWA
+        """
         assert swa_read_source.found
         device_type = swa_read_source.device_type
         source_engine = self.cache_engines[device_type]
@@ -2118,6 +2122,7 @@ class GlobalCacheEngine:
             if staging_slot < 0:
                 self._swa_release_load_lock(
                     node=source_node, source_device_type=device_type)
+                flexkv_logger.warning(f"Failed to allocate CPU SWA slot for device {device_type}")
                 return
             cpu_swa_slots = np.array([staging_slot], dtype=np.int64)
             source_slots = np.array([source_slot], dtype=np.int64)
@@ -2140,6 +2145,7 @@ class GlobalCacheEngine:
                 staging_slot=staging_slot,
                 source_device_type=device_type,
             )
+            flexkv_logger.warning(f"Failed to build SWA H2D chain for device {device_type}")
             return
 
         finished_ops_ids.append(swa_h2d_id)

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -89,6 +89,7 @@ class RadixNode:
     swa_host_slot: int = -1            # CPU SWA host-pool slot id (-1 = no SWA)
     swa_tombstone: bool = True         # True = no live SWA on this node
     swa_lock_ref: int = 0              # SWA lock ref (invariant: <= lock_cnt)
+    swa_ready: bool = False            # True once SWA bytes are published
     swa_last_access_time: float = 0.0  # SWA-LRU timestamp
     # intrusive SWA-LRU doubly-linked list pointers (independent of full LRU)
     swa_lru_prev: Optional['RadixNode'] = None
@@ -129,6 +130,10 @@ class RadixNode:
     def has_swa(self) -> bool:
         """True iff this node carries a live (non-tombstone) SWA slot."""
         return (not self.swa_tombstone) and self.swa_host_slot >= 0
+
+    def is_swa_readable(self) -> bool:
+        """True once mounted SWA is published on a ready Full-KV node."""
+        return self.has_swa() and self.is_ready and self.swa_ready
 
     def inc_swa_lock_ref(self) -> None:
         """Pin the SWA against eviction (mirror of CRadixNode.inc_swa_lock_ref)."""
@@ -173,6 +178,7 @@ class RadixNode:
         # new_node (prefix) inherits NO SWA — its trailing page is an interior
         # page of the original node, which never carried a window.
         assert new_node.swa_host_slot == -1 and new_node.swa_tombstone
+        assert not new_node.swa_ready
         self.block_hashes = self.block_hashes[prefix_length:]
         self.physical_blocks = self.physical_blocks[prefix_length:]
 
@@ -288,9 +294,9 @@ class RadixTreeIndex:
         node.on_swa_lru = False
 
     def _swa_lru_get_lru_unlocked(self) -> Optional[RadixNode]:
-        """Least-recently-used SWA node with swa_lock_ref == 0 (not just leaves)."""
+        """LRU published SWA node with swa_lock_ref == 0 (pending mounts skipped)."""
         x = self._swa_lru_tail.swa_lru_prev
-        while x is not self._swa_lru_head and x.swa_lock_ref > 0:
+        while x is not self._swa_lru_head and (x.swa_lock_ref > 0 or not x.swa_ready):
             x = x.swa_lru_prev
         return x if x is not self._swa_lru_head else None
 
@@ -306,6 +312,7 @@ class RadixTreeIndex:
             self._freed_swa_slots.append(node.swa_host_slot)
         node.swa_host_slot = -1
         node.swa_tombstone = True
+        node.swa_ready = False
         self._swa_lru_remove(node)
 
     def drain_freed_swa_slots(self) -> List[int]:
@@ -314,32 +321,38 @@ class RadixTreeIndex:
         self._freed_swa_slots = []
         return out
 
-    def set_swa(self, node: RadixNode, slot: int) -> None:
-        """Mount an SWA slot on ``node``'s trailing page (store side).
-
-        The caller guarantees ``node`` is the node whose LAST page is the target
-        window (split first if not — see insert / I0). A different existing slot
-        must be explicitly unmounted first; remounting the same slot refreshes
-        SWA-LRU recency.
-        """
+    def mount_swa(self, node: RadixNode, slot: int) -> None:
+        """Mount an SWA slot without publishing it (in-flight / PUT mount)."""
         assert node is not self.root_node
         assert node.swa_host_slot < 0 or node.swa_host_slot == slot
         node.swa_host_slot = slot
         node.swa_tombstone = False
+        node.swa_ready = False
+        node.swa_last_access_time = time.time()
+
+    def publish_swa(self, node: RadixNode) -> None:
+        """Publish a mounted SWA slot: matchable and on the SWA-LRU."""
+        assert node is not self.root_node
+        assert node.has_swa()
+        if node.swa_ready:
+            return
+        node.swa_ready = True
         node.swa_last_access_time = time.time()
         self._swa_lru_add_mru(node)
-        self._swa_enabled = True  # arm the I2 cascade in full-KV evict()
+        self._swa_enabled = True
+
+    def unmount_swa(self, node: RadixNode) -> None:
+        """Detach and buffer a node's SWA slot."""
+        self.record_freed_swa_slot(node)
+
+    def set_swa(self, node: RadixNode, slot: int) -> None:
+        """Mount + publish (legacy immediate-publish semantics)."""
+        self.mount_swa(node, slot)
+        self.publish_swa(node)
 
     def promote_swa(self, node: RadixNode) -> None:
-        """Refresh a node's SWA recency on read-hit: splice it to the SWA-LRU MRU.
-
-        SWA recency lives in the LRU *list position* (evict_swa walks the linked
-        list via _swa_lru_get_lru_unlocked and never reads swa_last_access_time),
-        so a hit that only bumped the timestamp would NOT survive eviction — we
-        must actually move the node to MRU. Mirror of set_swa's LRU touch, minus
-        the mount. No-op for root or a node with no live SWA (a tombstone is not
-        on the SWA-LRU; re-adding it would corrupt the list)."""
-        if node is self.root_node or not node.has_swa():
+        """Refresh a published SWA node's LRU recency on read-hit."""
+        if node is self.root_node or not node.is_swa_readable():
             return
         node.swa_last_access_time = time.time()
         self._swa_lru_add_mru(node)  # remove+reinsert = move to MRU (idempotent)
@@ -355,6 +368,7 @@ class RadixTreeIndex:
         assert node.num_children() == 1
         child = list(node.children.values())[0]
         child_slot = child.swa_host_slot
+        child_published = child.swa_ready
         node.merge_child()  # block-level merge + children.clear()
         # SWA handoff (I0): release parent's own (now-stale) SWA, then move the
         # child's SWA onto the merged node.
@@ -363,8 +377,11 @@ class RadixTreeIndex:
             self._swa_lru_remove(child)           # detach the doomed child
             child.swa_host_slot = -1
             child.swa_tombstone = True
+            child.swa_ready = False
             if node is not self.root_node:
-                self.set_swa(node, child_slot)    # remount on the merged node
+                self.mount_swa(node, child_slot)
+                if child_published:
+                    self.publish_swa(node)
             else:
                 # root can't carry SWA; free it rather than leak.
                 self._freed_swa_slots.append(child_slot)
@@ -379,8 +396,9 @@ class RadixTreeIndex:
         ready_prefix_blocks_num = 0
         last_node_matched_length = 0
         physical_blocks = np.array([], dtype=np.int64)
-        # SWA: deepest fully-matched ready node carrying a live SWA slot.
+        # SWA: structural mount node + deepest readable SWA hit.
         last_swa_node: Optional[RadixNode] = None
+        last_swa_hit_node: Optional[RadixNode] = None
         swa_hit_blocks = 0
         while prefix_blocks_num < sequence.num_blocks:
             if update_cache_info:
@@ -393,15 +411,14 @@ class RadixTreeIndex:
                 current_node.hit_count += 1
             child_hash = sequence.get_hash(prefix_blocks_num + current_node.size())
             if child_hash in current_node.children:
+                if current_node.has_swa():
+                    last_swa_node = current_node
                 if current_node.is_ready:
                     last_ready_node = current_node
                     ready_prefix_blocks_num += current_node.size()
-                    # current_node is FULLY matched (whole size consumed): if it
-                    # carries a live SWA at its trailing page, it is the new
-                    # deepest SWA hit (single forward pass, no backtracking).
-                    if current_node.has_swa():
-                        last_swa_node = current_node
+                    if current_node.is_swa_readable():
                         swa_hit_blocks = ready_prefix_blocks_num
+                        last_swa_hit_node = current_node
                 prefix_blocks_num += current_node.size()
                 physical_blocks = np.concatenate([physical_blocks, current_node.physical_blocks])
                 current_node = current_node.children[child_hash]
@@ -420,25 +437,20 @@ class RadixTreeIndex:
                     physical_blocks = np.concatenate([physical_blocks, current_node.physical_blocks[:matched_length]])
                 else:
                     matched_length = 0
+                if matched_length == current_node.size() and current_node.has_swa():
+                    last_swa_node = current_node
                 if current_node.is_ready:
                     last_ready_node = current_node
                     ready_prefix_blocks_num += matched_length
-                    # Only a FULL node match (matched_length == size) exposes the
-                    # trailing page, so only then can this node's SWA be reused.
-                    if matched_length == current_node.size() and current_node.has_swa():
-                        last_swa_node = current_node
+                    if matched_length == current_node.size() and current_node.is_swa_readable():
                         swa_hit_blocks = ready_prefix_blocks_num
+                        last_swa_hit_node = current_node
                 last_node_matched_length = matched_length
                 prefix_blocks_num += matched_length
                 break
-        # Read-hit heat update: on a real match (update_cache_info=True), promote
-        # the matched SWA node to its SWA-LRU MRU — the SWA peer of the per-node
-        # Full-KV heat bump above, so a reused SWA copy survives eviction over a
-        # never-reused one. last_swa_node is the deepest fully-matched ready node
-        # with a live SWA slot (or None); promote_swa no-ops on root / no-SWA.
-        # A probe (update_cache_info=False) must NOT touch the SWA-LRU.
-        if update_cache_info and last_swa_node is not None:
-            self.promote_swa(last_swa_node)
+        # Only a readable SWA hit is promoted. A probe must NOT touch SWA-LRU.
+        if update_cache_info and last_swa_hit_node is not None:
+            self.promote_swa(last_swa_hit_node)
         return MatchResult(num_matched_blocks=prefix_blocks_num,
                            num_ready_matched_blocks=ready_prefix_blocks_num,
                            last_ready_node=last_ready_node,

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -148,7 +148,7 @@ class SWACacheManager:
         op, like a CPU full-KV hit.) All ops carry ``is_swa=True``. Returns None
         when disabled / empty.
         """
-        assert gpu_slot_ids >0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         h2d_id = self.build_swa_op(
             graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
             dp_client_id=dp_client_id,
@@ -188,7 +188,7 @@ class SWACacheManager:
         exactly like the full-KV ``D2H`` / ``H2DISK`` / ``H2REMOTE``. All ops
         carry ``is_swa=True``. Returns None when disabled / empty.
         """
-        assert gpu_slot_ids >0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         d2h_id = self.build_swa_op(
             graph, TransferType.D2H, gpu_slot_ids, cpu_slot_ids,
             dp_client_id=dp_client_id,

--- a/tests/test_swa_cnode_cascade.py
+++ b/tests/test_swa_cnode_cascade.py
@@ -153,6 +153,21 @@ class TestStep2Cascade:
 # --------------------------------------------------------------------------- #
 
 class TestStep3TreeLevel:
+    def test_mount_publish_and_match_reports_last_swa_node(self):
+        tree = _make_tree()
+        tokens = np.arange(0, TPB * 3, dtype=np.int64)
+        node, block_hashes = _insert(tree, tokens, 0)
+        tree.mount_swa(node, 42)
+        mr_pending = tree.match_prefix(block_hashes, len(tokens) // TPB, False)
+        assert mr_pending.swa_hit_blocks == 0
+        assert mr_pending.last_swa_node is not None
+        assert mr_pending.last_swa_node.swa_host_slot == 42
+        tree.publish_swa(node)
+        mr = tree.match_prefix(block_hashes, len(tokens) // TPB, False)
+        assert mr.last_swa_node is not None
+        assert mr.last_swa_node.swa_host_slot == 42
+        assert mr.swa_hit_blocks == len(tokens) // TPB
+
     def test_set_swa_and_match_reports_last_swa_node(self):
         tree = _make_tree()
         tokens = np.arange(0, TPB * 3, dtype=np.int64)

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -294,7 +294,7 @@ def test_get_builds_full_plus_swa_load_chain():
     eng.cpu_cache_engine._pin_swa_node(node)
     assert node is not None and node.swa_lock_ref == 1
     assert node.get_lock_cnt() >= node.swa_lock_ref
-    eng._swa_release_load_lock(node, engine=eng.cpu_cache_engine)
+    eng._swa_release_load_lock(node, source_device_type=DeviceType.CPU)
     assert node.swa_lock_ref == 0
 
 

--- a/tests/test_swa_control_plane_e2e.py
+++ b/tests/test_swa_control_plane_e2e.py
@@ -235,7 +235,7 @@ def main() -> int:
     if node is not None:
         engine.cpu_cache_engine._pin_swa_node(node)
         lock_ok = (node.swa_lock_ref == 1)  # our fresh probe lock; prior load lock released
-        engine._swa_release_load_lock(node, engine=engine.cpu_cache_engine)
+        engine._swa_release_load_lock(node, source_device_type=DeviceType.CPU)
         print(f"[verify] {'OK   ' if lock_ok else 'FAIL '} SWA load lock released "
               f"(lock_ref after fresh probe == 1: {lock_ok})", flush=True)
         failed = failed or not lock_ok

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -67,6 +67,35 @@ def test_py_match_returns_last_swa_node():
     assert mr.swa_hit_blocks == 4
 
 
+def test_py_mount_without_publish_is_structurally_visible_not_readable():
+    """Mounted-but-unpublished SWA is structurally visible but not readable."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    n1 = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.mount_swa(n1, slot=101)
+    assert n1.has_swa() and not n1.swa_ready and not n1.on_swa_lru
+
+    mr = idx.match_prefix(_seq([1, 2, 3, 4]))
+    assert mr.swa_hit_blocks == 0 and mr.last_swa_node is n1
+
+    idx.publish_swa(n1)
+    assert n1.swa_ready and n1.on_swa_lru
+    mr2 = idx.match_prefix(_seq([1, 2, 3, 4]))
+    assert mr2.swa_hit_blocks == 2 and mr2.last_swa_node is n1
+
+
+def test_py_pending_mount_survives_swa_evict_pressure():
+    """Pending mounts must not be reclaimed by evict_swa (not on LRU)."""
+    idx = RadixTreeIndex(tokens_per_block=TPB)
+    published = idx.insert(_seq([5, 6, 7, 8]), _phys(2, 3), is_ready=True)
+    idx.set_swa(published, slot=10)
+    pending_node = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
+    idx.mount_swa(pending_node, slot=11)
+    idx.evict_swa(1)  # drops published (LRU), not pending
+    assert not published.has_swa()
+    assert pending_node.has_swa() and not pending_node.swa_ready
+    assert pending_node.swa_host_slot == 11
+
+
 def test_py_split_preserves_swa_on_suffix_half():
     """I0/I4: split keeps the SWA on the half that owns the original last page."""
     idx = RadixTreeIndex(tokens_per_block=TPB)


### PR DESCRIPTION
Simplify the 'SWAReadSource', and extract common ‘_append_swa_get_ops’ function.
