### PR TITLE
feat: add SWA multi-layer switch

### DIFF
--- a/docs/dsv4_compress_state_io_zh.md
+++ b/docs/dsv4_compress_state_io_zh.md
@@ -264,6 +264,8 @@ LayerwiseTransferOp
 
 `swa.multi_group=True` 时，SWA 池使用与 main-KV 同构的 `GroupParams + layer_members`；C4 层会等该层 state 写完再发 eventfd，无 state 的层只等 SWA KV + main。
 
+`swa_multi_layer` 控制上述融合路径，默认开启。显式设为 `false`（或通过环境变量设置 `FLEXKV_SWA_MULTI_LAYER=0`）时，main-KV 仍使用 layerwise restore，但 SWA/state 改由独立 H2D worker 搬运；主 layerwise op 会依赖该 worker 完成，因此不会提前暴露未恢复的 state。该开关不改变 `swa_multi_group` 是否注册 compress-state sidecar 的语义。
+
 非 layerwise GET 会等待整个 FlexKV task 完成后再把请求交还给 SGLang。
 
 ## 8. 关键约束与失败方式

--- a/docs/flexkv_config_reference/README_en.md
+++ b/docs/flexkv_config_reference/README_en.md
@@ -33,6 +33,7 @@ Or using JSON configuration:
 - `ssd_cache_dir`: Directory where SSD cache data is stored. If multiple SSDs are available, separate multiple mount paths with semicolons `;`. For example, `ssd_cache_dir: /data0/flexkv_ssd/;/data1/flexkv_ssd/` to improve bandwidth.
 - `enable_gds`: Whether to enable GPU Direct Storage (GDS). If hardware and drivers support it, enabling this can improve SSD to GPU data throughput. Disabled by default.
 - `swa_multi_group`: DeepSeek-V4 SWA sidecar switch. When omitted or set to `true`, SWA KV is stored and restored together with the attention/indexer compress states. Set it explicitly to `false` to keep SWA KV I/O while skipping state registration and I/O.
+- `swa_multi_layer`: Controls whether layerwise restore fuses SWA/state H2D into the main layerwise worker. It defaults to `true`; set it to `false` to use the standalone SWA/state H2D predecessor path.
 
 To switch to SWA-only mode, add the following explicit setting:
 
@@ -55,6 +56,7 @@ If the `FLEXKV_CONFIG_PATH` environment variable is not set, configuration can b
 | `FLEXKV_SSD_CACHE_DIR` | str | "./flexkv_ssd" | Directory where SSD cache data is stored. If multiple SSDs are available, separate multiple mount paths with semicolons `;`. For example, `"/data0/flexkv_ssd/;/data1/flexkv_ssd/"` to improve bandwidth |
 | `FLEXKV_ENABLE_GDS` | bool | 0 | Whether to enable GPU Direct Storage (GDS). If hardware and drivers support it, enabling this can improve SSD to GPU data throughput. Disabled by default, set to 1 to enable |
 | `FLEXKV_SWA_MULTI_GROUP` | bool | unset (auto-enabled) | For DeepSeek-V4, unset or `1` stores/restores SWA KV with attention/indexer compress states; `0` keeps SWA KV I/O only |
+| `FLEXKV_SWA_MULTI_LAYER` | bool | 1 | `1` fuses SWA/state H2D into layerwise restore; `0` uses the standalone SWA/state H2D predecessor worker |
 
 ---
 

--- a/docs/flexkv_config_reference/README_zh.md
+++ b/docs/flexkv_config_reference/README_zh.md
@@ -33,6 +33,7 @@ enable_gds: false
 - `ssd_cache_dir`：SSD 缓存数据的存放目录。若有多块 SSD，可通过分号 `;` 分隔多个挂载路径。例如 `ssd_cache_dir: /data0/flexkv_ssd/;/data1/flexkv_ssd/`，以提升带宽。
 - `enable_gds`：是否启用 GPU Direct Storage（GDS）。如硬件和驱动支持，开启后可提升 SSD 到 GPU 的数据吞吐能力。默认关闭。
 - `swa_multi_group`：DeepSeek-V4 SWA sidecar 开关。未配置或设为 `true` 时，SWA KV 会与 attention/indexer compress state 一起存取；显式设为 `false` 时保留 SWA KV 存取，但不注册或存取 state。
+- `swa_multi_layer`：控制 layerwise restore 是否把 SWA/state H2D 融合进主 layerwise worker。默认为 `true`；设为 `false` 时使用独立的 SWA/state H2D 前置 worker。
 
 如需切换到 SWA-only，可在配置文件中显式添加：
 
