### PR TITLE
Improve FlexKV reliability and operational logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/prometheus-cpp"]
 	path = third_party/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git
+[submodule "third_party/spdlog"]
+	path = third_party/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,19 @@ target_include_directories(xxhash PUBLIC
 
 install(FILES ${XXHASH_HEADERS} DESTINATION include)
 
+# ==================== Native Logging ====================
+if(NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include")
+    message(FATAL_ERROR
+        "third_party/spdlog is missing; run git submodule update --init third_party/spdlog")
+endif()
+
+add_library(flexkv_logging STATIC csrc/logging.cpp)
+set_target_properties(flexkv_logging PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(flexkv_logging PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include
+)
+
 # ==================== prometheus-cpp Library ====================
 # Step 1: Auto-detect default from directory existence
 if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/third_party/prometheus-cpp")
@@ -152,6 +165,7 @@ if(FLEXKV_ENABLE_MONITORING)
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/prometheus-cpp/pull/include
     )
     target_link_libraries(flexkv_monitoring PUBLIC
+        flexkv_logging
         prometheus-cpp::pull
         prometheus-cpp::core
     )

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -25,6 +25,11 @@
 #include "tp_transfer_thread_group.h"
 #include "transfer.cuh"
 #include "transfer_ssd.h"
+
+#ifndef FLEXKV_GIT_COMMIT
+#define FLEXKV_GIT_COMMIT "unknown"
+#endif
+
 #ifdef FLEXKV_ENABLE_P2P
 #include "dist/block_meta.h"
 #include "dist/distributed_radix_tree.h"
@@ -415,6 +420,8 @@ bool create_gds_file_binding(GDSManager &manager, const std::string &filename,
 #endif
 
 PYBIND11_MODULE(c_ext, m) {
+  m.attr("__git_commit__") = FLEXKV_GIT_COMMIT;
+
   // Metrics configuration function - allows Python to configure C++ metrics
   m.def(
       "configure_cpp_metrics",

--- a/csrc/compression/ans/nvcomp_ans.cu
+++ b/csrc/compression/ans/nvcomp_ans.cu
@@ -4,11 +4,11 @@
  */
 #include "compression/ans/nvcomp_ans.cuh"
 #include "compression/common/staging_transfer.cuh"
+#include "logging.h"
 
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <algorithm>
-#include <cstdio>
 #include <stdexcept>
 #include <string>
 
@@ -18,8 +18,9 @@ namespace flexkv {
   do {                                                                     \
     nvcompStatus_t _s = (call);                                            \
     if (_s != nvcompSuccess) {                                             \
-      fprintf(stderr, "[nvcomp] error %d at %s:%d\n", (int)_s, __FILE__,   \
-              __LINE__);                                                   \
+      FLEXKV_LOG_ERROR(                                                    \
+          "operation=nvcomp action=complete status=failed error_code=%d", \
+          static_cast<int>(_s));                                           \
       throw std::runtime_error("nvcomp ANS error");                        \
     }                                                                      \
   } while (0)
@@ -28,8 +29,10 @@ namespace flexkv {
   do {                                                                     \
     cudaError_t _e = (call);                                               \
     if (_e != cudaSuccess) {                                               \
-      fprintf(stderr, "[nvcomp] CUDA error: %s at %s:%d\n",                \
-              cudaGetErrorString(_e), __FILE__, __LINE__);                 \
+      FLEXKV_LOG_ERROR(                                                    \
+          "operation=nvcomp_cuda action=complete status=failed "           \
+          "error=\"%s\"",                                                \
+          cudaGetErrorString(_e));                                         \
       throw std::runtime_error(cudaGetErrorString(_e));                    \
     }                                                                      \
   } while (0)

--- a/csrc/compression/ans/nvcomp_ans.cu
+++ b/csrc/compression/ans/nvcomp_ans.cu
@@ -19,7 +19,7 @@ namespace flexkv {
     nvcompStatus_t _s = (call);                                            \
     if (_s != nvcompSuccess) {                                             \
       FLEXKV_LOG_ERROR(                                                    \
-          "operation=nvcomp action=complete status=failed error_code=%d", \
+          "operation=nvcomp act=complete status=failed error_code=%d",    \
           static_cast<int>(_s));                                           \
       throw std::runtime_error("nvcomp ANS error");                        \
     }                                                                      \
@@ -30,7 +30,7 @@ namespace flexkv {
     cudaError_t _e = (call);                                               \
     if (_e != cudaSuccess) {                                               \
       FLEXKV_LOG_ERROR(                                                    \
-          "operation=nvcomp_cuda action=complete status=failed "           \
+          "operation=nvcomp_cuda act=complete status=failed "              \
           "error=\"%s\"",                                                \
           cudaGetErrorString(_e));                                         \
       throw std::runtime_error(cudaGetErrorString(_e));                    \

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -1,5 +1,6 @@
 #include "gds_manager.h"
 #include "layout_transform.cuh"
+#include "logging.h"
 #include <fcntl.h>
 #include <unistd.h>
 #include <cstring>
@@ -653,9 +654,11 @@ void transfer_kv_blocks_gds(
     }
 
     if (verbose) {
-        std::cerr << "GDS: Allocated GPU buffer of " << total_buffer_size 
-                  << " bytes (" << num_slots << " slots x " 
-                  << ssd_block_stride_in_bytes << " bytes/slot)" << std::endl;
+        FLEXKV_LOG_DEBUG(
+            "operation=gds_buffer action=allocate status=success "
+            "buffer_bytes=%ld slots=%d slot_bytes=%ld",
+            static_cast<long>(total_buffer_size), num_slots,
+            static_cast<long>(ssd_block_stride_in_bytes));
     }
     
     // Create per-slot CUDA streams and mutexes
@@ -760,14 +763,6 @@ void transfer_kv_blocks_gds(
                     gds_manager.write(filename.c_str(), buffer_slot_ptr, gpu_buffer_size_in_bytes, ssd_block_offset);
                 }
                 
-                if (verbose) {
-                    std::cerr << "GDS: " << (is_read ? "Read" : "Write")
-                              << " SSD: " << ssd_block_id
-                              << " GPU: " << gpu_block_id
-                              << " Slot: " << slot_id
-                              << " Device: " << device_id
-                              << std::endl;
-                }
             }));
         }
     }
@@ -787,6 +782,14 @@ void transfer_kv_blocks_gds(
     }
     cudaFree(d_gpu_block_ids);
     cudaFree(buffer_ptr);
+
+    if (verbose) {
+        FLEXKV_LOG_DEBUG(
+            "operation=gds_transfer action=complete status=success "
+            "direction=%s blocks=%ld devices=%d worker_threads=%d",
+            is_read ? "SSD2D" : "D2SSD", static_cast<long>(num_transfers),
+            num_devices, num_worker_threads);
+    }
     
     gds_manager.synchronize();
 }

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -655,7 +655,7 @@ void transfer_kv_blocks_gds(
 
     if (verbose) {
         FLEXKV_LOG_DEBUG(
-            "operation=gds_buffer action=allocate status=success "
+            "operation=gds_buffer act=allocate status=success "
             "buffer_bytes=%ld slots=%d slot_bytes=%ld",
             static_cast<long>(total_buffer_size), num_slots,
             static_cast<long>(ssd_block_stride_in_bytes));
@@ -785,7 +785,7 @@ void transfer_kv_blocks_gds(
 
     if (verbose) {
         FLEXKV_LOG_DEBUG(
-            "operation=gds_transfer action=complete status=success "
+            "operation=gds_transfer act=complete status=success "
             "direction=%s blocks=%ld devices=%d worker_threads=%d",
             is_read ? "SSD2D" : "D2SSD", static_cast<long>(num_transfers),
             num_devices, num_worker_threads);

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -543,15 +543,15 @@ LayerwiseTransferGroup::LayerwiseTransferGroup(
     layer_eventfds_.assign(fds_ptr, fds_ptr + total_fds);
 
     FLEXKV_LOG_INFO(
-        "operation=layerwise_init action=complete status=success "
-        "transfer_mode=layerwise eventfd=true tp_size=%d counters=%d "
+        "operation=layerwise_init act=complete status=success "
+        "mode=layerwise eventfd=true tp_size=%d counters=%d "
         "layers=%d total_fds=%d",
         tp_size_, num_counters_, num_layers_, total_fds);
   } else {
     num_counters_ = 0;
     FLEXKV_LOG_INFO(
-        "operation=layerwise_init action=complete status=success "
-        "transfer_mode=layerwise eventfd=false tp_size=%d layers=%d",
+        "operation=layerwise_init act=complete status=success "
+        "mode=layerwise eventfd=false tp_size=%d layers=%d",
         tp_size_, num_layers_);
   }
 
@@ -1117,7 +1117,7 @@ void LayerwiseTransferGroup::layerwise_transfer(
   if (is_mla && mla_mode != "sharded" && mla_mode != "all_write" &&
       mla_mode != "rank0_only") {
     FLEXKV_LOG_WARNING(
-        "operation=layerwise_config action=fallback status=degraded "
+        "operation=layerwise_config act=fallback status=degraded "
         "field=mla_d2h_mode value=\"%s\" fallback=sharded",
         mla_mode.c_str());
     mla_mode = "sharded";
@@ -1272,10 +1272,9 @@ void LayerwiseTransferGroup::layerwise_transfer(
     const double total_bandwidth_gbps =
         total_time_s > 0.0 ? total_size_gb / total_time_s : 0.0;
     FLEXKV_LOG_DEBUG(
-        "operation=layerwise_transfer action=complete status=success "
-        "direction=H2D blocks=%d transfer_mode=layerwise "
-        "transfer_data_size=%.6fGB transfer_time=%.4fs "
-        "transfer_bandwidth=%.2fGB/s",
+        "operation=layerwise_transfer act=complete status=success "
+        "direction=H2D blocks=%d mode=layerwise "
+        "data_size=%.6fGB transfer_time=%.4fs bandwidth=%.2fGB/s",
         num_blocks, total_size_gb, total_time_s, total_bandwidth_gbps);
 
     cudaSetDevice(gpu_device_ids_[0]);
@@ -1327,7 +1326,7 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
   if (is_mla && mode != "sharded" && mode != "all_write" &&
       mode != "rank0_only") {
     FLEXKV_LOG_WARNING(
-        "operation=layerwise_config action=fallback status=degraded "
+        "operation=layerwise_config act=fallback status=degraded "
         "field=mla_d2h_mode value=\"%s\" fallback=sharded",
         mode.c_str());
     mode = "sharded";

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -1,4 +1,5 @@
 #include "layerwise.h"
+#include "logging.h"
 #include <atomic>
 #include <cstdio>
 #include <fcntl.h>
@@ -541,12 +542,17 @@ LayerwiseTransferGroup::LayerwiseTransferGroup(
     int32_t *fds_ptr = layer_eventfds_tensor.data_ptr<int32_t>();
     layer_eventfds_.assign(fds_ptr, fds_ptr + total_fds);
 
-    printf("[LayerwiseTransferGroup] Initialized with eventfds: "
-           "tp_size=%d, num_counters=%d, num_layers=%d, total_fds=%d\n",
-           tp_size_, num_counters_, num_layers_, total_fds);
+    FLEXKV_LOG_INFO(
+        "operation=layerwise_init action=complete status=success "
+        "transfer_mode=layerwise eventfd=true tp_size=%d counters=%d "
+        "layers=%d total_fds=%d",
+        tp_size_, num_counters_, num_layers_, total_fds);
   } else {
     num_counters_ = 0;
-    printf("[LayerwiseTransferGroup] Initialized without eventfds\n");
+    FLEXKV_LOG_INFO(
+        "operation=layerwise_init action=complete status=success "
+        "transfer_mode=layerwise eventfd=false tp_size=%d layers=%d",
+        tp_size_, num_layers_);
   }
 
   gpu_kv_strides_in_bytes_ = new int64_t[num_gpus];
@@ -989,15 +995,18 @@ void LayerwiseTransferGroup::layerwise_transfer(
       static_cast<int64_t *>(cpu_block_id_tensor.data_ptr());
   void *cpu_ptr = cpu_blocks_;
 
-  // Create CUDA events for timing each layer batch (on GPU 0)
   int num_batches = (num_layers + layer_granularity - 1) / layer_granularity;
-  std::vector<cudaEvent_t> timing_events(num_batches + 1); // +1 for start event
-  std::vector<int> batch_start_layers(num_batches);
-  std::vector<int> batch_layers_count(num_batches);
+  const bool log_timing =
+      notify_mode_ != NotifyMode::POLLING &&
+      logging::IsEnabled(logging::Level::Debug);
+  std::vector<cudaEvent_t> timing_events(log_timing ? num_batches + 1 : 0);
+  std::vector<int> batch_layers_count(log_timing ? num_batches : 0);
 
   cudaSetDevice(gpu_device_ids_[0]);
-  for (int i = 0; i <= num_batches; ++i) {
-    cudaEventCreate(&timing_events[i]);
+  if (log_timing) {
+    for (int i = 0; i <= num_batches; ++i) {
+      cudaEventCreate(&timing_events[i]);
+    }
   }
 
   // Prepare poll batches for event-based notification (#199)
@@ -1018,8 +1027,9 @@ void LayerwiseTransferGroup::layerwise_transfer(
     }
   }
 
-  // Record start event
-  cudaEventRecord(timing_events[0], streams_[0]);
+  if (log_timing) {
+    cudaEventRecord(timing_events[0], streams_[0]);
+  }
 
   // Allocate storage for NVTX range IDs (one per batch)
   std::vector<nvtxRangeId_t> h2d_range_ids(num_batches, 0);
@@ -1106,10 +1116,10 @@ void LayerwiseTransferGroup::layerwise_transfer(
   std::string mla_mode = mla_d2h_mode;
   if (is_mla && mla_mode != "sharded" && mla_mode != "all_write" &&
       mla_mode != "rank0_only") {
-    fprintf(stderr,
-            "[FlexKV] Warning: Invalid mla_d2h_mode='%s', using default "
-            "'sharded'\n",
-            mla_mode.c_str());
+    FLEXKV_LOG_WARNING(
+        "operation=layerwise_config action=fallback status=degraded "
+        "field=mla_d2h_mode value=\"%s\" fallback=sharded",
+        mla_mode.c_str());
     mla_mode = "sharded";
   }
 
@@ -1119,8 +1129,9 @@ void LayerwiseTransferGroup::layerwise_transfer(
     int layers_this_batch =
         std::min(layer_granularity, num_layers - start_layer);
 
-    batch_start_layers[batch_idx] = start_layer;
-    batch_layers_count[batch_idx] = layers_this_batch;
+    if (log_timing) {
+      batch_layers_count[batch_idx] = layers_this_batch;
+    }
 
     // Step 1: CPU -> GPU transfer
     // NVTX range for this batch was already started (by main thread for first
@@ -1194,9 +1205,10 @@ void LayerwiseTransferGroup::layerwise_transfer(
                             use_ce_transfer);
     }
 
-    // Record event after this batch on GPU 0
-    cudaSetDevice(gpu_device_ids_[0]);
-    cudaEventRecord(timing_events[batch_idx + 1], streams_[0]);
+    if (log_timing) {
+      cudaSetDevice(gpu_device_ids_[0]);
+      cudaEventRecord(timing_events[batch_idx + 1], streams_[0]);
+    }
 
     if (notify_mode_ == NotifyMode::POLLING) {
       // Record per-GPU events for the polling thread. Recorded after both the
@@ -1241,52 +1253,35 @@ void LayerwiseTransferGroup::layerwise_transfer(
     }
   }
 
-  // Calculate and print timing for each layer batch
-  // chunk_size per GPU * num_gpus * 2 (K+V) * layers_this_batch * num_blocks
-  // fprintf(stderr, "\n[LayerwiseTransfer] CPU->GPU Transfer Timing
-  // (num_blocks=%d):\n", num_blocks);
-  float total_time_ms = 0.0f;
-  int64_t total_bytes = 0;
-
-  for (int i = 0; i < num_batches; ++i) {
-    float elapsed_ms = 0.0f;
-    cudaEventElapsedTime(&elapsed_ms, timing_events[i], timing_events[i + 1]);
-
-    // Calculate bytes transferred for this batch
-    // For each GPU: chunk_size * 2 (K+V) * layers * num_blocks
-    int64_t bytes_this_batch = 0;
-    for (int g = 0; g < num_gpus_; ++g) {
-      bytes_this_batch +=
-          gpu_chunk_sizes_in_bytes_[g] * 2 * batch_layers_count[i] * num_blocks;
+  if (log_timing) {
+    float total_time_ms = 0.0f;
+    int64_t total_bytes = 0;
+    for (int i = 0; i < num_batches; ++i) {
+      float elapsed_ms = 0.0f;
+      cudaEventElapsedTime(&elapsed_ms, timing_events[i],
+                           timing_events[i + 1]);
+      for (int g = 0; g < num_gpus_; ++g) {
+        total_bytes += gpu_chunk_sizes_in_bytes_[g] * 2 *
+                       batch_layers_count[i] * num_blocks;
+      }
+      total_time_ms += elapsed_ms;
     }
+    const double total_size_gb =
+        total_bytes / (1024.0 * 1024.0 * 1024.0);
+    const double total_time_s = total_time_ms / 1000.0;
+    const double total_bandwidth_gbps =
+        total_time_s > 0.0 ? total_size_gb / total_time_s : 0.0;
+    FLEXKV_LOG_DEBUG(
+        "operation=layerwise_transfer action=complete status=success "
+        "direction=H2D blocks=%d transfer_mode=layerwise "
+        "transfer_data_size=%.6fGB transfer_time=%.4fs "
+        "transfer_bandwidth=%.2fGB/s",
+        num_blocks, total_size_gb, total_time_s, total_bandwidth_gbps);
 
-    double bandwidth_gbps =
-        (bytes_this_batch / (1024.0 * 1024.0 * 1024.0)) / (elapsed_ms / 1000.0);
-
-    // fprintf(stderr, "  Layers [%d, %d): time=%.3f ms, size=%.2f MB,
-    // bandwidth=%.2f GB/s\n",
-    //         batch_start_layers[i],
-    //         batch_start_layers[i] + batch_layers_count[i],
-    //         elapsed_ms,
-    //         bytes_this_batch / (1024.0 * 1024.0),
-    //         bandwidth_gbps);
-
-    total_time_ms += elapsed_ms;
-    total_bytes += bytes_this_batch;
-  }
-
-  double total_bandwidth_gbps =
-      (total_bytes / (1024.0 * 1024.0 * 1024.0)) / (total_time_ms / 1000.0);
-  // fprintf(stderr, "  Total: time=%.3f ms, size=%.2f MB, avg_bandwidth=%.2f
-  // GB/s\n\n",
-  //         total_time_ms, total_bytes / (1024.0 * 1024.0),
-  //         total_bandwidth_gbps);
-  // fflush(stderr);
-
-  // Cleanup timing events
-  cudaSetDevice(gpu_device_ids_[0]);
-  for (int i = 0; i <= num_batches; ++i) {
-    cudaEventDestroy(timing_events[i]);
+    cudaSetDevice(gpu_device_ids_[0]);
+    for (int i = 0; i <= num_batches; ++i) {
+      cudaEventDestroy(timing_events[i]);
+    }
   }
 }
 
@@ -1331,9 +1326,10 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
   std::string mode = mla_d2h_mode;
   if (is_mla && mode != "sharded" && mode != "all_write" &&
       mode != "rank0_only") {
-    fprintf(stderr,
-            "[FlexKV] Invalid mla_d2h_mode='%s'; using 'sharded'\n",
-            mode.c_str());
+    FLEXKV_LOG_WARNING(
+        "operation=layerwise_config action=fallback status=degraded "
+        "field=mla_d2h_mode value=\"%s\" fallback=sharded",
+        mode.c_str());
     mode = "sharded";
   }
 

--- a/csrc/logging.cpp
+++ b/csrc/logging.cpp
@@ -160,9 +160,9 @@ void Logf(Level level, const char *file, int line, const char *format,
       EmergencyWrite(buffer);
     }
   } catch (const std::exception &error) {
-    EmergencyWrite("operation=logging action=emit status=failed", error.what());
+    EmergencyWrite("operation=logging act=emit status=failed", error.what());
   } catch (...) {
-    EmergencyWrite("operation=logging action=emit status=failed error=unknown");
+    EmergencyWrite("operation=logging act=emit status=failed error=unknown");
   }
 }
 

--- a/csrc/logging.cpp
+++ b/csrc/logging.cpp
@@ -1,0 +1,169 @@
+#include "logging.h"
+
+#include <cctype>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <memory>
+#include <string>
+
+#include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/spdlog.h>
+
+namespace flexkv::logging {
+namespace {
+
+class UppercaseLevelFlag : public spdlog::custom_flag_formatter {
+public:
+  void format(const spdlog::details::log_msg &message, const std::tm &,
+              spdlog::memory_buf_t &destination) override {
+    const auto level = spdlog::level::to_string_view(message.level);
+    for (const char ch : level) {
+      destination.push_back(
+          static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+    }
+  }
+
+  std::unique_ptr<custom_flag_formatter> clone() const override {
+    return spdlog::details::make_unique<UppercaseLevelFlag>();
+  }
+};
+
+spdlog::level::level_enum ToSpdlogLevel(Level level) noexcept {
+  switch (level) {
+  case Level::Debug:
+    return spdlog::level::debug;
+  case Level::Info:
+    return spdlog::level::info;
+  case Level::Warning:
+    return spdlog::level::warn;
+  case Level::Error:
+    return spdlog::level::err;
+  case Level::Critical:
+    return spdlog::level::critical;
+  }
+  return spdlog::level::info;
+}
+
+spdlog::level::level_enum ParseLevel() {
+  const char *configured = std::getenv("FLEXKV_LOG_LEVEL");
+  if (configured == nullptr || configured[0] == '\0') {
+    return spdlog::level::info;
+  }
+
+  std::string level(configured);
+  for (char &ch : level) {
+    ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+  }
+  if (level == "DEBUG")
+    return spdlog::level::debug;
+  if (level == "INFO")
+    return spdlog::level::info;
+  if (level == "WARNING" || level == "WARN")
+    return spdlog::level::warn;
+  if (level == "ERROR")
+    return spdlog::level::err;
+  if (level == "CRITICAL")
+    return spdlog::level::critical;
+  if (level == "OFF")
+    return spdlog::level::off;
+  return spdlog::level::info;
+}
+
+std::string EscapePattern(std::string value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (const char ch : value) {
+    if (ch == '%')
+      escaped.push_back('%');
+    escaped.push_back(ch);
+  }
+  return escaped;
+}
+
+std::shared_ptr<spdlog::logger> CreateLogger() {
+  const char *configured_prefix = std::getenv("FLEXKV_LOGGING_PREFIX");
+  const std::string prefix = EscapePattern(
+      configured_prefix == nullptr || configured_prefix[0] == '\0'
+          ? "FLEXKV"
+          : configured_prefix);
+
+  auto sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
+  auto logger = std::make_shared<spdlog::logger>("flexkv_native", sink);
+  auto formatter = std::make_unique<spdlog::pattern_formatter>();
+  formatter->add_flag<UppercaseLevelFlag>('*').set_pattern(
+      "[" + prefix +
+      "] %* %m-%d %H:%M:%S.%e [pid=%P tid=%t] [%s:%#] "
+      "[FlexKV-Native] %v");
+  logger->set_formatter(std::move(formatter));
+  logger->set_level(ParseLevel());
+  logger->flush_on(spdlog::level::info);
+  return logger;
+}
+
+std::shared_ptr<spdlog::logger> &Logger() noexcept {
+  static std::shared_ptr<spdlog::logger> logger = [] {
+    try {
+      return CreateLogger();
+    } catch (...) {
+      return std::shared_ptr<spdlog::logger>{};
+    }
+  }();
+  return logger;
+}
+
+void EmergencyWrite(const char *message, const char *error = nullptr) noexcept {
+  // The logger must never break a transfer. This path is only used if spdlog
+  // initialization or a sink fails, so keeping it dependency-free is useful.
+  (void)std::fprintf(stderr, "[FLEXKV] ERROR [FlexKV-Native] %s%s%s%s\n",
+                     message, error == nullptr ? "" : " error=\"",
+                     error == nullptr ? "" : error,
+                     error == nullptr ? "" : "\"");
+  (void)std::fflush(stderr);
+}
+
+} // namespace
+
+bool IsEnabled(Level level) noexcept {
+  const auto &logger = Logger();
+  if (logger != nullptr)
+    return logger->should_log(ToSpdlogLevel(level));
+  return level == Level::Error || level == Level::Critical;
+}
+
+void Logf(Level level, const char *file, int line, const char *format,
+          ...) noexcept {
+  if (format == nullptr)
+    return;
+
+  try {
+    auto &logger = Logger();
+    if (logger != nullptr && !logger->should_log(ToSpdlogLevel(level)))
+      return;
+    if (logger == nullptr && level != Level::Error && level != Level::Critical)
+      return;
+
+    char buffer[2048];
+    va_list args;
+    va_start(args, format);
+    const int written = std::vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    if (written < 0)
+      return;
+
+    if (logger != nullptr) {
+      logger->log(spdlog::source_loc{file, line, ""}, ToSpdlogLevel(level),
+                  "{}", buffer);
+    } else {
+      EmergencyWrite(buffer);
+    }
+  } catch (const std::exception &error) {
+    EmergencyWrite("operation=logging action=emit status=failed", error.what());
+  } catch (...) {
+    EmergencyWrite("operation=logging action=emit status=failed error=unknown");
+  }
+}
+
+} // namespace flexkv::logging

--- a/csrc/logging.h
+++ b/csrc/logging.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace flexkv::logging {
+
+enum class Level {
+  Debug,
+  Info,
+  Warning,
+  Error,
+  Critical,
+};
+
+bool IsEnabled(Level level) noexcept;
+void Logf(Level level, const char *file, int line, const char *format,
+          ...) noexcept;
+
+} // namespace flexkv::logging
+
+#define FLEXKV_LOG_IMPL(level, ...)                                          \
+  do {                                                                       \
+    if (::flexkv::logging::IsEnabled(::flexkv::logging::Level::level)) {     \
+      ::flexkv::logging::Logf(::flexkv::logging::Level::level, __FILE__,     \
+                              __LINE__, __VA_ARGS__);                         \
+    }                                                                        \
+  } while (false)
+
+#define FLEXKV_LOG_DEBUG(...) FLEXKV_LOG_IMPL(Debug, __VA_ARGS__)
+#define FLEXKV_LOG_INFO(...) FLEXKV_LOG_IMPL(Info, __VA_ARGS__)
+#define FLEXKV_LOG_WARNING(...) FLEXKV_LOG_IMPL(Warning, __VA_ARGS__)
+#define FLEXKV_LOG_ERROR(...) FLEXKV_LOG_IMPL(Error, __VA_ARGS__)
+#define FLEXKV_LOG_CRITICAL(...) FLEXKV_LOG_IMPL(Critical, __VA_ARGS__)

--- a/csrc/monitoring/metrics_manager.cpp
+++ b/csrc/monitoring/metrics_manager.cpp
@@ -4,8 +4,8 @@
  */
 
 #include "metrics_manager.h"
+#include "logging.h"
 
-#include <iostream>
 #include <thread>
 
 namespace flexkv {
@@ -29,7 +29,9 @@ MetricsManager::~MetricsManager() {
 void MetricsManager::Configure(bool enabled, int port) {
     // Protect against duplicate configuration
     if (configured_) {
-        std::cout << "[FlexKV CppMetrics] Already configured, ignoring duplicate Configure() call" << std::endl;
+        FLEXKV_LOG_DEBUG(
+            "operation=metrics_config action=configure status=skipped "
+            "reason=already_configured");
         return;
     }
     configured_ = true;
@@ -37,9 +39,14 @@ void MetricsManager::Configure(bool enabled, int port) {
     port_ = port;
     
     if (enabled_) {
-        std::cout << "[FlexKV CppMetrics] Configured from Python: enabled=true, port=" << port_ << std::endl;
+        FLEXKV_LOG_INFO(
+            "operation=metrics_config action=configure status=success "
+            "enabled=true port=%d",
+            port_);
     } else {
-        std::cout << "[FlexKV CppMetrics] Configured from Python: disabled" << std::endl;
+        FLEXKV_LOG_DEBUG(
+            "operation=metrics_config action=configure status=success "
+            "enabled=false");
     }
 }
 
@@ -78,7 +85,9 @@ bool MetricsManager::Initialize(const std::string& bind_address) {
     }
 
     if (!enabled_) {
-        std::cout << "[FlexKV CppMetrics] Metrics disabled, skipping initialization" << std::endl;
+        FLEXKV_LOG_DEBUG(
+            "operation=metrics_init action=complete status=skipped "
+            "reason=disabled");
         return false;
     }
 
@@ -103,12 +112,16 @@ bool MetricsManager::Initialize(const std::string& bind_address) {
             .Register(*registry_);
 
         running_.store(true);
-        std::cout << "[FlexKV CppMetrics] Initialized successfully, exposing metrics at http://" 
-                  << bind_address << "/metrics" << std::endl;
+        FLEXKV_LOG_INFO(
+            "operation=metrics_init action=complete status=success "
+            "endpoint=\"http://%s/metrics\"",
+            bind_address.c_str());
         return true;
 
     } catch (const std::exception& e) {
-        std::cerr << "[FlexKV CppMetrics] Initialization failed: " << e.what() << std::endl;
+        FLEXKV_LOG_ERROR(
+            "operation=metrics_init action=complete status=failed error=\"%s\"",
+            e.what());
         registry_.reset();
         exposer_.reset();
         return false;
@@ -133,7 +146,8 @@ void MetricsManager::Shutdown() {
     exposer_.reset();
     registry_.reset();
 
-    std::cout << "[FlexKV CppMetrics] Shutdown completed" << std::endl;
+    FLEXKV_LOG_DEBUG(
+        "operation=metrics_shutdown action=complete status=success");
 #endif
 }
 

--- a/csrc/monitoring/metrics_manager.cpp
+++ b/csrc/monitoring/metrics_manager.cpp
@@ -30,7 +30,7 @@ void MetricsManager::Configure(bool enabled, int port) {
     // Protect against duplicate configuration
     if (configured_) {
         FLEXKV_LOG_DEBUG(
-            "operation=metrics_config action=configure status=skipped "
+            "operation=metrics_config act=configure status=skipped "
             "reason=already_configured");
         return;
     }
@@ -40,12 +40,12 @@ void MetricsManager::Configure(bool enabled, int port) {
     
     if (enabled_) {
         FLEXKV_LOG_INFO(
-            "operation=metrics_config action=configure status=success "
+            "operation=metrics_config act=configure status=success "
             "enabled=true port=%d",
             port_);
     } else {
         FLEXKV_LOG_DEBUG(
-            "operation=metrics_config action=configure status=success "
+            "operation=metrics_config act=configure status=success "
             "enabled=false");
     }
 }
@@ -86,7 +86,7 @@ bool MetricsManager::Initialize(const std::string& bind_address) {
 
     if (!enabled_) {
         FLEXKV_LOG_DEBUG(
-            "operation=metrics_init action=complete status=skipped "
+            "operation=metrics_init act=complete status=skipped "
             "reason=disabled");
         return false;
     }
@@ -113,14 +113,14 @@ bool MetricsManager::Initialize(const std::string& bind_address) {
 
         running_.store(true);
         FLEXKV_LOG_INFO(
-            "operation=metrics_init action=complete status=success "
+            "operation=metrics_init act=complete status=success "
             "endpoint=\"http://%s/metrics\"",
             bind_address.c_str());
         return true;
 
     } catch (const std::exception& e) {
         FLEXKV_LOG_ERROR(
-            "operation=metrics_init action=complete status=failed error=\"%s\"",
+            "operation=metrics_init act=complete status=failed error=\"%s\"",
             e.what());
         registry_.reset();
         exposer_.reset();
@@ -147,7 +147,7 @@ void MetricsManager::Shutdown() {
     registry_.reset();
 
     FLEXKV_LOG_DEBUG(
-        "operation=metrics_shutdown action=complete status=success");
+        "operation=metrics_shutdown act=complete status=success");
 #endif
 }
 

--- a/csrc/pcfs/pcfs.cpp
+++ b/csrc/pcfs/pcfs.cpp
@@ -1,7 +1,7 @@
 // Pcfs.cpp
 #include "pcfs.h"
+#include "logging.h"
 #include <fcntl.h>
-#define INIT_IO_SIZE (1024 * 1024)
 #define MAX_PCFS_LINK_NUM 64 // read + write <= 128, pcfs limits
 
 flexkv::Pcfs::Pcfs(const std::string &fsid, uint32_t port,
@@ -15,8 +15,10 @@ flexkv::Pcfs::~Pcfs() { destroy(); }
 bool flexkv::Pcfs::init() {
   fsctx = hifs_init(fsid.c_str(), port, ip.c_str(), false, nullptr);
   if (!fsctx) {
-    fprintf(stderr, "HIFS初始化失败 (fsid=%s, ip=%s)\n", fsid.c_str(),
-            ip.c_str());
+    FLEXKV_LOG_ERROR(
+        "operation=pcfs_init action=complete status=failed fsid=\"%s\" "
+        "ip=\"%s\" port=%u",
+        fsid.c_str(), ip.c_str(), port);
     return false;
   }
   return true;
@@ -57,8 +59,10 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     crreq.unique = 1000;
     snprintf(crreq.name, sizeof(crreq.name), "%s", filename.c_str());
     if (hifs_create(fsctx, &crreq, &crreply) != 0 || crreply.error != 0) {
-      fprintf(stderr, "embedded create file data pnodeid:%lu file %s fail\n",
-              parent_nodeid, crreq.name);
+      FLEXKV_LOG_ERROR(
+          "operation=pcfs_file_create action=complete status=failed "
+          "parent_node_id=%lu path=\"%s\" error_code=%d",
+          parent_nodeid, crreq.name, crreply.error);
       return 0;
     }
     file_nodeid = crreply.nodeid;
@@ -72,8 +76,10 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
 
     if (hifs_open(fsctx, &open_req, &open_reply) != 0 ||
         open_reply.error != 0) {
-      fprintf(stderr, "embedded open file data pnodeid:%lu file %s fail\n",
-              parent_nodeid, filename.c_str());
+      FLEXKV_LOG_ERROR(
+          "operation=pcfs_file_open action=complete status=failed "
+          "parent_node_id=%lu path=\"%s\" error_code=%d",
+          parent_nodeid, filename.c_str(), open_reply.error);
       return 0;
     }
     hifs_truncate_req_t truncate_req = {0};
@@ -85,45 +91,21 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     truncate_req.size = file_size;
     if (hifs_truncate(fsctx, &truncate_req, &truncate_reply) != 0 ||
         truncate_reply.error != 0) {
-      fprintf(
-          stderr,
-          "embedded truncate file data pnodeid:%lu file %s to size %lu fail\n",
-          parent_nodeid, filename.c_str(), file_size);
+      FLEXKV_LOG_ERROR(
+          "operation=pcfs_file_truncate action=complete status=failed "
+          "parent_node_id=%lu path=\"%s\" size=%lu error_code=%d",
+          parent_nodeid, filename.c_str(), file_size, truncate_reply.error);
       return 0;
     }
 
-    // init with 0x00
-    // char *buffer = static_cast<char*>(malloc(INIT_IO_SIZE));
-    // if (!buffer) {
-    //     return false;
-    // }
-    // memset(buffer, 0, INIT_IO_SIZE);
-
-    // size_t remaining = file_size;
-    // size_t offset = 0;
-    // for (offset = 0; remaining > 0; offset += INIT_IO_SIZE) {
-    //     size_t write_size = (remaining > INIT_IO_SIZE) ? INIT_IO_SIZE :
-    //     remaining; hifs_write_req_t wrreq = {0}; hifs_write_reply_t wrreply =
-    //     {0}; wrreq.fh = open_reply.fh; wrreq.offset = offset; wrreq.size =
-    //     write_size; wrreq.buf = buffer; wrreq.uid = 0; wrreq.gid = 0;
-    //     wrreq.unique= 1000;
-    //     if (hifs_write(fsctx, &wrreq, &wrreply) != 0 || wrreply.error != 0) {
-    //         fprintf(stderr, "embedded write file data pnodeid:%lu file %s
-    //         fail\n", open_reply.fh, filename.c_str()); free(buffer); return
-    //         0;
-    //     }
-
-    //     remaining -= write_size;
-    // }
-    // free(buffer);
   } else {
     // return 0 if the size is smaller than file_size
     uint64_t exist_file_size = lkreply.attr.size;
     if (exist_file_size < file_size) {
-      fprintf(
-          stderr,
-          "file exists and its size smaller than allocate: %lu file %s fail\n",
-          parent_nodeid, filename.c_str());
+      FLEXKV_LOG_ERROR(
+          "operation=pcfs_file_validate action=complete status=failed "
+          "parent_node_id=%lu path=\"%s\" existing_size=%lu required_size=%lu",
+          parent_nodeid, filename.c_str(), exist_file_size, file_size);
       return 0;
     }
     hifs_open_req_t open_req = {0};
@@ -136,8 +118,10 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
 
     if (hifs_open(fsctx, &open_req, &open_reply) != 0 ||
         open_reply.error != 0) {
-      fprintf(stderr, "embedded open file data pnodeid:%lu file %s fail\n",
-              parent_nodeid, filename.c_str());
+      FLEXKV_LOG_ERROR(
+          "operation=pcfs_file_open action=complete status=failed "
+          "parent_node_id=%lu path=\"%s\" error_code=%d",
+          parent_nodeid, filename.c_str(), open_reply.error);
       return 0;
     }
   }

--- a/csrc/pcfs/pcfs.cpp
+++ b/csrc/pcfs/pcfs.cpp
@@ -16,7 +16,7 @@ bool flexkv::Pcfs::init() {
   fsctx = hifs_init(fsid.c_str(), port, ip.c_str(), false, nullptr);
   if (!fsctx) {
     FLEXKV_LOG_ERROR(
-        "operation=pcfs_init action=complete status=failed fsid=\"%s\" "
+        "operation=pcfs_init act=complete status=failed fsid=\"%s\" "
         "ip=\"%s\" port=%u",
         fsid.c_str(), ip.c_str(), port);
     return false;
@@ -60,7 +60,7 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     snprintf(crreq.name, sizeof(crreq.name), "%s", filename.c_str());
     if (hifs_create(fsctx, &crreq, &crreply) != 0 || crreply.error != 0) {
       FLEXKV_LOG_ERROR(
-          "operation=pcfs_file_create action=complete status=failed "
+          "operation=pcfs_file_create act=complete status=failed "
           "parent_node_id=%lu path=\"%s\" error_code=%d",
           parent_nodeid, crreq.name, crreply.error);
       return 0;
@@ -77,7 +77,7 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     if (hifs_open(fsctx, &open_req, &open_reply) != 0 ||
         open_reply.error != 0) {
       FLEXKV_LOG_ERROR(
-          "operation=pcfs_file_open action=complete status=failed "
+          "operation=pcfs_file_open act=complete status=failed "
           "parent_node_id=%lu path=\"%s\" error_code=%d",
           parent_nodeid, filename.c_str(), open_reply.error);
       return 0;
@@ -92,7 +92,7 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     if (hifs_truncate(fsctx, &truncate_req, &truncate_reply) != 0 ||
         truncate_reply.error != 0) {
       FLEXKV_LOG_ERROR(
-          "operation=pcfs_file_truncate action=complete status=failed "
+          "operation=pcfs_file_truncate act=complete status=failed "
           "parent_node_id=%lu path=\"%s\" size=%lu error_code=%d",
           parent_nodeid, filename.c_str(), file_size, truncate_reply.error);
       return 0;
@@ -103,7 +103,7 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     uint64_t exist_file_size = lkreply.attr.size;
     if (exist_file_size < file_size) {
       FLEXKV_LOG_ERROR(
-          "operation=pcfs_file_validate action=complete status=failed "
+          "operation=pcfs_file_validate act=complete status=failed "
           "parent_node_id=%lu path=\"%s\" existing_size=%lu required_size=%lu",
           parent_nodeid, filename.c_str(), exist_file_size, file_size);
       return 0;
@@ -119,7 +119,7 @@ uint64_t flexkv::Pcfs::lookup_or_create_file(const std::string &filename,
     if (hifs_open(fsctx, &open_req, &open_reply) != 0 ||
         open_reply.error != 0) {
       FLEXKV_LOG_ERROR(
-          "operation=pcfs_file_open action=complete status=failed "
+          "operation=pcfs_file_open act=complete status=failed "
           "parent_node_id=%lu path=\"%s\" error_code=%d",
           parent_nodeid, filename.c_str(), open_reply.error);
       return 0;

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <errno.h>
 #include <execinfo.h>
-#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -13,6 +12,7 @@
 #include "cache_utils.h"
 #include "dist/lease_meta_mempool.h" // for flexkv::LeaseMeta
 #include "eviction_strategy.h"
+#include "logging.h"
 
 namespace flexkv {
 
@@ -381,7 +381,10 @@ public:
     if (swa_lru_tail != nullptr) { delete swa_lru_tail; swa_lru_tail = nullptr; }
 
     if (node_count) {
-      std::cerr << "CRadix Node count" << node_count << std::endl;
+      FLEXKV_LOG_WARNING(
+          "operation=radix_tree_shutdown action=complete status=degraded "
+          "remaining_nodes=%d",
+          node_count);
     }
   }
 

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -382,7 +382,7 @@ public:
 
     if (node_count) {
       FLEXKV_LOG_WARNING(
-          "operation=radix_tree_shutdown action=complete status=degraded "
+          "operation=radix_tree_shutdown act=complete status=degraded "
           "remaining_nodes=%d",
           node_count);
     }

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "tp_transfer_thread_group.h"
+#include "logging.h"
 #include "transfer.cuh"
 #ifdef FLEXKV_ENABLE_NVCOMP
 #include "compression/ans/nvcomp_ans_tp.h"
@@ -196,8 +197,10 @@ void TPTransferThreadGroup::tp_group_transfer(
   std::string mode = mla_d2h_mode;
   if (is_mla && mode != "sharded" && mode != "all_write" && mode != "rank0_only"
       && mode != "layer_parallel" && mode != "rank_rotate") {
-    fprintf(stderr, "[FlexKV] Warning: Invalid mla_d2h_mode='%s', using default 'sharded'\n",
-            mode.c_str());
+    FLEXKV_LOG_WARNING(
+        "operation=transfer_config action=fallback status=degraded "
+        "field=mla_d2h_mode value=\"%s\" fallback=sharded",
+        mode.c_str());
     mode = "sharded";
   }
 

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -198,7 +198,7 @@ void TPTransferThreadGroup::tp_group_transfer(
   if (is_mla && mode != "sharded" && mode != "all_write" && mode != "rank0_only"
       && mode != "layer_parallel" && mode != "rank_rotate") {
     FLEXKV_LOG_WARNING(
-        "operation=transfer_config action=fallback status=degraded "
+        "operation=transfer_config act=fallback status=degraded "
         "field=mla_d2h_mode value=\"%s\" fallback=sharded",
         mode.c_str());
     mode = "sharded";

--- a/csrc/transfer_ssd.cpp
+++ b/csrc/transfer_ssd.cpp
@@ -1,6 +1,6 @@
 #include <errno.h>
 #include <fcntl.h>
-#include <cstdio>
+#include <cstring>
 #include <torch/extension.h>
 #include <unistd.h>
 #include <vector>
@@ -198,11 +198,16 @@ static void _transfer_single_thread_impl(
                                 ssd_k_block_offset);
       }
       
-      if (bytes_transfer == -1){
-        perror("pread failed");
-      }
-
       if (bytes_transfer != chunk_size_in_bytes) {
+        const int error = bytes_transfer < 0 ? errno : 0;
+        FLEXKV_LOG_ERROR(
+            "operation=ssd_transfer action=complete status=failed "
+            "direction=%s kv=K expected_bytes=%ld transferred_bytes=%ld "
+            "errno=%d error=\"%s\"",
+            is_read ? "SSD2H" : "H2SSD",
+            static_cast<long>(chunk_size_in_bytes),
+            static_cast<long>(bytes_transfer), error,
+            error == 0 ? "short_io" : std::strerror(error));
         throw std::runtime_error("Failed to transfer K block");
       }
 
@@ -218,6 +223,15 @@ static void _transfer_single_thread_impl(
                                 ssd_v_block_offset);
       }
       if (bytes_transfer != chunk_size_in_bytes) {
+        const int error = bytes_transfer < 0 ? errno : 0;
+        FLEXKV_LOG_ERROR(
+            "operation=ssd_transfer action=complete status=failed "
+            "direction=%s kv=V expected_bytes=%ld transferred_bytes=%ld "
+            "errno=%d error=\"%s\"",
+            is_read ? "SSD2H" : "H2SSD",
+            static_cast<long>(chunk_size_in_bytes),
+            static_cast<long>(bytes_transfer), error,
+            error == 0 ? "short_io" : std::strerror(error));
         throw std::runtime_error("Failed to transfer V block");
       }
 

--- a/csrc/transfer_ssd.cpp
+++ b/csrc/transfer_ssd.cpp
@@ -201,7 +201,7 @@ static void _transfer_single_thread_impl(
       if (bytes_transfer != chunk_size_in_bytes) {
         const int error = bytes_transfer < 0 ? errno : 0;
         FLEXKV_LOG_ERROR(
-            "operation=ssd_transfer action=complete status=failed "
+            "operation=ssd_transfer act=complete status=failed "
             "direction=%s kv=K expected_bytes=%ld transferred_bytes=%ld "
             "errno=%d error=\"%s\"",
             is_read ? "SSD2H" : "H2SSD",
@@ -225,7 +225,7 @@ static void _transfer_single_thread_impl(
       if (bytes_transfer != chunk_size_in_bytes) {
         const int error = bytes_transfer < 0 ? errno : 0;
         FLEXKV_LOG_ERROR(
-            "operation=ssd_transfer action=complete status=failed "
+            "operation=ssd_transfer act=complete status=failed "
             "direction=%s kv=V expected_bytes=%ld transferred_bytes=%ld "
             "errno=%d error=\"%s\"",
             is_read ? "SSD2H" : "H2SSD",

--- a/csrc/transfer_ssd.h
+++ b/csrc/transfer_ssd.h
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include <vector>
 
+#include "logging.h"
+
 #ifndef IOPRIO_CLASS_SHIFT
 #define IOPRIO_CLASS_SHIFT 13
 #define IOPRIO_PRIO_MASK ((1UL << IOPRIO_CLASS_SHIFT) - 1)
@@ -34,9 +36,10 @@ public:
       if (!io_uring_queue_init(_entries, &ring, flags)) {
         entries = _entries;
       } else {
-        fprintf(stderr,
-                "IOUring(%p) init failed, entries(%d), flags(%d), errno(%d)\n",
-                this, _entries, flags, errno);
+        FLEXKV_LOG_ERROR(
+            "operation=io_uring_init action=complete status=failed "
+            "entries=%d flags=%d errno=%d",
+            _entries, flags, errno);
       }
     }
 
@@ -50,8 +53,10 @@ public:
     }
     write_ioprio = IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 4);
 
-    fprintf(stdout, "IOUring(%p) : RT ioprio %s\n", this,
-            rt_supported ? "supported" : "not supported, using BE");
+    FLEXKV_LOG_DEBUG(
+        "operation=io_uring_priority action=configure status=success "
+        "rt_ioprio=%s",
+        rt_supported ? "supported" : "unsupported fallback=best_effort");
   }
 
   ~IOUring() {
@@ -154,12 +159,23 @@ public:
 
   void dump(int force) {
     if (force || total_cqe_err || total_over_limit) {
-      fprintf(
-          stdout,
-          "IOUring(%p) : entries = %d, inflight = %d, prepared = %d, "
-          "submitted = %lu, completed = %lu, over_limit = %lu, cqe_err = %lu\n",
-          this, entries, inflight, prepared, total_submitted, total_completed,
-          total_over_limit, total_cqe_err);
+      const char *status =
+          total_cqe_err || total_over_limit ? "degraded" : "success";
+      if (total_cqe_err || total_over_limit) {
+        FLEXKV_LOG_WARNING(
+            "operation=io_uring action=summary status=%s entries=%d "
+            "inflight=%d prepared=%d submitted=%lu completed=%lu "
+            "over_limit=%lu cqe_errors=%lu",
+            status, entries, inflight, prepared, total_submitted,
+            total_completed, total_over_limit, total_cqe_err);
+      } else {
+        FLEXKV_LOG_DEBUG(
+            "operation=io_uring action=summary status=%s entries=%d "
+            "inflight=%d prepared=%d submitted=%lu completed=%lu "
+            "over_limit=%lu cqe_errors=%lu",
+            status, entries, inflight, prepared, total_submitted,
+            total_completed, total_over_limit, total_cqe_err);
+      }
     }
   }
 
@@ -221,8 +237,10 @@ public:
         fd_direct_io = open(ssd_files[i][j].c_str(), O_RDWR | O_DIRECT);
 
         if (fd_buffer_io < 0 || fd_direct_io < 0) {
-          std::cerr << "open file failed, path = " << ssd_files[i][j]
-                    << std::endl;
+          FLEXKV_LOG_ERROR(
+              "operation=ssd_file_open action=complete status=failed "
+              "path=\"%s\" buffered_fd=%d direct_fd=%d errno=%d",
+              ssd_files[i][j].c_str(), fd_buffer_io, fd_direct_io, errno);
           throw std::runtime_error("Failed to open file");
         } else {
           posix_fadvise(fd_buffer_io, 0, 0, POSIX_FADV_SEQUENTIAL);

--- a/csrc/transfer_ssd.h
+++ b/csrc/transfer_ssd.h
@@ -37,7 +37,7 @@ public:
         entries = _entries;
       } else {
         FLEXKV_LOG_ERROR(
-            "operation=io_uring_init action=complete status=failed "
+            "operation=io_uring_init act=complete status=failed "
             "entries=%d flags=%d errno=%d",
             _entries, flags, errno);
       }
@@ -54,7 +54,7 @@ public:
     write_ioprio = IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 4);
 
     FLEXKV_LOG_DEBUG(
-        "operation=io_uring_priority action=configure status=success "
+        "operation=io_uring_priority act=configure status=success "
         "rt_ioprio=%s",
         rt_supported ? "supported" : "unsupported fallback=best_effort");
   }
@@ -163,14 +163,14 @@ public:
           total_cqe_err || total_over_limit ? "degraded" : "success";
       if (total_cqe_err || total_over_limit) {
         FLEXKV_LOG_WARNING(
-            "operation=io_uring action=summary status=%s entries=%d "
+            "operation=io_uring act=summary status=%s entries=%d "
             "inflight=%d prepared=%d submitted=%lu completed=%lu "
             "over_limit=%lu cqe_errors=%lu",
             status, entries, inflight, prepared, total_submitted,
             total_completed, total_over_limit, total_cqe_err);
       } else {
         FLEXKV_LOG_DEBUG(
-            "operation=io_uring action=summary status=%s entries=%d "
+            "operation=io_uring act=summary status=%s entries=%d "
             "inflight=%d prepared=%d submitted=%lu completed=%lu "
             "over_limit=%lu cqe_errors=%lu",
             status, entries, inflight, prepared, total_submitted,
@@ -238,7 +238,7 @@ public:
 
         if (fd_buffer_io < 0 || fd_direct_io < 0) {
           FLEXKV_LOG_ERROR(
-              "operation=ssd_file_open action=complete status=failed "
+              "operation=ssd_file_open act=complete status=failed "
               "path=\"%s\" buffered_fd=%d direct_fd=%d errno=%d",
               ssd_files[i][j].c_str(), fd_buffer_io, fd_direct_io, errno);
           throw std::runtime_error("Failed to open file");

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import threading
 import time
 from functools import partial
@@ -30,7 +31,7 @@ from flexkv.cache.redis_meta import RedisMeta, dist_available
 from flexkv.cache.mempool import Mempool
 from flexkv.cache.radixtree import RadixTreeIndex, RadixNode, MatchResult
 from flexkv.cache.swa_cache_engine import SWAOpConstructor
-from flexkv.common.block import SequenceMeta
+from flexkv.common.block import SequenceMeta, format_block_hash
 from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.transfer import (
     DeviceType,
@@ -39,7 +40,11 @@ from flexkv.common.transfer import (
     TransferType,
     add_virtual_op_for_multiple_finished_ops,
 )
-from flexkv.common.debug import flexkv_logger, summarize_id_tensor
+from flexkv.common.debug import (
+    eviction_log_aggregator,
+    flexkv_logger,
+    summarize_id_tensor,
+)
 from flexkv.common.type import MatchResultAccel
 from flexkv.integration.dynamo.collector import KVEventCollector
 from flexkv.metrics import FlexKVMetricsCollector, init_global_collector, get_global_collector
@@ -219,11 +224,27 @@ class CacheEngineAccel:
         """Evict node-mounted SWA slots through the C++ radix tree."""
         if self.swa_pool is None:
             return 0
+        free_before = self.swa_pool.num_free
+        start_ns = time.perf_counter_ns()
         evicted_full = torch.zeros(0, dtype=torch.int64)
         num_freed = self.index.evict_swa(evicted_full, num_swa_evicted)
         if evicted_full.numel() > 0:
             self.mempool.recycle_blocks(evicted_full.numpy())
         self._drain_unmounted_swa_slots()
+        free_after = self.swa_pool.num_free
+        eviction_log_aggregator.record(
+            tier=DEVICE_TYPE[self.device_type].lower(),
+            scope="swa",
+            reason="capacity",
+            requested_blocks=num_swa_evicted,
+            required_blocks=num_swa_evicted,
+            evicted_blocks=num_freed,
+            free_blocks_before=free_before,
+            free_blocks_after=free_after,
+            total_blocks=self.swa_pool.num_slots,
+            duration_ms=(time.perf_counter_ns() - start_ns) / 1e6,
+            target_met=num_freed >= num_swa_evicted,
+        )
         return num_freed
 
     def reset(self) -> None:
@@ -331,6 +352,8 @@ class CacheEngineAccel:
             )
 
             if evict_block_num > 0:
+                free_before = self.mempool.num_free_blocks
+                start_ns = time.perf_counter_ns()
                 target_blocks = torch.zeros(evict_block_num, dtype=torch.int64)
                 evicted_block_hashes = torch.zeros(evict_block_num, dtype=torch.int64)
                 # evict() resizes both tensors in-place to the actual freed count
@@ -359,6 +382,35 @@ class CacheEngineAccel:
                         block_hashes=evicted_block_hashes.numpy(),
                         medium=DEVICE_TYPE[self.device_type]
                     )
+                free_after = self.mempool.num_free_blocks
+                target_met = free_after >= max(
+                    num_required_blocks, target_free_blocks
+                )
+                sample_block_hashes = None
+                batch_level = logging.DEBUG if target_met else logging.WARNING
+                if flexkv_logger.is_enabled_for(batch_level):
+                    sample_block_hashes = [
+                        format_block_hash(value)
+                        for value in evicted_block_hashes[:3].tolist()
+                    ]
+                eviction_log_aggregator.record(
+                    tier=DEVICE_TYPE[self.device_type].lower(),
+                    scope="full",
+                    reason=(
+                        "capacity"
+                        if num_required_blocks > free_before
+                        else "threshold"
+                    ),
+                    requested_blocks=num_required_blocks,
+                    required_blocks=evict_block_num,
+                    evicted_blocks=num_evicted,
+                    free_blocks_before=free_before,
+                    free_blocks_after=free_after,
+                    total_blocks=self.mempool.num_total_blocks,
+                    duration_ms=(time.perf_counter_ns() - start_ns) / 1e6,
+                    sample_block_hashes=sample_block_hashes,
+                    target_met=target_met,
+                )
             if protected_node is not None:
                 self.index.unlock(protected_node)
 
@@ -479,10 +531,26 @@ class CacheEngine:
         """Evict node-mounted SWA slots through the Python radix tree."""
         if self.swa_pool is None:
             return 0
+        free_before = self.swa_pool.num_free
+        start_ns = time.perf_counter_ns()
         evicted_full, num_freed = self.index.evict_swa(num_swa_evicted)
         if evicted_full.size > 0:
             self.mempool.recycle_blocks(evicted_full)
         self._drain_unmounted_swa_slots()
+        free_after = self.swa_pool.num_free
+        eviction_log_aggregator.record(
+            tier=DEVICE_TYPE[self.device_type].lower(),
+            scope="swa",
+            reason="capacity",
+            requested_blocks=num_swa_evicted,
+            required_blocks=num_swa_evicted,
+            evicted_blocks=num_freed,
+            free_blocks_before=free_before,
+            free_blocks_after=free_after,
+            total_blocks=self.swa_pool.num_slots,
+            duration_ms=(time.perf_counter_ns() - start_ns) / 1e6,
+            target_met=num_freed >= num_swa_evicted,
+        )
         return num_freed
 
     def reset(self) -> None:
@@ -547,6 +615,8 @@ class CacheEngine:
                 int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0  # Or minimum evict_ratio
             )
             if evict_block_num > 0:
+                free_before = self.mempool.num_free_blocks
+                start_ns = time.perf_counter_ns()
                 evicted_blocks, evicted_block_hashes = self.index.evict(evict_block_num)
                 self.mempool.recycle_blocks(evicted_blocks)
 
@@ -560,6 +630,35 @@ class CacheEngine:
                 if self.event_collector is not None:
                     self.event_collector.publish_removed(block_hashes=evicted_block_hashes,
                                                          medium=DEVICE_TYPE[self.device_type])
+                free_after = self.mempool.num_free_blocks
+                target_met = free_after >= max(
+                    num_required_blocks, target_free_blocks
+                )
+                sample_block_hashes = None
+                batch_level = logging.DEBUG if target_met else logging.WARNING
+                if flexkv_logger.is_enabled_for(batch_level):
+                    sample_block_hashes = [
+                        format_block_hash(value)
+                        for value in evicted_block_hashes[:3].tolist()
+                    ]
+                eviction_log_aggregator.record(
+                    tier=DEVICE_TYPE[self.device_type].lower(),
+                    scope="full",
+                    reason=(
+                        "capacity"
+                        if num_required_blocks > free_before
+                        else "threshold"
+                    ),
+                    requested_blocks=num_required_blocks,
+                    required_blocks=evict_block_num,
+                    evicted_blocks=len(evicted_blocks),
+                    free_blocks_before=free_before,
+                    free_blocks_after=free_after,
+                    total_blocks=self.mempool.num_total_blocks,
+                    duration_ms=(time.perf_counter_ns() - start_ns) / 1e6,
+                    sample_block_hashes=sample_block_hashes,
+                    target_met=target_met,
+                )
             if protected_node is not None:
                 self.index.unlock(protected_node)
 

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -11,6 +11,7 @@ from flexkv.cache.radix_remote import LocalRadixTree, DistributedRadixTree
 from flexkv.cache.redis_meta import RedisMetaChannel as _PyRedisMetaChannel
 from flexkv.cache.redis_meta import RedisMeta
 from flexkv.common.block import SequenceMeta
+from flexkv.common.debug import eviction_log_aggregator
 #if TYPE_CHECKING:
 from flexkv.common.config import CacheConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.transfer import DeviceType
@@ -455,6 +456,8 @@ class HierarchyLRCacheEngine:
             )
 
             if evict_block_num > 0:
+                free_before = self.mempool.num_free_blocks
+                start_ns = time.perf_counter_ns()
                 target_blocks = torch.zeros(evict_block_num, dtype=torch.int64)
                 # evict() resizes target_blocks in-place to the actual freed count
                 # (may EXCEED evict_block_num when the I2 tombstone cascade frees
@@ -464,6 +467,25 @@ class HierarchyLRCacheEngine:
                     target_blocks.resize_(num_evicted)
                 evicted_np = target_blocks.numpy()
                 self.mempool.recycle_blocks(evicted_np)
+                free_after = self.mempool.num_free_blocks
+                eviction_log_aggregator.record(
+                    tier=self.device_type.name.lower(),
+                    scope="full",
+                    reason=(
+                        "capacity"
+                        if num_required_blocks > free_before
+                        else "threshold"
+                    ),
+                    requested_blocks=num_required_blocks,
+                    required_blocks=evict_block_num,
+                    evicted_blocks=num_evicted,
+                    free_blocks_before=free_before,
+                    free_blocks_after=free_after,
+                    total_blocks=self.mempool.num_total_blocks,
+                    duration_ms=(time.perf_counter_ns() - start_ns) / 1e6,
+                    target_met=free_after
+                    >= max(num_required_blocks, target_free_blocks),
+                )
 
             if protected_node is not None:
                 self.local_index.unlock(protected_node)

--- a/flexkv/common/block.py
+++ b/flexkv/common/block.py
@@ -33,6 +33,14 @@ def hash_token(token_ids: np.ndarray, namespace: Optional[List[str]]) -> HashTyp
 
     return HashType(hasher.digest())
 
+
+def format_block_hash(value: Optional[int]) -> str:
+    """Format signed or unsigned 64-bit hashes as fixed-width hex."""
+    if value is None:
+        return "-"
+    return f"0x{int(value) & ((1 << 64) - 1):016x}"
+
+
 @dataclass
 class SequenceMeta:
 

--- a/flexkv/common/debug.py
+++ b/flexkv/common/debug.py
@@ -176,7 +176,7 @@ class EvictionLogAggregator:
         batch_level = logging.DEBUG if target_met else logging.WARNING
         if self.logger.is_enabled_for(batch_level):
             fields = (
-                "[FlexKV-EVICTION] operation=eviction action=batch status=%s "
+                "[FlexKV-EVICTION] operation=eviction act=batch status=%s "
                 "tier=%s scope=%s reason=%s requested_blocks=%d "
                 "required_blocks=%d evicted_blocks=%d free_blocks_before=%d "
                 "free_blocks_after=%d pool_total_blocks=%d target_met=%s "
@@ -246,7 +246,7 @@ class EvictionLogAggregator:
     ) -> None:
         for (tier, scope, reason), window in summaries:
             self.logger.info(
-                "[FlexKV-EVICTION] operation=eviction action=summary status=%s "
+                "[FlexKV-EVICTION] operation=eviction act=summary status=%s "
                 "tier=%s scope=%s reason=%s window=%.3fs "
                 "batches=%d requested_blocks=%d required_blocks=%d "
                 "evicted_blocks=%d target_miss_batches=%d "

--- a/flexkv/common/debug.py
+++ b/flexkv/common/debug.py
@@ -2,10 +2,13 @@ import logging
 import os
 import signal
 import sys
+import threading
 import time
 import inspect
+from collections import defaultdict
+from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -51,6 +54,9 @@ class FlexkvLogger:
         self.logger.setLevel(log_level)
         self.enabled = log_level != (logging.CRITICAL + 1)
 
+    def is_enabled_for(self, level: int) -> bool:
+        return self.enabled and self.logger.isEnabledFor(level)
+
     def _get_caller_info(self, skip: int = 2):
         frame = inspect.currentframe()
         try:
@@ -86,26 +92,184 @@ class FlexkvLogger:
         self.logger.handle(record)
 
     def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        if self.enabled and self.logger.isEnabledFor(logging.DEBUG):
+        if self.is_enabled_for(logging.DEBUG):
             self._log(logging.DEBUG, msg, args, kwargs)
 
     def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        if self.enabled and self.logger.isEnabledFor(logging.INFO):
+        if self.is_enabled_for(logging.INFO):
             self._log(logging.INFO, msg, args, kwargs)
 
     def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        if self.enabled and self.logger.isEnabledFor(logging.WARNING):
+        if self.is_enabled_for(logging.WARNING):
             self._log(logging.WARNING, msg, args, kwargs)
 
     def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        if self.enabled and self.logger.isEnabledFor(logging.ERROR):
+        if self.is_enabled_for(logging.ERROR):
             self._log(logging.ERROR, msg, args, kwargs)
 
     def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        if self.enabled and self.logger.isEnabledFor(logging.CRITICAL):
+        if self.is_enabled_for(logging.CRITICAL):
             self._log(logging.CRITICAL, msg, args, kwargs)
 
 flexkv_logger = FlexkvLogger(os.getenv("FLEXKV_LOG_LEVEL", "INFO"))
+
+
+@dataclass
+class _EvictionWindow:
+    batches: int = 0
+    requested_blocks: int = 0
+    required_blocks: int = 0
+    evicted_blocks: int = 0
+    duration_ms: float = 0.0
+    target_miss_batches: int = 0
+    free_blocks_min: Optional[int] = None
+    free_blocks_last: int = 0
+    total_blocks: int = 0
+
+
+class EvictionLogAggregator:
+    """Rate-limit eviction INFO logs while preserving per-batch diagnostics.
+
+    Metrics remain the source of truth for every eviction. Each batch is
+    available at DEBUG, failures to make enough space are emitted immediately
+    at WARNING, and routine activity is summarized at INFO once per window.
+    """
+
+    def __init__(
+        self,
+        interval_s: Optional[float] = None,
+        logger: FlexkvLogger = flexkv_logger,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if interval_s is None:
+            try:
+                interval_s = float(
+                    os.getenv("FLEXKV_EVICTION_LOG_INTERVAL_S", "10")
+                )
+            except ValueError:
+                interval_s = 10.0
+        self.interval_s = max(0.1, float(interval_s))
+        self.logger = logger
+        self.clock = clock
+        self._lock = threading.Lock()
+        self._window_started = self.clock()
+        self._windows: Dict[Tuple[str, str, str], _EvictionWindow] = defaultdict(
+            _EvictionWindow
+        )
+
+    def record(
+        self,
+        *,
+        tier: str,
+        scope: str,
+        reason: str,
+        requested_blocks: int,
+        required_blocks: int,
+        evicted_blocks: int,
+        free_blocks_before: int,
+        free_blocks_after: int,
+        total_blocks: int,
+        duration_ms: float,
+        sample_block_hashes: Optional[List[str]] = None,
+        target_met: bool,
+    ) -> None:
+        batch_level = logging.DEBUG if target_met else logging.WARNING
+        if self.logger.is_enabled_for(batch_level):
+            fields = (
+                "[FlexKV-EVICTION] operation=eviction action=batch status=%s "
+                "tier=%s scope=%s reason=%s requested_blocks=%d "
+                "required_blocks=%d evicted_blocks=%d free_blocks_before=%d "
+                "free_blocks_after=%d pool_total_blocks=%d target_met=%s "
+                "sample_block_hashes=%s eviction_time=%.4fs"
+            )
+            args = (
+                "success" if target_met else "target_miss",
+                tier,
+                scope,
+                reason,
+                requested_blocks,
+                required_blocks,
+                evicted_blocks,
+                free_blocks_before,
+                free_blocks_after,
+                total_blocks,
+                str(target_met).lower(),
+                ",".join((sample_block_hashes or [])[:3]) or "-",
+                duration_ms / 1000,
+            )
+            log = self.logger.debug if target_met else self.logger.warning
+            log(fields, *args)
+
+        if not self.logger.is_enabled_for(logging.INFO):
+            return
+
+        summaries = []
+        now = self.clock()
+        with self._lock:
+            window = self._windows[(tier, scope, reason)]
+            window.batches += 1
+            window.requested_blocks += requested_blocks
+            window.required_blocks += required_blocks
+            window.evicted_blocks += evicted_blocks
+            window.duration_ms += duration_ms
+            window.target_miss_batches += int(not target_met)
+            window.free_blocks_min = (
+                free_blocks_after
+                if window.free_blocks_min is None
+                else min(window.free_blocks_min, free_blocks_after)
+            )
+            window.free_blocks_last = free_blocks_after
+            window.total_blocks = total_blocks
+            if now - self._window_started >= self.interval_s:
+                summaries = list(self._windows.items())
+                elapsed = now - self._window_started
+                self._windows.clear()
+                self._window_started = now
+            else:
+                elapsed = 0.0
+        self._emit_summaries(summaries, elapsed)
+
+    def flush(self) -> None:
+        """Emit the current partial window, primarily for shutdown and tests."""
+        now = self.clock()
+        with self._lock:
+            summaries = list(self._windows.items())
+            elapsed = max(0.0, now - self._window_started)
+            self._windows.clear()
+            self._window_started = now
+        self._emit_summaries(summaries, elapsed)
+
+    def _emit_summaries(
+        self,
+        summaries: List[Tuple[Tuple[str, str, str], _EvictionWindow]],
+        elapsed: float,
+    ) -> None:
+        for (tier, scope, reason), window in summaries:
+            self.logger.info(
+                "[FlexKV-EVICTION] operation=eviction action=summary status=%s "
+                "tier=%s scope=%s reason=%s window=%.3fs "
+                "batches=%d requested_blocks=%d required_blocks=%d "
+                "evicted_blocks=%d target_miss_batches=%d "
+                "free_blocks_min=%d free_blocks_last=%d "
+                "pool_total_blocks=%d eviction_time=%.4fs",
+                "success" if window.target_miss_batches == 0 else "degraded",
+                tier,
+                scope,
+                reason,
+                elapsed,
+                window.batches,
+                window.requested_blocks,
+                window.required_blocks,
+                window.evicted_blocks,
+                window.target_miss_batches,
+                window.free_blocks_min or 0,
+                window.free_blocks_last,
+                window.total_blocks,
+                window.duration_ms / 1000,
+            )
+
+
+eviction_log_aggregator = EvictionLogAggregator()
 
 
 def format_process_exit(exitcode: Optional[int]) -> str:

--- a/flexkv/common/debug.py
+++ b/flexkv/common/debug.py
@@ -305,27 +305,12 @@ def install_worker_crash_diagnostics(worker_class_name: str, worker_id: int) -> 
     """Best-effort crash breadcrumbs inside FlexKV transfer worker subprocesses."""
     import faulthandler
 
-    flexkv_logger.info(
-        "[FlexKV-SEGV-DEBUG] install_worker_crash_diagnostics: "
-        f"class={worker_class_name}, worker_id={worker_id}, pid={os.getpid()}"
-    )
     try:
         faulthandler.enable(all_threads=True, file=sys.stderr)
-    except Exception as e:
-        flexkv_logger.warning(
-            f"[FlexKV-SEGV-DEBUG] faulthandler.enable failed pid={os.getpid()}: {e}"
-        )
+    except Exception:
+        pass
 
     def _fatal_signal_handler(signum: int, frame: Any) -> None:
-        try:
-            sig_name = signal.Signals(signum).name
-        except ValueError:
-            sig_name = f"SIG{signum}"
-        flexkv_logger.critical(
-            "[FlexKV-SEGV-DEBUG] worker fatal signal: "
-            f"class={worker_class_name}, worker_id={worker_id}, pid={os.getpid()}, "
-            f"signum={signum} ({sig_name})"
-        )
         try:
             faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
         except Exception:

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -26,7 +26,7 @@ from flexkv.server.server import KVServer, DPClient
 from flexkv.kvtask import KVTaskEngine, KVResponse
 from flexkv.common.config import ModelConfig, CacheConfig, GLOBAL_CONFIG_FROM_ENV, MooncakeTransferEngineConfig
 from flexkv.integration.dynamo.collector import KVEventCollector
-from flexkv.common.debug import flexkv_logger
+from flexkv.common.debug import eviction_log_aggregator, flexkv_logger
 from flexkv.cache.redis_meta import RedisMeta
 
 
@@ -38,8 +38,14 @@ class KVManager:
                  server_recv_port: str = "",
                  gpu_register_port: str = "",
                  event_collector: Optional[KVEventCollector] = None):
-        flexkv_logger.info(f"{model_config = }")
-        flexkv_logger.info(f"{cache_config = }")
+        # Use the curated ``__str__`` summaries. Dataclass repr includes
+        # credential-bearing fields such as ``redis_password``.
+        flexkv_logger.info(
+            "[FlexKV-CONFIG] operation=config action=load status=success "
+            "component=kv_manager model_config=%s cache_config=%s",
+            model_config,
+            cache_config,
+        )
         self.model_config = model_config
         self.cache_config = cache_config
 
@@ -129,6 +135,7 @@ class KVManager:
             return self.kv_task_engine.is_ready()
 
     def shutdown(self) -> None:
+        eviction_log_aggregator.flush()
         if self.server_client_mode:
             self.dp_client.shutdown()
             # Wait for the server process to exit after sending shutdown request

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -21,6 +21,7 @@ import time
 import numpy as np
 import torch
 
+from flexkv import c_ext
 from flexkv.server.client import KVDPClient
 from flexkv.server.server import KVServer, DPClient
 from flexkv.kvtask import KVTaskEngine, KVResponse
@@ -42,7 +43,8 @@ class KVManager:
         # credential-bearing fields such as ``redis_password``.
         flexkv_logger.info(
             "[FlexKV-CONFIG] operation=config act=load status=success "
-            "component=kv_manager model_config=%s cache_config=%s",
+            "component=kv_manager commit=%s model_config=%s cache_config=%s",
+            getattr(c_ext, "__git_commit__", "unknown"),
             model_config,
             cache_config,
         )

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -41,7 +41,7 @@ class KVManager:
         # Use the curated ``__str__`` summaries. Dataclass repr includes
         # credential-bearing fields such as ``redis_password``.
         flexkv_logger.info(
-            "[FlexKV-CONFIG] operation=config action=load status=success "
+            "[FlexKV-CONFIG] operation=config act=load status=success "
             "component=kv_manager model_config=%s cache_config=%s",
             model_config,
             cache_config,

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -1,8 +1,9 @@
+import logging
 import time
 from typing import Dict, Optional, List, Union, Tuple
 import threading
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 import multiprocessing as mp
 import copy
@@ -72,6 +73,7 @@ class KVTask:
     # SWA GPU slot_mapping (SWA-pool token index space), bound LATE at launch —
     # the SWA counterpart to slot_mapping. None when the request has no SWA ops.
     swa_slot_mapping: Optional[np.ndarray] = None
+    created_ns: int = field(default_factory=time.perf_counter_ns)
 
     def is_completed(self) -> bool:
         return self.status in [TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED]
@@ -207,6 +209,57 @@ class KVTaskManager:
             self.remote_process.close()
             self.remote_process = None
 
+    @staticmethod
+    def _operation_name(task_type: TaskType) -> str:
+        if task_type in (TaskType.GET, TaskType.BATCH_GET):
+            return "get"
+        if task_type in (TaskType.PUT, TaskType.BATCH_PUT):
+            return "put"
+        return "prefetch"
+
+    def _log_task_created(self, task: KVTask) -> None:
+        if not flexkv_logger.is_enabled_for(logging.DEBUG):
+            return
+        graph_id = task.graph.graph_id if task.graph is not None else -1
+        tokens = len(task.token_ids) if task.token_ids is not None else 0
+        flexkv_logger.debug(
+            "[FlexKV-IO] operation=%s action=create status=%s blocks=%d "
+            "flexkv_task_id=%d graph_id=%d tokens=%d graph_ops=%d",
+            self._operation_name(task.task_type),
+            task.status.value,
+            tokens // self.cache_config.tokens_per_block,
+            task.task_id,
+            graph_id,
+            tokens,
+            task.graph.num_ops if task.graph is not None else 0,
+        )
+
+    def _log_task_terminal(self, task: KVTask, status: TaskStatus) -> None:
+        graph_ops = task.graph.num_ops if task.graph is not None else 0
+        if status == TaskStatus.COMPLETED:
+            level = logging.INFO if graph_ops else logging.DEBUG
+        else:
+            level = logging.WARNING
+        if not flexkv_logger.is_enabled_for(level):
+            return
+        graph_id = task.graph.graph_id if task.graph is not None else -1
+        duration_s = (time.perf_counter_ns() - task.created_ns) / 1e9
+        if level == logging.INFO:
+            log = flexkv_logger.info
+        elif level == logging.DEBUG:
+            log = flexkv_logger.debug
+        else:
+            log = flexkv_logger.warning
+        log(
+            "[FlexKV-IO] operation=%s action=complete status=%s "
+            "flexkv_task_id=%d graph_id=%d task_time=%.4fs",
+            self._operation_name(task.task_type),
+            convert_to_response_status(status).value,
+            task.task_id,
+            graph_id,
+            duration_s,
+        )
+
     def create_get_task(self,
                         task_id: int,
                         token_ids: np.ndarray,
@@ -244,6 +297,7 @@ class KVTaskManager:
             op_callback_dict=op_callback_dict)
 
         self.graph_to_task[graph.graph_id] = task_id
+        self._log_task_created(self.tasks[task_id])
 
     def create_put_task(self,
                         task_id: int,
@@ -277,6 +331,7 @@ class KVTaskManager:
             callback=callback,
             op_callback_dict=op_callback_dict)
         self.graph_to_task[graph.graph_id] = task_id
+        self._log_task_created(self.tasks[task_id])
 
     def create_prefetch_task(self,
                             task_id: int,
@@ -316,6 +371,7 @@ class KVTaskManager:
         self.prefetch_tasks[self._gen_prefetch_key(token_ids, namespace)] = task_id
 
         self.graph_to_task[graph.graph_id] = task_id
+        self._log_task_created(self.tasks[task_id])
 
     def _launch_task(self, task_id: int) -> None:
         transfer_graph = self.check_task_ready(task_id)
@@ -378,6 +434,7 @@ class KVTaskManager:
         task = self.tasks[task_id]
         if not task.is_completed():
             task.status = TaskStatus.CANCELLED
+            self._log_task_terminal(task, TaskStatus.CANCELLED)
         self._release_task(task_id)
 
     def check_completed(self, task_id: int, completely: bool = False) -> bool:
@@ -436,6 +493,14 @@ class KVTaskManager:
         if task.status != TaskStatus.READY:
             raise ValueError(f"Task {task_id} status is {task.status}, cannot launch")
         task.status = TaskStatus.RUNNING
+        if flexkv_logger.is_enabled_for(logging.DEBUG):
+            flexkv_logger.debug(
+                "[FlexKV-IO] operation=%s action=launch status=running "
+                "flexkv_task_id=%d graph_id=%d",
+                self._operation_name(task.task_type),
+                task.task_id,
+                task.graph.graph_id,
+            )
         return task.graph
 
     def _release_task(self, task_id: int) -> None:
@@ -460,6 +525,7 @@ class KVTaskManager:
                 task.callback()
         task.status = TaskStatus.COMPLETED
         task.task_end_op_finished = True
+        self._log_task_terminal(task, TaskStatus.COMPLETED)
         self.graph_to_task.pop(task.graph.graph_id, None)
         task.shed_heavy_resources()
 
@@ -855,6 +921,20 @@ class KVTaskEngine(KVTaskManager):
             op_callback_dict=op_callback_dict,
         )
         self.graph_to_task[batch_task_graph.graph_id] = batch_id
+        if flexkv_logger.is_enabled_for(logging.INFO):
+            operation = self._operation_name(batch_task_type)
+            flexkv_logger.info(
+                "[FlexKV-IO] operation=%s action=merge status=ready direction=%s "
+                "child_task_ids=%s flexkv_batch_task_id=%d graph_id=%d "
+                "transfer_mode=%s graph_ops=%d",
+                operation,
+                "H2D" if operation == "get" else "D2H",
+                ",".join(str(task_id) for task_id in task_ids),
+                batch_id,
+                batch_task_graph.graph_id,
+                "layerwise" if layerwise_transfer else "no-layerwise",
+                batch_task_graph.num_ops,
+            )
         for task_id in task_ids:
             child_task = self.tasks[task_id]
             if child_task.graph is not None:

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -223,7 +223,7 @@ class KVTaskManager:
         graph_id = task.graph.graph_id if task.graph is not None else -1
         tokens = len(task.token_ids) if task.token_ids is not None else 0
         flexkv_logger.debug(
-            "[FlexKV-IO] operation=%s action=create status=%s blocks=%d "
+            "[FlexKV-IO] operation=%s act=create status=%s blocks=%d "
             "flexkv_task_id=%d graph_id=%d tokens=%d graph_ops=%d",
             self._operation_name(task.task_type),
             task.status.value,
@@ -251,7 +251,7 @@ class KVTaskManager:
         else:
             log = flexkv_logger.warning
         log(
-            "[FlexKV-IO] operation=%s action=complete status=%s "
+            "[FlexKV-IO] operation=%s act=complete status=%s "
             "flexkv_task_id=%d graph_id=%d task_time=%.4fs",
             self._operation_name(task.task_type),
             convert_to_response_status(status).value,
@@ -495,7 +495,7 @@ class KVTaskManager:
         task.status = TaskStatus.RUNNING
         if flexkv_logger.is_enabled_for(logging.DEBUG):
             flexkv_logger.debug(
-                "[FlexKV-IO] operation=%s action=launch status=running "
+                "[FlexKV-IO] operation=%s act=launch status=running "
                 "flexkv_task_id=%d graph_id=%d",
                 self._operation_name(task.task_type),
                 task.task_id,
@@ -924,9 +924,9 @@ class KVTaskEngine(KVTaskManager):
         if flexkv_logger.is_enabled_for(logging.INFO):
             operation = self._operation_name(batch_task_type)
             flexkv_logger.info(
-                "[FlexKV-IO] operation=%s action=merge status=ready direction=%s "
+                "[FlexKV-IO] operation=%s act=merge status=ready direction=%s "
                 "child_task_ids=%s flexkv_batch_task_id=%d graph_id=%d "
-                "transfer_mode=%s graph_ops=%d",
+                "mode=%s graph_ops=%d",
                 operation,
                 "H2D" if operation == "get" else "D2H",
                 ",".join(str(task_id) for task_id in task_ids),

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import os
 import copy
 
@@ -278,39 +279,57 @@ class TransferWorkerBase(ABC):
                                   start_time: float,
                                   end_time: float,
                                   uncompressed_size: Optional[int] = None) -> None:
-        """Common method to log transfer performance"""
-        size_text = (
-            f"comp_ratio: {uncompressed_size / transfer_size:.3f}x "
-            f"comp_size: {transfer_size / (1024 * 1024 * 1024):.3f} GB "
-            f"uncomp_size: {uncompressed_size / (1024 * 1024 * 1024):.3f} GB "
-            if uncompressed_size is not None and transfer_size > 0
-            else f"transfer data size: {transfer_size / (1024 * 1024 * 1024)} GB "
+        """Emit one terminal record per transfer op."""
+        if not flexkv_logger.is_enabled_for(logging.INFO):
+            return
+        duration_s = max(end_time - start_time, 1e-9)
+        is_layerwise = transfer_op.transfer_type == TransferType.LAYERWISE
+        direction = "H2D" if is_layerwise else transfer_op.transfer_type.value
+        blocks = (
+            len(transfer_op.src_block_ids_h2d)
+            if is_layerwise
+            else transfer_op.valid_block_num
         )
-        flexkv_logger.info(
-            f"[FlexKV-IO] direction={self._io_direction(transfer_op.transfer_type)} "
-            f"path={self._io_path(transfer_op.transfer_type)} phase=complete "
-            f"request_id={transfer_op.transfer_op_id} "
-            f"graph_id={transfer_op.transfer_graph_id} bytes={transfer_size} "
-            f"{transfer_op.transfer_type.name} transfer request: "
-            f"{transfer_op.transfer_op_id} finished "
-            f"{size_text}"
-            f"transfer time: {end_time - start_time:.4f} s "
-            f"transfer bandwidth: {transfer_size / (end_time - start_time) / 1e9:.2f} GB/s"
-        )
+        transfer_mode = "layerwise" if is_layerwise else "no-layerwise"
+        bandwidth = transfer_size / duration_s / 1e9
 
-    @staticmethod
-    def _io_direction(transfer_type: TransferType) -> str:
-        if transfer_type in (TransferType.H2D, TransferType.LAYERWISE):
-            return "H2D"
-        if transfer_type == TransferType.D2H:
-            return "D2H"
-        return transfer_type.name
-
-    @staticmethod
-    def _io_path(transfer_type: TransferType) -> str:
-        if transfer_type == TransferType.LAYERWISE:
-            return "layerwise"
-        return "bulk"
+        if (
+            uncompressed_size is not None
+            and transfer_size > 0
+            and uncompressed_size != transfer_size
+        ):
+            flexkv_logger.info(
+                "[FlexKV-IO] operation=transfer action=complete status=success "
+                "direction=%s blocks=%d op_id=%d graph_id=%d transfer_mode=%s "
+                "compressed_size=%.6gGB original_size=%.6gGB "
+                "compression_ratio=%.2fx transfer_time=%.4fs "
+                "transfer_bandwidth=%.2fGB/s",
+                direction,
+                blocks,
+                transfer_op.transfer_op_id,
+                transfer_op.transfer_graph_id,
+                transfer_mode,
+                transfer_size / (1024**3),
+                uncompressed_size / (1024**3),
+                uncompressed_size / transfer_size,
+                duration_s,
+                bandwidth,
+            )
+        else:
+            flexkv_logger.info(
+                "[FlexKV-IO] operation=transfer action=complete status=success "
+                "direction=%s blocks=%d op_id=%d graph_id=%d transfer_mode=%s "
+                "transfer_data_size=%.6gGB transfer_time=%.4fs "
+                "transfer_bandwidth=%.2fGB/s",
+                direction,
+                blocks,
+                transfer_op.transfer_op_id,
+                transfer_op.transfer_graph_id,
+                transfer_mode,
+                transfer_size / (1024**3),
+                duration_s,
+                bandwidth,
+            )
 
     @abstractmethod
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
@@ -340,15 +359,39 @@ class TransferWorkerBase(ABC):
                         batch_ops.append(op)
                     for op in batch_ops:
                         transfer_status = False
+                        transfer_start_ns = time.perf_counter_ns()
+                        nvtx_pushed = False
                         try:
                             nvtx.push_range(f"launch {op.transfer_type.name} op_id: {op.transfer_op_id}, "
                                                 f"graph_id: {op.transfer_graph_id}",
                                                 color=get_nvtx_range_color(op.transfer_graph_id))
+                            nvtx_pushed = True
                             transfer_status = self.launch_transfer(op)
-                            nvtx.pop_range()
                         except Exception as e:
-                            flexkv_logger.error(f"Error launching transfer: {e}\n"
-                                        f"Failed transfer op: {op}")
+                            is_layerwise = op.transfer_type == TransferType.LAYERWISE
+                            direction = "H2D" if is_layerwise else op.transfer_type.value
+                            blocks = (
+                                len(op.src_block_ids_h2d)
+                                if is_layerwise
+                                else op.valid_block_num
+                            )
+                            flexkv_logger.error(
+                                "[FlexKV-IO] operation=transfer action=complete "
+                                "status=failed direction=%s blocks=%d op_id=%d "
+                                "graph_id=%d transfer_mode=%s transfer_time=%.4fs "
+                                "error=%r",
+                                direction,
+                                blocks,
+                                op.transfer_op_id,
+                                op.transfer_graph_id,
+                                "layerwise" if is_layerwise else "no-layerwise",
+                                (time.perf_counter_ns() - transfer_start_ns) / 1e9,
+                                str(e),
+                                exc_info=True,
+                            )
+                        finally:
+                            if nvtx_pushed:
+                                nvtx.pop_range()
                         if transfer_status:
                             ## only put the op when transfer success
                             self.finished_ops_queue.put(op.transfer_op_id)

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -299,11 +299,11 @@ class TransferWorkerBase(ABC):
             and uncompressed_size != transfer_size
         ):
             flexkv_logger.info(
-                "[FlexKV-IO] operation=transfer action=complete status=success "
-                "direction=%s blocks=%d op_id=%d graph_id=%d transfer_mode=%s "
+                "[FlexKV-IO] operation=transfer act=complete status=success "
+                "direction=%s blocks=%d op_id=%d graph_id=%d mode=%s "
                 "compressed_size=%.6gGB original_size=%.6gGB "
                 "compression_ratio=%.2fx transfer_time=%.4fs "
-                "transfer_bandwidth=%.2fGB/s",
+                "bandwidth=%.2fGB/s",
                 direction,
                 blocks,
                 transfer_op.transfer_op_id,
@@ -317,10 +317,9 @@ class TransferWorkerBase(ABC):
             )
         else:
             flexkv_logger.info(
-                "[FlexKV-IO] operation=transfer action=complete status=success "
-                "direction=%s blocks=%d op_id=%d graph_id=%d transfer_mode=%s "
-                "transfer_data_size=%.6gGB transfer_time=%.4fs "
-                "transfer_bandwidth=%.2fGB/s",
+                "[FlexKV-IO] operation=transfer act=complete status=success "
+                "direction=%s blocks=%d op_id=%d graph_id=%d mode=%s "
+                "data_size=%.6gGB transfer_time=%.4fs bandwidth=%.2fGB/s",
                 direction,
                 blocks,
                 transfer_op.transfer_op_id,
@@ -376,9 +375,9 @@ class TransferWorkerBase(ABC):
                                 else op.valid_block_num
                             )
                             flexkv_logger.error(
-                                "[FlexKV-IO] operation=transfer action=complete "
+                                "[FlexKV-IO] operation=transfer act=complete "
                                 "status=failed direction=%s blocks=%d op_id=%d "
-                                "graph_id=%d transfer_mode=%s transfer_time=%.4fs "
+                                "graph_id=%d mode=%s transfer_time=%.4fs "
                                 "error=%r",
                                 direction,
                                 blocks,

--- a/install.sh
+++ b/install.sh
@@ -283,8 +283,8 @@ if [ "$ENABLE_METRICS" -eq 1 ]; then
     info "Metrics enabled: initializing all submodules (including prometheus-cpp)..."
     git submodule update --init --recursive
 else
-    info "Metrics disabled: initializing only xxHash submodule..."
-    git submodule update --init --recursive third_party/xxHash
+    info "Metrics disabled: initializing required xxHash and spdlog submodules..."
+    git submodule update --init --recursive third_party/xxHash third_party/spdlog
 fi
 success "Git submodules initialized."
 

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,28 @@ def get_version():
     except Exception:
         return "0.0.0+unknown"
 
+
+def get_git_commit():
+    commit = os.environ.get("FLEXKV_GIT_COMMIT") or os.environ.get("GITHUB_SHA")
+    if not commit:
+        import subprocess
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                stderr=subprocess.PIPE,
+                cwd=os.path.dirname(os.path.abspath(__file__)),
+            ).decode().strip()
+        except Exception:
+            return "unknown"
+
+    commit = commit.strip().lower()
+    if not commit or any(char not in "0123456789abcdef" for char in commit):
+        return "unknown"
+    return commit[:12]
+
+
+build_git_commit = get_git_commit()
+
 build_dir = "build"
 os.makedirs(build_dir, exist_ok=True)
 
@@ -287,7 +309,11 @@ if not os.environ.get("TORCH_CUDA_ARCH_LIST"):
     os.environ["TORCH_CUDA_ARCH_LIST"] = detect_cuda_arch()
 print(f"TORCH_CUDA_ARCH_LIST = {os.environ['TORCH_CUDA_ARCH_LIST']}")
 
-extra_compile_args = ["-std=c++17", "-O3"]
+extra_compile_args = [
+    "-std=c++17",
+    "-O3",
+    f'-DFLEXKV_GIT_COMMIT=\\"{build_git_commit}\\"',
+]
 if enable_metrics:
     extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")
 include_dirs = [

--- a/setup.py
+++ b/setup.py
@@ -217,6 +217,13 @@ def get_version():
 build_dir = "build"
 os.makedirs(build_dir, exist_ok=True)
 
+spdlog_include_dir = os.path.abspath("third_party/spdlog/include")
+if not os.path.isdir(spdlog_include_dir):
+    raise RuntimeError(
+        "third_party/spdlog is missing; run "
+        "git submodule update --init third_party/spdlog"
+    )
+
 # Check if we're in debug mode using environment variable
 debug = os.environ.get("FLEXKV_DEBUG") == "1"
 if debug:
@@ -233,6 +240,7 @@ enable_metrics = os.environ.get("FLEXKV_ENABLE_METRICS", "0") == "1"
 # Define C++ extensions (base: no dist/Redis)
 cpp_sources = [
     "csrc/bindings.cpp",
+    "csrc/logging.cpp",
     "csrc/transfer.cu",  # Skip CUDA file for now
     "csrc/ce_transfer.cu",
     "csrc/hash.cpp",
@@ -245,6 +253,7 @@ cpp_sources = [
 ]
 
 hpp_sources = [
+    "csrc/logging.h",
     "csrc/cache_utils.h",
     "csrc/tp_transfer_thread_group.h",
     "csrc/transfer_ssd.h",
@@ -284,6 +293,7 @@ if enable_metrics:
 include_dirs = [
     os.path.abspath(os.path.join(build_dir, "include")),
     os.path.abspath("csrc"),
+    spdlog_include_dir,
 ]
 
 # Add rpath to find libraries at runtime

--- a/tests/test_namespace_isolation.py
+++ b/tests/test_namespace_isolation.py
@@ -1,10 +1,18 @@
 import pytest
 import numpy as np
 
-from flexkv.common.block import SequenceMeta
+from flexkv.common.block import (
+    SequenceMeta,
+    format_block_hash,
+)
 
 
 class TestNamespace:
+    def test_block_hash_format_is_fixed_width_unsigned_hex(self):
+        assert format_block_hash(None) == "-"
+        assert format_block_hash(1) == "0x0000000000000001"
+        assert format_block_hash(-1) == "0xffffffffffffffff"
+
     def test_different_namespace_different_hash(self):
         tokens_per_block = 4
         token_ids = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64)

--- a/tests/test_operational_logging.py
+++ b/tests/test_operational_logging.py
@@ -53,7 +53,7 @@ def test_eviction_logging_keeps_batches_at_debug_and_aggregates_info():
     levels = [level for level, _ in logger.records]
     assert levels == ["debug", "debug", "info"]
     summary = logger.records[-1][1]
-    assert "operation=eviction action=summary status=success" in summary
+    assert "operation=eviction act=summary status=success" in summary
     assert "schema_version" not in summary
     assert "batches=2" in summary
     assert "evicted_blocks=6" in summary
@@ -70,6 +70,6 @@ def test_eviction_target_miss_warns_immediately():
 
     assert [level for level, _ in logger.records] == ["warning"]
     warning = logger.records[-1][1]
-    assert "operation=eviction action=batch status=target_miss" in warning
+    assert "operation=eviction act=batch status=target_miss" in warning
     assert "target_met=false" in warning
     assert "eviction_time=0.0013s" in warning

--- a/tests/test_operational_logging.py
+++ b/tests/test_operational_logging.py
@@ -1,0 +1,75 @@
+import logging
+
+from flexkv.common.debug import EvictionLogAggregator
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.records = []
+
+    def debug(self, message, *args):
+        self.records.append(("debug", message % args))
+
+    def info(self, message, *args):
+        self.records.append(("info", message % args))
+
+    def warning(self, message, *args):
+        self.records.append(("warning", message % args))
+
+    def is_enabled_for(self, level):
+        return level >= logging.DEBUG
+
+
+def _record(aggregator, *, target_met=True, evicted_blocks=3):
+    aggregator.record(
+        tier="cpu",
+        scope="full",
+        reason="capacity",
+        requested_blocks=2,
+        required_blocks=3,
+        evicted_blocks=evicted_blocks,
+        free_blocks_before=0,
+        free_blocks_after=evicted_blocks,
+        total_blocks=100,
+        duration_ms=1.25,
+        sample_block_hashes=["0x0000000000000001"],
+        target_met=target_met,
+    )
+
+
+def test_eviction_logging_keeps_batches_at_debug_and_aggregates_info():
+    now = [0.0]
+    logger = _FakeLogger()
+    aggregator = EvictionLogAggregator(
+        interval_s=10.0, logger=logger, clock=lambda: now[0]
+    )
+
+    _record(aggregator)
+    assert [level for level, _ in logger.records] == ["debug"]
+
+    now[0] = 10.0
+    _record(aggregator)
+
+    levels = [level for level, _ in logger.records]
+    assert levels == ["debug", "debug", "info"]
+    summary = logger.records[-1][1]
+    assert "operation=eviction action=summary status=success" in summary
+    assert "schema_version" not in summary
+    assert "batches=2" in summary
+    assert "evicted_blocks=6" in summary
+    assert "eviction_time=0.0025s" in summary
+
+
+def test_eviction_target_miss_warns_immediately():
+    logger = _FakeLogger()
+    aggregator = EvictionLogAggregator(
+        interval_s=10.0, logger=logger, clock=lambda: 0.0
+    )
+
+    _record(aggregator, target_met=False, evicted_blocks=0)
+
+    assert [level for level, _ in logger.records] == ["warning"]
+    warning = logger.records[-1][1]
+    assert "operation=eviction action=batch status=target_miss" in warning
+    assert "target_met=false" in warning
+    assert "eviction_time=0.0013s" in warning


### PR DESCRIPTION
## Summary

- Add correlated lifecycle logs across FlexKV tasks, transfer graphs, and transfer operations using `flexkv_task_id`, `graph_id`, and `op_id`.
- Standardize transfer, layerwise merge, task completion, and eviction logs around readable `operation/action/status` fields and consistent transfer statistics.
- Add a unified native C++ logging facade backed by pinned spdlog v1.17.0, using synchronous stdout and the existing `FLEXKV_LOG_LEVEL` and `FLEXKV_LOGGING_PREFIX` settings.
- Replace native `printf`/`fprintf`/`perror`/`cout`/`cerr` calls across IOUring, SSD, PCFS, layerwise, GDS, metrics, radix tree, and nvcomp paths.
- Keep routine eviction batches at DEBUG, emit a periodic INFO summary, and warn immediately when an eviction target is not met.
- Gate log-only formatting and layerwise CUDA timing events behind level checks, and avoid exposing credential-bearing configuration reprs.

## Why

The previous Python and native logs used several incompatible formats and did not expose enough stable identifiers to reconstruct a request across SGLang and FlexKV. Native output bypassed log-level filtering and lacked consistent timestamps, process/thread context, and structured fields. Transfer completion and layerwise merge events were also difficult to join, while logging every eviction batch or GDS block would create unnecessary noise.

## Validation

- Operational logging tests: 2 passed.
- Native logger smoke tests verified INFO, DEBUG, OFF, and custom-prefix behavior.
- CMake builds passed with Prometheus monitoring both enabled and disabled.
- Standalone native logger and metrics-manager compilation passed.
- Python, shell, and diff hygiene checks passed.
- The full FlexKV test suite could not be collected on the macOS development host because `libcudart.so.11` is unavailable.
- Ruff reports only rule violations already present on `main` for the touched Python code paths.
