### PR TITLE
fix(layerwise): use defined empty tensor for SWA ctor defaults

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -437,13 +437,13 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("has_swa") = false,
            py::arg("swa_gpu_blocks") =
                std::vector<std::vector<torch::Tensor>>(),
-           py::arg("swa_cpu_blocks") = torch::Tensor(),
+           py::arg("swa_cpu_blocks") = torch::empty({0}),
            py::arg("swa_ssd_files") =
                std::map<int, std::vector<std::string>>(),
-           py::arg("swa_gpu_kv_strides_tensor") = torch::Tensor(),
-           py::arg("swa_gpu_block_strides_tensor") = torch::Tensor(),
-           py::arg("swa_gpu_layer_strides_tensor") = torch::Tensor(),
-           py::arg("swa_gpu_chunk_sizes_tensor") = torch::Tensor())
+           py::arg("swa_gpu_kv_strides_tensor") = torch::empty({0}),
+           py::arg("swa_gpu_block_strides_tensor") = torch::empty({0}),
+           py::arg("swa_gpu_layer_strides_tensor") = torch::empty({0}),
+           py::arg("swa_gpu_chunk_sizes_tensor") = torch::empty({0}))
       .def(
           py::init<
               int, const std::vector<std::vector<std::vector<torch::Tensor>>> &,
@@ -478,13 +478,13 @@ PYBIND11_MODULE(c_ext, m) {
           py::arg("has_swa") = false,
           py::arg("swa_gpu_blocks") =
               std::vector<std::vector<torch::Tensor>>(),
-          py::arg("swa_cpu_blocks") = torch::Tensor(),
+          py::arg("swa_cpu_blocks") = torch::empty({0}),
           py::arg("swa_ssd_files") =
               std::map<int, std::vector<std::string>>(),
-          py::arg("swa_gpu_kv_strides_tensor") = torch::Tensor(),
-          py::arg("swa_gpu_block_strides_tensor") = torch::Tensor(),
-          py::arg("swa_gpu_layer_strides_tensor") = torch::Tensor(),
-          py::arg("swa_gpu_chunk_sizes_tensor") = torch::Tensor())
+          py::arg("swa_gpu_kv_strides_tensor") = torch::empty({0}),
+          py::arg("swa_gpu_block_strides_tensor") = torch::empty({0}),
+          py::arg("swa_gpu_layer_strides_tensor") = torch::empty({0}),
+          py::arg("swa_gpu_chunk_sizes_tensor") = torch::empty({0}))
       .def("layerwise_transfer",
            &flexkv::LayerwiseTransferGroup::layerwise_transfer,
            py::arg("ssd_block_ids"), py::arg("cpu_block_ids_d2h"),


### PR DESCRIPTION
## Problem

`LayerwiseTransferGroup` construction from Python raises
`TypeError: incompatible constructor arguments` whenever the SWA
arguments are **omitted** — which is every non-SWA layerwise path,
including the multi-group (indexer) layout. Concretely, all 4
parametrizations of `test_kvmanager_with_indexer_layerwise`
(`indexer_compress_ratio` ∈ {1,4} × cache tier ∈ {CPU-only, CPU+SSD})
fail at worker init, before any data movement runs.

## Root cause

The SWA `torch::Tensor` parameters default to `torch::Tensor()` (an
*undefined* tensor) in the `py::arg` defaults of **both** the
single-group and multi-group `py::init<>` overloads. On the current
image (torch 2.11 / cu130), pybind bakes an undefined-tensor default
into the signature as Python `None`:

```
swa_cpu_blocks: torch.Tensor = None
swa_gpu_kv_strides_tensor: torch.Tensor = None
...
```

When a caller omits those args, pybind substitutes `None` and then
tries to `load()` it back into a non-optional `torch::Tensor`. This
torch version's `type_caster<at::Tensor>::load(None)` **rejects None**,
so the *entire* overload fails to match → `TypeError`.

This is version-dependent (older pybind/torch tolerated undefined-tensor
defaults), which is why it was latent and easy to miss in review — the
source looks correct, but the default fails to round-trip on this image.

## Fix

Default these parameters to a **defined** empty tensor
(`torch::empty({0})`) so the round-tripped default is loadable. The
`has_swa` flag still gates all SWA usage, so the placeholder is never
read on the non-SWA path. 10-line, bindings-only change (both overloads).

## Validation (cu130 image)

- `test_kvmanager_with_indexer_layerwise` — **4 passed** (was 4 failed).
- Layerwise / SWA / indexer slice — **8 passed / 0 failed** (no regression
  on the SWA-enabled or single-group paths, which pass explicit tensors).
- Standalone repro: constructing with the SWA args omitted now succeeds,
  where it previously raised `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)