### PR TITLE
fix(swa): allow empty SWA slot ids in build_get/put_chain

### DIFF
--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -148,7 +148,7 @@ class SWACacheManager:
         op, like a CPU full-KV hit.) All ops carry ``is_swa=True``. Returns None
         when disabled / empty.
         """
-        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         h2d_id = self.build_swa_op(
             graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
             dp_client_id=dp_client_id,
@@ -188,7 +188,7 @@ class SWACacheManager:
         exactly like the full-KV ``D2H`` / ``H2DISK`` / ``H2REMOTE``. All ops
         carry ``is_swa=True``. Returns None when disabled / empty.
         """
-        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
+        assert gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
         d2h_id = self.build_swa_op(
             graph, TransferType.D2H, gpu_slot_ids, cpu_slot_ids,
             dp_client_id=dp_client_id,


### PR DESCRIPTION
## What

`SWACacheManager.build_get_chain` / `build_put_chain` assert
`gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size`.
This drops the `.size > 0` clause, keeping only the size-consistency check:

```python
assert gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
```

## Why

#220 correctly fixed the numpy truth-value crash (`gpu_slot_ids > 0` on an
ndarray → `ValueError: truth value ... ambiguous`, or a false result for the
late-bind placeholder `[0]`) by switching to `gpu_slot_ids.size > 0`.

But `.size > 0` is still too strict: on the legitimate **full-KV only, no SWA**
path the SWA slot arrays are empty, so the chain builders raise
`AssertionError: GPU and CPU SWA slot ids must have the same size` instead of
returning `None`.

`build_swa_op` already no-ops on empty/disabled input:

```python
if src.size == 0 or dst.size == 0:
    return None
```

and its docstring says callers may invoke it unconditionally. So the chain
builders should only assert size **consistency**, not non-emptiness — the empty
case then flows through `build_swa_op` → `None` → chain returns `None`, matching
the docstring ("Returns None when disabled / empty").

## Verification

On an isolated `dpskv4_refactor` build, the SWA control-plane suite goes from
**23 failing → 46 passing**:

| file | before | after |
|---|---|---|
| test_kvtask_lifecycle.py | 2 fail | pass |
| test_swa_control_plane.py | 12 fail | pass |
| test_swa_peer_op.py | 9 fail | pass |

`test_swa_peer_op::test_get_full_only_no_swa` (passes empty arrays, expects
`swa_id is None`) fails on the current `dpskv4_refactor` tip and is restored by
this change. The 3 SWA e2e files also pass once this is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)