### PR TITLE
Dsv4 metrics on main

### DIFF
--- a/docs/monitoring/README_en.md
+++ b/docs/monitoring/README_en.md
@@ -13,6 +13,7 @@ FlexKV integrates a [Prometheus](https://prometheus.io/)-based runtime metrics m
 | `FLEXKV_ENABLE_METRICS` | `0` | Enable metrics collection (set to `1` to enable, disabled by default) |
 | `FLEXKV_PY_METRICS_PORT` | `8080` | Python metrics HTTP server port |
 | `FLEXKV_CPP_METRICS_PORT` | `8081` | C++ metrics HTTP server port |
+| `PROMETHEUS_MULTIPROC_DIR` | - | Optional. Directory for `prometheus_client` multiprocess aggregation. Set it (before process start) to export metrics recorded in spawned subprocesses — currently the layerwise startup/submit metrics recorded in the TransferManager process. Metrics recorded in the main process (cache/SWA/transfer/pool) are exported without it. |
 
 ### 1.2 Configuration
 
@@ -45,6 +46,38 @@ Python metrics are recorded by `GlobalCacheEngine` in `cache_engine.py` and coll
 | `flexkv_py_evicted_blocks_total` | Counter | `device` | Total number of evicted blocks |
 | `flexkv_py_allocated_blocks_total` | Counter | `device` | Total number of allocated blocks |
 | `flexkv_py_allocation_failures_total` | Counter | `mode` | Number of allocation failures |
+
+#### DSV4 Metrics (SWA / Cache Query / Layerwise)
+
+Metrics for DeepSeek-V4-style deployments: sliding-window attention (SWA) cache, per-tier match readiness, and layerwise transfer startup/dispatch. Recorded by `GlobalCacheEngine` (main process) and `TransferEngine` (TransferManager subprocess; layerwise metrics require `PROMETHEUS_MULTIPROC_DIR` to be aggregated into the HTTP endpoint).
+
+**SWA:**
+
+| Metric Name | Type | Labels | Description |
+|---|---|---|---|
+| `flexkv_py_swa_query_total` | Counter | `result` (`hit`/`miss`) | SWA-aware GET queries by result |
+| `flexkv_py_swa_hit_blocks_total` | Counter | - | Blocks served from an SWA read source on hits |
+| `flexkv_py_swa_slot_used` | Gauge | `device` | SWA host-pool slots currently in use, per tier |
+| `flexkv_py_swa_slot_total` | Gauge | `device` | SWA host-pool total slots, per tier |
+| `flexkv_py_swa_slot_alloc_failed_total` | Counter | `device` | SWA slot allocation failures (pool still full after one eviction retry) |
+| `flexkv_py_swa_evicted_slots_total` | Counter | `device`, `reason` (`pool_full`/`cascade`) | SWA slots freed: `pool_full` = SWA-LRU eviction under pool pressure; `cascade` = detached by radix-tree structural changes |
+| `flexkv_py_swa_transfer_bytes_total` | Counter | `operation` | Bytes transferred by SWA (`is_swa`) ops after completion |
+
+**Cache query / readiness:**
+
+| Metric Name | Type | Labels | Description |
+|---|---|---|---|
+| `flexkv_py_cache_query_total` | Counter | `result` (`full`/`partial`/`miss`) | GET queries by coverage of the queried window |
+| `flexkv_py_cache_match_blocks_total` | Counter | `device`, `ready` (`true`/`false`) | Blocks matched in the radix tree per tier, split by data readiness. `ready=true` is immediately reusable ("effective reuse"); `ready=false` is matched but still in flight |
+
+**Layerwise:**
+
+| Metric Name | Type | Labels | Description |
+|---|---|---|---|
+| `flexkv_py_layerwise_workers_ready` | Gauge | - | Layerwise workers that finished initialization (eventfd handshake) |
+| `flexkv_py_layerwise_workers_expected` | Gauge | - | Layerwise workers expected at startup |
+| `flexkv_py_layerwise_submit_seconds` | Histogram | - | Time to fan out a LAYERWISE op to all sibling workers (successful fan-outs only) |
+| `flexkv_py_layerwise_submit_total` | Counter | `status` (`ok`/`error`) | LAYERWISE op fan-out count by status |
 
 ---
 

--- a/docs/monitoring/README_zh.md
+++ b/docs/monitoring/README_zh.md
@@ -13,6 +13,7 @@ FlexKV 集成了基于 [Prometheus](https://prometheus.io/) 的运行时指标�
 | `FLEXKV_ENABLE_METRICS` | `0` | 启用指标收集（设为 `1` 启用，默认禁用） |
 | `FLEXKV_PY_METRICS_PORT` | `8080` | Python 指标 HTTP 服务端口 |
 | `FLEXKV_CPP_METRICS_PORT` | `8081` | C++ 指标 HTTP 服务端口 |
+| `PROMETHEUS_MULTIPROC_DIR` | - | 可选。`prometheus_client` 多进程聚合目录。在进程启动前设置后，可汇聚 spawn 子进程中记录的指标（目前是 TransferManager 进程中的 layerwise 启动/提交指标）。主进程指标（缓存/SWA/传输/内存池）不依赖此变量 |
 
 ### 1.2 配置方式
 
@@ -45,6 +46,38 @@ Python 指标由 `GlobalCacheEngine` 在 `cache_engine.py` 中记录，通过 `F
 | `flexkv_py_evicted_blocks_total` | Counter | `device` | 驱逐的 blocks 总数 |
 | `flexkv_py_allocated_blocks_total` | Counter | `device` | 分配的 blocks 总数 |
 | `flexkv_py_allocation_failures_total` | Counter | `mode` | 资源分配失败次数 |
+
+#### DSV4 指标（SWA / 缓存查询 / Layerwise）
+
+面向 DeepSeek-V4 形态部署的指标：滑动窗口注意力（SWA）缓存、分层匹配就绪状态、layerwise 传输启动/派发。由 `GlobalCacheEngine`（主进程）和 `TransferEngine`（TransferManager 子进程；layerwise 指标需设置 `PROMETHEUS_MULTIPROC_DIR` 才会汇聚到 HTTP 端点）记录。
+
+**SWA：**
+
+| 指标名称 | 类型 | 标签 | 描述 |
+|---|---|---|---|
+| `flexkv_py_swa_query_total` | Counter | `result`（`hit`/`miss`） | SWA 感知 GET 查询次数，按结果分类 |
+| `flexkv_py_swa_hit_blocks_total` | Counter | - | SWA 读源命中服务的 blocks 总数 |
+| `flexkv_py_swa_slot_used` | Gauge | `device` | SWA host-pool 已用 slot 数（按层级） |
+| `flexkv_py_swa_slot_total` | Gauge | `device` | SWA host-pool 总 slot 数（按层级） |
+| `flexkv_py_swa_slot_alloc_failed_total` | Counter | `device` | SWA slot 分配失败次数（淘汰重试后池仍满） |
+| `flexkv_py_swa_evicted_slots_total` | Counter | `device`, `reason`（`pool_full`/`cascade`） | SWA slot 释放数：`pool_full` = 池满触发 SWA-LRU 淘汰；`cascade` = radix 树结构变化级联释放 |
+| `flexkv_py_swa_transfer_bytes_total` | Counter | `operation` | SWA（`is_swa`）op 完成后统计的传输字节数 |
+
+**缓存查询 / 就绪状态：**
+
+| 指标名称 | 类型 | 标签 | 描述 |
+|---|---|---|---|
+| `flexkv_py_cache_query_total` | Counter | `result`（`full`/`partial`/`miss`） | GET 查询按查询窗口覆盖度分类的次数 |
+| `flexkv_py_cache_match_blocks_total` | Counter | `device`, `ready`（`true`/`false`） | radix 树命中的 blocks 按层级与数据就绪状态拆分。`ready=true` 即可直接复用量（有效复用）；`ready=false` 为已匹配但仍在传输中 |
+
+**Layerwise：**
+
+| 指标名称 | 类型 | 标签 | 描述 |
+|---|---|---|---|
+| `flexkv_py_layerwise_workers_ready` | Gauge | - | 已完成初始化（eventfd 握手）的 layerwise worker 数 |
+| `flexkv_py_layerwise_workers_expected` | Gauge | - | 启动时预期的 layerwise worker 数 |
+| `flexkv_py_layerwise_submit_seconds` | Histogram | - | 将 LAYERWISE op 扇出到全部 sibling worker 的耗时（仅统计成功扇出） |
+| `flexkv_py_layerwise_submit_total` | Counter | `status`（`ok`/`error`） | LAYERWISE op 扇出次数（按状态） |
 
 ---
 

--- a/docs/monitoring/dsv4_metrics_test_report_zh.md
+++ b/docs/monitoring/dsv4_metrics_test_report_zh.md
@@ -19,6 +19,7 @@
 | 5 | 实机部署（sglang + DSV4-Flash tp4） | 真实推理请求 + `/metrics` 抓取 | 服务稳定，SWA/传输指标实时变化 |
 | 6 | 引擎级命中路径 | kvtask 测试 + multiproc 聚合 | 命中类指标准确触发（`cache_query{full}`、`cache_match{ready=true}`、`swa_query{hit}`） |
 | 7 | 关闭路径零副作用 | 单测 disabled 用例 + 关闭态全量回归 | 所有 `record_*` 为 no-op，行为与改造前一致 |
+| 8 | 单进程端点输出 | 独立进程起 8080 + curl | 修复后全部 13 个新指标准确输出（见第 8 节） |
 
 ---
 
@@ -160,6 +161,34 @@ flexkv_py_allocated_blocks_total {'device': 'cpu'} = 16.0
 
 - 单测 `TestDisabledPath`：metrics 关闭时全部 `record_*`（含 Histogram `observe`）为 no-op 且不抛异常；
 - 关闭态全量回归（见第 2 节）与改造前基线一致。
+
+## 8. 单进程端点输出（含一次实测暴露问题的修复记录）
+
+验证中单进程模式（未设 `PROMETHEUS_MULTIPROC_DIR`）曾暴露问题：8080 端点无任何 `flexkv_py_*` 输出。根因：collector 支持 registry 注入的实现将 `registry=None` 显式传给指标构造函数，而 prometheus_client 在**显式** `registry=None` 时完全跳过注册（与"不传该参数默认注册到全局 REGISTRY"语义不同）。此前未暴露的原因：单测均注入独立 registry；多进程模式数值写 mmap 文件、`MultiProcessCollector` 直接读文件聚合，不依赖注册。
+
+修复（commit `fix(metrics)`）：未注入 registry 时回退到 prometheus 默认 `REGISTRY`；新增回归用例 `TestDefaultRegistry::test_metrics_land_in_default_registry`（覆盖默认 REGISTRY 路径，且通过前后清理做到与套件执行顺序无关）。
+
+修复后单进程独立验证：
+
+```
+$ FLEXKV_ENABLE_METRICS=1 python <standalone_server_script> &
+$ curl -s http://127.0.0.1:8080/metrics | grep ^flexkv_py_
+
+flexkv_py_cache_match_blocks_total{device="cpu",ready="true"} 20.0
+flexkv_py_cache_match_blocks_total{device="cpu",ready="false"} 3.0
+flexkv_py_cache_query_total{result="full"} 1.0
+flexkv_py_layerwise_submit_seconds_count 1.0
+flexkv_py_layerwise_submit_seconds_sum 0.004
+flexkv_py_layerwise_submit_total{status="ok"} 1.0
+flexkv_py_swa_evicted_slots_total{device="cpu",reason="pool_full"} 2.0
+flexkv_py_swa_hit_blocks_total 12.0
+flexkv_py_swa_query_total{result="hit"} 1.0
+flexkv_py_swa_slot_total{device="cpu"} 256.0
+flexkv_py_swa_slot_used{device="cpu"} 1.0
+...（13 个新指标全部正常输出，含 0 值 label 组合）
+```
+
+修复后测试：单测 14/14 通过（新增 1 例回归），metrics 开启回归 218 通过。
 
 ---
 

--- a/docs/monitoring/dsv4_metrics_test_report_zh.md
+++ b/docs/monitoring/dsv4_metrics_test_report_zh.md
@@ -1,0 +1,171 @@
+# DSV4 指标功能测试记录
+
+| 项目 | 内容 |
+|---|---|
+| 被测功能 | DSV4 可观测性指标（SWA / 缓存查询就绪拆分 / Layerwise），共 13 个 `flexkv_py_*` 新指标 |
+| 代码分支 | `dsv4-metrics-on-main`（基于 `main` @ `3ecd83f`） |
+| 提交 | `270ab1c` feat(metrics): add DSV4 metrics infrastructure<br>`6746948` feat(metrics): instrument DSV4 SWA/cache-query/layerwise hook points |
+| 测试日期 | 2026-07-26 |
+| 测试环境 | 8×NVIDIA H20（使用 0-3 卡），CUDA 13.0，Python 3.12（venv `/data/workspace/dsv4-flexkv`），模型 `/data1/models/deepseek-ai/DeepSeek-V4-Flash` |
+
+## 结果汇总
+
+| # | 测试项 | 方式 | 结果 |
+|---|---|---|---|
+| 1 | 新增指标单元测试 | `pytest tests/test_metrics_dsv4.py` | 13/13 通过 |
+| 2 | 回归（metrics 关闭，默认） | 相关测试集 | 254 通过，5 失败（均为 main 自带上游测试漂移，与本改动无关，见末节） |
+| 3 | 回归（metrics 开启） | 相关测试集 | 217/217 通过 |
+| 4 | 多进程聚合冒烟 | spawn 子进程 + `MultiProcessCollector` | 聚合值正确（3+1=4） |
+| 5 | 实机部署（sglang + DSV4-Flash tp4） | 真实推理请求 + `/metrics` 抓取 | 服务稳定，SWA/传输指标实时变化 |
+| 6 | 引擎级命中路径 | kvtask 测试 + multiproc 聚合 | 命中类指标准确触发（`cache_query{full}`、`cache_match{ready=true}`、`swa_query{hit}`） |
+| 7 | 关闭路径零副作用 | 单测 disabled 用例 + 关闭态全量回归 | 所有 `record_*` 为 no-op，行为与改造前一致 |
+
+---
+
+## 1. 单元测试
+
+```
+$ python -m pytest tests/test_metrics_dsv4.py -v
+
+tests/test_metrics_dsv4.py::TestSWAMetrics::test_swa_query_and_hit_blocks PASSED [  7%]
+tests/test_metrics_dsv4.py::TestSWAMetrics::test_swa_slot_stats_and_failures PASSED [ 15%]
+tests/test_metrics_dsv4.py::TestSWAMetrics::test_swa_evicted_by_reason PASSED [ 23%]
+tests/test_metrics_dsv4.py::TestSWAMetrics::test_swa_transfer_bytes PASSED [ 30%]
+tests/test_metrics_dsv4.py::TestCacheEngineSWAHooks::test_slot_gauge_follows_alloc_and_free PASSED [ 38%]
+tests/test_metrics_dsv4.py::TestCacheEngineSWAHooks::test_alloc_failure_counts_after_eviction_retry PASSED [ 46%]
+tests/test_metrics_dsv4.py::TestCacheEngineSWAHooks::test_evict_and_cascade_counted PASSED [ 53%]
+tests/test_metrics_dsv4.py::TestCacheQueryMetrics::test_query_results PASSED [ 61%]
+tests/test_metrics_dsv4.py::TestCacheQueryMetrics::test_match_blocks_ready_split PASSED [ 69%]
+tests/test_metrics_dsv4.py::TestLayerwiseMetrics::test_workers_progress PASSED [ 76%]
+tests/test_metrics_dsv4.py::TestLayerwiseMetrics::test_submit_count_and_latency PASSED [ 84%]
+tests/test_metrics_dsv4.py::TestDisabledPath::test_all_record_methods_noop PASSED [ 92%]
+tests/test_metrics_dsv4.py::TestDisabledPath::test_engine_hooks_noop PASSED [100%]
+
+============================== 13 passed in 0.13s ==============================
+```
+
+覆盖：SWA 查询/命中块数、slot 水位 gauge、slot 分配失败、按原因淘汰（pool_full/cascade）、SWA 传输字节、缓存查询三态、ready/not-ready 拆分、layerwise 进度与提交时延、关闭态全 no-op（含引擎挂点）。
+
+## 2. 回归测试（metrics 关闭，默认路径）
+
+```
+$ python -m pytest tests/test_metrics_dsv4.py tests/test_cache_engine.py \
+    tests/test_kvtask_lifecycle.py tests/test_batch_kvtask.py \
+    tests/test_swa_control_plane.py tests/test_swa_peer_op.py \
+    tests/test_swa_state_sidecars.py tests/test_config_swa_multi_group.py -q
+
+FAILED tests/test_swa_state_sidecars.py::test_swa_multi_layer_false_keeps_sidecar_h2d_as_predecessor
+FAILED tests/test_config_swa_multi_group.py::test_swa_multi_layer_defaults_to_enabled
+FAILED tests/test_config_swa_multi_group.py::test_swa_multi_layer_env_override[0-False]
+FAILED tests/test_config_swa_multi_group.py::test_swa_multi_layer_env_override[1-True]
+FAILED tests/test_config_swa_multi_group.py::test_swa_multi_layer_rejects_non_boolean_config_value
+5 failed, 254 passed in 10.51s
+```
+
+5 个失败均为 **main 分支自带的上游测试漂移**：用例引用已不存在的 `swa_multi_layer` 配置属性（`UserConfig` 现仅有 `swa_multi_group`）。在未应用本改动的干净 main 上同样失败，与本 feature 无关。
+
+## 3. 回归测试（metrics 开启）
+
+```
+$ FLEXKV_ENABLE_METRICS=1 python -m pytest tests/test_metrics_dsv4.py \
+    tests/test_cache_engine.py tests/test_swa_control_plane.py -q
+
+217 passed in 2.66s
+```
+
+## 4. 多进程聚合冒烟
+
+模拟生产形态：spawn 子进程（worker 角色，不绑端口）记录 3 次计数，主进程记录 1 次，`MultiProcessCollector` 聚合：
+
+```
+$ PROMETHEUS_MULTIPROC_DIR=/tmp/prom_test FLEXKV_ENABLE_METRICS=1 python test_multiproc.py
+
+[FLEXKV] INFO [collector.py:263] Prometheus metrics collector initialized   # 子进程
+[FLEXKV] INFO [collector.py:263] Prometheus metrics collector initialized   # 主进程
+aggregated swa_query hit = 4.0
+multiprocess aggregation OK
+```
+
+## 5. 实机部署验证
+
+启动命令（关键点：`--moe-runner-backend marlin` 必需，当前 sglang 的 `auto` 不解析，否则 fp4 权重落到 fp8 triton kernel 报 `Hidden size mismatch`）：
+
+```
+FLEXKV_ENABLE_METRICS=1 PROMETHEUS_MULTIPROC_DIR=/tmp/flexkv_prom \
+python -m sglang.launch_server \
+  --model-path /data1/models/deepseek-ai/DeepSeek-V4-Flash \
+  --tp-size 4 --trust-remote-code --page-size 256 \
+  --mem-fraction-static 0.9 --kv-cache-dtype fp8_e4m3 \
+  --max-running-requests 4 --chunked-prefill-size 8192 \
+  --disable-cuda-graph --moe-runner-backend marlin \
+  --enable-flexkv --flexkv-config-file /data/flexkv-dsv4-test/flexkv_config.yaml
+```
+
+启动日志确认：
+
+```
+[FlexKV PyMetrics] Initialized successfully, exposing metrics at http://127.0.0.1:8080/metrics
+The server is fired up and ready to roll!
+```
+
+发送 2 次相同长 prompt 请求（均 200 正常返回；上一版分支无 keepalive 修复时首请求即 `tp_group_transfer failed: illegal memory access`，main 已修复）。
+
+请求后 `curl -s http://127.0.0.1:8080/metrics` 抓取（非零项）：
+
+```
+flexkv_py_swa_query_total{result="miss"} 2.0
+flexkv_py_swa_slot_total{device="cpu"} 2048.0
+flexkv_py_swa_slot_used{device="cpu"} 2.0
+flexkv_py_swa_transfer_bytes_total{operation="put"} 1.59616e+07
+flexkv_py_transfer_ops_total{operation="put",transfer_type="D2H"} 2.0
+flexkv_py_transfer_blocks_total{operation="put",transfer_type="D2H"} 3.0
+flexkv_py_transfer_bytes_total{operation="put",transfer_type="D2H"} 2.39424e+07
+```
+
+说明：SWA 查询 miss（首次无缓存）、slot 池 2/2048 使用中、SWA PUT 约 16MB、D2H 下沉 2 次/3 块/约 24MB，指标与流量行为一致。
+
+## 6. 引擎级命中路径验证
+
+实机洪泛难以可靠挤出 GPU 前缀（DSV4 hybrid 池 full-KV 仅 10%），改用 kvtask 级测试驱动真实引擎 GET/PUT 往返：
+
+```
+$ FLEXKV_ENABLE_METRICS=1 PROMETHEUS_MULTIPROC_DIR=/tmp/prom_rt \
+  python -m pytest tests/test_batch_kvtask.py tests/test_kvtask_lifecycle.py -q
+
+22 passed in 6.86s
+```
+
+`MultiProcessCollector` 聚合读取（非零项）：
+
+```
+flexkv_py_cache_query_total {'result': 'full'} = 7.0
+flexkv_py_cache_match_blocks_total {'device': 'cpu', 'ready': 'true'} = 20.0
+flexkv_py_cache_hit_blocks_total {'device': 'cpu'} = 20.0
+flexkv_py_swa_query_total {'result': 'hit'} = 3.0
+flexkv_py_swa_hit_blocks_total {} = 12.0
+flexkv_py_swa_slot_used {'device': 'cpu'} = 1.0
+flexkv_py_swa_slot_total {'device': 'cpu'} = 256.0
+flexkv_py_transfer_ops_total {'operation': 'get', 'transfer_type': 'H2D'} = 1.0
+flexkv_py_transfer_ops_total {'operation': 'unknown', 'transfer_type': 'D2H'} = 1.0
+flexkv_py_transfer_bytes_total {'operation': 'get', 'transfer_type': 'H2D'} = 8388608.0
+flexkv_py_transfer_bytes_total {'operation': 'unknown', 'transfer_type': 'D2H'} = 8388608.0
+flexkv_py_mempool_total_blocks {'device': 'cpu'} = 4096.0
+flexkv_py_mempool_free_blocks {'device': 'cpu'} = 4092.0
+flexkv_py_allocated_blocks_total {'device': 'cpu'} = 16.0
+```
+
+一致性校验：新指标 `cache_match_blocks_total{ready=true}`（20）与存量指标 `cache_hit_blocks_total{cpu}`（20）数值一致，"有效复用量"口径正确；H2D(get) 与 D2H(put) 字节数一致（8388608 B）。
+
+## 7. 关闭路径零副作用
+
+- 单测 `TestDisabledPath`：metrics 关闭时全部 `record_*`（含 Histogram `observe`）为 no-op 且不抛异常；
+- 关闭态全量回归（见第 2 节）与改造前基线一致。
+
+---
+
+## 已知问题与说明
+
+1. **上游测试漂移（非本改动引入）**：`tests/test_config_swa_multi_group.py` 4 例、`tests/test_swa_state_sidecars.py` 1 例引用已删除的 `swa_multi_layer` 配置属性，在干净 main 上即失败。
+2. **`CPURemoteTransferWorker.launch_transfer` 缺 `return True`**（上游 main 已确认存在）：remote op 永不回报完成、任务等满 20s 假超时。本部署未启用 remote tier 不受影响；做 remote IO 指标前需先修。
+3. **layerwise 指标**（workers_ready/expected、submit_*）产生在 TransferManager 子进程，需设置 `PROMETHEUS_MULTIPROC_DIR` 才能经 8080 端点聚合暴露；本次部署形态（layerwise=False）下恒为 0，属预期。
+4. **多进程端口仲裁**：各进程均尝试绑定 8080，先到先得，其余探测后跳过；sglang 会重命名进程，不可依赖进程名区分主/子。

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -185,10 +185,20 @@ class CacheEngineAccel:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
         from flexkv.swa.swa_host_pool import SWAHostPool
         self.swa_pool = SWAHostPool(swa_config)
+        self._record_swa_slot_stats()
 
     @property
     def swa_enabled(self) -> bool:
         return self.swa_pool is not None
+
+    def _swa_device_label(self) -> str:
+        return DEVICE_TYPE[self.device_type].lower()
+
+    def _record_swa_slot_stats(self) -> None:
+        """Push current SWA pool usage to metrics (no-op when disabled)."""
+        if self._metrics_collector is not None and self.swa_pool is not None:
+            self._metrics_collector.update_swa_slot_stats(
+                self._swa_device_label(), self.swa_pool.num_used, self.swa_pool.num_slots)
 
     def _alloc_swa_slot(self, protected_node=None) -> int:
         """Allocate one SWA slot; evict SWA-LRU once when the pool is full."""
@@ -196,6 +206,7 @@ class CacheEngineAccel:
             return -1
         slot = self.swa_pool.allocate()
         if slot is not None:
+            self._record_swa_slot_stats()
             return slot
         # can not allocate SWA slot, evict SWA-LRU once
         if protected_node is not None:
@@ -206,18 +217,30 @@ class CacheEngineAccel:
             if protected_node is not None:
                 self.unlock(protected_node)
         slot = self.swa_pool.allocate()
-        return slot if slot is not None else -1
+        if slot is None:
+            if self._metrics_collector is not None:
+                self._metrics_collector.record_swa_slot_alloc_failed(self._swa_device_label())
+            return -1
+        self._record_swa_slot_stats()
+        return slot
 
     def _free_swa_slot(self, slot: int) -> None:
         """Return one detached SWA slot to this tier's pool."""
         self.swa_pool.free(int(slot))
+        self._record_swa_slot_stats()
 
     def _drain_unmounted_swa_slots(self) -> None:
         """Return slots detached by radix-tree structural changes to the pool."""
         if self.swa_pool is None:
             return
-        for slot in self.index.drain_freed_swa_slots():
-            self._free_swa_slot(slot)
+        drained = list(self.index.drain_freed_swa_slots())
+        for slot in drained:
+            self.swa_pool.free(int(slot))
+        if drained:
+            if self._metrics_collector is not None:
+                self._metrics_collector.record_swa_evicted(
+                    self._swa_device_label(), "cascade", len(drained))
+            self._record_swa_slot_stats()
 
     def _pin_swa_node(self, node) -> None:
         self.index.lock(node)
@@ -233,6 +256,9 @@ class CacheEngineAccel:
             return 0
         evicted_full = torch.zeros(0, dtype=torch.int64)
         num_freed = self.index.evict_swa(evicted_full, num_swa_evicted)
+        if num_freed > 0 and self._metrics_collector is not None:
+            self._metrics_collector.record_swa_evicted(
+                self._swa_device_label(), "pool_full", num_freed)
         if evicted_full.numel() > 0:
             self.mempool.recycle_blocks(evicted_full.numpy())
         self._drain_unmounted_swa_slots()
@@ -445,11 +471,21 @@ class CacheEngine:
         """Initialize the SWA host pool for node-mounted SWA on this engine."""
         from flexkv.swa.swa_host_pool import SWAHostPool
         self.swa_pool = SWAHostPool(swa_config)
+        self._record_swa_slot_stats()
 
     @property
     def swa_enabled(self) -> bool:
         return self.tier_swa_config is not None and self.tier_swa_config.enabled \
                and self.swa_pool is not None
+
+    def _swa_device_label(self) -> str:
+        return DEVICE_TYPE[self.device_type].lower()
+
+    def _record_swa_slot_stats(self) -> None:
+        """Push current SWA pool usage to metrics (no-op when disabled)."""
+        if self._metrics_collector is not None and self.swa_pool is not None:
+            self._metrics_collector.update_swa_slot_stats(
+                self._swa_device_label(), self.swa_pool.num_used, self.swa_pool.num_slots)
 
     def _alloc_swa_slot(self, protected_node=None) -> int:
         """Allocate one SWA slot; evict SWA-LRU once when the pool is full."""
@@ -457,6 +493,7 @@ class CacheEngine:
             return -1
         slot = self.swa_pool.allocate()
         if slot is not None:
+            self._record_swa_slot_stats()
             return slot
         if protected_node is not None:
             self.lock_node(protected_node)
@@ -466,18 +503,30 @@ class CacheEngine:
             if protected_node is not None:
                 self.unlock(protected_node)
         slot = self.swa_pool.allocate()
-        return slot if slot is not None else -1
+        if slot is None:
+            if self._metrics_collector is not None:
+                self._metrics_collector.record_swa_slot_alloc_failed(self._swa_device_label())
+            return -1
+        self._record_swa_slot_stats()
+        return slot
 
     def _free_swa_slot(self, slot: int) -> None:
         """Return one detached SWA slot to this tier's pool."""
         self.swa_pool.free(int(slot))
+        self._record_swa_slot_stats()
 
     def _drain_unmounted_swa_slots(self) -> None:
         """Return slots detached by radix-tree structural changes to the pool."""
         if self.swa_pool is None:
             return
-        for slot in self.index.drain_freed_swa_slots():
-            self._free_swa_slot(slot)
+        drained = list(self.index.drain_freed_swa_slots())
+        for slot in drained:
+            self.swa_pool.free(int(slot))
+        if drained:
+            if self._metrics_collector is not None:
+                self._metrics_collector.record_swa_evicted(
+                    self._swa_device_label(), "cascade", len(drained))
+            self._record_swa_slot_stats()
 
     def _pin_swa_node(self, node) -> None:
         self.index.lock(node)
@@ -492,6 +541,9 @@ class CacheEngine:
         if self.swa_pool is None:
             return 0
         evicted_full, num_freed = self.index.evict_swa(num_swa_evicted)
+        if num_freed > 0 and self._metrics_collector is not None:
+            self._metrics_collector.record_swa_evicted(
+                self._swa_device_label(), "pool_full", num_freed)
         if evicted_full.size > 0:
             self.mempool.recycle_blocks(evicted_full)
         self._drain_unmounted_swa_slots()
@@ -1053,6 +1105,7 @@ class GlobalCacheEngine:
                 total_query_blocks = block_mask_end - block_mask_start
                 if total_query_blocks > 0:
                     self._metrics_collector.record_cache_miss(total_query_blocks)
+                    self._metrics_collector.record_cache_query("miss")
             return self._empty_get_return(request_id)
         assert fragment123_num_blocks <= len(gpu_block_ids)
 
@@ -1120,6 +1173,15 @@ class GlobalCacheEngine:
             self._metrics_collector.record_cache_hit("ssd", fragment2_num_blocks)
             # Remote hit blocks (blocks loaded from remote)
             self._metrics_collector.record_cache_hit("remote", fragment3_num_blocks)
+            # Query result over the requested window + per-tier readiness split
+            query_result = "full" if fragment123_num_blocks >= total_query_blocks else "partial"
+            self._metrics_collector.record_cache_query(query_result)
+            for _dev, _res in (("cpu", cpu_matched_result),
+                               ("ssd", ssd_matched_result),
+                               ("remote", remote_matched_result)):
+                _matched = max(0, min(_res.num_matched_blocks, block_mask_end) - block_mask_start)
+                _ready = max(0, min(_res.num_ready_matched_blocks, block_mask_end) - block_mask_start)
+                self._metrics_collector.record_cache_match_blocks(_dev, _ready, _matched - _ready)
             # Miss blocks (not in any cache)
             miss_blocks = total_query_blocks - fragment123_num_blocks
             if miss_blocks > 0:
@@ -1317,6 +1379,7 @@ class GlobalCacheEngine:
                 total_query_blocks = block_mask_end - block_mask_start
                 if total_query_blocks > 0:
                     self._metrics_collector.record_cache_miss(total_query_blocks)
+                    self._metrics_collector.record_cache_query("miss")
             nvtx.end_range(nvtx_range)
             return self._empty_get_return(request_id)
         assert fragment12_num_blocks <= len(gpu_block_ids)
@@ -1373,6 +1436,14 @@ class GlobalCacheEngine:
             self._metrics_collector.record_cache_hit("cpu", fragment1_num_blocks)
             # SSD hit blocks (loaded directly to GPU with GDS, otherwise via CPU)
             self._metrics_collector.record_cache_hit("ssd", fragment2_num_blocks)
+            # Query result over the requested window + per-tier readiness split
+            query_result = "full" if fragment12_num_blocks >= total_query_blocks else "partial"
+            self._metrics_collector.record_cache_query(query_result)
+            for _dev, _res in (("cpu", cpu_matched_result),
+                               ("ssd", ssd_matched_result)):
+                _matched = max(0, min(_res.num_matched_blocks, block_mask_end) - block_mask_start)
+                _ready = max(0, min(_res.num_ready_matched_blocks, block_mask_end) - block_mask_start)
+                self._metrics_collector.record_cache_match_blocks(_dev, _ready, _matched - _ready)
             # Miss blocks (not in any cache)
             miss_blocks = total_query_blocks - fragment12_num_blocks
             if miss_blocks > 0:
@@ -2219,6 +2290,9 @@ class GlobalCacheEngine:
                     "mooncake SWA source selection requires sequence_meta "
                     "for the tail hash")
                 tail_hash = str(sequence_meta.block_hashes[usable_end - 1])
+                if self._metrics_collector is not None:
+                    self._metrics_collector.record_swa_query("hit")
+                    self._metrics_collector.record_swa_hit_blocks(usable_end - block_mask_start)
                 return usable_end, SWAReadSource(
                     hit_blocks=usable_end,
                     device_type=device_type,
@@ -2229,6 +2303,9 @@ class GlobalCacheEngine:
             source_slot = int(source_node.swa_host_slot)
             assert source_slot >= 0
 
+            if self._metrics_collector is not None:
+                self._metrics_collector.record_swa_query("hit")
+                self._metrics_collector.record_swa_hit_blocks(usable_end - block_mask_start)
             return usable_end, SWAReadSource(
                 hit_blocks=usable_end,
                 host_slot=source_slot,
@@ -2237,6 +2314,8 @@ class GlobalCacheEngine:
                 engine=engine,
             )
 
+        if self._metrics_collector is not None:
+            self._metrics_collector.record_swa_query("miss")
         return block_mask_start, SWAReadSource()
 
     def _reserve_swa_read_source(

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -24,6 +24,8 @@ class CompletedOp:
     transfer_type: Optional[str] = None
     num_blocks: int = 0
     num_bytes: int = 0
+    # True when this op moved SWA KV (separate slot-id space); used only for metrics.
+    is_swa: bool = False
 
     def is_graph_completed(self) -> bool:
         return self.op_id == -1

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -368,6 +368,7 @@ class KVTaskManager:
                     completed_op.num_blocks,
                     completed_op.num_bytes,
                     operation,
+                    is_swa=completed_op.is_swa,
                 )
             if completed_op.is_graph_completed():
                 self._mark_completed(task_id)

--- a/flexkv/metrics/collector.py
+++ b/flexkv/metrics/collector.py
@@ -17,13 +17,14 @@ from typing import Dict, Optional
 
 # Optional import for prometheus_client
 try:
-    from prometheus_client import Counter, Gauge, Histogram
+    from prometheus_client import Counter, Gauge, Histogram, REGISTRY as DEFAULT_REGISTRY
     PROMETHEUS_AVAILABLE = True
 except ImportError:
     PROMETHEUS_AVAILABLE = False
     Counter = None
     Gauge = None
     Histogram = None
+    DEFAULT_REGISTRY = None
 
 from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.debug import flexkv_logger
@@ -159,7 +160,10 @@ class FlexKVMetricsCollector:
         """
         if role is None:
             role = _detect_process_role()
-        self._registry = registry
+        # NOTE: prometheus_client skips registration entirely when a metric is
+        # constructed with registry=None, so fall back to the default REGISTRY
+        # explicitly (None only means "caller did not inject one").
+        self._registry = registry if registry is not None else DEFAULT_REGISTRY
 
         # Check if metrics should be enabled (controlled by env var and prometheus availability)
         should_enable = PROMETHEUS_AVAILABLE and _should_enable_metrics()

--- a/flexkv/metrics/collector.py
+++ b/flexkv/metrics/collector.py
@@ -12,16 +12,18 @@ When enabled, the metrics HTTP server will automatically start on port 8080
 """
 
 import os
+import functools
 from typing import Dict, Optional
 
 # Optional import for prometheus_client
 try:
-    from prometheus_client import Counter, Gauge
+    from prometheus_client import Counter, Gauge, Histogram
     PROMETHEUS_AVAILABLE = True
 except ImportError:
     PROMETHEUS_AVAILABLE = False
     Counter = None
     Gauge = None
+    Histogram = None
 
 from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.debug import flexkv_logger
@@ -30,6 +32,28 @@ logger = flexkv_logger
 
 # Flag to track if metrics server auto-start has been attempted
 _metrics_server_auto_started = False
+
+# DSV4 metric label value sets (kept bounded; IDs must never become labels)
+CACHE_QUERY_RESULTS = ("full", "partial", "miss")
+SWA_QUERY_RESULTS = ("hit", "miss")
+SWA_DEVICE_TYPES = ("cpu", "ssd", "remote")
+SWA_EVICT_REASONS = ("pool_full", "cascade")
+TRANSFER_OPERATIONS = ("get", "put", "unknown")
+SUBMIT_STATUSES = ("ok", "error")
+
+
+def _detect_process_role() -> str:
+    """Default role for a collector created without an explicit role.
+
+    Every process returns "main": they all attempt to bind the metrics port
+    and the existing port-conflict probe (server.py) lets exactly one win.
+    This is required because serving frameworks (e.g. sglang) run FlexKV in
+    renamed/spawned processes where no process is literally named
+    "MainProcess" — name-based detection would leave no HTTP server at all.
+    In multiprocess mode (PROMETHEUS_MULTIPROC_DIR) the single winner exposes
+    the aggregated view of all processes via MultiProcessCollector.
+    """
+    return "main"
 
 
 def _should_enable_metrics() -> bool:
@@ -119,69 +143,89 @@ class FlexKVMetricsCollector:
         collector.record_transfer_completed("H2D", 5, 1048576, "get")
     """
     
-    def __init__(self):
+    def __init__(self, role: Optional[str] = None, registry=None):
         """
         Initialize the metrics collector.
-        
-        When metrics are enabled (FLEXKV_ENABLE_METRICS=1), it will
-        automatically start the metrics HTTP server (if not already started).
+
+        When metrics are enabled (FLEXKV_ENABLE_METRICS=1) and role is "main",
+        it will automatically start the metrics HTTP server (if not already
+        started). Worker-role collectors (spawned subprocesses) skip the
+        server; their metrics are aggregated via PROMETHEUS_MULTIPROC_DIR.
+
+        Args:
+            role: "main" or "worker" (auto-detected from process name if None).
+            registry: Prometheus registry to register into (default REGISTRY
+                when None). Tests pass a fresh CollectorRegistry for isolation.
         """
-        
+        if role is None:
+            role = _detect_process_role()
+        self._registry = registry
+
         # Check if metrics should be enabled (controlled by env var and prometheus availability)
         should_enable = PROMETHEUS_AVAILABLE and _should_enable_metrics()
         self.enabled = should_enable
-        
+
         if not PROMETHEUS_AVAILABLE and _should_enable_metrics():
             raise RuntimeError(
                 "[FlexKV PyMetrics] prometheus_client not installed but FLEXKV_ENABLE_METRICS=1. "
                 "Run 'pip3 install prometheus_client' to enable metrics, or set FLEXKV_ENABLE_METRICS=0 to disable."
             )
-        
-        _auto_start_metrics_server()
-        
+
+        # prometheus_client multiprocess mode requires the dir to exist before
+        # any metric is created.
+        multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        if self.enabled and multiproc_dir:
+            os.makedirs(multiproc_dir, exist_ok=True)
+
+        if role == "main":
+            _auto_start_metrics_server()
+
         if self.enabled:
             self._init_metrics()
+            self._init_dsv4_metrics()
         else:
             self._init_dummy_metrics()
     
     def _init_metrics(self):
         """Initialize Prometheus metrics for cache engine."""
+        _Counter = functools.partial(Counter, registry=self._registry)
+        _Gauge = functools.partial(Gauge, registry=self._registry)
         
         # ========== Cache Engine Metrics ==========
         # Cache hit/miss counters by device (cpu/ssd/remote)
-        self.cache_hit_blocks_total = Counter(
+        self.cache_hit_blocks_total = _Counter(
             name="flexkv_py_cache_hit_blocks_total",
             documentation="Total number of cache hit blocks by device",
             labelnames=["device"],
         )
         
         # Cache miss counter (no device label - miss means not found in any cache level)
-        self.cache_miss_blocks_total = Counter(
+        self.cache_miss_blocks_total = _Counter(
             name="flexkv_py_cache_miss_blocks_total",
             documentation="Total number of cache miss blocks (not found in any cache level)",
         )
         
         # Allocation failure counter by mode (global/local)
-        self.allocation_failures_total = Counter(
+        self.allocation_failures_total = _Counter(
             name="flexkv_py_allocation_failures_total",
             documentation="Total number of allocation failures by mode (global/local)",
             labelnames=["mode"],
         )
         
         # Transfer counters by transfer type and operation (get/put)
-        self.transfer_blocks_total = Counter(
+        self.transfer_blocks_total = _Counter(
             name="flexkv_py_transfer_blocks_total",
             documentation="Total number of blocks transferred by transfer type and operation",
             labelnames=["transfer_type", "operation"],
         )
         
-        self.transfer_ops_total = Counter(
+        self.transfer_ops_total = _Counter(
             name="flexkv_py_transfer_ops_total",
             documentation="Total number of transfer operations by transfer type and operation",
             labelnames=["transfer_type", "operation"],
         )
         
-        self.transfer_bytes_total = Counter(
+        self.transfer_bytes_total = _Counter(
             name="flexkv_py_transfer_bytes_total",
             documentation="Total number of bytes transferred by transfer type and operation",
             labelnames=["transfer_type", "operation"],
@@ -194,32 +238,136 @@ class FlexKVMetricsCollector:
         if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
             mempool_gauge_kwargs["multiprocess_mode"] = "livesum"
         
-        self.mempool_total_blocks = Gauge(
+        self.mempool_total_blocks = _Gauge(
             name="flexkv_py_mempool_total_blocks",
             documentation="Total blocks in memory pool by device",
             **mempool_gauge_kwargs,
         )
         
-        self.mempool_free_blocks = Gauge(
+        self.mempool_free_blocks = _Gauge(
             name="flexkv_py_mempool_free_blocks",
             documentation="Free blocks in memory pool by device",
             **mempool_gauge_kwargs,
         )
         
         # Eviction and allocation counters by device
-        self.evicted_blocks_total = Counter(
+        self.evicted_blocks_total = _Counter(
             name="flexkv_py_evicted_blocks_total",
             documentation="Total number of evicted blocks by device",
             labelnames=["device"],
         )
         
-        self.allocated_blocks_total = Counter(
+        self.allocated_blocks_total = _Counter(
             name="flexkv_py_allocated_blocks_total",
             documentation="Total number of allocated blocks by device",
             labelnames=["device"],
         )
         
         logger.info("[FlexKV PyMetrics] Prometheus metrics collector initialized")
+
+    def _init_dsv4_metrics(self):
+        """Initialize DSV4-specific metrics: SWA, cache query/readiness, layerwise.
+
+        All hot-path label combinations are pre-resolved into child dicts so
+        recording never pays the .labels() lookup cost per call.
+        """
+        gauge_kwargs = {}
+        if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+            gauge_kwargs["multiprocess_mode"] = "livesum"
+        _Counter = functools.partial(Counter, registry=self._registry)
+        _Gauge = functools.partial(Gauge, registry=self._registry)
+        _Histogram = functools.partial(Histogram, registry=self._registry)
+
+        # ---- SWA ----
+        self.swa_query_total = _Counter(
+            name="flexkv_py_swa_query_total",
+            documentation="SWA-aware GET queries by result",
+            labelnames=["result"],
+        )
+        self._swa_query = {r: self.swa_query_total.labels(result=r) for r in SWA_QUERY_RESULTS}
+
+        self.swa_hit_blocks_total = _Counter(
+            name="flexkv_py_swa_hit_blocks_total",
+            documentation="Blocks served from an SWA read source on SWA-aware GET hits",
+        )
+
+        self.swa_slot_used = _Gauge(
+            name="flexkv_py_swa_slot_used",
+            documentation="SWA host-pool slots currently in use, by tier",
+            labelnames=["device"], **gauge_kwargs,
+        )
+        self.swa_slot_total = _Gauge(
+            name="flexkv_py_swa_slot_total",
+            documentation="SWA host-pool total slots, by tier",
+            labelnames=["device"], **gauge_kwargs,
+        )
+        self._swa_slot_used = {d: self.swa_slot_used.labels(device=d) for d in SWA_DEVICE_TYPES}
+        self._swa_slot_total = {d: self.swa_slot_total.labels(device=d) for d in SWA_DEVICE_TYPES}
+
+        self.swa_slot_alloc_failed_total = _Counter(
+            name="flexkv_py_swa_slot_alloc_failed_total",
+            documentation="SWA slot allocation failures (still full after one eviction retry), by tier",
+            labelnames=["device"],
+        )
+        self._swa_alloc_failed = {d: self.swa_slot_alloc_failed_total.labels(device=d)
+                                  for d in SWA_DEVICE_TYPES}
+
+        self.swa_evicted_slots_total = _Counter(
+            name="flexkv_py_swa_evicted_slots_total",
+            documentation="SWA slots freed, by tier and reason (pool_full/cascade)",
+            labelnames=["device", "reason"],
+        )
+        self._swa_evicted = {(d, r): self.swa_evicted_slots_total.labels(device=d, reason=r)
+                             for d in SWA_DEVICE_TYPES for r in SWA_EVICT_REASONS}
+
+        self.swa_transfer_bytes_total = _Counter(
+            name="flexkv_py_swa_transfer_bytes_total",
+            documentation="Bytes transferred by SWA (is_swa) ops after completion",
+            labelnames=["operation"],
+        )
+        self._swa_transfer_bytes = {op: self.swa_transfer_bytes_total.labels(operation=op)
+                                    for op in TRANSFER_OPERATIONS}
+
+        # ---- Cache query / readiness ----
+        self.cache_query_total = _Counter(
+            name="flexkv_py_cache_query_total",
+            documentation="GET queries by result (full/partial/miss over the queried window)",
+            labelnames=["result"],
+        )
+        self._cache_query = {r: self.cache_query_total.labels(result=r) for r in CACHE_QUERY_RESULTS}
+
+        self.cache_match_blocks_total = _Counter(
+            name="flexkv_py_cache_match_blocks_total",
+            documentation="Blocks matched in the radix tree per tier, split by data readiness",
+            labelnames=["device", "ready"],
+        )
+        self._cache_match = {(d, r): self.cache_match_blocks_total.labels(device=d, ready=r)
+                             for d in SWA_DEVICE_TYPES for r in ("true", "false")}
+
+        # ---- Layerwise ----
+        self.layerwise_workers_ready = _Gauge(
+            name="flexkv_py_layerwise_workers_ready",
+            documentation="Layerwise workers that finished initialization (eventfd handshake)",
+            **gauge_kwargs,
+        )
+        self.layerwise_workers_expected = _Gauge(
+            name="flexkv_py_layerwise_workers_expected",
+            documentation="Layerwise workers expected at startup",
+            **gauge_kwargs,
+        )
+        self.layerwise_submit_seconds = _Histogram(
+            name="flexkv_py_layerwise_submit_seconds",
+            documentation="Time to fan out a LAYERWISE op to all sibling workers",
+            buckets=(.0005, .001, .005, .01, .05, .1, .5, 1, 5),
+        )
+        self.layerwise_submit_total = _Counter(
+            name="flexkv_py_layerwise_submit_total",
+            documentation="LAYERWISE op fan-out count by status",
+            labelnames=["status"],
+        )
+        self._layerwise_submit = {s: self.layerwise_submit_total.labels(status=s)
+                                  for s in SUBMIT_STATUSES}
+
     
     def _init_dummy_metrics(self):
         """Initialize dummy metrics when prometheus_client is not available."""
@@ -230,9 +378,11 @@ class FlexKVMetricsCollector:
                 pass
             def set(self, *args, **kwargs):
                 pass
-        
+            def observe(self, *args, **kwargs):
+                pass
+
         dummy = DummyMetric()
-        
+
         # Cache engine dummy metrics
         self.cache_hit_blocks_total = dummy
         self.cache_miss_blocks_total = dummy
@@ -244,6 +394,32 @@ class FlexKVMetricsCollector:
         self.mempool_free_blocks = dummy
         self.evicted_blocks_total = dummy
         self.allocated_blocks_total = dummy
+
+        # DSV4 dummy metrics
+        self.swa_query_total = dummy
+        self.swa_hit_blocks_total = dummy
+        self.swa_slot_used = dummy
+        self.swa_slot_total = dummy
+        self.swa_slot_alloc_failed_total = dummy
+        self.swa_evicted_slots_total = dummy
+        self.swa_transfer_bytes_total = dummy
+        self.cache_query_total = dummy
+        self.cache_match_blocks_total = dummy
+        self.layerwise_workers_ready = dummy
+        self.layerwise_workers_expected = dummy
+        self.layerwise_submit_seconds = dummy
+        self.layerwise_submit_total = dummy
+        # Pre-resolved children stay empty: every record_* early-returns on
+        # `not self.enabled` before touching them.
+        self._swa_query = {}
+        self._swa_slot_used = {}
+        self._swa_slot_total = {}
+        self._swa_alloc_failed = {}
+        self._swa_evicted = {}
+        self._swa_transfer_bytes = {}
+        self._cache_query = {}
+        self._cache_match = {}
+        self._layerwise_submit = {}
     
 
     
@@ -283,19 +459,21 @@ class FlexKVMetricsCollector:
             return
         self.allocation_failures_total.labels(mode=mode).inc()
     
-    def record_transfer_completed(self, transfer_type: str, num_blocks: int, num_bytes: int, operation: str = "unknown"):
+    def record_transfer_completed(self, transfer_type: str, num_blocks: int, num_bytes: int,
+                                  operation: str = "unknown", is_swa: bool = False):
         """
         Record metrics for a completed transfer operation (post-completion).
-        
+
         Called from KVTaskManager._update_tasks() when a CompletedOp is consumed.
         Updates ops_total, blocks_total, and bytes_total counters.
         All three transfer metrics are unified here, updated only after transfer completion.
-        
+
         Args:
             transfer_type: Transfer type (e.g., "H2D", "D2H", "DISK2H", etc.)
             num_blocks: Number of blocks transferred
             num_bytes: Number of bytes transferred
             operation: Operation type ("get" or "put")
+            is_swa: Whether this op moved SWA KV (also counted in swa_transfer_bytes_total)
         """
         if not self.enabled:
             return
@@ -304,6 +482,10 @@ class FlexKVMetricsCollector:
             self.transfer_blocks_total.labels(transfer_type=transfer_type, operation=operation).inc(num_blocks)
         if num_bytes > 0:
             self.transfer_bytes_total.labels(transfer_type=transfer_type, operation=operation).inc(num_bytes)
+        if is_swa and num_bytes > 0:
+            child = self._swa_transfer_bytes.get(operation) or self._swa_transfer_bytes.get("unknown")
+            if child is not None:
+                child.inc(num_bytes)
     
     def update_mempool_stats(self, device: str, total_blocks: int, free_blocks: int):
         """
@@ -334,7 +516,7 @@ class FlexKVMetricsCollector:
     def record_allocation(self, device: str, num_blocks: int):
         """
         Record allocated blocks for a device.
-        
+
         Args:
             device: Device type ("cpu", "ssd", "remote")
             num_blocks: Number of allocated blocks
@@ -342,6 +524,92 @@ class FlexKVMetricsCollector:
         if not self.enabled or num_blocks <= 0:
             return
         self.allocated_blocks_total.labels(device=device).inc(num_blocks)
+
+    # ========== DSV4 Recording Methods (SWA / cache query / layerwise) ==========
+
+    def record_swa_query(self, result: str):
+        """Record one SWA-aware GET query. result: "hit" or "miss"."""
+        if not self.enabled:
+            return
+        child = self._swa_query.get(result)
+        if child is not None:
+            child.inc()
+
+    def record_swa_hit_blocks(self, num_blocks: int):
+        """Record blocks served from an SWA read source."""
+        if not self.enabled or num_blocks <= 0:
+            return
+        self.swa_hit_blocks_total.inc(num_blocks)
+
+    def update_swa_slot_stats(self, device: str, used: int, total: int):
+        """Update SWA host-pool slot gauges for one tier (cpu/ssd/remote)."""
+        if not self.enabled:
+            return
+        child_used = self._swa_slot_used.get(device)
+        child_total = self._swa_slot_total.get(device)
+        if child_used is not None:
+            child_used.set(used)
+        if child_total is not None:
+            child_total.set(total)
+
+    def record_swa_slot_alloc_failed(self, device: str):
+        """Record an SWA slot allocation failure (pool still full after eviction retry)."""
+        if not self.enabled:
+            return
+        child = self._swa_alloc_failed.get(device)
+        if child is not None:
+            child.inc()
+
+    def record_swa_evicted(self, device: str, reason: str, num_slots: int):
+        """Record SWA slots freed. reason: "pool_full" (SWA-LRU eviction) or
+        "cascade" (detached by radix-tree structural changes)."""
+        if not self.enabled or num_slots <= 0:
+            return
+        child = self._swa_evicted.get((device, reason))
+        if child is not None:
+            child.inc(num_slots)
+
+    def record_cache_query(self, result: str):
+        """Record one GET query. result: "full", "partial" or "miss"."""
+        if not self.enabled:
+            return
+        child = self._cache_query.get(result)
+        if child is not None:
+            child.inc()
+
+    def record_cache_match_blocks(self, device: str, ready_blocks: int, not_ready_blocks: int):
+        """Record radix-matched blocks for one tier, split by data readiness.
+        ready_blocks are immediately reusable ("effective reuse"); not_ready
+        blocks are matched but still in flight."""
+        if not self.enabled:
+            return
+        if ready_blocks > 0:
+            child = self._cache_match.get((device, "true"))
+            if child is not None:
+                child.inc(ready_blocks)
+        if not_ready_blocks > 0:
+            child = self._cache_match.get((device, "false"))
+            if child is not None:
+                child.inc(not_ready_blocks)
+
+    def update_layerwise_workers(self, ready: int, expected: int):
+        """Update layerwise worker startup progress (called from the
+        TransferManager process; visible via PROMETHEUS_MULTIPROC_DIR)."""
+        if not self.enabled:
+            return
+        self.layerwise_workers_ready.set(ready)
+        self.layerwise_workers_expected.set(expected)
+
+    def record_layerwise_submit(self, status: str, seconds: float):
+        """Record one LAYERWISE op fan-out. status: "ok" or "error".
+        Latency is observed only on success."""
+        if not self.enabled:
+            return
+        child = self._layerwise_submit.get(status)
+        if child is not None:
+            child.inc()
+        if status == "ok":
+            self.layerwise_submit_seconds.observe(max(seconds, 0.0))
     
 # Global collector instance
 _global_collector: Optional[FlexKVMetricsCollector] = None
@@ -352,14 +620,19 @@ def get_global_collector() -> Optional[FlexKVMetricsCollector]:
     return _global_collector
 
 
-def init_global_collector() -> FlexKVMetricsCollector:
+def init_global_collector(role: Optional[str] = None) -> FlexKVMetricsCollector:
     """
     Initialize and return the global metrics collector.
-    
+
+    Args:
+        role: "main" (default, auto-detected) starts the HTTP server;
+              "worker" (spawned subprocesses) records into
+              PROMETHEUS_MULTIPROC_DIR without binding the port.
+
     Returns:
         The global FlexKVMetricsCollector instance
     """
     global _global_collector
     if _global_collector is None:
-        _global_collector = FlexKVMetricsCollector()
+        _global_collector = FlexKVMetricsCollector(role=role)
     return _global_collector

--- a/flexkv/metrics/server.py
+++ b/flexkv/metrics/server.py
@@ -96,7 +96,7 @@ def start_metrics_server(port: Optional[int] = None) -> bool:
             return True
         
         try:
-            from prometheus_client import start_http_server, REGISTRY
+            from prometheus_client import start_http_server, REGISTRY  # noqa: F401
         except ImportError:
             raise RuntimeError(
                 "[FlexKV PyMetrics] prometheus_client not installed but metrics server requested. "
@@ -107,10 +107,24 @@ def start_metrics_server(port: Optional[int] = None) -> bool:
             port = get_metrics_port()
         
         try:
-            # Start server with default registry (single process mode)
-            # Always bind to localhost (127.0.0.1) for security
-            start_http_server(port, addr=BIND_ADDRESS, registry=REGISTRY)
-            
+            # Multiprocess mode: when PROMETHEUS_MULTIPROC_DIR is set, worker
+            # subprocesses write metric files into that dir and we expose an
+            # aggregating registry. Otherwise keep the single-process default.
+            import os
+            if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+                from prometheus_client import CollectorRegistry, start_http_server
+                from prometheus_client.multiprocess import MultiProcessCollector
+                registry = CollectorRegistry()
+                MultiProcessCollector(registry)
+                start_http_server(port, addr=BIND_ADDRESS, registry=registry)
+                print(
+                    f"[FlexKV PyMetrics] multiprocess mode: aggregating "
+                    f"{os.environ['PROMETHEUS_MULTIPROC_DIR']}"
+                )
+            else:
+                from prometheus_client import start_http_server, REGISTRY
+                start_http_server(port, addr=BIND_ADDRESS, registry=REGISTRY)
+
             _server_started = True
             print(
                 f"[FlexKV PyMetrics] Initialized successfully, exposing metrics at http://{BIND_ADDRESS}:{port}/metrics"

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -196,6 +196,12 @@ class TransferEngine:
             layerwise_enabled=GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer,
         )
 
+        # Metrics: this engine usually runs in the TransferManager subprocess,
+        # so the collector takes the "worker" role automatically (no HTTP port
+        # bind; aggregated via PROMETHEUS_MULTIPROC_DIR when set).
+        from flexkv.metrics.collector import init_global_collector
+        self._metrics_collector = init_global_collector()
+
         # Used for LAYERWISE PP fan-out: a parent op spawns one replica per PP
         # sibling worker; each replica's completion decrements the parent's
         # pending_count and the parent finalizes when count hits 0.
@@ -967,10 +973,19 @@ class TransferEngine:
             flexkv_logger.debug(f"{label} is ready")
 
         # Wait for all main KV workers to ready
+        layerwise_expected = len(self._worker_map.get(TransferType.LAYERWISE, {}))
+        layerwise_ready = 0
+        if layerwise_expected > 0 and self._metrics_collector is not None:
+            self._metrics_collector.update_layerwise_workers(0, layerwise_expected)
         for transfer_type, worker in self._worker_map.items():
             if isinstance(worker, dict):
                 for wk, w in worker.items():
                     _wait_worker_ready(w, transfer_type, wk)
+                    if transfer_type == TransferType.LAYERWISE:
+                        layerwise_ready += 1
+                        if self._metrics_collector is not None:
+                            self._metrics_collector.update_layerwise_workers(
+                                layerwise_ready, layerwise_expected)
             else:
                 _wait_worker_ready(worker, transfer_type)
 
@@ -1169,6 +1184,7 @@ class TransferEngine:
             transfer_type=transfer_type_str,
             num_blocks=num_blocks,
             num_bytes=num_bytes,
+            is_swa=getattr(op, "is_swa", False),
         ))
         finished_ops.append(op)
         del self.op_id_to_op[op.op_id]
@@ -1318,7 +1334,17 @@ class TransferEngine:
             raise ValueError(f"Unsupported transfer type: {op.transfer_type}")
 
         if op.transfer_type == TransferType.LAYERWISE:
-            self._assign_layerwise_op_to_workers(op)
+            collector = self._metrics_collector
+            t0 = time.monotonic() if (collector is not None and collector.enabled) else 0.0
+            status = "ok"
+            try:
+                self._assign_layerwise_op_to_workers(op)
+            except Exception:
+                status = "error"
+                raise
+            finally:
+                if collector is not None and collector.enabled:
+                    collector.record_layerwise_submit(status, time.monotonic() - t0)
             return
 
         worker = self._worker_map[op.transfer_type]

--- a/tests/test_metrics_dsv4.py
+++ b/tests/test_metrics_dsv4.py
@@ -1,0 +1,227 @@
+"""Tests for DSV4 metrics: SWA, cache query/readiness, layerwise.
+
+Covers:
+- enabled path: metric values are recorded correctly (incl. cache-engine SWA hooks)
+- disabled path (default): all record_* are no-ops and never raise
+"""
+import numpy as np
+import pytest
+
+from prometheus_client import CollectorRegistry
+
+from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.transfer import DeviceType
+from flexkv.metrics.collector import FlexKVMetricsCollector
+from flexkv.swa.swa_host_pool import SWAHostPool
+
+
+@pytest.fixture()
+def enabled_collector(monkeypatch):
+    """Fresh registry per test: full isolation from the process-global default
+    REGISTRY (which other tests populate via GlobalCacheEngine)."""
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "enable_metrics", True)
+    registry = CollectorRegistry()
+    collector = FlexKVMetricsCollector(role="worker", registry=registry)
+    assert collector.enabled
+    collector.test_registry = registry
+    return collector
+
+
+def sample(collector, name, labels=None):
+    return collector.test_registry.get_sample_value(name, labels or {}) or 0.0
+
+
+class TestSWAMetrics:
+    def test_swa_query_and_hit_blocks(self, enabled_collector):
+        c = enabled_collector
+        before_hit = sample(c, "flexkv_py_swa_query_total", {"result": "hit"})
+        before_miss = sample(c, "flexkv_py_swa_query_total", {"result": "miss"})
+        before_blocks = sample(c, "flexkv_py_swa_hit_blocks_total")
+
+        c.record_swa_query("hit")
+        c.record_swa_hit_blocks(7)
+        c.record_swa_query("miss")
+        c.record_swa_hit_blocks(0)   # ignored
+        c.record_swa_query("bogus")  # unknown label value, ignored
+
+        assert sample(c, "flexkv_py_swa_query_total", {"result": "hit"}) == before_hit + 1
+        assert sample(c, "flexkv_py_swa_query_total", {"result": "miss"}) == before_miss + 1
+        assert sample(c, "flexkv_py_swa_hit_blocks_total") == before_blocks + 7
+
+    def test_swa_slot_stats_and_failures(self, enabled_collector):
+        c = enabled_collector
+        c.update_swa_slot_stats("cpu", 3, 100)
+        assert sample(c, "flexkv_py_swa_slot_used", {"device": "cpu"}) == 3
+        assert sample(c, "flexkv_py_swa_slot_total", {"device": "cpu"}) == 100
+
+        before = sample(c, "flexkv_py_swa_slot_alloc_failed_total", {"device": "cpu"})
+        c.record_swa_slot_alloc_failed("cpu")
+        assert sample(c, "flexkv_py_swa_slot_alloc_failed_total", {"device": "cpu"}) == before + 1
+
+    def test_swa_evicted_by_reason(self, enabled_collector):
+        c = enabled_collector
+        before_pf = sample(c, "flexkv_py_swa_evicted_slots_total",
+                           {"device": "cpu", "reason": "pool_full"})
+        before_ca = sample(c, "flexkv_py_swa_evicted_slots_total",
+                           {"device": "cpu", "reason": "cascade"})
+        c.record_swa_evicted("cpu", "pool_full", 2)
+        c.record_swa_evicted("cpu", "cascade", 5)
+        c.record_swa_evicted("cpu", "cascade", 0)  # ignored
+        assert sample(c, "flexkv_py_swa_evicted_slots_total",
+                      {"device": "cpu", "reason": "pool_full"}) == before_pf + 2
+        assert sample(c, "flexkv_py_swa_evicted_slots_total",
+                      {"device": "cpu", "reason": "cascade"}) == before_ca + 5
+
+    def test_swa_transfer_bytes(self, enabled_collector):
+        c = enabled_collector
+        before = sample(c, "flexkv_py_swa_transfer_bytes_total", {"operation": "get"})
+        c.record_transfer_completed("H2D", 4, 2048, "get", is_swa=True)
+        c.record_transfer_completed("H2D", 4, 1024, "get", is_swa=False)
+        assert sample(c, "flexkv_py_swa_transfer_bytes_total", {"operation": "get"}) == before + 2048
+
+
+class _FakeIndex:
+    """Minimal stand-in for the radix index used by SWA hook paths."""
+    def __init__(self, evict_freed=0, drain_slots=()):
+        self._evict_freed = evict_freed
+        self._drain_slots = list(drain_slots)
+
+    def evict_swa(self, num):
+        return np.array([], dtype=np.int64), self._evict_freed
+
+    def drain_freed_swa_slots(self):
+        slots, self._drain_slots = self._drain_slots, []
+        return slots
+
+
+class _FakeMempool:
+    @staticmethod
+    def recycle_blocks(blocks):
+        pass
+
+
+def _make_engine_stub(collector, num_slots, index):
+    """CacheEngine (Python variant) with only the SWA hook dependencies set."""
+    from types import SimpleNamespace
+    from flexkv.cache.cache_engine import CacheEngine
+
+    engine = CacheEngine.__new__(CacheEngine)
+    engine._metrics_collector = collector
+    engine.device_type = DeviceType.CPU
+    engine.swa_pool = SWAHostPool(SimpleNamespace(num_slots=num_slots, pin_memory=False))
+    engine.index = index
+    engine.mempool = _FakeMempool()
+    return engine
+
+
+class TestCacheEngineSWAHooks:
+    def test_slot_gauge_follows_alloc_and_free(self, enabled_collector):
+        c = enabled_collector
+        engine = _make_engine_stub(enabled_collector, num_slots=4, index=_FakeIndex())
+        engine._record_swa_slot_stats()
+        assert sample(c, "flexkv_py_swa_slot_used", {"device": "cpu"}) == 0
+        assert sample(c, "flexkv_py_swa_slot_total", {"device": "cpu"}) == 4
+
+        slot = engine._alloc_swa_slot()
+        assert slot >= 0
+        assert sample(c, "flexkv_py_swa_slot_used", {"device": "cpu"}) == 1
+
+        engine._free_swa_slot(slot)
+        assert sample(c, "flexkv_py_swa_slot_used", {"device": "cpu"}) == 0
+
+    def test_alloc_failure_counts_after_eviction_retry(self, enabled_collector):
+        c = enabled_collector
+        # Pool of 1, already exhausted; eviction frees nothing.
+        engine = _make_engine_stub(enabled_collector, num_slots=1, index=_FakeIndex(evict_freed=0))
+        assert engine._alloc_swa_slot() >= 0
+        before = sample(c, "flexkv_py_swa_slot_alloc_failed_total", {"device": "cpu"})
+        assert engine._alloc_swa_slot() == -1
+        assert sample(c, "flexkv_py_swa_slot_alloc_failed_total", {"device": "cpu"}) == before + 1
+
+    def test_evict_and_cascade_counted(self, enabled_collector):
+        c = enabled_collector
+        engine = _make_engine_stub(enabled_collector, num_slots=2,
+                                   index=_FakeIndex(evict_freed=1, drain_slots=[0]))
+        before_pf = sample(c, "flexkv_py_swa_evicted_slots_total",
+                           {"device": "cpu", "reason": "pool_full"})
+        before_ca = sample(c, "flexkv_py_swa_evicted_slots_total",
+                           {"device": "cpu", "reason": "cascade"})
+        freed = engine._evict_swa_slots(1)
+        assert freed == 1
+        assert sample(c, "flexkv_py_swa_evicted_slots_total",
+                      {"device": "cpu", "reason": "pool_full"}) == before_pf + 1
+        # drain happened inside _evict_swa_slots
+        assert sample(c, "flexkv_py_swa_evicted_slots_total",
+                      {"device": "cpu", "reason": "cascade"}) == before_ca + 1
+
+
+class TestCacheQueryMetrics:
+    def test_query_results(self, enabled_collector):
+        c = enabled_collector
+        for result in ("full", "partial", "miss"):
+            before = sample(c, "flexkv_py_cache_query_total", {"result": result})
+            c.record_cache_query(result)
+            assert sample(c, "flexkv_py_cache_query_total", {"result": result}) == before + 1
+
+    def test_match_blocks_ready_split(self, enabled_collector):
+        c = enabled_collector
+        before_r = sample(c, "flexkv_py_cache_match_blocks_total", {"device": "cpu", "ready": "true"})
+        before_n = sample(c, "flexkv_py_cache_match_blocks_total", {"device": "cpu", "ready": "false"})
+        c.record_cache_match_blocks("cpu", ready_blocks=6, not_ready_blocks=2)
+        c.record_cache_match_blocks("cpu", ready_blocks=0, not_ready_blocks=0)  # ignored
+        assert sample(c, "flexkv_py_cache_match_blocks_total",
+                      {"device": "cpu", "ready": "true"}) == before_r + 6
+        assert sample(c, "flexkv_py_cache_match_blocks_total",
+                      {"device": "cpu", "ready": "false"}) == before_n + 2
+
+
+class TestLayerwiseMetrics:
+    def test_workers_progress(self, enabled_collector):
+        c = enabled_collector
+        c.update_layerwise_workers(2, 4)
+        assert sample(c, "flexkv_py_layerwise_workers_ready") == 2
+        assert sample(c, "flexkv_py_layerwise_workers_expected") == 4
+
+    def test_submit_count_and_latency(self, enabled_collector):
+        c = enabled_collector
+        before_ok = sample(c, "flexkv_py_layerwise_submit_total", {"status": "ok"})
+        before_err = sample(c, "flexkv_py_layerwise_submit_total", {"status": "error"})
+        before_cnt = sample(c, "flexkv_py_layerwise_submit_seconds_count")
+        c.record_layerwise_submit("ok", 0.25)
+        c.record_layerwise_submit("error", 0.0)  # counted, but no latency sample
+        assert sample(c, "flexkv_py_layerwise_submit_total", {"status": "ok"}) == before_ok + 1
+        assert sample(c, "flexkv_py_layerwise_submit_total", {"status": "error"}) == before_err + 1
+        assert sample(c, "flexkv_py_layerwise_submit_seconds_count") == before_cnt + 1
+
+
+class TestDisabledPath:
+    """Metrics off: everything must be a safe no-op."""
+
+    @pytest.fixture()
+    def disabled_collector(self, monkeypatch):
+        monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "enable_metrics", False)
+        c = FlexKVMetricsCollector(role="worker")
+        assert not c.enabled
+        return c
+
+    def test_all_record_methods_noop(self, disabled_collector):
+        c = disabled_collector
+        c.record_swa_query("hit")
+        c.record_swa_hit_blocks(3)
+        c.update_swa_slot_stats("cpu", 1, 10)
+        c.record_swa_slot_alloc_failed("cpu")
+        c.record_swa_evicted("cpu", "pool_full", 1)
+        c.record_cache_query("full")
+        c.record_cache_match_blocks("cpu", 1, 1)
+        c.update_layerwise_workers(1, 4)
+        c.record_layerwise_submit("ok", 0.1)  # exercises DummyMetric.observe
+        c.record_transfer_completed("H2D", 1, 8, "get", is_swa=True)
+
+    def test_engine_hooks_noop(self, disabled_collector):
+        engine = _make_engine_stub(disabled_collector,
+                                   num_slots=2, index=_FakeIndex(evict_freed=1, drain_slots=[0]))
+        engine._record_swa_slot_stats()
+        assert engine._alloc_swa_slot() >= 0
+        engine._free_swa_slot(0)
+        assert engine._evict_swa_slots(1) == 1
+        engine._drain_unmounted_swa_slots()

--- a/tests/test_metrics_dsv4.py
+++ b/tests/test_metrics_dsv4.py
@@ -225,3 +225,36 @@ class TestDisabledPath:
         engine._free_swa_slot(0)
         assert engine._evict_swa_slots(1) == 1
         engine._drain_unmounted_swa_slots()
+
+
+class TestDefaultRegistry:
+    """Regression: without an injected registry, metrics must register into the
+    process default REGISTRY (prometheus_client skips registration when a
+    metric is constructed with registry=None)."""
+
+    @staticmethod
+    def _unregister_all_flexkv(registry):
+        # Other tests (e.g. GlobalCacheEngine with metrics on) may have
+        # populated the default REGISTRY; clear flexkv entries so this test
+        # is order-independent. Uses the private name map (test-only).
+        for name in list(getattr(registry, "_names_to_collectors", {})):
+            if name.startswith("flexkv_py_"):
+                try:
+                    registry.unregister(registry._names_to_collectors[name])
+                except Exception:
+                    pass
+
+    def test_metrics_land_in_default_registry(self, monkeypatch):
+        from prometheus_client import REGISTRY
+
+        self._unregister_all_flexkv(REGISTRY)
+        try:
+            monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "enable_metrics", True)
+            c = FlexKVMetricsCollector(role="worker")  # no registry injected
+            assert c._registry is REGISTRY
+            c.record_swa_query("hit")
+            assert REGISTRY.get_sample_value(
+                "flexkv_py_swa_query_total", {"result": "hit"}) >= 1
+        finally:
+            self._unregister_all_flexkv(REGISTRY)
+


### PR DESCRIPTION
DSV4 可观测性指标（SWA / 缓存查询 /
  Layerwise）

  ## 概述

  在现有 `flexkv_py_*` Prometheus 体系上增量扩展 13 个 DSV4
  强相关指标，覆盖
  SWA 缓存、缓存查询与就绪状态、Layerwise
  传输链路。
  ## 改动内容

  **指标基础设施**
  - Collector：main/worker 角色初始化、registry
  注入（测试隔离）、Histogram
    支持、`DummyMetric.observe()`、热路径 label 子项预解析
  - Server：设置 `PROMETHEUS_MULTIPROC_DIR` 时经
  `MultiProcessCollector`
    聚合多进程指标；单进程行为不变

  **新增指标**
  - SWA：`swa_query_total{hit|miss}`、`swa_hit_blocks_total`、
    `swa_slot_used/total{device}`、`swa_slot_alloc_failed_total
  {device}`、
    `swa_evicted_slots_total{device,pool_full|cascade}`、
    `swa_transfer_bytes_total{operation}`
  - 缓存查询：`cache_query_total{full|partial|miss}`、
    `cache_match_blocks_total{device,ready}`（ready=true
  即有效复用口径）
  - Layerwise：`layerwise_workers_ready/expected`、
    `layerwise_submit_seconds`（Histogram）、`layerwise_submit_
  total{ok|error}`

  **挂点**（只读旁路，不触碰状态机）
  - `cache_engine.py`：SWA slot
  分配/淘汰/级联释放、`_select_swa_read_source`
    （含 mooncake 分支）、`_get_impl_global` 与
  `_get_impl_local`
  - `transfer_engine.py`：layerwise worker
  就绪进度、提交时延/状态、
    `CompletedOp.is_swa`
  - `kvtask.py`：完成回调透传 `is_swa`
  - 文档（中英）+ 验证报告（中文）

  ## 验证

  - 新增测试 `tests/test_metrics_dsv4.py` 14
  例（开启态数值断言、关闭态
    no-op、默认 REGISTRY 回归）全部通过
  - 回归：metrics 关 254 通过 / 开 218 通过（5 个失败为 main
  自带的上游
    测试漂移，与本改动无关）
  - 实机部署（DSV4-Flash，tp4，sglang）：指标随真实流量精确变化
  ；命中路径

  端到端验证（`cache_query{full}`、`cache_match{ready=true}`、
    `swa_query{hit}`）；多进程聚合实测正确
  - 完整测试记录见
  `docs/monitoring/dsv4_metrics_test_report_zh.md`