### PR TITLE
Moritzxu/swa refactor

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -756,6 +756,8 @@ PYBIND11_MODULE(c_ext, m) {
       .def("get_lock_cnt", &flexkv::CRadixNode::get_lock_cnt)
       .def("lock", &flexkv::CRadixNode::lock)
       .def("unlock", &flexkv::CRadixNode::unlock)
+      .def("is_ready", &flexkv::CRadixNode::is_ready)
+      .def("merge_child", &flexkv::CRadixNode::merge_child)
       .def("has_swa", &flexkv::CRadixNode::has_swa)
       .def("is_swa_readable", &flexkv::CRadixNode::is_swa_readable)
       .def_property_readonly("parent", &flexkv::CRadixNode::get_parent,
@@ -765,12 +767,12 @@ PYBIND11_MODULE(c_ext, m) {
                     &flexkv::CRadixNode::set_swa_host_slot)
       .def_property("swa_tombstone", &flexkv::CRadixNode::get_swa_tombstone,
                     &flexkv::CRadixNode::set_swa_tombstone)
-      .def_property("swa_ready", &flexkv::CRadixNode::swa_ready,
+      .def_property("swa_ready", &flexkv::CRadixNode::is_swa_ready,
                     &flexkv::CRadixNode::set_swa_ready)
-      .def_property_readonly("swa_lock_ref",
-                             &flexkv::CRadixNode::get_swa_lock_ref)
-      .def("inc_swa_lock_ref", &flexkv::CRadixNode::inc_swa_lock_ref)
-      .def("dec_swa_lock_ref", &flexkv::CRadixNode::dec_swa_lock_ref);
+      .def_property_readonly("swa_lock_cnt",
+                             &flexkv::CRadixNode::get_swa_lock_cnt)
+      .def("swa_lock", &flexkv::CRadixNode::swa_lock)
+      .def("swa_unlock", &flexkv::CRadixNode::swa_unlock);
 
   py::class_<flexkv::CMatchResult, std::shared_ptr<flexkv::CMatchResult>>(
       m, "CMatchResult")

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -186,6 +186,8 @@ void CRadixNode::merge_child() {
 
   assert(get_num_children() == 1);
   assert(child->is_leaf());
+  // Parent SWA (if any) is freed below; do not free a still-pinned slot.
+  assert(swa_lock_cnt == 0);
 
   block_hashes.insert(block_hashes.end(), child->get_block_hashes().cbegin(),
                       child->get_block_hashes().cend());
@@ -198,6 +200,8 @@ void CRadixNode::merge_child() {
       std::max(get_last_access_time(), child->get_last_access_time()));
   set_creation_time(std::min(get_creation_time(), child->get_creation_time()));
   set_hit_count(std::max(get_hit_count(), child->get_hit_count()));
+  // Combined node is ready only if both halves are ready.
+  set_ready(is_ready() && child->is_ready());
   if (block_node_ids != nullptr) {
     block_node_ids->insert(block_node_ids->end(),
                            child->get_block_node_ids()->cbegin(),
@@ -211,17 +215,27 @@ void CRadixNode::merge_child() {
           std::min(lease_meta->lease_time, child_lm->lease_time);
     }
   }
+
+  // Absorb child's Full locks onto the surviving node; clear child so
+  // remove_node does not destroy a still-pinned object.
+  lock_cnt += child->lock_cnt;
+  child->lock_cnt = 0;
+
   children.clear();
 
   // SWA (node-mount, I0): after merging, the combined node's LAST page is the
-  // child's last page. So the SWA snapshot should follow the child: free the
-  // parent's own (now-stale) SWA, then move the child's SWA onto `this`. The
-  // child is about to be deleted, so unthread it from the SWA-LRU without
-  // buffering its slot for release (the slot is being kept, not freed).
+  // child's last page. Free the parent's own (now-stale) SWA, then move the
+  // child's SWA onto `this`. Child is deleted below, so detach it from the
+  // SWA-LRU without buffering its slot for release (slot is kept, not freed).
   index->record_freed_swa_slot(this); // release parent's old SWA (if any)
-  int child_slot = child->get_swa_host_slot();
-  bool child_published = child->swa_ready();
-  if (child_slot != -1) {
+
+  const bool child_has_swa = child->has_swa();
+  const int child_slot = child->get_swa_host_slot();
+  const bool child_published = child->is_swa_ready();
+  const int child_swa_locks = child->swa_lock_cnt;
+  child->swa_lock_cnt = 0;
+
+  if (child_has_swa) {
     index->swa_lru_remove(child); // detach child from SWA-LRU
     child->set_swa_host_slot(-1); // child no longer owns it
     child->set_swa_tombstone(true);
@@ -231,15 +245,29 @@ void CRadixNode::merge_child() {
       if (child_published) {
         index->publish_swa(this);
       }
+      // SWA pins follow the slot onto the merged node.
+      swa_lock_cnt += child_swa_locks;
+      assert(lock_cnt >= swa_lock_cnt); // I3
     } else {
       // root cannot carry SWA; free the slot rather than leak it.
+      assert(child_swa_locks == 0);
       index->buffer_freed_swa_slot(child_slot);
     }
+  } else {
+    assert(child_swa_locks == 0);
   }
 
   child->clear_parent();
   index->remove_leaf(child);
   index->remove_node(child);
+
+  // Parent was internal; after absorbing its only child it becomes a leaf and
+  // must re-enter the Full-KV leaf list so eviction can see it.
+  if (!index->is_root(this)) {
+    assert(is_leaf());
+    assert(!get_leaf_state());
+    index->add_leaf(this);
+  }
 }
 
 std::pair<std::deque<int64_t> *, std::deque<HashType> *>
@@ -569,8 +597,8 @@ CRadixNode *CRadixTreeIndex::inc_lock_ref(CRadixNode *node) {
     cur->lock(); // full_lock on every node from [node, root)
     // SWA-lock only the single deepest node carrying a live SWA.
     if (swa_boundary == nullptr && cur->has_swa()) {
-      cur->inc_swa_lock_ref();
-      assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref()); // I3
+      cur->swa_lock();
+      assert(cur->get_lock_cnt() >= cur->get_swa_lock_cnt()); // I3
       swa_boundary = cur;
     }
     cur = cur->get_parent();
@@ -584,10 +612,10 @@ void CRadixTreeIndex::dec_lock_ref(CRadixNode *node, CRadixNode *swa_boundary,
   while (cur != nullptr && !is_root(cur)) {
     cur->unlock(); // asserts lock_cnt > 0
     // Release the SWA lock only on the exact boundary node inc_lock_ref locked.
-    if (!skip_swa && cur == swa_boundary && cur->get_swa_lock_ref() > 0) {
-      cur->dec_swa_lock_ref();
+    if (!skip_swa && cur == swa_boundary && cur->get_swa_lock_cnt() > 0) {
+      cur->swa_unlock();
     }
-    assert(cur->get_lock_cnt() >= cur->get_swa_lock_ref()); // I3
+    assert(cur->get_lock_cnt() >= cur->get_swa_lock_cnt()); // I3
     cur = cur->get_parent();
   }
 }
@@ -596,9 +624,9 @@ void CRadixTreeIndex::dec_swa_lock_only(CRadixNode *swa_boundary) {
   if (swa_boundary == nullptr) {
     return;
   }
-  assert(swa_boundary->get_swa_lock_ref() > 0);
-  swa_boundary->dec_swa_lock_ref();
-  if (swa_boundary->get_swa_lock_ref() == 0 && swa_boundary->has_swa()) {
+  assert(swa_boundary->get_swa_lock_cnt() > 0);
+  swa_boundary->swa_unlock();
+  if (swa_boundary->get_swa_lock_cnt() == 0 && swa_boundary->has_swa()) {
     if (swa_boundary->is_leaf()) {
       // Leaf: free SWA now (Full stays until the full lock drops).
       record_freed_swa_slot(swa_boundary);

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -53,7 +53,7 @@ private:
   // i.e. a node may have full KV without SWA (tombstone), but never the reverse.
   int swa_host_slot = -1;          // CPU SWA host pool slot id (-1 = no backup)
   bool swa_tombstone = true;       // true = no SWA data available (default)
-  int swa_lock_ref = 0;            // SWA lock reference count
+  int swa_lock_cnt = 0;            // SWA lock count (mirror of lock_cnt)
   bool swa_ready = false;       // true once SWA bytes are published (readable)
   uint64_t swa_last_access_time = 0; // SWA LRU timestamp
   // Intrusive SWA-only LRU doubly-linked list pointers (independent of the
@@ -139,13 +139,13 @@ public:
 
   void set_swa_tombstone(bool tombstone) { swa_tombstone = tombstone; }
 
-  int get_swa_lock_ref() { return swa_lock_ref; }
+  int get_swa_lock_cnt() { return swa_lock_cnt; }
 
-  void inc_swa_lock_ref() { swa_lock_ref++; }
+  void swa_lock() { swa_lock_cnt++; }
 
-  void dec_swa_lock_ref() {
-    assert(swa_lock_ref > 0);
-    swa_lock_ref--;
+  void swa_unlock() {
+    assert(swa_lock_cnt > 0);
+    swa_lock_cnt--;
   }
 
   void set_swa_last_access_time(uint64_t time) { swa_last_access_time = time; }
@@ -251,8 +251,12 @@ public:
   bool is_leaf() { return get_num_children() == 0; }
 
   // A node is in use (not full-evictable) if its Full KV is locked, its SWA is
-  // locked (I3: swa_lock_ref>0 implies it must stay), or it is not ready.
-  bool in_use() { return lock_cnt > 0 || swa_lock_ref > 0 || !ready; }
+  // locked (I3: swa_lock_cnt>0 implies it must stay), it is not ready, or it
+  // still has a pending (mounted-but-unpublished) SWA transfer.
+  bool in_use() {
+    return lock_cnt > 0 || swa_lock_cnt > 0 || !ready ||
+           (has_swa() && !swa_ready);
+  }
 
   bool evictable();
 
@@ -514,12 +518,12 @@ public:
     node->set_on_swa_lru(false);
   }
 
-  // Least-recently-used published SWA node with swa_lock_ref == 0. Pending
+  // Least-recently-used published SWA node with swa_lock_cnt == 0. Pending
   // mounts (!swa_ready) are not on the SWA-LRU and are skipped here.
   CRadixNode *swa_lru_get_lru_unlocked() {
     CRadixNode *x = swa_lru_tail->get_swa_lru_prev();
     while (x != swa_lru_head &&
-           (x->get_swa_lock_ref() > 0 || !x->swa_ready())) {
+           (x->get_swa_lock_cnt() > 0 || !x->is_swa_ready())) {
       x = x->get_swa_lru_prev();
     }
     return x != swa_lru_head ? x : nullptr;
@@ -542,10 +546,14 @@ public:
   }
 
   // Publish a previously mounted SWA slot: matchable and on the SWA-LRU.
+  // Does NOT require is_ready (the SWA data plane may complete before Full-KV).
+  // match_prefix gates SWA hits on is_swa_readable() = has_swa && is_ready &&
+  // swa_ready, so a transient (is_ready=false, swa_ready=true) state is
+  // invisible to GETs until Full-KV also becomes ready.
   void publish_swa(CRadixNode *node) {
     assert(node != root);
     assert(node->has_swa());
-    if (node->swa_ready()) {
+    if (node->is_swa_ready()) {
       return;
     }
     node->set_swa_ready(true);
@@ -607,7 +615,7 @@ public:
   // RadixTreeIndex methods and sglang inc/dec_lock_ref (design §7). FlexKV's SWA
   // window == one page == one node's trailing page, so exactly the single
   // deepest node with a live SWA on [node, root) is SWA-locked; full_lock (the
-  // node lock_cnt) is taken on every node. Invariant I3: lock_cnt >= swa_lock_ref.
+  // node lock_cnt) is taken on every node. Invariant I3: lock_cnt >= swa_lock_cnt.
   //
   // inc_lock_ref returns the SWA boundary node (or nullptr) — pass it back to
   // dec_lock_ref / dec_swa_lock_only so the release is symmetric.

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -56,6 +56,17 @@ class GetTransferPlan:
     op_callback_dict: Dict[int, Callable]
     buffer_to_free: Dict[DeviceType, np.ndarray]
     num_gpu_blocks_to_transfer: int
+    # Mounted SWA destinations: swa_lock at transfer launch, swa_unlock in
+    # _transfer_callback (mirrors Full-KV lock_node / unlock).
+    swa_nodes_to_unlock: Dict[DeviceType, object] = field(default_factory=dict) # target node to unlock and set ready
+    # GET source nodes pinned via _pin_swa_node during plan build; Full+swa
+    # unlock deferred to _transfer_callback (op callbacks only publish / free
+    # transient staging).
+    swa_source_pins: List[Tuple[DeviceType, object]] = field(default_factory=list) # source node pin
+    # Global GET: SWA publish deferred to _transfer_callback (same place Full
+    # set_ready runs). Local GET leaves this empty and publishes on the SWA
+    # H2D op callback instead.
+    swa_publications: Dict[DeviceType, object] = field(default_factory=dict) # only used for global get
 
     @classmethod
     def empty(cls) -> "GetTransferPlan":
@@ -66,6 +77,9 @@ class GetTransferPlan:
             op_callback_dict={},
             buffer_to_free={},
             num_gpu_blocks_to_transfer=0,
+            swa_nodes_to_unlock={},
+            swa_source_pins=[],
+            swa_publications={},
         )
 
 
@@ -78,6 +92,9 @@ class PutTransferPlan:
     buffer_to_free: Dict[DeviceType, np.ndarray]
     num_gpu_blocks_to_transfer: int
     skipped_gpu_blocks: int
+    # Mounted SWA destinations: swa_lock at transfer launch, swa_unlock in
+    # _transfer_callback (protects write-through after op-level publish).
+    swa_nodes_to_unlock: Dict[DeviceType, object] = field(default_factory=dict) # target node to unlock and set rady
 
     @classmethod
     def empty(cls) -> "PutTransferPlan":
@@ -89,6 +106,7 @@ class PutTransferPlan:
             buffer_to_free={},
             num_gpu_blocks_to_transfer=0,
             skipped_gpu_blocks=0,
+            swa_nodes_to_unlock={},
         )
 
 
@@ -197,7 +215,7 @@ class CacheEngineAccel:
     def _pin_swa_node(self, node) -> None:
         self.index.lock(node)
         try:
-            node.inc_swa_lock_ref()
+            node.swa_lock()
         except Exception:
             self.index.unlock(node)
             raise
@@ -452,7 +470,7 @@ class CacheEngine:
     def _pin_swa_node(self, node) -> None:
         self.index.lock(node)
         try:
-            node.inc_swa_lock_ref()
+            node.swa_lock()
         except Exception:
             self.index.unlock(node)
             raise
@@ -846,10 +864,17 @@ class GlobalCacheEngine:
 
         for device_type in plan.node_to_unlock:
             self.cache_engines[device_type].lock_node(plan.node_to_unlock[device_type][0])
+        # SWA flight locks after Full lock (I3: lock_cnt >= swa_lock_cnt).
+        for node in plan.swa_nodes_to_unlock.values():
+            if node is not None:
+                node.swa_lock()
 
         callback = partial(self._transfer_callback,
                            node_to_unlock=plan.node_to_unlock,
-                           buffer_to_free=plan.buffer_to_free)
+                           buffer_to_free=plan.buffer_to_free,
+                           swa_nodes_to_unlock=plan.swa_nodes_to_unlock,
+                           swa_source_pins=plan.swa_source_pins,
+                           swa_publications=plan.swa_publications)
 
         op_callback_dict = plan.op_callback_dict
 
@@ -885,21 +910,84 @@ class GlobalCacheEngine:
 
         op_callback_dict[op_id] = combined_callback
 
-    def _publish_swa_put_slot(self,
-                              device_type: DeviceType,
-                              node,
-                              slot: int) -> None:
-        """Make a reserved PUT slot readable after its tier transfer completes.
+    def _reserve_swa_slot(self,
+                          engine: "CacheEngineAccel",
+                          node) -> int:
+        """Allocate one SWA slot; ``node`` is passed only as the eviction-protect
+        target for ``_alloc_swa_slot(protected_node=node)``.
 
-        The slot id is allocated before graph construction so the data plane can
-        address it, but it is deliberately not mounted on the radix node until
-        this callback.  Full-KV and SWA publication therefore remain independent:
-        either transfer may finish first without exposing unfilled SWA bytes.
+        Returns:
+          * -1 if SWA is disabled on this tier or alloc + evict both failed
+          * the freshly-allocated slot id on success
+        """
+        if engine is None or not getattr(engine, "swa_enabled", False):
+            return -1
+        return engine._alloc_swa_slot(protected_node=node)
+
+    def _mount_swa_slot(self,
+                            device_type: DeviceType,
+                            node,
+                            slot: int) -> bool:
+        """Mount an SWA slot on ``node`` in the "not yet published" state.
+
+        Called synchronously right after the SWA slot is allocated and before
+        the SWA transfer op is built, so that:
+          * The slot is addressable for the in-flight D2H/H2DISK/H2REMOTE ops.
+          * Concurrent PUTs matching the same prefix see ``node.swa_host_slot >= 0``
+            and lose the race in this method (caller frees the losing slot).
+          * ``match_prefix`` still hides the node from GET (SWA hit gated by
+            ``is_swa_readable`` = has_swa && is_ready && swa_ready).
+
+        Idempotency: if ``node`` is already SWA-mounted (concurrent PUT of the
+        same sequence won the race), return False without mounting — the caller
+        must free ``slot`` (via ``_try_mount_swa_slot``).
+
+        The corresponding ``publish_swa`` fires from the SWA peer-op callback
+        once that tier's SWA bytes have landed (PUT: D2H/H2DISK/H2REMOTE;
+        GET promotion: H2D), aligning with Full-KV set_ready which may already
+        have fired (or still fire later — matchability ANDs both flags).
+
+        Returns True when the slot was actually mounted on ``node`` (caller
+        should proceed to publish); False when the node is already mounted
+        (caller must free ``slot`` itself — see ``_try_mount_swa_slot``).
         """
         assert node is not None
         assert slot >= 0
         engine = self.cache_engines[device_type]
-        engine.index.set_swa(node, int(slot))
+        if getattr(node, "swa_host_slot", -1) >= 0:
+            flexkv_logger.warning(
+                f"SWA slot {slot} has already been mounted on node {node}")
+            return False
+        engine.index.mount_swa(node, int(slot))
+        return True
+
+    def _try_mount_swa_slot(self,
+                                device_type: DeviceType,
+                                node,
+                                slot: int) -> bool:
+        """Mount an SWA slot; on race loss free ``slot`` and return False."""
+        if node is None or slot < 0:
+            return False
+        if self._mount_swa_slot(device_type, node, slot):
+            return True
+        engine = self.cache_engines.get(device_type)
+        if engine is not None:
+            engine._free_swa_slot(slot)
+        return False
+
+    def _publish_swa_slot(self,
+                              device_type: DeviceType,
+                              node) -> None:
+        """Publish a previously mounted SWA slot once that tier's SWA data landed.
+
+        Attached to the completing SWA peer op (PUT: D2H / H2DISK / H2REMOTE;
+        GET promotion: H2D). Assumes ``mount_swa`` has already run; only flips
+        ``swa_ready`` and adds the node to the SWA-LRU. Matchability still
+        requires Full-KV ``is_ready`` via ``is_swa_readable``.
+        """
+        assert node is not None
+        engine = self.cache_engines[device_type]
+        engine.index.publish_swa(node)
 
     def _fail_put_before_insert(
             self,
@@ -911,6 +999,18 @@ class GlobalCacheEngine:
             ssd_swa_slot: int = -1,
             remote_blocks: Optional[np.ndarray] = None,
             remote_swa_slot: int = -1) -> PutTransferPlan:
+        """Rollback a PUT that failed BEFORE any radix mutation.
+
+        Called only when SWA slot reservation fails and the Full-KV nodes have
+        NOT been inserted yet. Because our _reserve_swa_slot returns a bare
+        slot id without ever calling ``mount_swa`` (mount happens later, after
+        the Full-KV insert), a failing PUT here only needs to free the slot
+        back to its host pool — the slot was never attached to a radix node.
+
+        If a future change moves mount BEFORE this failure point, this path
+        must also call ``engine.index.unmount_swa(node)`` for each mounted
+        tier. Today that's guaranteed unnecessary by construction.
+        """
         flexkv_logger.warning(
             "[FlexKV-SWA] PUT request failed before radix insert; "
             f"request_id={request_id}, reason={reason}, "
@@ -1138,6 +1238,9 @@ class GlobalCacheEngine:
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
         num_gpu_blocks_to_transfer = len(fragment123_gpu_blocks) if enable_gpu else 0
         op_callback_dict = {}
+        swa_nodes_to_unlock: Dict[DeviceType, RadixNode] = {}
+        swa_source_pins: List[Tuple[DeviceType, RadixNode]] = []
+        swa_publications: Dict[DeviceType, RadixNode] = {}
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
             self._append_swa_get_ops(
@@ -1146,6 +1249,12 @@ class GlobalCacheEngine:
                 op_callback_dict,
                 swa_read_source,
                 dp_client_id,
+                cpu_node_for_promotion=cpu_node_to_unlock,
+                swa_nodes_to_unlock=swa_nodes_to_unlock,
+                swa_source_pins=swa_source_pins,
+                # Global GET: Full set_ready only in _transfer_callback — match that.
+                defer_swa_publish=True,
+                swa_publications=swa_publications,
             )
 
         return GetTransferPlan(
@@ -1155,6 +1264,9 @@ class GlobalCacheEngine:
             op_callback_dict=op_callback_dict,
             buffer_to_free=buffer_to_free,
             num_gpu_blocks_to_transfer=num_gpu_blocks_to_transfer,
+            swa_nodes_to_unlock=swa_nodes_to_unlock,
+            swa_source_pins=swa_source_pins,
+            swa_publications=swa_publications,
         )
 
     def _get_impl_local(self,
@@ -1383,6 +1495,8 @@ class GlobalCacheEngine:
         num_gpu_blocks_to_transfer = len(fragment12_gpu_blocks) if enable_gpu else 0
         op_callback_dict = self._build_op_callback_dict(op_node_to_ready)
 
+        swa_nodes_to_unlock: Dict[DeviceType, RadixNode] = {}
+        swa_source_pins: List[Tuple[DeviceType, RadixNode]] = []
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
             self._append_swa_get_ops(
@@ -1391,6 +1505,12 @@ class GlobalCacheEngine:
                 op_callback_dict,
                 swa_read_source,
                 dp_client_id,
+                cpu_node_for_promotion=cpu_node_to_unlock,
+                swa_nodes_to_unlock=swa_nodes_to_unlock,
+                swa_source_pins=swa_source_pins,
+                # Local GET: Full set_ready on staging op callbacks — publish
+                # SWA when DISK2H/REMOTE2H lands on CPU.
+                defer_swa_publish=False,
             )
         nvtx.end_range(nvtx_range)
         return GetTransferPlan(
@@ -1400,6 +1520,8 @@ class GlobalCacheEngine:
             op_callback_dict=op_callback_dict,
             buffer_to_free=buffer_to_free,
             num_gpu_blocks_to_transfer=num_gpu_blocks_to_transfer,
+            swa_nodes_to_unlock=swa_nodes_to_unlock,
+            swa_source_pins=swa_source_pins,
         )
 
     def put(self,
@@ -1462,10 +1584,17 @@ class GlobalCacheEngine:
         for device_type in plan.node_to_unlock:
             self.cache_engines[device_type].lock_node(plan.node_to_unlock[device_type][0])
 
+        # SWA flight locks after Full lock (I3: lock_cnt >= swa_lock_cnt).
+        # lock all the target swa nodes
+        for node in plan.swa_nodes_to_unlock.values():
+            if node is not None:
+                node.swa_lock()
+
         callback = partial(self._transfer_callback,
                            node_to_unlock=plan.node_to_unlock,
                            buffer_to_free=plan.buffer_to_free,
-                           is_put=True)
+                           is_put=True,
+                           swa_nodes_to_unlock=plan.swa_nodes_to_unlock)
 
         op_callback_dict = plan.op_callback_dict
 
@@ -1573,20 +1702,28 @@ class GlobalCacheEngine:
         ssd_swa_slot = -1
         remote_swa_slot = -1
 
+        # SWA slot alloc before Full insert (peer of mempool.take). A failed
+        # alloc on a required tier aborts before any radix mutation.
         if self.swa_cache.enabled:
-            cpu_swa_slot = self.cpu_cache_engine._alloc_swa_slot(
-                cpu_matched_result.last_node)
-            if cpu_swa_slot >= 0 and put_to_ssd:
-                ssd_swa_slot = self.ssd_cache_engine._alloc_swa_slot(
-                    ssd_matched_result.last_node)
-            if (cpu_swa_slot >= 0 and
-                    (not put_to_ssd or ssd_swa_slot >= 0) and
-                    put_to_remote):
-                remote_swa_slot = self.remote_cache_engine._alloc_swa_slot(
-                    remote_matched_result.last_node)
-            if (cpu_swa_slot < 0 or
-                    (put_to_ssd and ssd_swa_slot < 0) or
-                    (put_to_remote and remote_swa_slot < 0)):
+            # the cpu parent node that need to be protected.
+            cpu_target = cpu_matched_result.last_node
+            cpu_swa_slot = self._reserve_swa_slot(self.cpu_cache_engine, cpu_target)
+            
+            if put_to_ssd:
+                # the ssd parent node that need to be protected.
+                ssd_target = ssd_matched_result.last_node
+                ssd_swa_slot = self._reserve_swa_slot(
+                    self.ssd_cache_engine, ssd_target)
+
+            if put_to_remote:
+                # the remote parent node that need to be protected.
+                remote_target = remote_matched_result.last_node
+                remote_swa_slot = self._reserve_swa_slot(
+                    self.remote_cache_engine, remote_target)
+
+            if ((cpu_swa_slot < 0)
+                    or (put_to_ssd and ssd_swa_slot < 0)
+                    or (put_to_remote and remote_swa_slot < 0)):
                 return self._fail_put_before_insert(
                     request_id=request_id,
                     reason="swa_slot_alloc_failed",
@@ -1609,16 +1746,6 @@ class GlobalCacheEngine:
             dst_block_ids = fragment12_cpu_blocks,
             dp_client_id = dp_client_id,
         )
-        # flexkv_logger.info(
-        #     "[FlexKV-SEGV-DEBUG] cache_engine create D2H op (global_put) "
-        #     f"request_id={request_id}, op_id={op_d2h.op_id}, "
-        #     f"graph_id={transfer_graph.graph_id}, dp_client_id={dp_client_id}, "
-        #     f"fragment12_num_blocks={fragment12_num_blocks}, "
-        #     f"fragment2_num_blocks={fragment2_num_blocks}, "
-        #     f"fragment3_num_blocks={fragment3_num_blocks}, "
-        #     f"{summarize_id_tensor('gpu_src', fragment12_gpu_blocks)}, "
-        #     f"{summarize_id_tensor('cpu_dst', fragment12_cpu_blocks)}"
-        # )
         transfer_graph.add_transfer_op(op_d2h)
         finished_ops_ids.append(op_d2h.op_id)
 
@@ -1657,26 +1784,8 @@ class GlobalCacheEngine:
             transfer_graph.add_transfer_op(op_h2remote)
             transfer_graph.add_dependency(op_h2remote.op_id, op_d2h.op_id)
 
-        if cpu_swa_slot >= 0:
-            empty = np.array([], dtype=np.int64)
-            swa_ops = self.swa_cache.build_put_chain(
-                transfer_graph,
-                gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
-                cpu_slot_ids=np.array([cpu_swa_slot], dtype=np.int64),
-                ssd_slot_ids=(np.array([ssd_swa_slot], dtype=np.int64)
-                              if ssd_swa_slot >= 0 else empty),
-                remote_slot_ids=(np.array([remote_swa_slot], dtype=np.int64)
-                                 if remote_swa_slot >= 0 else empty),
-                dp_client_id=dp_client_id,
-                return_op_ids=True,
-            )
-            assert swa_ops.d2h_id is not None
-            if put_to_ssd:
-                assert swa_ops.h2disk_id is not None
-            if put_to_remote:
-                assert swa_ops.h2remote_id is not None
-            finished_ops_ids.append(swa_ops.d2h_id)
-
+        # Full-KV insert(is_ready=False) before SWA mount/graph — same
+        # "structure first, ready later" binding as the Full path itself.
         cpu_node_to_unlock = self.cpu_cache_engine.insert(
             sequence_meta,
             fragment12_cpu_blocks,
@@ -1717,27 +1826,20 @@ class GlobalCacheEngine:
             node_to_unlock[DeviceType.REMOTE] = (remote_node_to_unlock, remote_node_to_unlock.size())
 
         op_callback_dict = self._build_op_callback_dict(op_node_to_ready)
-        if cpu_swa_slot >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_ops.d2h_id,
-                partial(self._publish_swa_put_slot,
-                        DeviceType.CPU, cpu_node_to_unlock, cpu_swa_slot),
-            )
-        if ssd_swa_slot >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_ops.h2disk_id,
-                partial(self._publish_swa_put_slot,
-                        DeviceType.SSD, ssd_node_to_unlock, ssd_swa_slot),
-            )
-        if remote_swa_slot >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_ops.h2remote_id,
-                partial(self._publish_swa_put_slot,
-                        DeviceType.REMOTE, remote_node_to_unlock, remote_swa_slot),
-            )
+
+        swa_nodes_to_unlock = self._append_swa_put_ops(
+            transfer_graph=transfer_graph,
+            finished_ops_ids=finished_ops_ids,
+            op_callback_dict=op_callback_dict,
+            dp_client_id=dp_client_id,
+            cpu_swa_slot=cpu_swa_slot,
+            ssd_swa_slot=ssd_swa_slot,
+            remote_swa_slot=remote_swa_slot,
+            cpu_node=cpu_node_to_unlock,
+            ssd_node=ssd_node_to_unlock,
+            remote_node=remote_node_to_unlock,
+        )
+
         skipped_gpu_blocks = len(cpu_matched_blocks)
         return PutTransferPlan(
             transfer_graph=transfer_graph,
@@ -1747,6 +1849,7 @@ class GlobalCacheEngine:
             buffer_to_free={},
             num_gpu_blocks_to_transfer=len(fragment12_gpu_blocks),
             skipped_gpu_blocks=skipped_gpu_blocks,
+            swa_nodes_to_unlock=swa_nodes_to_unlock,
         )
 
     def _put_impl_local(self,
@@ -1831,13 +1934,15 @@ class GlobalCacheEngine:
         ssd_swa_slot = -1
 
         if self.swa_cache.enabled:
-            cpu_swa_slot = self.cpu_cache_engine._alloc_swa_slot(
-                cpu_matched_result.last_node)
-            if cpu_swa_slot >= 0 and fragment2_num_blocks > 0:
-                ssd_swa_slot = self.ssd_cache_engine._alloc_swa_slot(
-                    ssd_matched_result.last_node)
-            if (cpu_swa_slot < 0 or
-                    (fragment2_num_blocks > 0 and ssd_swa_slot < 0)):
+            cpu_target = cpu_matched_result.last_node
+            cpu_swa_slot = self._reserve_swa_slot(self.cpu_cache_engine, cpu_target)
+            ssd_required = fragment2_num_blocks > 0
+            if ssd_required:
+                ssd_target = ssd_matched_result.last_node
+                ssd_swa_slot = self._reserve_swa_slot(
+                    self.ssd_cache_engine, ssd_target)
+
+            if cpu_swa_slot < 0 or (ssd_required and ssd_swa_slot < 0):
                 return self._fail_put_before_insert(
                     request_id=request_id,
                     reason="swa_slot_alloc_failed",
@@ -1858,15 +1963,7 @@ class GlobalCacheEngine:
             dst_block_ids = fragment12_cpu_blocks,
             dp_client_id = dp_client_id,
         )
-        # flexkv_logger.info(
-        #     "[FlexKV-SEGV-DEBUG] cache_engine create D2H op (local_put) "
-        #     f"request_id={request_id}, op_id={op_d2h.op_id}, "
-        #     f"graph_id={transfer_graph.graph_id}, dp_client_id={dp_client_id}, "
-        #     f"fragment12_num_blocks={fragment12_num_blocks}, "
-        #     f"fragment2_num_blocks={fragment2_num_blocks}, "
-        #     f"{summarize_id_tensor('gpu_src', fragment12_gpu_blocks)}, "
-        #     f"{summarize_id_tensor('cpu_dst', fragment12_cpu_blocks)}"
-        # )
+
         transfer_graph.add_transfer_op(op_d2h)
         finished_ops_ids.append(op_d2h.op_id)
 
@@ -1892,23 +1989,6 @@ class GlobalCacheEngine:
 
             transfer_graph.add_dependency(op_h2disk.op_id, op_d2h.op_id)
 
-        if cpu_swa_slot >= 0:
-            empty = np.array([], dtype=np.int64)
-            swa_ops = self.swa_cache.build_put_chain(
-                transfer_graph,
-                gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
-                cpu_slot_ids=np.array([cpu_swa_slot], dtype=np.int64),
-                ssd_slot_ids=(np.array([ssd_swa_slot], dtype=np.int64)
-                              if ssd_swa_slot >= 0 else empty),
-                remote_slot_ids=empty,
-                dp_client_id=dp_client_id,
-                return_op_ids=True,
-            )
-            assert swa_ops.d2h_id is not None
-            if fragment2_num_blocks > 0:
-                assert swa_ops.h2disk_id is not None
-            finished_ops_ids.append(swa_ops.d2h_id)
-
         """insert and lock"""
         cpu_node_to_unlock = self.cpu_cache_engine.insert(
             sequence_meta,
@@ -1933,20 +2013,20 @@ class GlobalCacheEngine:
             node_to_unlock[DeviceType.SSD] = (ssd_node_to_unlock, ssd_node_to_unlock.size())
 
         op_callback_dict = self._build_op_callback_dict(op_node_to_ready)
-        if cpu_swa_slot >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_ops.d2h_id,
-                partial(self._publish_swa_put_slot,
-                        DeviceType.CPU, cpu_node_to_unlock, cpu_swa_slot),
-            )
-        if ssd_swa_slot >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_ops.h2disk_id,
-                partial(self._publish_swa_put_slot,
-                        DeviceType.SSD, ssd_node_to_unlock, ssd_swa_slot),
-            )
+
+        swa_nodes_to_unlock = self._append_swa_put_ops(
+            transfer_graph=transfer_graph,
+            finished_ops_ids=finished_ops_ids,
+            op_callback_dict=op_callback_dict,
+            dp_client_id=dp_client_id,
+            cpu_swa_slot=cpu_swa_slot,
+            ssd_swa_slot=ssd_swa_slot,
+            remote_swa_slot=-1,
+            cpu_node=cpu_node_to_unlock,
+            ssd_node=ssd_node_to_unlock,
+            remote_node=None,
+        )
+
         skipped_gpu_blocks = len(cpu_matched_blocks)
         return PutTransferPlan(
             transfer_graph=transfer_graph,
@@ -1956,12 +2036,29 @@ class GlobalCacheEngine:
             buffer_to_free={},
             num_gpu_blocks_to_transfer=len(fragment12_gpu_blocks),
             skipped_gpu_blocks=skipped_gpu_blocks,
+            swa_nodes_to_unlock=swa_nodes_to_unlock,
         )
 
     def _transfer_callback(self,
                            node_to_unlock: Dict[DeviceType, Tuple[RadixNode, int]],
                            buffer_to_free: Optional[Dict[DeviceType, np.ndarray]] = None,
-                           is_put: bool = False) -> None:
+                           is_put: bool = False,
+                           swa_nodes_to_unlock: Optional[Dict[DeviceType, RadixNode]] = None,
+                           swa_source_pins: Optional[List[Tuple[DeviceType, RadixNode]]] = None,
+                           swa_publications: Optional[Dict[DeviceType, RadixNode]] = None) -> None:
+        # SWA unlocks before Full unlock to preserve I3 (lock_cnt >= swa_lock_cnt).
+        # Deferred Global-GET publications stay !swa_ready until after set_ready
+        # below, so unlocking here is still safe w.r.t. SWA-LRU eviction.
+        if swa_nodes_to_unlock:
+            for node in swa_nodes_to_unlock.values():
+                if node is not None and getattr(node, "swa_lock_cnt", 0) > 0:
+                    node.swa_unlock()
+
+        if swa_source_pins:
+            for device_type, node in swa_source_pins:
+                self._swa_release_load_lock(
+                    node=node, source_device_type=device_type)
+
         if DeviceType.CPU in node_to_unlock:
             assert self.cpu_cache_engine is not None
             cpu_node = node_to_unlock[DeviceType.CPU][0]
@@ -1984,6 +2081,15 @@ class GlobalCacheEngine:
             )
             if is_put and self.enable_kv_sharing:
                 self.remote_cache_engine.insert_and_publish(node_to_unlock[DeviceType.REMOTE][0])
+
+        # Global GET: publish alongside Full set_ready (local GET / PUT already
+        # published from the completing SWA peer-op callback).
+        if swa_publications:
+            for device_type, node in swa_publications.items():
+                if node is None:
+                    continue
+                self._publish_swa_slot(device_type, node)
+
         if buffer_to_free is not None:
             if DeviceType.CPU in buffer_to_free:
                 assert self.cpu_cache_engine is not None
@@ -2096,29 +2202,45 @@ class GlobalCacheEngine:
                             finished_ops_ids: List[int],
                             op_callback_dict: Dict[int, Callable],
                             swa_read_source: SWAReadSource,
-                            dp_client_id: int) -> None:
-        """
-        Pin the SWA source node and append SWA GET peer ops to ``transfer_graph``.
-        Now we only support CPU, SSD and REMOTE as SWA sourc.
-        NOTE:
-        - if device_type is SSD, we need to allocate a cpu slot for SWA
-        - if device_type is REMOTE, we need to allocate a cpu slot for SWA
+                            dp_client_id: int,
+                            cpu_node_for_promotion: Optional[RadixNode] = None,
+                            swa_nodes_to_unlock: Optional[Dict[DeviceType, RadixNode]] = None,
+                            swa_source_pins: Optional[List[Tuple[DeviceType, RadixNode]]] = None,
+                            defer_swa_publish: bool = False,
+                            swa_publications: Optional[Dict[DeviceType, RadixNode]] = None) -> None:
+        """Pin the SWA source and append SWA GET peer ops.
+
+        SSD/REMOTE promotion mounts onto ``cpu_node_for_promotion`` before
+        ``build_get_chain``. Publish timing mirrors Full-KV GET ready:
+
+        * ``defer_swa_publish=True`` (global GET): register for
+          ``_transfer_callback`` publish alongside Full ``set_ready``.
+        * ``defer_swa_publish=False`` (local GET): publish when SWA
+          ``DISK2H`` / ``REMOTE2H`` completes (CPU bytes landed), matching
+          local Full op-level ``set_ready`` on staging ops.
+
+        Source pin / destination flight ``swa_lock`` always release in
+        ``_transfer_callback``.
         """
         assert swa_read_source.found
         device_type = swa_read_source.device_type
         source_engine = self.cache_engines[device_type]
         source_node = swa_read_source.node
         source_slot = swa_read_source.host_slot
-
+        # pin the source node (SSD、REMOTE or CPU)
         source_engine._pin_swa_node(source_node)
+
         swa_empty = np.array([], dtype=np.int64)
         staging_slot = -1
         cpu_swa_slots = np.array([source_slot], dtype=np.int64)
         ssd_swa_slots = swa_empty
         remote_swa_slots = swa_empty
+        mount_success = False
+        cleanup_staging = -1
 
         if device_type != DeviceType.CPU:
-            staging_slot = self.cpu_cache_engine._alloc_swa_slot()
+            staging_slot = self._reserve_swa_slot(
+                self.cpu_cache_engine, cpu_node_for_promotion)
             if staging_slot < 0:
                 self._swa_release_load_lock(
                     node=source_node, source_device_type=device_type)
@@ -2131,58 +2253,218 @@ class GlobalCacheEngine:
             else:
                 remote_swa_slots = source_slots
 
-        swa_h2d_id = self.swa_cache.build_get_chain(
+            # Try to promote onto the CPU fragment123 node.
+            #
+            # Race loss (another PUT/GET already mounted SWA on that node):
+            # DO NOT free the staging slot and DO NOT skip SWA — this GET's
+            # staging slot is a private allocation from _reserve_swa_slot, not
+            # a shared resource. Degrade to transient staging: leave
+            # mount_success=False, keep staging_slot alive, let build_get_chain
+            # use it as a one-shot CPU buffer for this SWA H2D. The staging
+            # slot is freed in the SWA H2D completion callback below
+            # (cleanup_staging = staging_slot when !mount_success).
+            #
+            # Skipping SWA here would hand the caller a graph with no SWA ops,
+            # leaving the GPU SWA slot uninitialised for this request.
+            if cpu_node_for_promotion is not None:
+                if self._mount_swa_slot(
+                        DeviceType.CPU, cpu_node_for_promotion, staging_slot):
+                    mount_success = True
+                else:
+                    flexkv_logger.warning(
+                        "SWA promotion mount lost a race on node "
+                        f"{cpu_node_for_promotion}; degrading to transient "
+                        f"staging for device {device_type}")
+
+        # append swa ops to the transfer graph
+        swa_ops = self.swa_cache.build_get_chain(
             transfer_graph,
-            gpu_slot_ids=self._SWA_GPU_PLACEHOLDER.copy(),
+            gpu_slot_ids=_SWA_GPU_PLACEHOLDER.copy(),
             cpu_slot_ids=cpu_swa_slots,
             ssd_slot_ids=ssd_swa_slots,
             remote_slot_ids=remote_swa_slots,
             dp_client_id=dp_client_id,
+            return_op_ids=True,
         )
+        swa_h2d_id = swa_ops.h2d_id
+
         if swa_h2d_id is None:
+            # Graph build failed: if we already mounted, unmount before free so
+            # the node does not keep a slot we return to the pool.
+            cleanup_staging = staging_slot
+            if mount_success and cpu_node_for_promotion is not None:
+                self.cpu_cache_engine.index.unmount_swa(cpu_node_for_promotion)
+                self.cpu_cache_engine._drain_unmounted_swa_slots()
+                cleanup_staging = -1
             self._swa_release_load_lock(
                 node=source_node,
-                staging_slot=staging_slot,
+                staging_slot=cleanup_staging,
                 source_device_type=device_type,
             )
-            flexkv_logger.warning(f"Failed to build SWA H2D chain for device {device_type}")
+            flexkv_logger.warning(
+                f"Failed to build SWA H2D chain for device {device_type}")
             return
 
         finished_ops_ids.append(swa_h2d_id)
-        self._append_op_callback(
-            op_callback_dict,
-            swa_h2d_id,
-            partial(
-                self._swa_release_load_lock,
-                node=source_node,
-                staging_slot=staging_slot,
-                source_device_type=device_type,
-            ),
+        # Defer source Full+swa unlock to _transfer_callback.
+        if swa_source_pins is not None:
+            swa_source_pins.append((device_type, source_node))
+        # Destination flight lock is taken at transfer launch (after Full lock).
+        if mount_success:
+            assert cpu_node_for_promotion is not None
+            if swa_nodes_to_unlock is not None:
+                swa_nodes_to_unlock[DeviceType.CPU] = cpu_node_for_promotion
+
+            
+            if defer_swa_publish:
+                # Global GET publish the SWA slot when the H2D completes, use swa_publications to record the node
+                assert swa_publications is not None
+                swa_publications[DeviceType.CPU] = cpu_node_for_promotion
+            else:
+                # Local GET: CPU SWA ready once staging lands (DISK2H/REMOTE2H),
+                # same moment Full Local set_ready runs on its staging ops.
+                publish_op_id = swa_ops.disk2h_id or swa_ops.remote2h_id
+                assert publish_op_id is not None, (
+                    "Local SWA promotion requires a DISK2H/REMOTE2H staging op")
+                self._append_op_callback(
+                    op_callback_dict,
+                    publish_op_id,
+                    partial[None](
+                        self._publish_swa_slot,
+                        DeviceType.CPU,
+                        cpu_node_for_promotion,
+                    ),
+                )
+        # Transient staging (no mount) is freed when H2D completes.
+        # TODO: if the task is cancelled, the staging slot will be freed here, 
+        # but the node is not unlocked and set ready, slot will be leaked, 
+        # so we need to handle this case.
+        cleanup_staging = -1 if mount_success else staging_slot
+        if cleanup_staging >= 0:
+            self._append_op_callback(
+                op_callback_dict,
+                swa_h2d_id,
+                partial[None](
+                    self._swa_release_load_lock,
+                    node=None,
+                    staging_slot=cleanup_staging,
+                    source_device_type=None,
+                ),
+            )
+
+    def _append_swa_put_ops(self,
+                            transfer_graph: TransferOpGraph,
+                            finished_ops_ids: List[int],
+                            op_callback_dict: Dict[int, Callable],
+                            dp_client_id: int,
+                            cpu_swa_slot: int,
+                            ssd_swa_slot: int,
+                            remote_swa_slot: int,
+                            cpu_node,
+                            ssd_node,
+                            remote_node) -> Dict[DeviceType, "RadixNode"]:
+        """Mount reserved PUT SWA slots, build the put chain, publish per tier.
+
+        Op callbacks only ``publish_swa`` (set ``swa_ready``). Mounted nodes are
+        returned for ``swa_lock`` at transfer launch and ``swa_unlock`` in
+        ``_transfer_callback``, covering write-through after early publish.
+        """
+        swa_nodes_to_unlock: Dict[DeviceType, RadixNode] = {}
+
+        # Mount each tier before build_put_chain. Race loss: _try_mount_swa_slot
+        # already frees that tier's reserved slot; clear the local id so we skip
+        # its ops (Full-KV insert/lock stays — unlike GET which also unpins).
+        if cpu_swa_slot >= 0 and cpu_node is not None:
+            if self._try_mount_swa_slot(DeviceType.CPU, cpu_node, cpu_swa_slot):
+                swa_nodes_to_unlock[DeviceType.CPU] = cpu_node
+            else:
+                cpu_swa_slot = -1
+
+        if ssd_swa_slot >= 0 and ssd_node is not None:
+            if self._try_mount_swa_slot(DeviceType.SSD, ssd_node, ssd_swa_slot):
+                swa_nodes_to_unlock[DeviceType.SSD] = ssd_node
+            else:
+                ssd_swa_slot = -1
+
+        if remote_swa_slot >= 0 and remote_node is not None:
+            if self._try_mount_swa_slot(
+                    DeviceType.REMOTE, remote_node, remote_swa_slot):
+                swa_nodes_to_unlock[DeviceType.REMOTE] = remote_node
+            else:
+                remote_swa_slot = -1
+
+        if cpu_swa_slot < 0 and ssd_swa_slot < 0 and remote_swa_slot < 0:
+            return swa_nodes_to_unlock
+
+        empty = np.array([], dtype=np.int64)
+        swa_ops = self.swa_cache.build_put_chain(
+            transfer_graph,
+            gpu_slot_ids=_SWA_GPU_PLACEHOLDER.copy(),
+            cpu_slot_ids=(np.array([cpu_swa_slot], dtype=np.int64)
+                          if cpu_swa_slot >= 0 else empty),
+            ssd_slot_ids=(np.array([ssd_swa_slot], dtype=np.int64)
+                          if ssd_swa_slot >= 0 else empty),
+            remote_slot_ids=(np.array([remote_swa_slot], dtype=np.int64)
+                             if remote_swa_slot >= 0 else empty),
+            dp_client_id=dp_client_id,
+            return_op_ids=True,
         )
+        if cpu_swa_slot >= 0:
+            assert swa_ops.d2h_id is not None
+            finished_ops_ids.append(swa_ops.d2h_id)
+            assert cpu_node is not None
+            self._append_op_callback(
+                op_callback_dict,
+                swa_ops.d2h_id,
+                partial[None](self._publish_swa_slot, DeviceType.CPU, cpu_node),
+            )
+        if ssd_swa_slot >= 0:
+            assert swa_ops.h2disk_id is not None
+            assert ssd_node is not None
+            self._append_op_callback(
+                op_callback_dict,
+                swa_ops.h2disk_id,
+                partial[None](self._publish_swa_slot, DeviceType.SSD, ssd_node),
+            )
+        if remote_swa_slot >= 0:
+            assert swa_ops.h2remote_id is not None
+            assert remote_node is not None
+            self._append_op_callback(
+                op_callback_dict,
+                swa_ops.h2remote_id,
+                partial[None](
+                    self._publish_swa_slot, DeviceType.REMOTE, remote_node),
+            )
+
+        return swa_nodes_to_unlock
 
     def _swa_release_load_lock(self,
                                node,
                                staging_slot: int = -1,
                                source_device_type: Optional[DeviceType] = None) -> None:
-        """SWA H2D completion callback: release the source pin and free any
-        transient CPU staging slot.
+        """SWA H2D completion callback: release the source-tier pin (and, in
+        legacy paths, free a transient staging slot).
 
-        For a CPU-sourced load, ``node`` is the matched CPU SWA node and its pin
-        is dropped with the plain dec (dec_swa_lock_ref, NOT dec_swa_lock_only):
-        the loaded window stays cached for future reuse. For a staged
-        (SSD/REMOTE) source, ``node`` is the source-tier node (same pin release)
-        and ``staging_slot`` is the transient CPU SWA slot used as the DISK2H/
-        REMOTE2H destination — it is unmounted (not a cached entry), so free it
-        back to the CPU SWA pool. No-op on parts that are absent."""
+        ``node`` is the source-tier SWA node (CPU / SSD / REMOTE) that was pinned
+        by ``_pin_swa_node`` before the H2D. The pin is released with the plain
+        dec (swa_unlock, NOT dec_swa_lock_only) so the source stays cached
+        for future reuse.
+
+        ``staging_slot``:
+          * ``>= 0`` (legacy path): the transient CPU SWA slot used as DISK2H/
+            REMOTE2H destination was NOT mounted onto a radix node; free it
+            back to the CPU SWA pool here (op-callback path).
+          * ``-1``: no staging free (promoted slot belongs to the radix /
+            unlock is handled by the caller).
+        Successful GET plans defer node unlock to ``_transfer_callback``; this
+        helper is then used for source pins (and early-fail cleanup)."""
         try:
-            if node is not None and getattr(node, "swa_lock_ref", 0) > 0:
-                node.dec_swa_lock_ref()
+            if node is not None and getattr(node, "swa_lock_cnt", 0) > 0:
+                node.swa_unlock()
                 if source_device_type is not None:
                     engine = self.cache_engines.get(source_device_type)
                     if engine is not None:
                         engine.index.unlock(node)
-                elif hasattr(node, "unlock"):
-                    node.unlock()
                 else:
                     node.lock_cnt -= 1
         except Exception:  # noqa: BLE001 — never let a callback crash the loop

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -60,13 +60,16 @@ class GetTransferPlan:
     # _transfer_callback (mirrors Full-KV lock_node / unlock).
     swa_nodes_to_unlock: Dict[DeviceType, object] = field(default_factory=dict) # target node to unlock and set ready
     # GET source nodes pinned via _pin_swa_node during plan build; Full+swa
-    # unlock deferred to _transfer_callback (op callbacks only publish / free
-    # transient staging).
+    # unlock deferred to _transfer_callback (op callbacks only publish).
     swa_source_pins: List[Tuple[DeviceType, object]] = field(default_factory=list) # source node pin
     # Global GET: SWA publish deferred to _transfer_callback (same place Full
     # set_ready runs). Local GET leaves this empty and publishes on the SWA
     # H2D op callback instead.
     swa_publications: Dict[DeviceType, object] = field(default_factory=dict) # only used for global get
+    # Transient CPU SWA staging slots (promotion mount lost the race, slot was
+    # NOT mounted onto a radix node). Freed in _transfer_callback, mirroring
+    # the Full-KV buffer_to_free lifecycle.
+    swa_slot_to_free: List[int] = field(default_factory=list)
 
     @classmethod
     def empty(cls) -> "GetTransferPlan":
@@ -80,6 +83,7 @@ class GetTransferPlan:
             swa_nodes_to_unlock={},
             swa_source_pins=[],
             swa_publications={},
+            swa_slot_to_free=[],
         )
 
 
@@ -874,7 +878,8 @@ class GlobalCacheEngine:
                            buffer_to_free=plan.buffer_to_free,
                            swa_nodes_to_unlock=plan.swa_nodes_to_unlock,
                            swa_source_pins=plan.swa_source_pins,
-                           swa_publications=plan.swa_publications)
+                           swa_publications=plan.swa_publications,
+                           swa_slot_to_free=plan.swa_slot_to_free)
 
         op_callback_dict = plan.op_callback_dict
 
@@ -1241,6 +1246,7 @@ class GlobalCacheEngine:
         swa_nodes_to_unlock: Dict[DeviceType, RadixNode] = {}
         swa_source_pins: List[Tuple[DeviceType, RadixNode]] = []
         swa_publications: Dict[DeviceType, RadixNode] = {}
+        swa_slot_to_free: List[int] = []
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
             self._append_swa_get_ops(
@@ -1255,6 +1261,7 @@ class GlobalCacheEngine:
                 # Global GET: Full set_ready only in _transfer_callback — match that.
                 defer_swa_publish=True,
                 swa_publications=swa_publications,
+                swa_slot_to_free=swa_slot_to_free,
             )
 
         return GetTransferPlan(
@@ -1267,6 +1274,7 @@ class GlobalCacheEngine:
             swa_nodes_to_unlock=swa_nodes_to_unlock,
             swa_source_pins=swa_source_pins,
             swa_publications=swa_publications,
+            swa_slot_to_free=swa_slot_to_free,
         )
 
     def _get_impl_local(self,
@@ -1497,6 +1505,7 @@ class GlobalCacheEngine:
 
         swa_nodes_to_unlock: Dict[DeviceType, RadixNode] = {}
         swa_source_pins: List[Tuple[DeviceType, RadixNode]] = []
+        swa_slot_to_free: List[int] = []
         if (self.swa_cache.enabled and num_gpu_blocks_to_transfer > 0
                 and swa_read_source.found):
             self._append_swa_get_ops(
@@ -1511,6 +1520,7 @@ class GlobalCacheEngine:
                 # Local GET: Full set_ready on staging op callbacks — publish
                 # SWA when DISK2H/REMOTE2H lands on CPU.
                 defer_swa_publish=False,
+                swa_slot_to_free=swa_slot_to_free,
             )
         nvtx.end_range(nvtx_range)
         return GetTransferPlan(
@@ -1522,6 +1532,7 @@ class GlobalCacheEngine:
             num_gpu_blocks_to_transfer=num_gpu_blocks_to_transfer,
             swa_nodes_to_unlock=swa_nodes_to_unlock,
             swa_source_pins=swa_source_pins,
+            swa_slot_to_free=swa_slot_to_free,
         )
 
     def put(self,
@@ -2045,7 +2056,8 @@ class GlobalCacheEngine:
                            is_put: bool = False,
                            swa_nodes_to_unlock: Optional[Dict[DeviceType, RadixNode]] = None,
                            swa_source_pins: Optional[List[Tuple[DeviceType, RadixNode]]] = None,
-                           swa_publications: Optional[Dict[DeviceType, RadixNode]] = None) -> None:
+                           swa_publications: Optional[Dict[DeviceType, RadixNode]] = None,
+                           swa_slot_to_free: Optional[List[int]] = None) -> None:
         # SWA unlocks before Full unlock to preserve I3 (lock_cnt >= swa_lock_cnt).
         # Deferred Global-GET publications stay !swa_ready until after set_ready
         # below, so unlocking here is still safe w.r.t. SWA-LRU eviction.
@@ -2100,6 +2112,15 @@ class GlobalCacheEngine:
             if DeviceType.REMOTE in buffer_to_free:
                 assert self.remote_cache_engine is not None
                 self.remote_cache_engine.recycle(buffer_to_free[DeviceType.REMOTE])
+
+        # Transient SWA staging slots (mount-race losers) are private one-shot
+        # buffers; their last consumer is the SWA H2D, so releasing at graph
+        # completion is safe — same lifecycle as buffer_to_free above.
+        if swa_slot_to_free:
+            assert self.cpu_cache_engine is not None
+            for slot in swa_slot_to_free:
+                if slot is not None and slot >= 0:
+                    self.cpu_cache_engine._free_swa_slot(int(slot))
 
     def _op_callback(self, device_type: DeviceType, node_to_ready: RadixNode, ready_length: int) -> None:
         if device_type == DeviceType.CPU:
@@ -2207,7 +2228,8 @@ class GlobalCacheEngine:
                             swa_nodes_to_unlock: Optional[Dict[DeviceType, RadixNode]] = None,
                             swa_source_pins: Optional[List[Tuple[DeviceType, RadixNode]]] = None,
                             defer_swa_publish: bool = False,
-                            swa_publications: Optional[Dict[DeviceType, RadixNode]] = None) -> None:
+                            swa_publications: Optional[Dict[DeviceType, RadixNode]] = None,
+                            swa_slot_to_free: Optional[List[int]] = None) -> None:
         """Pin the SWA source and append SWA GET peer ops.
 
         SSD/REMOTE promotion mounts onto ``cpu_node_for_promotion`` before
@@ -2261,8 +2283,8 @@ class GlobalCacheEngine:
             # a shared resource. Degrade to transient staging: leave
             # mount_success=False, keep staging_slot alive, let build_get_chain
             # use it as a one-shot CPU buffer for this SWA H2D. The staging
-            # slot is freed in the SWA H2D completion callback below
-            # (cleanup_staging = staging_slot when !mount_success).
+            # slot is registered in swa_slot_to_free and reclaimed in
+            # _transfer_callback (same lifecycle as Full-KV buffer_to_free).
             #
             # Skipping SWA here would hand the caller a graph with no SWA ops,
             # leaving the GPU SWA slot uninitialised for this request.
@@ -2335,22 +2357,17 @@ class GlobalCacheEngine:
                         cpu_node_for_promotion,
                     ),
                 )
-        # Transient staging (no mount) is freed when H2D completes.
-        # TODO: if the task is cancelled, the staging slot will be freed here, 
-        # but the node is not unlocked and set ready, slot will be leaked, 
-        # so we need to handle this case.
+        # Transient staging (no mount) is freed in _transfer_callback together
+        # with the Full-KV buffer_to_free, keeping one single release point at
+        # graph completion.
+        # TODO: if the task is cancelled the transfer callback never runs and
+        # the slot leaks (same gap as node unlock / set_ready) — needs a
+        # dedicated cancellation rollback.
         cleanup_staging = -1 if mount_success else staging_slot
         if cleanup_staging >= 0:
-            self._append_op_callback(
-                op_callback_dict,
-                swa_h2d_id,
-                partial[None](
-                    self._swa_release_load_lock,
-                    node=None,
-                    staging_slot=cleanup_staging,
-                    source_device_type=None,
-                ),
-            )
+            assert swa_slot_to_free is not None, (
+                "transient SWA staging requires a swa_slot_to_free list")
+            swa_slot_to_free.append(cleanup_staging)
 
     def _append_swa_put_ops(self,
                             transfer_graph: TransferOpGraph,
@@ -2442,8 +2459,7 @@ class GlobalCacheEngine:
                                node,
                                staging_slot: int = -1,
                                source_device_type: Optional[DeviceType] = None) -> None:
-        """SWA H2D completion callback: release the source-tier pin (and, in
-        legacy paths, free a transient staging slot).
+        """Release an SWA source-tier pin (and optionally free a staging slot).
 
         ``node`` is the source-tier SWA node (CPU / SSD / REMOTE) that was pinned
         by ``_pin_swa_node`` before the H2D. The pin is released with the plain
@@ -2451,9 +2467,11 @@ class GlobalCacheEngine:
         for future reuse.
 
         ``staging_slot``:
-          * ``>= 0`` (legacy path): the transient CPU SWA slot used as DISK2H/
-            REMOTE2H destination was NOT mounted onto a radix node; free it
-            back to the CPU SWA pool here (op-callback path).
+          * ``>= 0``: free the given CPU SWA slot back to the host pool. Only
+            used by synchronous early-fail cleanup (alloc / graph-build failure
+            before launch). In-flight transient staging is instead registered
+            in ``swa_slot_to_free`` and reclaimed in ``_transfer_callback``
+            (mirrors Full-KV buffer_to_free).
           * ``-1``: no staging free (promoted slot belongs to the radix /
             unlock is handled by the caller).
         Successful GET plans defer node unlock to ``_transfer_callback``; this

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -27,7 +27,7 @@ Core invariants (enforced here):
 * I1: SWA subset of Full. Freeing a node's Full KV always frees its SWA slot.
 * I2: every leaf must have SWA unless its Full is locked (a leaf that lost its
       SWA and is not full-locked is meaningless and gets deleted).
-* I3: full_lock_ref (== node.lock_cnt here) >= swa_lock_ref always.
+* I3: lock_cnt >= swa_lock_cnt always.
 * I4: a non-tombstone node is homogeneous (whole node SWA-mapped, or tombstone).
 
 This module is the non-accel mirror; DSv4 uses the C++ CRadixTreeIndex. Kept
@@ -88,7 +88,7 @@ class RadixNode:
     # ===== SWA (node-mounted) state — mirrors CRadixNode =====
     swa_host_slot: int = -1            # CPU SWA host-pool slot id (-1 = no SWA)
     swa_tombstone: bool = True         # True = no live SWA on this node
-    swa_lock_ref: int = 0              # SWA lock ref (invariant: <= lock_cnt)
+    swa_lock_cnt: int = 0              # SWA lock count (invariant: <= lock_cnt)
     swa_ready: bool = False            # True once SWA bytes are published
     swa_last_access_time: float = 0.0  # SWA-LRU timestamp
     # intrusive SWA-LRU doubly-linked list pointers (independent of full LRU)
@@ -124,8 +124,12 @@ class RadixNode:
 
     def in_use(self) -> bool:
         # A node is in use (not full-evictable) if its Full KV is locked, its SWA
-        # is locked (I3: swa_lock_ref>0 implies it must stay), or it is not ready.
-        return self.lock_cnt > 0 or self.swa_lock_ref > 0 or not self.is_ready
+        # is locked (I3: swa_lock_cnt>0 implies it must stay), it is not ready, or
+        # it still has a pending (mounted-but-unpublished) SWA transfer — mirror
+        # of CRadixNode::in_use in csrc/radix_tree.h.
+        return (self.lock_cnt > 0 or self.swa_lock_cnt > 0
+                or not self.is_ready
+                or (self.has_swa() and not self.swa_ready))
 
     def has_swa(self) -> bool:
         """True iff this node carries a live (non-tombstone) SWA slot."""
@@ -135,17 +139,17 @@ class RadixNode:
         """True once mounted SWA is published on a ready Full-KV node."""
         return self.has_swa() and self.is_ready and self.swa_ready
 
-    def inc_swa_lock_ref(self) -> None:
-        """Pin the SWA against eviction (mirror of CRadixNode.inc_swa_lock_ref)."""
-        self.swa_lock_ref += 1
+    def swa_lock(self) -> None:
+        """Pin the SWA against eviction (mirror of CRadixNode.swa_lock)."""
+        self.swa_lock_cnt += 1
 
-    def dec_swa_lock_ref(self) -> None:
-        """Release one SWA eviction pin (mirror of CRadixNode.dec_swa_lock_ref).
+    def swa_unlock(self) -> None:
+        """Release one SWA eviction pin (mirror of CRadixNode.swa_unlock).
 
         Keeps the SWA slot cached (unlike dec_swa_lock_only, which frees a leaf's
         SWA); used to drop a load-time pin once the SWA H2D has read the slot."""
-        assert self.swa_lock_ref > 0
-        self.swa_lock_ref -= 1
+        assert self.swa_lock_cnt > 0
+        self.swa_lock_cnt -= 1
 
     def lock(self) -> None:
         assert self.lock_cnt >= 0
@@ -294,9 +298,9 @@ class RadixTreeIndex:
         node.on_swa_lru = False
 
     def _swa_lru_get_lru_unlocked(self) -> Optional[RadixNode]:
-        """LRU published SWA node with swa_lock_ref == 0 (pending mounts skipped)."""
+        """LRU published SWA node with swa_lock_cnt == 0 (pending mounts skipped)."""
         x = self._swa_lru_tail.swa_lru_prev
-        while x is not self._swa_lru_head and (x.swa_lock_ref > 0 or not x.swa_ready):
+        while x is not self._swa_lru_head and (x.swa_lock_cnt > 0 or not x.swa_ready):
             x = x.swa_lru_prev
         return x if x is not self._swa_lru_head else None
 
@@ -331,7 +335,15 @@ class RadixTreeIndex:
         node.swa_last_access_time = time.time()
 
     def publish_swa(self, node: RadixNode) -> None:
-        """Publish a mounted SWA slot: matchable and on the SWA-LRU."""
+        """Publish a mounted SWA slot: matchable and on the SWA-LRU.
+
+        NOTE: does not require ``node.is_ready`` — the SWA data plane may
+        complete before Full-KV. ``match_prefix`` gates SWA hits on
+        ``is_swa_readable() = has_swa && is_ready && swa_ready``, so any
+        temporary ``(is_ready=False, swa_ready=True)`` state stays invisible
+        to GETs until Full-KV also becomes ready. eviction is likewise safe
+        (Full-KV lock keeps unready nodes pinned; SWA-LRU skips locked nodes).
+        """
         assert node is not self.root_node
         assert node.has_swa()
         if node.swa_ready:
@@ -669,8 +681,8 @@ class RadixTreeIndex:
         while cur is not None and not cur.is_root():
             cur.lock_cnt += 1
             if swa_boundary is None and cur.has_swa():
-                cur.swa_lock_ref += 1
-                assert cur.lock_cnt >= cur.swa_lock_ref  # I3
+                cur.swa_lock()
+                assert cur.lock_cnt >= cur.swa_lock_cnt  # I3
                 swa_boundary = cur
             cur = cur.parent
         return swa_boundary
@@ -687,9 +699,9 @@ class RadixTreeIndex:
             cur.lock_cnt -= 1
             # Release the SWA lock only on the exact boundary node (symmetric
             # with inc_lock_ref, which locked only that one node).
-            if not skip_swa and cur is swa_boundary and cur.swa_lock_ref > 0:
-                cur.swa_lock_ref -= 1
-            assert cur.lock_cnt >= cur.swa_lock_ref  # I3
+            if not skip_swa and cur is swa_boundary and cur.swa_lock_cnt > 0:
+                cur.swa_unlock()
+            assert cur.lock_cnt >= cur.swa_lock_cnt  # I3
             cur = cur.parent
 
     def dec_swa_lock_only(self, swa_boundary: Optional[RadixNode]) -> None:
@@ -704,9 +716,9 @@ class RadixTreeIndex:
         if swa_boundary is None:
             return
         cur = swa_boundary
-        assert cur.swa_lock_ref > 0, "dec_swa_lock_only on an unlocked SWA node"
-        cur.swa_lock_ref -= 1
-        if cur.swa_lock_ref == 0 and cur.has_swa():
+        assert cur.swa_lock_cnt > 0, "dec_swa_lock_only on an unlocked SWA node"
+        cur.swa_unlock()
+        if cur.swa_lock_cnt == 0 and cur.has_swa():
             if cur.is_leaf():
                 # Leaf: free SWA now (Full stays until the full lock drops).
                 self.record_freed_swa_slot(cur)

--- a/flexkv/cache/swa_cache_engine.py
+++ b/flexkv/cache/swa_cache_engine.py
@@ -64,6 +64,13 @@ class SWAPutChainOpIds:
     h2remote_id: Optional[int] = None
 
 
+@dataclass
+class SWAGetChainOpIds:
+    h2d_id: Optional[int] = None
+    disk2h_id: Optional[int] = None
+    remote2h_id: Optional[int] = None
+
+
 class SWACacheManager:
     """SWA peer-op graph construction.
 
@@ -137,38 +144,54 @@ class SWACacheManager:
                         cpu_slot_ids: np.ndarray,
                         ssd_slot_ids: Optional[np.ndarray] = None,
                         remote_slot_ids: Optional[np.ndarray] = None,
-                        dp_client_id: int = 0) -> Optional[int]:
-        """Build the GET-side SWA load chain into ``graph``; return the terminal
-        SWA ``H2D`` op_id (to be appended to the graph's finished_ops_ids so it
-        joins the VIRTUAL barrier alongside the full-KV H2D).
+                        dp_client_id: int = 0,
+                        return_op_ids: bool = False) -> Union[Optional[int], SWAGetChainOpIds]:
+        """Build the GET-side SWA load chain into ``graph``.
+
+        Returns the terminal SWA ``H2D`` op_id by default (for finished_ops /
+        VIRTUAL barrier). With ``return_op_ids=True``, returns ``SWAGetChainOpIds``
+        including staging ``DISK2H`` / ``REMOTE2H`` ids for CPU-ready publish.
 
         Mirrors the full-KV GET graph: the SWA ``H2D`` (CPU SWA slot -> GPU swa
         pool) depends on the staging ops ``DISK2H`` / ``REMOTE2H`` when the SWA
         bytes are sourced from SSD / REMOTE. (CPU-resident SWA needs no staging
         op, like a CPU full-KV hit.) All ops carry ``is_swa=True``. Returns None
-        when disabled / empty.
+        when disabled / empty (or empty ``SWAGetChainOpIds`` with return_op_ids).
         """
-        assert gpu_slot_ids.size > 0 and gpu_slot_ids.size == cpu_slot_ids.size, "GPU and CPU SWA slot ids must have the same size"
-        h2d_id = self.build_swa_op(
-            graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
-            dp_client_id=dp_client_id,
-        )
-        if h2d_id is None:
-            return None
-        if ssd_slot_ids is not None and ssd_slot_ids.size == cpu_slot_ids.size:
+        assert cpu_slot_ids.size > 0 and cpu_slot_ids.size == gpu_slot_ids.size, \
+            "CPU and GPU SWA slot ids must have the same size"
+        ssd2h_id = None
+        remote2h_id = None
+        h2d_id = None
+        if (ssd_slot_ids is not None and ssd_slot_ids.size > 0
+                and ssd_slot_ids.size == cpu_slot_ids.size):
             ssd2h_id = self.build_swa_op(
                 graph, TransferType.DISK2H, ssd_slot_ids, cpu_slot_ids,
                 dp_client_id=dp_client_id,
             )
-            if ssd2h_id is not None:
-                graph.add_dependency(h2d_id, ssd2h_id)
-        if remote_slot_ids is not None and remote_slot_ids.size == cpu_slot_ids.size:
+
+        if (remote_slot_ids is not None and remote_slot_ids.size > 0
+                and remote_slot_ids.size == cpu_slot_ids.size):
             remote2h_id = self.build_swa_op(
                 graph, TransferType.REMOTE2H, remote_slot_ids, cpu_slot_ids,
                 dp_client_id=dp_client_id,
             )
-            if remote2h_id is not None:
-                graph.add_dependency(h2d_id, remote2h_id)
+
+        h2d_id = self.build_swa_op(
+            graph, TransferType.H2D, cpu_slot_ids, gpu_slot_ids,
+            dp_client_id=dp_client_id,
+        )
+        if h2d_id is not None and ssd2h_id is not None:
+            graph.add_dependency(h2d_id, ssd2h_id)
+        if h2d_id is not None and remote2h_id is not None:
+            graph.add_dependency(h2d_id, remote2h_id)
+
+        if return_op_ids:
+            return SWAGetChainOpIds(
+                h2d_id=h2d_id,
+                disk2h_id=ssd2h_id,
+                remote2h_id=remote2h_id,
+            )
         return h2d_id
 
     def build_put_chain(self,

--- a/tests/test_kvtask_lifecycle.py
+++ b/tests/test_kvtask_lifecycle.py
@@ -10,7 +10,7 @@ Two concerns, both cheap (no TransferManager subprocess, no GPU):
 2. The SWA load-lock lifecycle on ``GlobalCacheEngine``: a GET pins the matched
    CPU SWA node while building the GET plan, and the SWA H2D completion callback
    releases it (``_swa_release_load_lock``), leaving the
-   node cached (dec_swa_lock_ref, NOT dec_swa_lock_only). This documents that
+   node cached (swa_unlock, NOT dec_swa_lock_only). This documents that
    the SWA lock follows the SAME lifecycle as the full-KV node lock (both taken
    in get()/put(), both released via the op/transfer callbacks) — so a fresh
    GET after a completed GET re-locks cleanly with no residual pin.
@@ -177,7 +177,7 @@ def _put(eng, tok):
 
 def test_get_pins_then_releases_swa_lock():
     """GET pins the matched CPU SWA node; the SWA H2D callback releases it
-    (dec_swa_lock_ref -> node stays cached, lock back to 0)."""
+    (swa_unlock -> node stays cached, lock back to 0)."""
     eng = _engine()
     tok = _tokens(21)
     _put(eng, tok)
@@ -195,7 +195,7 @@ def test_get_pins_then_releases_swa_lock():
     # The node carries the load pin (>=1) taken while building the GET plan.
     node = mr.last_swa_node
     assert node is not None
-    assert node.swa_lock_ref >= 1
+    assert node.swa_lock_cnt >= 1
 
     # Complete the ops: the SWA H2D callback releases the pin.
     for c in op_cb.values():
@@ -203,8 +203,8 @@ def test_get_pins_then_releases_swa_lock():
     cb()
     node2 = eng.cpu_cache_engine.index.match_prefix(
         torch.from_numpy(sm.block_hashes[:4]).to(torch.int64), 4, False).last_swa_node
-    assert node2.swa_lock_ref == 0, "SWA load lock not released on H2D completion"
-    # slot still live (dec_swa_lock_ref keeps the cache, unlike dec_swa_lock_only)
+    assert node2.swa_lock_cnt == 0, "SWA load lock not released on H2D completion"
+    # slot still live (swa_unlock keeps the cache, unlike dec_swa_lock_only)
     assert node2.has_swa()
 
 
@@ -227,7 +227,7 @@ def test_repeated_get_relocks_cleanly():
             c()
         cb()
         node = eng.cpu_cache_engine.index.match_prefix(bh, 4, False).last_swa_node
-        assert node.swa_lock_ref == 0, f"residual SWA lock after GET {req}"
+        assert node.swa_lock_cnt == 0, f"residual SWA lock after GET {req}"
 
 
 if __name__ == "__main__":

--- a/tests/test_swa_cnode_cascade.py
+++ b/tests/test_swa_cnode_cascade.py
@@ -64,7 +64,7 @@ class TestStep1Fields:
         assert node is not None
         assert node.swa_host_slot == -1
         assert node.swa_tombstone is True
-        assert node.swa_lock_ref == 0
+        assert node.swa_lock_cnt == 0
 
     def test_setters_roundtrip(self):
         tree = _make_tree()
@@ -79,11 +79,11 @@ class TestStep1Fields:
         tree = _make_tree()
         tokens = np.arange(0, TPB * 3, dtype=np.int64)
         node, _ = _insert(tree, tokens, 0)
-        node.inc_swa_lock_ref()
-        node.inc_swa_lock_ref()
-        assert node.swa_lock_ref == 2
-        node.dec_swa_lock_ref()
-        assert node.swa_lock_ref == 1
+        node.swa_lock()
+        node.swa_lock()
+        assert node.swa_lock_cnt == 2
+        node.swa_unlock()
+        assert node.swa_lock_cnt == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -205,10 +205,10 @@ class TestStep3TreeLevel:
         boundary = tree.inc_lock_ref(node)
         assert boundary is not None
         assert node.get_lock_cnt() >= 1
-        assert node.swa_lock_ref == 1
-        assert node.get_lock_cnt() >= node.swa_lock_ref  # I3
+        assert node.swa_lock_cnt == 1
+        assert node.get_lock_cnt() >= node.swa_lock_cnt  # I3
         tree.dec_lock_ref(node, boundary)
-        assert node.get_lock_cnt() == 0 and node.swa_lock_ref == 0
+        assert node.get_lock_cnt() == 0 and node.swa_lock_cnt == 0
 
     def test_dec_swa_lock_only_then_skip(self):
         tree = _make_tree()
@@ -218,7 +218,7 @@ class TestStep3TreeLevel:
         boundary = tree.inc_lock_ref(node)
         tree.dec_swa_lock_only(boundary)
         # leaf: SWA freed early + tombstone; full lock still held
-        assert node.swa_lock_ref == 0
+        assert node.swa_lock_cnt == 0
         assert node.swa_tombstone is True
         assert node.get_lock_cnt() == 1
         assert 66 in tree.drain_freed_swa_slots()

--- a/tests/test_swa_control_plane.py
+++ b/tests/test_swa_control_plane.py
@@ -175,7 +175,9 @@ def test_put_builds_full_plus_swa_store_chain():
     sm = SequenceMeta(token_ids=tok, tokens_per_block=TPB); sm.gen_hashes()
     pending = eng.cpu_cache_engine.match(sm)
     assert pending.num_ready_matched_blocks == 0
-    assert pending.last_node.swa_host_slot == -1
+    # Mount-first: the SWA slot is already attached to the node, but not yet
+    # published (swa_ready=False) — so match still sees no readable SWA.
+    assert pending.last_node.swa_host_slot >= 0
     assert pending.swa_hit_blocks == 0
 
     full_d2h = next(o for o in full if o.transfer_type == TransferType.D2H)
@@ -184,17 +186,24 @@ def test_put_builds_full_plus_swa_store_chain():
     assert barrier.transfer_type == TransferType.VIRTUAL
     assert barrier.predecessors == {full_d2h.op_id, swa_d2h.op_id}
 
-    # Full-KV may become readable first, but the reserved SWA slot must remain a
-    # miss until its independent sibling D2H completes.
+    # Full-KV may become readable first; SWA publishes from the SWA D2H op
+    # callback (not the task-level transfer callback).
     op_cb[full_d2h.op_id]()
     full_only = eng.cpu_cache_engine.match(sm)
     assert full_only.num_ready_matched_blocks == 4
     assert full_only.swa_hit_blocks == 0
-    assert full_only.last_node.swa_host_slot == -1
+    assert full_only.last_node.swa_host_slot >= 0
+    assert not full_only.last_node.swa_ready
 
+    # SWA D2H completion publishes; with Full already ready, SWA is matchable
+    # before the task-level callback runs.
     op_cb[swa_d2h.op_id]()
+    ready_before_task_cb = eng.cpu_cache_engine.match(sm)
+    assert ready_before_task_cb.swa_hit_blocks == 4
+    assert ready_before_task_cb.last_swa_node is not None
+    assert ready_before_task_cb.last_swa_node.swa_host_slot >= 0
+
     cb()
-    # SWA completion publishes the reserved slot independently.
     ready = eng.cpu_cache_engine.match(sm)
     assert ready.swa_hit_blocks == 4
     assert ready.last_swa_node is not None
@@ -219,13 +228,14 @@ def test_put_swa_first_stays_hidden_until_full_kv_is_ready():
                    if o.transfer_type == TransferType.D2H)
     seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
 
-    # The SWA bytes may land first.  Mounting the completed slot is safe because
-    # match_prefix still requires the owning Full-KV node to be ready.
-    op_cb[swa_d2h.op_id]()
+    # Mount-first: SWA D2H publishes swa_ready, but is_swa_readable still
+    # requires Full-KV is_ready — so match stays a SWA miss until Full D2H.
+    op_cb.get(swa_d2h.op_id, lambda: None)()
     swa_only = eng.cpu_cache_engine.match(seq)
     assert swa_only.num_ready_matched_blocks == 0
     assert swa_only.swa_hit_blocks == 0
     assert swa_only.last_node.swa_host_slot >= 0
+    assert swa_only.last_node.swa_ready
 
     op_cb[full_d2h.op_id]()
     cb()
@@ -292,10 +302,10 @@ def test_get_builds_full_plus_swa_load_chain():
     node = ready.last_swa_node
     assert node is not None
     eng.cpu_cache_engine._pin_swa_node(node)
-    assert node is not None and node.swa_lock_ref == 1
-    assert node.get_lock_cnt() >= node.swa_lock_ref
+    assert node is not None and node.swa_lock_cnt == 1
+    assert node.get_lock_cnt() >= node.swa_lock_cnt
     eng._swa_release_load_lock(node, source_device_type=DeviceType.CPU)
-    assert node.swa_lock_ref == 0
+    assert node.swa_lock_cnt == 0
 
 
 def test_gate_off_no_swa_ops_in_control_plane_graph():
@@ -479,12 +489,14 @@ def test_put_writethrough_ssd_builds_swa_h2disk():
     assert barrier.predecessors == {full_d2h.op_id, swa_d2h.op_id}
     assert swa_h2disk.op_id not in barrier.predecessors
 
-    # SSD SWA is allocated but is not mounted while write-through is in flight.
+    # Mount-first: SSD SWA slot is attached at graph-build time; match_prefix
+    # remains a miss until SWA H2DISK publishes (and Full is ready).
     assert eng.ssd_cache_engine.swa_pool.num_used == 1
     seq = SequenceMeta(token_ids=tok, tokens_per_block=TPB); seq.gen_hashes()
     pending = eng.ssd_cache_engine.match(seq)
     assert pending.num_ready_matched_blocks == 0
-    assert pending.last_node.swa_host_slot == -1
+    assert pending.last_node.swa_host_slot >= 0
+    assert not pending.last_node.swa_ready
     assert pending.swa_hit_blocks == 0
 
     op_cb[full_d2h.op_id]()
@@ -492,17 +504,16 @@ def test_put_writethrough_ssd_builds_swa_h2disk():
     full_only = eng.ssd_cache_engine.match(seq)
     assert full_only.num_ready_matched_blocks == 4
     assert full_only.swa_hit_blocks == 0
+    assert not full_only.last_node.swa_ready
 
+    # CPU SWA publishes on D2H; SSD SWA publishes on its own H2DISK — no need
+    # to wait for the task-level callback.
     op_cb[swa_d2h.op_id]()
     op_cb[swa_h2disk.op_id]()
-    for op_id, callback in op_cb.items():
-        if op_id not in {
-            full_d2h.op_id,
-            full_h2disk.op_id,
-            swa_d2h.op_id,
-            swa_h2disk.op_id,
-        }:
-            callback()
+    ready_before_task_cb = eng.ssd_cache_engine.match(seq)
+    assert ready_before_task_cb.swa_hit_blocks == 4
+    assert ready_before_task_cb.last_swa_node is not None
+
     cb()
     ready = eng.ssd_cache_engine.match(seq)
     assert ready.swa_hit_blocks == 4

--- a/tests/test_swa_control_plane_e2e.py
+++ b/tests/test_swa_control_plane_e2e.py
@@ -234,7 +234,7 @@ def main() -> int:
     node = mr.last_swa_node if mr.swa_hit_blocks == 1 else None
     if node is not None:
         engine.cpu_cache_engine._pin_swa_node(node)
-        lock_ok = (node.swa_lock_ref == 1)  # our fresh probe lock; prior load lock released
+        lock_ok = (node.swa_lock_cnt == 1)  # our fresh probe lock; prior load lock released
         engine._swa_release_load_lock(node, source_device_type=DeviceType.CPU)
         print(f"[verify] {'OK   ' if lock_ok else 'FAIL '} SWA load lock released "
               f"(lock_ref after fresh probe == 1: {lock_ok})", flush=True)

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -23,7 +23,7 @@ Invariants:
   I1  SWA ⊆ Full: freeing a node's Full KV frees its SWA slot (drained to pool).
   I2  SWA-only eviction prefers interior nodes; a leaf that loses its SWA with no
       full lock is deleted, with a full lock its Full KV is kept.
-  I3  full_lock_ref (lock_cnt) ≥ swa_lock_ref, symmetric inc/dec.
+  I3  lock_cnt ≥ swa_lock_cnt, symmetric lock/unlock.
   I4  match returns the deepest fully-matched ready node with a live SWA in one
       pass; a partial node match must not expose its trailing-page SWA.
 """
@@ -216,15 +216,15 @@ def test_py_reuse_promotes_swa_over_never_reused():
 
 
 def test_py_dual_lock_invariant():
-    """I3: full_lock_ref (lock_cnt) >= swa_lock_ref, with paired inc/dec."""
+    """I3: lock_cnt >= swa_lock_cnt, with paired lock/unlock."""
     idx = RadixTreeIndex(tokens_per_block=TPB)
     n1 = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
     idx.set_swa(n1, slot=700)
     b = idx.inc_lock_ref(n1)
-    assert n1.lock_cnt == 1 and n1.swa_lock_ref == 1 and b is n1
-    assert n1.lock_cnt >= n1.swa_lock_ref
+    assert n1.lock_cnt == 1 and n1.swa_lock_cnt == 1 and b is n1
+    assert n1.lock_cnt >= n1.swa_lock_cnt
     idx.dec_lock_ref(n1, swa_boundary=b)
-    assert n1.lock_cnt == 0 and n1.swa_lock_ref == 0
+    assert n1.lock_cnt == 0 and n1.swa_lock_cnt == 0
 
 
 def test_py_dec_swa_lock_only_early_release():
@@ -233,7 +233,7 @@ def test_py_dec_swa_lock_only_early_release():
     idx.set_swa(n1, slot=701)
     b = idx.inc_lock_ref(n1)
     idx.dec_swa_lock_only(b)
-    assert n1.swa_lock_ref == 0 and n1.swa_tombstone  # leaf SWA freed early
+    assert n1.swa_lock_cnt == 0 and n1.swa_tombstone  # leaf SWA freed early
     assert n1.lock_cnt == 1  # full lock still held
     assert idx.drain_freed_swa_slots() == [701]
     idx.dec_lock_ref(n1, swa_boundary=b, skip_swa=True)
@@ -252,19 +252,19 @@ def test_py_dual_lock_only_deepest_swa_node_locked():
     idx.set_swa(A, slot=11)  # both internal A and leaf a carry SWA
     b = idx.inc_lock_ref(a)
     assert b is a  # deepest SWA node
-    assert a.swa_lock_ref == 1 and A.swa_lock_ref == 0  # only deepest SWA locked
+    assert a.swa_lock_cnt == 1 and A.swa_lock_cnt == 0  # only deepest SWA locked
     assert a.lock_cnt == 1 and A.lock_cnt == 1  # full locked on both
     idx.dec_lock_ref(a, swa_boundary=b)
-    assert a.swa_lock_ref == 0 and A.swa_lock_ref == 0
+    assert a.swa_lock_cnt == 0 and A.swa_lock_cnt == 0
     assert a.lock_cnt == 0 and A.lock_cnt == 0
 
 
 def test_py_swa_locked_node_not_full_evictable():
-    """in_use() includes swa_lock_ref: a SWA-locked node is not full-evictable."""
+    """in_use() includes swa_lock_cnt: a SWA-locked node is not full-evictable."""
     idx = RadixTreeIndex(tokens_per_block=TPB)
     n = idx.insert(_seq([1, 2, 3, 4]), _phys(0, 1), is_ready=True)
     idx.set_swa(n, slot=5)
-    n.swa_lock_ref = 1
+    n.swa_lock_cnt = 1
     assert n.in_use()
     assert not n.evictable()
 
@@ -405,7 +405,8 @@ c_ext = pytest.importorskip("flexkv.c_ext")
 
 _CEXT_OK = "swa_host_slot" in dir(c_ext.CRadixNode) and all(
     n in dir(c_ext.CRadixNode)
-    for n in ("is_leaf", "get_lock_cnt", "has_swa", "lock", "unlock")
+    for n in ("is_leaf", "get_lock_cnt", "has_swa", "lock", "unlock",
+              "merge_child", "is_ready", "swa_lock", "swa_unlock")
 )
 _cext_reason = "CRadixNode SWA/structural bindings not present (rebuild c_ext)"
 cext = pytest.mark.skipif(not _CEXT_OK, reason=_cext_reason)
@@ -530,6 +531,76 @@ def test_cpp_split_preserves_swa_on_suffix():
 
 
 @cext
+def test_cpp_merge_child_swa_locks_ready_and_leaf():
+    """C++ merge_child: SWA follows child (I0), locks migrate, ready ANDs,
+    and the surviving parent re-enters the Full-KV leaf list."""
+    t = _tree()
+    a = _insert(t, [1, 2, 3, 4, 5, 6, 7, 8], 0)
+    t.set_swa(a, 901)
+    sd = [1, 2, 3, 4, 55, 66, 77, 88]
+    m = t.match_prefix(_hashes(sd), 4, False)
+    sib = _insert(t, sd, 8, match=m)
+    A = a.parent
+    assert A is not None and not A.is_leaf() and A.num_children() == 2
+    t.set_swa(A, 900)
+
+    # Pin the kept branch so eviction reclaims the divergent sibling.
+    boundary = t.inc_lock_ref(a)
+    assert boundary is a
+    ev = _evict_full(t, 2)
+    assert len(ev) == 2
+    assert A.num_children() == 1
+
+    # Child carries Full+SWA locks; parent Full lock only (I3 deepest SWA).
+    assert a.get_lock_cnt() == 1 and a.swa_lock_cnt == 1
+    assert A.get_lock_cnt() == 1 and A.swa_lock_cnt == 0
+
+    A.merge_child()
+    # Surviving node is a leaf again; SWA followed the child's last page.
+    assert A.is_leaf() and A.num_children() == 0
+    assert A.has_swa() and A.swa_host_slot == 901 and A.swa_ready
+    assert 900 in t.drain_freed_swa_slots()
+    # Child locks absorbed onto A (Full: 1+1, SWA: 0+1).
+    assert A.get_lock_cnt() == 2 and A.swa_lock_cnt == 1
+    assert A.is_ready()
+
+    A.swa_unlock()
+    A.unlock()
+    A.unlock()
+    # Leaf bookkeeping restored: full eviction can reclaim the merged node.
+    ev2 = _evict_full(t, 4)
+    assert len(ev2) == 4
+    assert 901 in t.drain_freed_swa_slots()
+    assert t.is_empty()
+
+
+@cext
+def test_cpp_merge_child_ready_is_and():
+    """Merged node is ready only if both parent and child were ready."""
+    t = _tree()
+    a = _insert(t, [1, 2, 3, 4, 5, 6, 7, 8], 0, ready=False)
+    t.mount_swa(a, 70)  # unpublished pending SWA
+    sd = [1, 2, 3, 4, 55, 66, 77, 88]
+    m = t.match_prefix(_hashes(sd), 4, False)
+    # Divergent insert ready; shared prefix half inherits a's unready bit on split.
+    _insert(t, sd, 8, ready=True, match=m)
+    A = a.parent
+    assert A is not None and not A.is_ready()
+    assert not a.is_ready() and a.has_swa() and not a.swa_ready
+
+    boundary = t.inc_lock_ref(a)
+    assert boundary is a
+    _evict_full(t, 2)
+    assert A.num_children() == 1
+    t.dec_lock_ref(a, boundary)
+
+    A.merge_child()
+    assert A.is_leaf()
+    assert not A.is_ready()  # unready child => unready merged node
+    assert A.has_swa() and A.swa_host_slot == 70 and not A.swa_ready
+
+
+@cext
 def test_cpp_full_evict_frees_swa_slot():
     t = _tree()
     n = _insert(t, [1, 2, 3, 4], 0)
@@ -602,10 +673,10 @@ def test_cpp_dual_lock_symmetric():
     t.set_swa(n, 700)
     b = t.inc_lock_ref(n)
     assert b is not None
-    assert n.get_lock_cnt() == 1 and n.swa_lock_ref == 1
-    assert n.get_lock_cnt() >= n.swa_lock_ref     # I3
+    assert n.get_lock_cnt() == 1 and n.swa_lock_cnt == 1
+    assert n.get_lock_cnt() >= n.swa_lock_cnt     # I3
     t.dec_lock_ref(n, b, False)
-    assert n.get_lock_cnt() == 0 and n.swa_lock_ref == 0
+    assert n.get_lock_cnt() == 0 and n.swa_lock_cnt == 0
 
 
 @cext
@@ -621,10 +692,10 @@ def test_cpp_only_deepest_swa_node_locked():
     b = t.inc_lock_ref(a)
     assert b is not None
     # deepest SWA node (the leaf a) is the boundary; only it is SWA-locked.
-    assert a.swa_lock_ref == 1 and A.swa_lock_ref == 0
+    assert a.swa_lock_cnt == 1 and A.swa_lock_cnt == 0
     assert a.get_lock_cnt() == 1 and A.get_lock_cnt() == 1   # full on both
     t.dec_lock_ref(a, b, False)
-    assert a.swa_lock_ref == 0 and A.swa_lock_ref == 0
+    assert a.swa_lock_cnt == 0 and A.swa_lock_cnt == 0
     assert a.get_lock_cnt() == 0 and A.get_lock_cnt() == 0
 
 
@@ -635,7 +706,7 @@ def test_cpp_dec_swa_lock_only_early_release():
     t.set_swa(n, 701)
     b = t.inc_lock_ref(n)
     t.dec_swa_lock_only(b)
-    assert n.swa_lock_ref == 0 and n.swa_tombstone   # leaf SWA freed early
+    assert n.swa_lock_cnt == 0 and n.swa_tombstone   # leaf SWA freed early
     assert n.get_lock_cnt() == 1                      # full lock still held
     assert 701 in t.drain_freed_swa_slots()
     t.dec_lock_ref(n, b, True)                         # skip_swa
@@ -644,15 +715,15 @@ def test_cpp_dec_swa_lock_only_early_release():
 
 @cext
 def test_cpp_swa_locked_node_not_full_evictable():
-    """in_use() includes swa_lock_ref: SWA-locked node survives full eviction."""
+    """in_use() includes swa_lock_cnt: SWA-locked node survives full eviction."""
     t = _tree()
     n = _insert(t, [1, 2, 3, 4], 0)
     t.set_swa(n, 5)
-    n.inc_swa_lock_ref()
+    n.swa_lock()
     ev = _evict_full(t, 2)
     assert len(ev) == 0            # locked -> not evicted
     assert not t.is_empty()
-    n.dec_swa_lock_ref()
+    n.swa_unlock()
 
 
 @cext

--- a/tests/test_swa_ssd_staging_e2e.py
+++ b/tests/test_swa_ssd_staging_e2e.py
@@ -16,8 +16,9 @@ does not cover:
         GPU SWA slot -> byte-exact.
 
 This exercises SWA graph append inside _put_impl_* (write-through) and
-_get_impl_* (SSD->CPU transient staging slot + H2D), plus the transient staging
-slot free on H2D completion.
+_get_impl_* (SSD->CPU staging slot promoted onto the fragment123 CPU node
+via mount_swa + publish_swa on H2D completion), aligning SWA GET with
+Full-KV GET fragment23 (SSD/REMOTE data cached in CPU on the way through).
 
 Run INSIDE the container on a free GPU:
     CUDA_VISIBLE_DEVICES=0 python3 tests/test_swa_ssd_staging_e2e.py
@@ -230,20 +231,30 @@ def main() -> int:
         print(f"[verify] OK    SWA: {len(expected_sw)} bytes match "
               f"GPU->CPU/SSD->(evict CPU)->DISK2H->H2D->GPU", flush=True)
 
-    # transient CPU staging slot must be freed on H2D completion (no leak).
+    # After GET, the SSD->CPU staging slot must have been PROMOTED onto the
+    # fragment123 CPU node (mount_swa + publish_swa on SWA DISK2H completion),
+    # mirroring Full-KV GET fragment23 which caches SSD/REMOTE data in CPU.
+    # Post-conditions:
+    #   (a) CPU SWA pool holds exactly 1 slot (the promoted one)
+    #   (b) CPU tier match now returns swa_hit > 0 (the window is visible)
+    seq_after = SequenceMeta(token_ids=tok, tokens_per_block=TOKENS_PER_BLOCK); seq_after.gen_hashes()
+    cpu_hit_after = engine.cpu_cache_engine.match(seq_after).swa_hit_blocks
     staging_used = engine.cpu_cache_engine.swa_pool.num_used
-    if staging_used != 0:
-        print(f"[verify] FAIL transient CPU staging slot leaked (num_used={staging_used})", flush=True)
+    if staging_used != 1:
+        print(f"[verify] FAIL CPU SWA promotion did not stick (num_used={staging_used}, expected 1)", flush=True)
+        failed = True
+    elif cpu_hit_after == 0:
+        print(f"[verify] FAIL CPU SWA promotion mounted but did not publish (cpu_hit={cpu_hit_after})", flush=True)
         failed = True
     else:
-        print("[verify] OK    transient CPU staging slot freed (no leak)", flush=True)
+        print(f"[verify] OK    SSD staging slot promoted to CPU (num_used=1, cpu_hit={cpu_hit_after})", flush=True)
 
     te.shutdown()
     if os.path.isdir(SSD_CACHE_DIR):
         shutil.rmtree(SSD_CACHE_DIR)
     if failed:
         return 4
-    print("[verify] PASS: SSD SWA staging byte-exact, transient slot freed", flush=True)
+    print("[verify] PASS: SSD SWA staging byte-exact, staging slot promoted to CPU", flush=True)
     return 0
 
 


### PR DESCRIPTION
Resolving reapeted reading and writing causing by swa mount timing.

- Split SWA lifecycle into mount_swa() and publish_swa(). Mounted-but-unpublished slots remain invisible to GETs and outside the SWA LRU.
- Require has_swa && full_ready && swa_ready for SWA cache hits.
- Publish SWA at op completion for PUT and Local GET. Global GET publishes after the full transfer graph completes.
- Handle concurrent GET promotion races using transient CPU staging, ensuring correct GPU data without overwriting the winning mount.
- Skip duplicate SWA writes when PUT loses a mount race.
- Add destination flight locks and source pins to prevent eviction during in-flight transfers.
- Preserve the lock invariant: Full lock before SWA lock, SWA unlock before Full unlock.
- Return individual SWA transfer op IDs so readiness callbacks can attach to the correct DISK2H, REMOTE2H, D2H, or write-through operation.
- Protect pending SWA mounts from Full KV eviction and align Python in_use() behavior with C++.
- Update control-plane, node-mount, staging, lifecycle, and eviction tests.

Known limitation: task cancellation cleanup remains separate work and may still leave locks or transient resources unreleased.