@@ -58,6 +59,7 @@ swa_multi_group: false
 | `FLEXKV_USE_HUGEPAGE_TMP_BUFFER` | bool | 0 | 是否为 `enable_p2p_ssd` 场景下的 tmp CPU staging buffer 启用 HugePage。默认关闭，开启请设为 1 |
 | `FLEXKV_HUGEPAGE_SIZE_BYTES` | int | 2097152 | HugePage 大小，默认 2 MiB。如果宿主机准备的是 1 GiB HugePage，可设为 `1073741824` |
 | `FLEXKV_SWA_MULTI_GROUP` | bool | 未设置（自动开启） | DeepSeek-V4 下未设置或设为 `1` 时，SWA KV 与 attention/indexer compress state 一起存取；设为 `0` 时只保留 SWA KV 存取 |
+| `FLEXKV_SWA_MULTI_LAYER` | bool | 1 | `1` 表示把 SWA/state H2D 融合进 layerwise restore；`0` 表示使用独立的 SWA/state H2D 前置 worker |
 
 ---
 

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -690,6 +690,11 @@ class CacheConfig:
     # transfer type" in the transfer engine. Flip to True once the worker lands.
     enable_swa_transfer: bool = False
 
+    # Fuse SWA (including heterogeneous state sidecars) into the layerwise H2D
+    # worker.  When disabled, layerwise main-KV restore stays enabled while SWA
+    # uses its standalone H2D worker and completes before the main layerwise op.
+    swa_multi_layer: bool = True
+
     def __post_init__(self):
         self.enable_kv_sharing = self.enable_p2p_cpu or \
             self.enable_p2p_ssd or self.enable_3rd_remote
@@ -805,6 +810,10 @@ class UserConfig:
     # path. None is intentionally distinct from False so old configs default
     # to the correctness-preserving state restore path.
     swa_multi_group: Optional[bool] = None
+    # Fuse SWA/state H2D into the main layerwise restore worker. Disable this to
+    # keep SWA/state on the standalone predecessor worker as a compatibility or
+    # debugging fallback.
+    swa_multi_layer: bool = True
 
     def __post_init__(self):
         if self.cpu_cache_gb <= 0:
@@ -820,6 +829,11 @@ class UserConfig:
             raise ValueError(
                 "swa_multi_group must be a boolean when configured, "
                 f"got {self.swa_multi_group!r}"
+            )
+        if not isinstance(self.swa_multi_layer, bool):
+            raise ValueError(
+                "swa_multi_layer must be a boolean, "
+                f"got {self.swa_multi_layer!r}"
             )
 
 def parse_path_list(path_str: str) -> List[str]:
@@ -868,6 +882,7 @@ def load_user_config_from_env() -> UserConfig:
             if swa_multi_group_env is None
             else bool(int(swa_multi_group_env))
         ),
+        swa_multi_layer=bool(int(os.getenv('FLEXKV_SWA_MULTI_LAYER', 1))),
     )
 
 def convert_to_block_num(size_in_GB: float, block_size_in_bytes: int) -> int:
