### PR TITLE
fix(swa): guard SWA slot ids by size, not value (late-bind placeholder is [0])

### DIFF
--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -148,7 +148,7 @@ class SWACacheManager:
         op, like a CPU full-KV hit.) All ops carry ``is_swa=True``. Returns None
         when disabled / empty.
         """
-        assert gpu_slot_ids >0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         h2d_id = self.build_swa_op(
             graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
             dp_client_id=dp_client_id,
@@ -188,7 +188,7 @@ class SWACacheManager:
         exactly like the full-KV ``D2H`` / ``H2DISK`` / ``H2REMOTE``. All ops
         carry ``is_swa=True``. Returns None when disabled / empty.
         """
-        assert gpu_slot_ids >0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         d2h_id = self.build_swa_op(
             graph, TransferType.D2H, gpu_slot_ids, cpu_slot_ids,
             dp_client_id=dp_client_id,


### PR DESCRIPTION
## Problem

`SWACacheManager.build_get_chain` / `build_put_chain` assert `gpu_slot_ids > 0`.
But at graph-build time `gpu_slot_ids` is the size-1 **late-bound placeholder**
`_SWA_GPU_PLACEHOLDER == np.array([0])` — the real GPU SWA slot is bound later
in `launch` via `TransferOpGraph.set_swa_gpu_blocks()`.

`np.array([0]) > 0` is `array([False])`, so the assert fires on **every** SWA op
whenever `enable_swa_transfer=True`: the SWA byte-offload data plane (GET `H2D` /
PUT `D2H`) crashes at the first SWA op. The exception is raised inside the
KVServer process. Deployments running `enable_swa_transfer=False` never enter
this path, which is why end-to-end looked fine.

## Fix

The placeholder's *value* is meaningless at build time; only the *size* invariant
matters (must be 1:1 with `cpu_slot_ids` for the late-bind). The `> 0` clause was
an intended non-empty check — restore it to `.size > 0` in both `build_get_chain`
and `build_put_chain`. (`build_swa_op` already no-ops on empty arrays.)

## Verification

With this fix, a DSv4-Pro DP2/CP2/TP4 stress run with `enable_swa_transfer=True`
(layerwise + swa + ssd, heavy CPU/SSD eviction) is SWA byte-exact over a 1h run;
a control run confirms 0 SWA transfer failures. Without it, the run aborts at the
first SWA PUT during warmup.
