### PR TITLE
perf(transfer): dispatch from a dirty set instead of sweeping every graph

### DIFF
--- a/benchmarks/microbenchmark_transfer_scheduler.py
+++ b/benchmarks/microbenchmark_transfer_scheduler.py
@@ -1,0 +1,163 @@
+"""Microbenchmark: TransferScheduler.schedule() cost vs in-flight concurrency.
+
+The transfer scheduler runs on a single thread and is woken once per batch of
+finished ops. What we want to know is whether the cost of one wake-up depends on
+how much actually changed, or on how many requests happen to be in flight.
+
+This drives a fixed amount of real work per tick -- exactly one op of one graph
+completes -- while varying the number of other, idle in-flight graphs. A
+scheduler whose cost tracks real work stays flat; one that sweeps every graph
+grows linearly with concurrency. Note this is the extreme case, exactly one
+dirty graph per tick; with k dirty the incremental cost is O(k), which is the
+whole point.
+
+CPU only: no GPU, no c_ext transfers, no storage. Run with:
+    python benchmarks/microbenchmark_transfer_scheduler.py --baseline
+"""
+from argparse import ArgumentParser
+import time
+
+import numpy as np
+
+from flexkv.common.transfer import (
+    TransferOp,
+    TransferOpGraph,
+    TransferOpStatus,
+    TransferType,
+)
+from flexkv.transfer.scheduler import TransferScheduler
+
+
+class FullSweepScheduler:
+    """The pre-change scheduler, kept here so `--baseline` can print a
+    before/after table from one run instead of asking you to check out the
+    previous revision.
+
+    `tests/test_transfer_scheduler_incremental.py` keeps its own copy, where it
+    serves as the equivalence oracle; keep the two in step.
+    """
+
+    def __init__(self) -> None:
+        self._transfer_graphs = {}
+
+    def add_transfer_graph(self, graph) -> None:
+        self._transfer_graphs[graph.graph_id] = graph
+
+    def schedule(self, finished_ops):
+        for op in finished_ops:
+            if op.graph_id in self._transfer_graphs:
+                self._transfer_graphs[op.graph_id].mark_completed(op.op_id)
+
+        next_ops = []
+        for graph in self._transfer_graphs.values():
+            for op_id in graph.take_ready_ops():
+                op = graph._op_map[op_id]
+                if op.transfer_type == TransferType.VIRTUAL:
+                    self._transfer_graphs[op.graph_id].mark_completed(op_id)
+                next_ops.append(op)
+
+        completed_graph_ids = [
+            graph_id for graph_id, graph in self._transfer_graphs.items()
+            if graph.all_transfer_ops_completed()
+        ]
+        for graph_id in completed_graph_ids:
+            self._transfer_graphs.pop(graph_id)
+        return completed_graph_ids, next_ops
+
+
+def build_chain_graph(num_ops: int):
+    """A linear chain op0 -> op1 -> ... -> op[n-1], like a staged transfer."""
+    graph = TransferOpGraph.create_empty_graph()
+    ops = []
+    for i in range(num_ops):
+        op = TransferOp(
+            graph_id=graph.graph_id,
+            transfer_type=TransferType.H2D if i % 2 else TransferType.D2H,
+            src_block_ids=np.arange(4, dtype=np.int64),
+            dst_block_ids=np.arange(4, dtype=np.int64),
+        )
+        graph.add_transfer_op(op)
+        ops.append(op)
+    for i in range(1, num_ops):
+        graph.add_dependency(ops[i].op_id, ops[i - 1].op_id)
+    return graph, ops
+
+
+def measure(num_graphs: int, ops_per_graph: int, cls=TransferScheduler,
+            repeat: int = 5) -> float:
+    """Microseconds per schedule() call that advances exactly one op.
+
+    Best of `repeat` runs: a single run only times `ops_per_graph - 1` calls,
+    which at low concurrency is a window of tens of microseconds -- short
+    enough that the sign of the delta flips between runs.
+    """
+    return min(_measure_once(num_graphs, ops_per_graph, cls)
+               for _ in range(repeat))
+
+
+def _measure_once(num_graphs: int, ops_per_graph: int, cls) -> float:
+    scheduler = cls()
+    target_ops = None
+    for i in range(num_graphs):
+        graph, ops = build_chain_graph(ops_per_graph)
+        scheduler.add_transfer_graph(graph)
+        if i == 0:
+            target_ops = ops
+
+    scheduler.schedule([])  # prime: dispatch the head op of every graph
+
+    idx = 0
+    ticks = 0
+    start = time.perf_counter()
+    while idx < ops_per_graph - 1:
+        op = target_ops[idx]
+        if op.status != TransferOpStatus.RUNNING:
+            # Would silently shorten the run and still print a plausible
+            # number, so fail loudly instead.
+            raise RuntimeError(
+                f"op {op.op_id} is {op.status}, expected RUNNING -- the chain "
+                f"did not advance as expected")
+        scheduler.schedule([op])
+        idx += 1
+        ticks += 1
+    elapsed = time.perf_counter() - start
+    return elapsed / max(ticks, 1) * 1e6
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--ops-per-graph", type=int, default=16)
+    parser.add_argument("--concurrency", type=int, nargs="+",
+                        default=[1, 8, 32, 128, 512, 1024, 2048])
+    parser.add_argument("--baseline", action="store_true",
+                        help="also measure the pre-change full-sweep scheduler")
+    parser.add_argument("--repeat", type=int, default=5,
+                        help="runs per data point; the best is reported")
+    args = parser.parse_args()
+
+    print(f"one schedule() tick advancing exactly one op "
+          f"({args.ops_per_graph} ops per graph)\n")
+    if args.baseline:
+        print(f"{'in-flight graphs':>17} | {'full sweep us':>14} | {'dirty set us':>13}")
+        print("-" * 50)
+        for num_graphs in args.concurrency:
+            before = measure(num_graphs, args.ops_per_graph,
+                             FullSweepScheduler, args.repeat)
+            after = measure(num_graphs, args.ops_per_graph,
+                            TransferScheduler, args.repeat)
+            print(f"{num_graphs:>17} | {before:>14.2f} | {after:>13.2f}")
+        print("\nThe left column grows with concurrency, the right one does not.")
+    else:
+        print(f"{'in-flight graphs':>17} | {'us / tick':>10} | "
+              f"{'us per in-flight graph':>23}")
+        print("-" * 58)
+        for num_graphs in args.concurrency:
+            us = measure(num_graphs, args.ops_per_graph,
+                         repeat=args.repeat)
+            print(f"{num_graphs:>17} | {us:>10.2f} | {us / num_graphs:>23.4f}")
+        print("\nA flat middle column means per-tick cost tracks real work "
+              "rather than total in-flight concurrency.")
+
+
+if __name__ == "__main__":
+    main()