@@ -1032,6 +1047,7 @@ def update_default_config_from_user_config(rank_info: RankInfo,
     cache_config.enable_p2p_cpu = user_config.enable_p2p_cpu
     cache_config.enable_p2p_ssd = user_config.enable_p2p_ssd
     cache_config.enable_3rd_remote = user_config.enable_3rd_remote
+    cache_config.swa_multi_layer = user_config.swa_multi_layer
 
     # Update derived flags after setting p2p and remote configs
     cache_config.enable_kv_sharing = (cache_config.enable_p2p_cpu or

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -828,9 +828,9 @@ class KVTaskEngine(KVTaskManager):
                 task_end_op_ids.append(self.tasks[task_id].task_end_op_id)
                 callbacks.append(self.tasks[task_id].callback)
                 return_masks.append(self.tasks[task_id].return_mask)
-        # Always fuse SWA/state H2D into LAYERWISE when layerwise GET is on.
-        # Multi-group SWA (DSv4 + c4 state sidecars) is handled inside C++ by
-        # launch_swa_mg_h2d_layer_; do not keep standalone SWA H2D predecessors.
+        # Multi-group SWA (DSv4 + c4 state sidecars) can run inside C++ via
+        # launch_swa_mg_h2d_layer_.  Keep the standalone predecessor path
+        # available behind swa_multi_layer for compatibility and debugging.
         batch_task_graph, task_end_op_id, op_callback_dict = merge_to_batch_graph(
             batch_id,
             transfer_graphs,
@@ -838,7 +838,7 @@ class KVTaskEngine(KVTaskManager):
             op_callback_dict,
             layerwise_transfer,
             counter_id,
-            fuse_swa_into_layerwise=True,
+            fuse_swa_into_layerwise=self.cache_config.swa_multi_layer,
         )
         self.tasks[batch_id] = KVTask(
             task_id=batch_id,

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -345,11 +345,11 @@ class TransferEngine:
     def _get_layerwise_swa_kwargs(self, worker_key: WorkerKey) -> dict:
         """SWA args for LayerwiseTransferWorker (uniform or multi-group).
 
-        Layerwise GET fuses main-KV + SWA/state into one LAYERWISE op, so both
-        layouts are wired into the layerwise worker rather than a standalone
-        SWA H2D worker.
+        With ``swa_multi_layer`` enabled, layerwise GET fuses main-KV +
+        SWA/state into one LAYERWISE op, so both layouts are wired into the
+        layerwise worker rather than a standalone SWA H2D worker.
         """
-        if not self._has_swa:
+        if not self._has_swa or not self.cache_config.swa_multi_layer:
             return {}
         swa_ssd_files = (
             self._swa_ssd_handle.get_file_list()
@@ -399,6 +399,9 @@ class TransferEngine:
 
         assert self._cpu_handle is not None
         _enable_layerwise = GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer
+        _fuse_swa_into_layerwise = (
+            _enable_layerwise and self.cache_config.swa_multi_layer
+        )
         # Use num_gpu_groups to support multi-instance mode
         # Use gpu_device_id from StorageHandle for correct CUDA device selection
         
@@ -700,10 +703,11 @@ class TransferEngine:
         # reuse this channel with heterogeneous multi-group worker arguments.
         if self._has_swa:
             self._swa_worker_map: Dict[TransferType, Dict[WorkerKey, WorkerHandle]] = {}
-            # Layerwise GET fuses SWA/state H2D into LAYERWISE (uniform via
-            # launch_swa_h2d_layer_, multi-group via launch_swa_mg_h2d_layer_).
-            # Standalone SWA H2D workers are only needed when layerwise is off.
-            if not _enable_layerwise:
+            # With swa_multi_layer enabled, layerwise GET fuses SWA/state H2D
+            # into LAYERWISE (uniform via launch_swa_h2d_layer_, multi-group via
+            # launch_swa_mg_h2d_layer_). Otherwise retain the standalone SWA
+            # H2D worker as a predecessor of the main layerwise op.
+            if not _fuse_swa_into_layerwise:
                 if self.model_config.effective_tp_size_per_node == 1:
                     self._swa_h2d_workers: Dict[WorkerKey, WorkerHandle] = {
                         worker_key: GPUCPUTransferWorker.create_worker(
@@ -894,7 +898,7 @@ class TransferEngine:
                 flexkv_logger.info("TransferEngine: swa GDS workers initialized")
             self._has_swa = True
             # Must mirror the create condition above.
-            if not _enable_layerwise:
+            if not _fuse_swa_into_layerwise:
                 flexkv_logger.info(
                     f"TransferEngine: swa workers initialized "
                     f"({len(self._swa_h2d_workers)} H2D + {len(self._swa_d2h_workers)} D2H)")

--- a/tests/test_config_swa_multi_group.py
+++ b/tests/test_config_swa_multi_group.py
@@ -31,3 +31,30 @@ def test_swa_multi_group_env_override(
 def test_swa_multi_group_rejects_non_boolean_config_value() -> None:
     with pytest.raises(ValueError, match="swa_multi_group must be a boolean"):
         UserConfig(swa_multi_group="false")
+
+
+def test_swa_multi_layer_defaults_to_enabled(monkeypatch) -> None:
+    monkeypatch.delenv("FLEXKV_SWA_MULTI_LAYER", raising=False)
+
+    config = load_user_config_from_env()
+
+    assert config.swa_multi_layer is True
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [("0", False), ("1", True)],
+)
+def test_swa_multi_layer_env_override(
+    monkeypatch, raw_value: str, expected: bool
+) -> None:
+    monkeypatch.setenv("FLEXKV_SWA_MULTI_LAYER", raw_value)
+
+    config = load_user_config_from_env()
+
+    assert config.swa_multi_layer is expected
+
+
+def test_swa_multi_layer_rejects_non_boolean_config_value() -> None:
+    with pytest.raises(ValueError, match="swa_multi_layer must be a boolean"):
+        UserConfig(swa_multi_layer="false")

--- a/tests/test_layerwise_swa_eventfd_contract.py
+++ b/tests/test_layerwise_swa_eventfd_contract.py
@@ -17,6 +17,10 @@ def test_layerwise_posts_one_eventfd_token_per_layer() -> None:
 def test_dense_layer_waits_for_swa_before_notification() -> None:
     source = (ROOT / "csrc/layerwise.cpp").read_text(encoding="utf-8")
 
-    assert "if (!layer_members_[orig].empty() || swa_active)" in source
-    assert "if (!layer_members_[orig].empty() || swa_active) {\n      work_origs.push_back(orig);" in source
-    assert "members_this_layer + (swa_active ? 1 : 0)" in source
+    assert "swa_slots_for_orig_(orig, swa_active) > 0" in source
+    assert (
+        "if (!layer_members_[orig].empty() ||\n"
+        "        swa_slots_for_orig_(orig, swa_active) > 0) {\n"
+        "      work_origs.push_back(orig);"
+    ) in source
+    assert "int slots_per_gpu = members_this_layer + swa_slots;" in source

--- a/tests/test_swa_state_sidecars.py
+++ b/tests/test_swa_state_sidecars.py
@@ -109,3 +109,48 @@ def test_layerwise_fuses_heterogeneous_swa_state_h2d() -> None:
         layerwise_ops[0].swa_dst_block_ids_h2d, np.array([41], dtype=np.int64)
     )
     assert task_end == layerwise_ops[0].op_id
+
+
+def test_swa_multi_layer_false_keeps_sidecar_h2d_as_predecessor() -> None:
+    """The compatibility switch keeps SWA/state outside LAYERWISE."""
+    graph = TransferOpGraph()
+    main_h2d = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.H2D,
+        src_block_ids=np.array([11], dtype=np.int64),
+        dst_block_ids=np.array([21], dtype=np.int64),
+    )
+    swa_h2d = TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=TransferType.H2D,
+        src_block_ids=np.array([31], dtype=np.int64),
+        dst_block_ids=np.array([41], dtype=np.int64),
+        is_swa=True,
+    )
+    graph.add_transfer_op(main_h2d)
+    graph.add_transfer_op(swa_h2d)
+
+    merged, task_end, _ = merge_to_batch_graph(
+        batch_id=99,
+        transfer_graphs=[graph],
+        task_end_op_ids=[main_h2d.op_id],
+        op_callback_dict={},
+        layerwise_transfer=True,
+        counter_id=2,
+        fuse_swa_into_layerwise=False,
+    )
+
+    layerwise_ops = [
+        op for op in merged._op_map.values() if isinstance(op, LayerwiseTransferOp)
+    ]
+    standalone_swa = [
+        op
+        for op in merged._op_map.values()
+        if op.transfer_type == TransferType.H2D and op.is_swa
+    ]
+    assert len(layerwise_ops) == 1
+    assert len(standalone_swa) == 1
+    assert standalone_swa[0].op_id in layerwise_ops[0].predecessors
+    assert layerwise_ops[0].swa_src_block_ids_h2d.size == 0
+    assert layerwise_ops[0].swa_dst_block_ids_h2d.size == 0
+    assert task_end == layerwise_ops[0].op_id


### PR DESCRIPTION
## What changed

- add the `swa_multi_layer` user/config switch, enabled by default
- support `FLEXKV_SWA_MULTI_LAYER=0/1`
- route layerwise batch graph construction through the switch
- create a standalone SWA/state H2D predecessor worker when fusion is disabled
- keep the fused multi-group layerwise path as the default
- update configuration/design docs and eventfd contract assertions

## Why

The latest DSv4 commit fused SWA and compress-state H2D into the layerwise worker unconditionally. Although the non-fused graph path still existed, configuration and worker initialization no longer exposed a consistent way to select it. This change reconnects that fallback without changing the new default behavior.

## Impact

- `swa_multi_layer: true` (default): SWA/state H2D is fused into layerwise restore.
- `swa_multi_layer: false`: SWA/state H2D uses a standalone worker that completes before the main layerwise operation.
- `swa_multi_group` remains independent and continues to control compress-state sidecar registration.

## Validation

- 19 focused unit tests passed
- modified Python files pass `py_compile`
- `git diff --check` passed