--- a/flexkv/transfer/scheduler.py
+++ b/flexkv/transfer/scheduler.py
@@ -8,10 +8,22 @@ class TransferScheduler:
     def __init__(self) -> None:
         # Store all transfer graphs
         self._transfer_graphs: OrderedDict[int, TransferOpGraph] = OrderedDict()
+        # Graph ids whose op state changed since the last schedule() call, in
+        # the order they became dirty. Dependencies never cross graphs, so a
+        # graph can only expose new ready ops after one of its OWN ops
+        # completes; visiting just these is equivalent to sweeping every
+        # in-flight graph, at O(changed) instead of O(in-flight) per call.
+        #
+        # Standing requirement: any path that completes an op or otherwise
+        # changes a graph's readiness must dirty that graph here. The old full
+        # sweep tolerated such a path silently; this one will never revisit the
+        # graph. TransferOpGraph.trigger_op() is one such path (no callers).
+        self._dirty_graph_ids: OrderedDict[int, None] = OrderedDict()
 
     def add_transfer_graph(self, graph: TransferOpGraph) -> None:
         """Add a new transfer graph to the scheduler"""
         self._transfer_graphs[graph.graph_id] = graph
+        self._dirty_graph_ids[graph.graph_id] = None
 
     def schedule(self,
                 finished_ops: List[TransferOp]
@@ -27,29 +39,52 @@ class TransferScheduler:
                 - List of completed transfer graph IDs
                 - List of next executable transfer operations
         """
-        # Mark completed operations
+        # Mark completed operations. Dirty the graph before completing the op:
+        # mark_completed() clears the op from its successors' predecessor sets
+        # in a loop, so a raise partway through leaves the graph half-advanced
+        # and needing a revisit. (Its leading assert fires before any mutation,
+        # so that case needs no recovery either way -- this ordering is free
+        # insurance for the partial-mutation one, not for the assert.)
         for op in finished_ops:
             if op.graph_id in self._transfer_graphs:
+                self._dirty_graph_ids[op.graph_id] = None
                 self._transfer_graphs[op.graph_id].mark_completed(op.op_id)
 
-        # Get next batch of executable operations
+        # Drain the dirty set. Peek at the head and drop the dirty bit only once
+        # the graph has been fully processed, so a raise below leaves the id
+        # dirty and the graph gets revisited -- the caller logs and keeps
+        # looping (TransferEngine._scheduler_loop), so a dropped dirty bit would
+        # strand that graph for good. This recovers the dirty BIT, not the work:
+        # ops already collected into next_ops are discarded along with the
+        # exception, exactly as they were under the full sweep.
         next_ops = []
-        for graph in self._transfer_graphs.values():
-            ready_op_ids = graph.take_ready_ops()
-            for op_id in ready_op_ids:
-                op = graph._op_map[op_id]
-                if op.transfer_type == TransferType.VIRTUAL:
-                    self._transfer_graphs[op.graph_id].mark_completed(op_id)
-                next_ops.append(op)
-
-        # Find completed transfer graphs
         completed_graph_ids = []
-        for graph_id, graph in self._transfer_graphs.items():
-            if graph.all_transfer_ops_completed():
-                completed_graph_ids.append(graph_id)
-
-        # Remove completed graphs from scheduler
-        for graph_id in completed_graph_ids:
-            self._transfer_graphs.pop(graph_id)
+        while self._dirty_graph_ids:
+            graph_id = next(iter(self._dirty_graph_ids))
+            # Defensive: every id reaching here should resolve, since the only
+            # writers pair the two dicts. Skipping beats a KeyError, which the
+            # caller would swallow and then retry forever on the same id.
+            graph = self._transfer_graphs.get(graph_id)
+            revisit = False
+            if graph is not None:
+                for op_id in graph.take_ready_ops():
+                    op = graph._op_map[op_id]
+                    if op.transfer_type == TransferType.VIRTUAL:
+                        # Self-completing, and that can unblock successors, so
+                        # the graph needs another pass before this call returns.
+                        graph.mark_completed(op_id)
+                        revisit = True
+                    next_ops.append(op)
+                if graph.all_transfer_ops_completed():
+                    completed_graph_ids.append(graph_id)
+                    del self._transfer_graphs[graph_id]
+                    # A finished graph needs no further pass. This is the common
+                    # case -- a terminal virtual sink both sets revisit and
+                    # completes the graph -- so skipping the re-queue keeps it
+                    # off the hot path.
+                    revisit = False
+            del self._dirty_graph_ids[graph_id]
+            if revisit:
+                self._dirty_graph_ids[graph_id] = None  # re-queue at the tail
 
         return completed_graph_ids, next_ops

--- a/tests/test_transfer_scheduler_incremental.py
+++ b/tests/test_transfer_scheduler_incremental.py
@@ -1,0 +1,362 @@
+"""TransferScheduler dispatches from a dirty set instead of sweeping every graph.
+
+The scheduler used to visit every in-flight graph on every call. Dependencies
+never cross graphs, so a graph can only expose new ready ops after one of its
+own ops completes -- visiting only the changed graphs is equivalent.
+
+These tests pin that equivalence down: a reference implementation of the old
+full-sweep behavior is driven in lockstep with the real scheduler over random
+DAGs, and both must dispatch the same ops and complete the same graphs on every
+tick. Separate tests cover where the new scheduler deliberately differs
+(non-terminal virtual ops), where it must not regress (losing a dirty bit on
+error), and the limit of that guarantee (ops an exception loses regardless).
+"""
+import random
+
+import numpy as np
+import pytest
+
+from flexkv.common.transfer import (
+    TransferOp,
+    TransferOpGraph,
+    TransferOpStatus,
+    TransferType,
+)
+from flexkv.transfer.scheduler import TransferScheduler
+
+pytestmark = pytest.mark.unit
+
+
+class _FullSweepScheduler:
+    """Reference: the pre-change scheduler, sweeping all graphs every call.
+
+    Verbatim behavior of TransferScheduler as of the parent of this commit.
+    `benchmarks/microbenchmark_transfer_scheduler.py` keeps its own copy for the
+    --baseline table; keep the two in step if either is ever touched.
+
+    Note this is only an oracle for *which graphs get visited* -- it calls the
+    same TransferOpGraph methods the real scheduler does.
+    """
+
+    def __init__(self):
+        self._transfer_graphs = {}
+
+    def add_transfer_graph(self, graph):
+        self._transfer_graphs[graph.graph_id] = graph
+
+    def schedule(self, finished_ops):
+        for op in finished_ops:
+            if op.graph_id in self._transfer_graphs:
+                self._transfer_graphs[op.graph_id].mark_completed(op.op_id)
+
+        next_ops = []
+        for graph in self._transfer_graphs.values():
+            for op_id in graph.take_ready_ops():
+                op = graph._op_map[op_id]
+                if op.transfer_type == TransferType.VIRTUAL:
+                    self._transfer_graphs[op.graph_id].mark_completed(op_id)
+                next_ops.append(op)
+
+        completed_graph_ids = [
+            graph_id for graph_id, graph in self._transfer_graphs.items()
+            if graph.all_transfer_ops_completed()
+        ]
+        for graph_id in completed_graph_ids:
+            self._transfer_graphs.pop(graph_id)
+        return completed_graph_ids, next_ops
+
+
+def _make_op(graph, transfer_type=TransferType.H2D, n=2):
+    return TransferOp(
+        graph_id=graph.graph_id,
+        transfer_type=transfer_type,
+        src_block_ids=np.arange(n, dtype=np.int64),
+        dst_block_ids=np.arange(n, dtype=np.int64),
+    )
+
+
+def _build_from_spec(spec):
+    """spec = (list of TransferType, list of (successor_idx, predecessor_idx))"""
+    types, edges = spec
+    graph = TransferOpGraph.create_empty_graph()
+    ops = []
+    for t in types:
+        n = 0 if t == TransferType.VIRTUAL else 2
+        op = _make_op(graph, t, n)
+        graph.add_transfer_op(op)
+        ops.append(op)
+    for succ, pred in edges:
+        graph.add_dependency(ops[succ].op_id, ops[pred].op_id)
+    return graph, ops
+
+
+def _random_spec(rng, n_ops):
+    """Random DAG. A virtual op is only ever placed LAST, with edges running
+    from lower to higher index, so it is always a terminal sink -- which is
+    what every virtual op in FlexKV actually is today. A non-terminal virtual
+    op is deliberately NOT equivalent between the two schedulers; see
+    test_non_terminal_virtual_op_dispatches_successor_same_tick.
+    """
+    types = [rng.choice([TransferType.H2D, TransferType.D2H]) for _ in range(n_ops)]
+    if rng.random() < 0.25:
+        types[-1] = TransferType.VIRTUAL
+    edges = [(i, j) for i in range(n_ops) for j in range(i) if rng.random() < 0.35]
+    return types, edges
+
+
+# --------------------------------------------------------------------------
+# Basic behavior
+# --------------------------------------------------------------------------
+
+def test_linear_chain_advances_one_op_per_tick():
+    sched = TransferScheduler()
+    graph = TransferOpGraph.create_empty_graph()
+    ops = [_make_op(graph) for _ in range(4)]
+    for op in ops:
+        graph.add_transfer_op(op)
+    for i in range(1, 4):
+        graph.add_dependency(ops[i].op_id, ops[i - 1].op_id)
+    sched.add_transfer_graph(graph)
+
+    completed, dispatched = sched.schedule([])
+    assert [o.op_id for o in dispatched] == [ops[0].op_id]
+    assert completed == []
+
+    for i in range(3):
+        completed, dispatched = sched.schedule([ops[i]])
+        assert [o.op_id for o in dispatched] == [ops[i + 1].op_id]
+
+    completed, dispatched = sched.schedule([ops[3]])
+    assert completed == [graph.graph_id]
+    assert dispatched == []
+
+
+def test_graph_with_no_ops_completes_immediately():
+    sched = TransferScheduler()
+    graph = TransferOpGraph.create_empty_graph()
+    sched.add_transfer_graph(graph)
+    completed, dispatched = sched.schedule([])
+    assert completed == [graph.graph_id]
+    assert dispatched == []
+
+
+def test_terminal_virtual_op_completes_graph_in_same_tick():
+    """A virtual task-end op is dispatched and self-completes, so the graph
+    finishes without waiting for another external event."""
+    sched = TransferScheduler()
+    graph = TransferOpGraph.create_empty_graph()
+    real = _make_op(graph)
+    virt = _make_op(graph, TransferType.VIRTUAL, n=0)
+    graph.add_transfer_op(real)
+    graph.add_transfer_op(virt)
+    graph.add_dependency(virt.op_id, real.op_id)
+    sched.add_transfer_graph(graph)
+
+    _, dispatched = sched.schedule([])
+    assert [o.op_id for o in dispatched] == [real.op_id]
+
+    completed, dispatched = sched.schedule([real])
+    assert [o.op_id for o in dispatched] == [virt.op_id]
+    assert completed == [graph.graph_id]
+
+
+def test_idle_graphs_are_not_revisited():
+    """A tick that advances one graph must not re-scan the others."""
+    sched = TransferScheduler()
+    graphs = []
+    for _ in range(5):
+        graph = TransferOpGraph.create_empty_graph()
+        a, b = _make_op(graph), _make_op(graph)
+        graph.add_transfer_op(a)
+        graph.add_transfer_op(b)
+        graph.add_dependency(b.op_id, a.op_id)
+        sched.add_transfer_graph(graph)
+        graphs.append((graph, a, b))
+    sched.schedule([])
+
+    target_graph, target_a, _ = graphs[0]
+    calls = {g.graph_id: 0 for g, _, _ in graphs}
+    try:
+        for g, _, _ in graphs:
+            def counting(_g=g, _orig=g.take_ready_ops):
+                calls[_g.graph_id] += 1
+                return _orig()
+
+            g.take_ready_ops = counting
+        sched.schedule([target_a])
+    finally:
+        for g, _, _ in graphs:
+            # drop the instance attribute, restoring the class method
+            g.__dict__.pop("take_ready_ops", None)
+
+    assert calls[target_graph.graph_id] == 1
+    for g, _, _ in graphs[1:]:
+        assert calls[g.graph_id] == 0, "untouched graph should not be swept"
+
+
+# --------------------------------------------------------------------------
+# Where the new scheduler must differ, and where it must not regress
+# --------------------------------------------------------------------------
+
+def test_non_terminal_virtual_op_dispatches_successor_same_tick():
+    """Deliberate divergence from the old full-sweep scheduler.
+
+    With `real -> virtual -> real`, completing the virtual op unblocks its
+    successor. The old code deferred that successor to the NEXT schedule()
+    call, which the engine only makes on a new external event -- so a graph
+    whose only remaining work sat behind a virtual op could stall. Every
+    virtual op FlexKV builds today is a terminal sink, so this is latent
+    rather than live, but the dirty-set drain fixes it for free.
+    """
+    sched = TransferScheduler()
+    graph = TransferOpGraph.create_empty_graph()
+    head = _make_op(graph)
+    virt = _make_op(graph, TransferType.VIRTUAL, n=0)
+    tail = _make_op(graph)
+    for op in (head, virt, tail):
+        graph.add_transfer_op(op)
+    graph.add_dependency(virt.op_id, head.op_id)
+    graph.add_dependency(tail.op_id, virt.op_id)
+    sched.add_transfer_graph(graph)
+
+    sched.schedule([])  # dispatches head
+    _, dispatched = sched.schedule([head])
+
+    assert [o.op_id for o in dispatched] == [virt.op_id, tail.op_id], \
+        "successor of a virtual op must be dispatched in the same tick"
+
+
+def _drain_with_exploding_graph(position, num_graphs=3):
+    """Build `num_graphs` single-op graphs, make the one at `position` raise
+    during the drain, then retry. Returns how many ops the retry dispatches."""
+    sched = TransferScheduler()
+    graphs = []
+    for _ in range(num_graphs):
+        graph = TransferOpGraph.create_empty_graph()
+        graph.add_transfer_op(_make_op(graph))
+        sched.add_transfer_graph(graph)
+        graphs.append(graph)
+
+    boom = graphs[position]
+
+    def exploding():
+        raise RuntimeError("boom")
+
+    try:
+        boom.take_ready_ops = exploding
+        with pytest.raises(RuntimeError):
+            sched.schedule([])
+    finally:
+        boom.__dict__.pop("take_ready_ops", None)
+    _, dispatched = sched.schedule([])
+    return len(dispatched)
+
+
+def test_dirty_bit_survives_an_exception_mid_drain():
+    """The engine's scheduler loop logs and continues on exception. Dropping a
+    graph's dirty bit before it is processed would mean it is never revisited,
+    so its request hangs. Dropping the bit only afterwards keeps the graph
+    reachable: with the raise at the head of the drain, nothing has been
+    dispatched yet and the retry recovers every graph."""
+    assert _drain_with_exploding_graph(position=0) == 3
+
+
+def test_exception_mid_drain_still_loses_already_collected_ops():
+    """Pins the limit of the above, so the guarantee is not overstated.
+
+    A raise partway through the drain discards the `next_ops` collected so far,
+    and take_ready_ops() will not hand back an op it already flipped to RUNNING.
+    Those ops are lost even though the dirty bit is intact. This is not a
+    regression -- the full-sweep scheduler loses them identically -- but the
+    dirty bit is not what saves you here.
+    """
+    assert _drain_with_exploding_graph(position=1) == 2
+
+
+# --------------------------------------------------------------------------
+# Equivalence with the old full-sweep scheduler
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("seed", range(60))
+def test_matches_full_sweep_scheduler_on_random_dags(seed):
+    rng = random.Random(seed)
+    specs = [_random_spec(rng, rng.randint(1, 8))
+             for _ in range(rng.randint(1, 6))]
+    # The engine adds graphs from the same loop that calls schedule(), so some
+    # arrive while others are already draining. Hold a suffix back and inject it
+    # mid-run, which makes add_transfer_graph's dirty-marking accountable to the
+    # oracle rather than only to the liveness assert at the end.
+    deferred_from = rng.randint(1, len(specs))
+
+    ref_sched, new_sched = _FullSweepScheduler(), TransferScheduler()
+    ref_graphs, new_graphs = [], []
+    ref_idx, new_idx = {}, {}
+    pending = []
+    for pos, spec in enumerate(specs):
+        rg, r_ops = _build_from_spec(spec)
+        ng, n_ops = _build_from_spec(spec)
+        ref_graphs.append((rg, r_ops))
+        new_graphs.append((ng, n_ops))
+        for k, op in enumerate(r_ops):
+            ref_idx[op.op_id] = (pos, k)
+        for k, op in enumerate(n_ops):
+            new_idx[op.op_id] = (pos, k)
+        if pos < deferred_from:
+            ref_sched.add_transfer_graph(rg)
+            new_sched.add_transfer_graph(ng)
+        else:
+            pending.append((rg, ng))
+
+    ref_pos = {g.graph_id: i for i, (g, _) in enumerate(ref_graphs)}
+    new_pos = {g.graph_id: i for i, (g, _) in enumerate(new_graphs)}
+
+    ref_running, new_running = [], []
+    ref_finished, new_finished = [], []
+
+    for tick in range(200):
+        # Inject one held-back graph per tick, into both schedulers alike.
+        if pending and tick > 0:
+            rg, ng = pending.pop(0)
+            ref_sched.add_transfer_graph(rg)
+            new_sched.add_transfer_graph(ng)
+
+        ref_done, ref_next = ref_sched.schedule(ref_finished)
+        new_done, new_next = new_sched.schedule(new_finished)
+
+        assert sorted(ref_pos[g] for g in ref_done) == \
+               sorted(new_pos[g] for g in new_done)
+        assert sorted(ref_idx[o.op_id] for o in ref_next) == \
+               sorted(new_idx[o.op_id] for o in new_next)
+
+        # Queue dispatched work in a canonical order on both sides so the
+        # random completion picks below refer to the same logical ops.
+        ref_running += [o for o in sorted(ref_next, key=lambda o: ref_idx[o.op_id])
+                        if o.transfer_type != TransferType.VIRTUAL]
+        new_running += [o for o in sorted(new_next, key=lambda o: new_idx[o.op_id])
+                        if o.transfer_type != TransferType.VIRTUAL]
+        if not ref_running:
+            if not pending:
+                break
+            ref_finished, new_finished = [], []
+            continue  # nothing in flight, but graphs are still arriving
+
+        order = list(range(len(ref_running)))
+        rng.shuffle(order)
+        picked = set(order[:rng.randint(1, len(ref_running))])
+        ref_finished = [o for i, o in enumerate(ref_running) if i in picked]
+        new_finished = [o for i, o in enumerate(new_running) if i in picked]
+        ref_running = [o for i, o in enumerate(ref_running) if i not in picked]
+        new_running = [o for i, o in enumerate(new_running) if i not in picked]
+
+    # Liveness: every graph must drain, and every op must reach COMPLETED. A
+    # scheduler that skipped a graph it should have revisited would park one
+    # here forever -- in production a hung request rather than a wrong answer.
+    assert not new_sched._transfer_graphs, \
+        f"graphs left un-completed: {list(new_sched._transfer_graphs)}"
+    assert not ref_sched._transfer_graphs, \
+        f"reference left graphs un-completed: {list(ref_sched._transfer_graphs)}"
+    assert not pending, "held-back graphs were never injected"
+    for _graph, ops in new_graphs:
+        for op in ops:
+            assert op.status == TransferOpStatus.COMPLETED, \
+                f"op {op.op_id} stuck in {op.status}"


### PR DESCRIPTION
## Problem

`TransferScheduler.schedule()` visited every in-flight graph on every call: `take_ready_ops()` on all of them, then `all_transfer_ops_completed()` on all of them.

Dependencies never cross graphs — `add_dependency()` asserts both ops belong to the same graph — so a graph can only expose new ready ops after one of its **own** ops completes. Sweeping the rest is wasted work, and it makes the cost of one wake-up scale with total in-flight concurrency rather than with how much actually changed.

## Change

Track the graphs dirtied since the last call and drain only those. `flexkv/transfer/scheduler.py` is the only production file touched.

## Measurements

`python benchmarks/microbenchmark_transfer_scheduler.py --baseline` runs the old full-sweep scheduler and the new one in the same process, so the table is reproducible from one command (best of 5 per point, single machine):

| in-flight graphs | full sweep | dirty set |
|---:|---:|---:|
| 1 | 1.61 us | 1.59 us |
| 8 | 5.16 us | 1.61 us |
| 32 | 16.07 us | 1.66 us |
| 128 | 63.66 us | 1.69 us |
| 512 | 266.32 us | 1.84 us |
| 1024 | 532.37 us | 1.98 us |
| 2048 | 1074.83 us | 1.93 us |

Flat in concurrency instead of linear.

### Scope of that claim

I would rather state the limits than have a reviewer find them:

- This is the extreme case, exactly **one** dirty graph per tick. With `k` dirty the cost is `O(k)`, which is the point, but the table is the most favorable shape.
- This is **control-plane Python overhead only**. Whether it shows up end to end depends on the scheduler thread being a bottleneck. It will not be at low concurrency, nor when batch merging keeps the in-flight graph count small, and the same tick also pays `multiprocessing` pickle costs that dominate at modest concurrency.
- I have **not** measured this end to end on a real GPU deployment.

## The failure mode this had to be careful about

The full sweep was self-healing: any state drift got picked up on the next tick. An incremental scheduler is not, so losing a dirty bit means the graph is never revisited and its request hangs.

The drain therefore drops a graph's dirty bit only **after** that graph has been processed, so a raise leaves it queued for the next call. That recovers the dirty bit, **not** the work: ops already collected into `next_ops` are discarded with the exception, and `take_ready_ops()` will not re-emit an op it already flipped to `RUNNING`. The full-sweep scheduler loses those identically — `test_exception_mid_drain_still_loses_already_collected_ops` pins that limit so the guarantee is not overstated.

## One deliberate behavior change

Completing a virtual op now revisits its graph within the same call. The old code deferred the successors to the next external event, which `TransferEngine._scheduler_loop` only produces when an op finishes or a graph arrives — so a graph whose remaining work sat behind a **non-terminal** virtual op could stall.

Every virtual op FlexKV builds today is a terminal sink (`add_virtual_op_for_multiple_finished_ops`, `_add_batch_sink`), so this is latent rather than live. `test_non_terminal_virtual_op_dispatches_successor_same_tick` covers it.

## Testing

`tests/test_transfer_scheduler_incremental.py` (marked `unit`, no GPU, runs in <0.1s) keeps a reference implementation of the old full-sweep scheduler and drives it in lockstep with the new one over random DAGs — with some graphs arriving mid-run, as the engine does it. Both must dispatch the same ops and complete the same graphs on every tick, and every graph must drain.

I mutation-tested the suite; each of the following is killed by at least one test:

- substituting the old scheduler verbatim → only the two intended divergences fail
- dropping the dirty bit before processing instead of after
- removing the virtual-op revisit
- not dirtying on `add_transfer_graph` (67/67 fail)
- not dirtying on a finished op
- removing the `graph is not None` guard

## Notes for the reviewer

- `completed_graph_ids` and `next_ops` now come back in dirty order rather than scheduler insertion order. Ops in different graphs are independent and the only consumer fans both onto queues per element (`TransferEngine._scheduler_loop`), so I believe the order carries no meaning — worth a second opinion.
- The reference full-sweep scheduler is duplicated in the test and in the benchmark (`--baseline`). I kept both and cross-referenced them in their docstrings; happy to drop `--baseline` instead if you would rather not carry the copy.
- `TransferOpGraph.trigger_op()` completes an op outside `schedule()` and so would not dirty its graph. It has no callers today; I noted the standing requirement next to `_dirty_graph_ids` rather than change it here.
