### PR TITLE
fix(kvtask): roll back plan resources when cancelling a never-launched task

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -933,6 +933,9 @@ PYBIND11_MODULE(c_ext, m) {
                &flexkv::CRadixTreeIndex::evict),
            py::arg("evicted_blocks"), py::arg("evicted_block_hashes"),
            py::arg("num_evicted"), py::call_guard<py::gil_scoped_release>())
+      .def("remove_unready_leaf",
+           &flexkv::CRadixTreeIndex::remove_unready_leaf, py::arg("node"),
+           py::arg("freed_blocks"), py::call_guard<py::gil_scoped_release>())
       .def("total_cached_blocks", &flexkv::CRadixTreeIndex::total_cached_blocks)
       .def("total_unready_blocks",
            &flexkv::CRadixTreeIndex::total_unready_blocks)

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -736,4 +736,37 @@ CRadixTreeIndex::match_prefix(torch::Tensor &block_hashes, int num_blocks,
       last_swa_node, swa_hit_blocks);
 }
 
+// Roll back a not-yet-ready inserted leaf (planned transfer aborted before
+// launch). Only removes the node when unambiguously safe: it must still be an
+// unready, unlocked, SWA-unlocked leaf. If another request split it or
+// inserted below it in the create-to-cancel window, it is left in place
+// (pre-existing behavior) rather than risk detaching blocks another plan
+// references. Mirrors flexkv/cache/radixtree.py::remove_unready_leaf.
+int CRadixTreeIndex::remove_unready_leaf(CRadixNode *node,
+                                         torch::Tensor &freed_blocks) {
+  if (node == nullptr || is_root(node) || node->is_ready() ||
+      node->get_lock_cnt() > 0 || node->get_swa_lock_ref() > 0 ||
+      !node->is_leaf()) {
+    freed_blocks.resize_({0});
+    return 0;
+  }
+  std::vector<int64_t> freed;
+  auto parent = detach_leaf_collect(node, freed, nullptr);
+  if (swa_enabled_) {
+    // I2 cascade, exactly as evict() does after a leaf deletion.
+    cascade_delete_tombstone_leaves(parent, freed, nullptr);
+  } else if (parent != nullptr && parent->is_leaf() && !is_root(parent)) {
+    add_leaf(parent);
+  }
+  int n = static_cast<int>(freed.size());
+  freed_blocks.resize_({n});
+  if (n > 0) {
+    auto *out = freed_blocks.data_ptr<int64_t>();
+    for (int i = 0; i < n; ++i) {
+      out[i] = freed[i];
+    }
+  }
+  return n;
+}
+
 } //  namespace flexkv

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -633,6 +633,15 @@ public:
   virtual int evict(torch::Tensor &evicted_blocks, int num_evicted);
   virtual int evict(torch::Tensor &evicted_blocks,
                     torch::Tensor &evicted_block_hashes, int num_evicted);
+  // Roll back a not-yet-ready inserted leaf whose completion callback will
+  // never run (planned transfer aborted before launch). Removes the node only
+  // when unambiguously safe (still an unready, unlocked, SWA-unlocked leaf)
+  // and publishes its physical blocks into freed_blocks (resized; possibly
+  // plus a tombstone-leaf cascade, mirroring evict()). Returns the number of
+  // freed blocks; 0 when the node was left in place. Mirrors
+  // flexkv/cache/radixtree.py::remove_unready_leaf (the executable spec).
+  virtual int remove_unready_leaf(CRadixNode *node,
+                                  torch::Tensor &freed_blocks);
   virtual std::shared_ptr<CMatchResult>
   match_prefix(torch::Tensor &block_hashes, int num_blocks,
                bool update_cache_info = true);

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -31,7 +31,7 @@ from flexkv.cache.mempool import Mempool
 from flexkv.cache.radixtree import RadixTreeIndex, RadixNode, MatchResult
 from flexkv.cache.swa_cache_engine import SWAOpConstructor
 from flexkv.common.block import SequenceMeta
-from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV, SWAPoolConfig
 from flexkv.common.transfer import (
     DeviceType,
     TransferOpGraph,
@@ -56,6 +56,9 @@ class GetTransferPlan:
     op_callback_dict: Dict[int, Callable]
     buffer_to_free: Dict[DeviceType, np.ndarray]
     num_gpu_blocks_to_transfer: int
+    # SWA read reservation held by this plan; released by an op callback on the
+    # normal path, or by the abort path when the plan is cancelled unlaunched.
+    swa_reservation: Optional["SWAReadReservation"] = None
 
     @classmethod
     def empty(cls) -> "GetTransferPlan":
@@ -78,6 +81,9 @@ class PutTransferPlan:
     buffer_to_free: Dict[DeviceType, np.ndarray]
     num_gpu_blocks_to_transfer: int
     skipped_gpu_blocks: int
+    # SWA slots reserved for this put but not yet mounted (publication happens
+    # in an op callback); the abort path must return them to the host pool.
+    swa_slots_to_free: List[Tuple[DeviceType, int]] = field(default_factory=list)
 
     @classmethod
     def empty(cls) -> "PutTransferPlan":
@@ -123,6 +129,37 @@ class SWAReadReservation:
     source: SWAReadSource
     staging_slot: int
     h2d_id: int
+
+
+class TransferPlanHandle:
+    """Completion callback for a planned get/put, with an abort path.
+
+    Calling the handle (the pre-existing contract for ``task.callback``)
+    publishes the plan's results exactly as the plain completion partial did.
+    ``abort()`` instead rolls back a plan whose graph was never launched:
+    unlock, drop unready inserts, recycle staging, release SWA state. At most
+    one of the two may run, and only once; the handle enforces that so a
+    cancel racing a completion cannot double-unlock.
+    """
+
+    __slots__ = ("_complete", "_abort", "_consumed")
+
+    def __init__(self, complete: Callable[[], None], abort: Callable[[], None]):
+        self._complete = complete
+        self._abort = abort
+        self._consumed = False
+
+    def __call__(self) -> None:
+        if self._consumed:
+            return
+        self._consumed = True
+        self._complete()
+
+    def abort(self) -> None:
+        if self._consumed:
+            return
+        self._consumed = True
+        self._abort()
 
 
 class CacheEngineAccel:
@@ -322,10 +359,12 @@ class CacheEngineAccel:
              protected_node: Optional[CRadixNode] = None,
              strict: bool = True) -> np.ndarray:
         # Calculate current utilization
-        utilization = (self.mempool.num_total_blocks - self.mempool.num_free_blocks) / self.mempool.num_total_blocks if self.mempool.num_total_blocks > 0 else 0
+        utilization = ((self.mempool.num_total_blocks - self.mempool.num_free_blocks)
+                       / self.mempool.num_total_blocks) if self.mempool.num_total_blocks > 0 else 0
 
         # Proactive eviction: trigger when utilization exceeds threshold OR when blocks are needed
-        should_evict = (utilization >= self.evict_start_threshold) or (num_required_blocks > self.mempool.num_free_blocks)
+        should_evict = (utilization >= self.evict_start_threshold) or \
+            (num_required_blocks > self.mempool.num_free_blocks)
 
         if should_evict:
             if protected_node is not None:
@@ -339,7 +378,8 @@ class CacheEngineAccel:
             evict_block_num = max(
                 num_required_blocks - self.mempool.num_free_blocks,  # At least meet current demand
                 evict_to_reach_target,                               # Or reach target free ratio
-                int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0  # Or minimum evict_ratio
+                # Or minimum evict_ratio
+                int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0
             )
 
             if evict_block_num > 0:
@@ -391,6 +431,21 @@ class CacheEngineAccel:
         self.mempool.recycle_blocks(physical_blocks)
         self._drain_unmounted_swa_slots()
 
+    def rollback_unready_insert(self, node: Optional[CRadixNode]) -> int:
+        """Undo an ``is_ready=False`` insert whose completion callback will
+        never run (plan aborted before launch). No-op for ready nodes, so it is
+        safe to call on every entry of a plan's node_to_unlock: only nodes this
+        plan inserted are unready. Recycles the freed blocks."""
+        if node is None:
+            return 0
+        freed = torch.zeros(node.size(), dtype=torch.int64)
+        num_freed = self.index.remove_unready_leaf(node, freed)
+        if freed.numel() != num_freed:
+            freed.resize_(num_freed)
+        if num_freed > 0:
+            self.recycle(freed.numpy())
+        return num_freed
+
 class CacheEngine:
     def __init__(self,
                  device_type: DeviceType,
@@ -420,8 +475,10 @@ class CacheEngine:
 
         self.device_type = device_type
 
-        self.index = RadixTreeIndex(tokens_per_block=tokens_per_block, hit_reward_seconds=hit_reward_seconds, eviction_policy=eviction_policy,
-                                       protected_threshold=protected_threshold)
+        self.index = RadixTreeIndex(tokens_per_block=tokens_per_block,
+                                    hit_reward_seconds=hit_reward_seconds,
+                                    eviction_policy=eviction_policy,
+                                    protected_threshold=protected_threshold)
 
         self.mempool = Mempool(num_total_blocks=num_total_blocks)
 
@@ -520,7 +577,8 @@ class CacheEngine:
                                  is_ready=is_ready,
                                  match_result=match_result)
         if self.event_collector is not None:
-            self.event_collector.publish_stored(block_hashes=sequence_meta.block_hashes[:None if num_insert_blocks == -1 else num_insert_blocks],
+            self.event_collector.publish_stored(
+                block_hashes=sequence_meta.block_hashes[:None if num_insert_blocks == -1 else num_insert_blocks],
                                                 block_size=self.tokens_per_block,
                                                 medium=DEVICE_TYPE[self.device_type])
         return node
@@ -539,10 +597,12 @@ class CacheEngine:
              protected_node: Optional[RadixNode] = None,
              strict: bool = True) -> np.ndarray:
         # Calculate current utilization
-        utilization = (self.mempool.num_total_blocks - self.mempool.num_free_blocks) / self.mempool.num_total_blocks if self.mempool.num_total_blocks > 0 else 0
+        utilization = ((self.mempool.num_total_blocks - self.mempool.num_free_blocks)
+                       / self.mempool.num_total_blocks) if self.mempool.num_total_blocks > 0 else 0
 
         # Proactive eviction: trigger when utilization exceeds threshold OR when blocks are needed
-        should_evict = (utilization >= self.evict_start_threshold) or (num_required_blocks > self.mempool.num_free_blocks)
+        should_evict = (utilization >= self.evict_start_threshold) or \
+            (num_required_blocks > self.mempool.num_free_blocks)
 
         if should_evict:
             if protected_node is not None:
@@ -556,7 +616,8 @@ class CacheEngine:
             evict_block_num = max(
                 num_required_blocks - self.mempool.num_free_blocks,  # At least meet current demand
                 evict_to_reach_target,                               # Or reach target free ratio
-                int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0  # Or minimum evict_ratio
+                # Or minimum evict_ratio
+                int(self.mempool.num_total_blocks * self.evict_ratio) if self.evict_ratio > 0 else 0
             )
             if evict_block_num > 0:
                 evicted_blocks, evicted_block_hashes = self.index.evict(evict_block_num)
@@ -591,6 +652,18 @@ class CacheEngine:
     def recycle(self, physical_blocks: np.ndarray) -> None:
         self.mempool.recycle_blocks(physical_blocks)
         self._drain_unmounted_swa_slots()
+
+    def rollback_unready_insert(self, node: Optional[RadixNode]) -> int:
+        """Undo an ``is_ready=False`` insert whose completion callback will
+        never run (plan aborted before launch). No-op for ready nodes, so it is
+        safe to call on every entry of a plan's node_to_unlock: only nodes this
+        plan inserted are unready. Recycles the freed blocks."""
+        if node is None:
+            return 0
+        freed = self.index.remove_unready_leaf(node)
+        if freed.size > 0:
+            self.recycle(freed)
+        return int(freed.size)
 
 @dataclass
 class CacheStrategy:
@@ -654,7 +727,8 @@ class GlobalCacheEngine:
 
         if cache_config.enable_cpu:
             if cache_config.enable_p2p_cpu:
-                self.cpu_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.CPU, meta=self.redis_meta)
+                self.cpu_cache_engine = HierarchyLRCacheEngine.from_cache_config(
+                    cache_config, self.node_id, DeviceType.CPU, meta=self.redis_meta)
             elif self.index_accel:
                 self.cpu_cache_engine = CacheEngineAccel(
                     device_type=DeviceType.CPU,
@@ -686,7 +760,8 @@ class GlobalCacheEngine:
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
         if cache_config.enable_ssd:
             if cache_config.enable_p2p_ssd:
-                self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta)
+                self.ssd_cache_engine = HierarchyLRCacheEngine.from_cache_config(
+                    cache_config, self.node_id, DeviceType.SSD, meta=self.redis_meta)
             elif self.index_accel:
                 self.ssd_cache_engine = CacheEngineAccel(
                     device_type=DeviceType.SSD,
@@ -724,7 +799,8 @@ class GlobalCacheEngine:
                 )
             elif cache_config.enable_kv_sharing:
                 # Build PCFSCacheEngine from CacheConfig directly (replacing RemotePCFSCacheEngine) TODO
-                self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta)
+                self.remote_cache_engine = HierarchyLRCacheEngine.from_cache_config(
+                    cache_config, self.node_id, DeviceType.REMOTE, meta=self.redis_meta)
             elif self.index_accel:
                 self.remote_cache_engine = CacheEngineAccel(
                     device_type=DeviceType.REMOTE,
@@ -894,9 +970,15 @@ class GlobalCacheEngine:
         for device_type in plan.node_to_unlock:
             self.cache_engines[device_type].lock_node(plan.node_to_unlock[device_type][0])
 
-        callback = partial(self._transfer_callback,
-                           node_to_unlock=plan.node_to_unlock,
-                           buffer_to_free=plan.buffer_to_free)
+        callback = TransferPlanHandle(
+            complete=partial(self._transfer_callback,
+                             node_to_unlock=plan.node_to_unlock,
+                             buffer_to_free=plan.buffer_to_free),
+            abort=partial(self._abort_transfer_plan,
+                          node_to_unlock=plan.node_to_unlock,
+                          buffer_to_free=plan.buffer_to_free,
+                          swa_reservation=plan.swa_reservation),
+        )
 
         op_callback_dict = plan.op_callback_dict
 
@@ -1231,6 +1313,7 @@ class GlobalCacheEngine:
             op_callback_dict=op_callback_dict,
             buffer_to_free=buffer_to_free,
             num_gpu_blocks_to_transfer=num_gpu_blocks_to_transfer,
+            swa_reservation=swa_reservation,
         )
 
     def _get_impl_local(self,
@@ -1262,7 +1345,8 @@ class GlobalCacheEngine:
         assert self.cpu_cache_engine is not None
 
         if self.index_accel:
-            cpu_matched_result, ssd_matched_result = self.match_local_accel(sequence_meta, temp_cache_strategy, is_put=False, gpu_matched_blocks=block_mask_start)
+            cpu_matched_result, ssd_matched_result = self.match_local_accel(
+                sequence_meta, temp_cache_strategy, is_put=False, gpu_matched_blocks=block_mask_start)
         else:
             cpu_matched_result, ssd_matched_result = self.match_local(sequence_meta, temp_cache_strategy)
 
@@ -1292,7 +1376,10 @@ class GlobalCacheEngine:
 
         # DEBUG: Log GET operation with hash info
         #if len(sequence_meta.block_hashes) > 0:
-        #    print(f"[GET {request_id}] hash[0]={sequence_meta.block_hashes[0]}, CPU={cpu_matched_result.num_matched_blocks}/{cpu_matched_result.num_ready_matched_blocks}, SSD={ssd_matched_result.num_matched_blocks}/{ssd_matched_result.num_ready_matched_blocks}, pos_CPU={cpu_matched_result.matched_pos}, pos_SSD={ssd_matched_result.matched_pos}")
+        #    print(f"[GET {request_id}] hash[0]={sequence_meta.block_hashes[0]}, "
+        #          f"CPU={cpu_matched_result.num_matched_blocks}/{cpu_matched_result.num_ready_matched_blocks}, "
+        #          f"SSD={ssd_matched_result.num_matched_blocks}/{ssd_matched_result.num_ready_matched_blocks}, "
+        #          f"pos_CPU={cpu_matched_result.matched_pos}, pos_SSD={ssd_matched_result.matched_pos}")
 
         # tailor the blocks to assure:
         # the blocks are needed by the mask & the blocks are ready
@@ -1390,7 +1477,8 @@ class GlobalCacheEngine:
                 dp_client_id = dp_client_id,
             )
             transfer_graph.add_transfer_op(op_peerh2h)
-            #TODO here we dont combine peer cpu or local cpu match results, so we can safely add remote results to local cpu
+            # TODO here we dont combine peer cpu or local cpu match results,
+            # so we can safely add remote results to local cpu
             #TODO here assume all matched blocks are ready blocks for peer cpu
             if (cpu_matched_result.insert_to_local_cpu_index and
                 cpu_matched_result.num_ready_matched_blocks >= block_mask_start and
@@ -1422,18 +1510,22 @@ class GlobalCacheEngine:
 
                 op_disk2h = TransferOp(
                     graph_id = transfer_graph.graph_id,
-                    transfer_type = TransferType.PEERSSD2H if ssd_matched_result.matched_pos == "remote" else TransferType.DISK2H,
+                    transfer_type = TransferType.PEERSSD2H
+                        if ssd_matched_result.matched_pos == "remote" else TransferType.DISK2H,
                     src_block_ids = fragment2_ssd_blocks,
                     dst_block_ids = fragment2_cpu_blocks,
-                    remote_node_ids = ssd_matched_result.matched_node_ids if ssd_matched_result.matched_pos == "remote" else None,
-                    src_block_node_ids = ssd_matched_result.matched_node_ids if ssd_matched_result.matched_pos == "remote" else None,
+                    remote_node_ids = ssd_matched_result.matched_node_ids
+                        if ssd_matched_result.matched_pos == "remote" else None,
+                    src_block_node_ids = ssd_matched_result.matched_node_ids
+                        if ssd_matched_result.matched_pos == "remote" else None,
                     dp_client_id = dp_client_id,
                 )
                 transfer_graph.add_transfer_op(op_disk2h)
                 # we only insert the buffer blocks to cpu cache engine only:
                 # 1. the cpu cache engine satisfies prefix cache after insertion
                 # 2. the sequence is all ready blocks
-                # TODO: for simplicity, if we use peer cpu results, we dont insert the buffer ssd blocks to local cpu any more
+                # TODO: for simplicity, if we use peer cpu results,
+                # we dont insert the buffer ssd blocks to local cpu any more
                 if (cpu_matched_result.matched_pos == "local" and
                     cpu_matched_result.num_ready_matched_blocks >= block_mask_start and
                     cpu_matched_result.num_ready_matched_blocks == cpu_matched_result.num_matched_blocks):
@@ -1496,6 +1588,7 @@ class GlobalCacheEngine:
             op_callback_dict=op_callback_dict,
             buffer_to_free=buffer_to_free,
             num_gpu_blocks_to_transfer=num_gpu_blocks_to_transfer,
+            swa_reservation=swa_reservation,
         )
 
     def put(self,
@@ -1552,16 +1645,24 @@ class GlobalCacheEngine:
             dp_client_id,
         )
         return_mask = np.zeros_like(token_mask, dtype=np.bool_)
-        return_mask[(block_start_idx + plan.skipped_gpu_blocks)* self.tokens_per_block:
-                    (block_start_idx + plan.skipped_gpu_blocks + plan.num_gpu_blocks_to_transfer) * self.tokens_per_block] = True
+        mask_lo = (block_start_idx + plan.skipped_gpu_blocks) * self.tokens_per_block
+        mask_hi = (block_start_idx + plan.skipped_gpu_blocks
+                   + plan.num_gpu_blocks_to_transfer) * self.tokens_per_block
+        return_mask[mask_lo:mask_hi] = True
 
         for device_type in plan.node_to_unlock:
             self.cache_engines[device_type].lock_node(plan.node_to_unlock[device_type][0])
 
-        callback = partial(self._transfer_callback,
-                           node_to_unlock=plan.node_to_unlock,
-                           buffer_to_free=plan.buffer_to_free,
-                           is_put=True)
+        callback = TransferPlanHandle(
+            complete=partial(self._transfer_callback,
+                             node_to_unlock=plan.node_to_unlock,
+                             buffer_to_free=plan.buffer_to_free,
+                             is_put=True),
+            abort=partial(self._abort_transfer_plan,
+                          node_to_unlock=plan.node_to_unlock,
+                          buffer_to_free=plan.buffer_to_free,
+                          swa_slots_to_free=plan.swa_slots_to_free),
+        )
 
         op_callback_dict = plan.op_callback_dict
 
@@ -1868,6 +1969,10 @@ class GlobalCacheEngine:
                         DeviceType.REMOTE, remote_node_to_unlock, remote_swa_slot),
             )
         skipped_gpu_blocks = len(cpu_matched_blocks)
+        swa_slots_to_free = [(device_type, slot) for device_type, slot in
+                             ((DeviceType.CPU, cpu_swa_slot),
+                              (DeviceType.SSD, ssd_swa_slot),
+                              (DeviceType.REMOTE, remote_swa_slot)) if slot >= 0]
         return PutTransferPlan(
             transfer_graph=transfer_graph,
             finished_ops_ids=finished_ops_ids,
@@ -1876,6 +1981,7 @@ class GlobalCacheEngine:
             buffer_to_free={},
             num_gpu_blocks_to_transfer=len(fragment12_gpu_blocks),
             skipped_gpu_blocks=skipped_gpu_blocks,
+            swa_slots_to_free=swa_slots_to_free,
         )
 
     def _put_impl_local(self,
@@ -1950,7 +2056,9 @@ class GlobalCacheEngine:
 
         if len(fragment12_cpu_blocks) < fragment12_num_blocks or \
             len(fragment2_ssd_blocks) < fragment2_num_blocks:
-            print(f"[WARNING] PUT request {request_id} FAILED: CPU={len(fragment12_cpu_blocks)}/{fragment12_num_blocks}, SSD={len(fragment2_ssd_blocks)}/{fragment2_num_blocks}")
+            print(f"[WARNING] PUT request {request_id} FAILED: "
+                  f"CPU={len(fragment12_cpu_blocks)}/{fragment12_num_blocks}, "
+                  f"SSD={len(fragment2_ssd_blocks)}/{fragment2_num_blocks}")
             self.cpu_cache_engine.recycle(fragment12_cpu_blocks)
             if enable_ssd:
                 self.ssd_cache_engine.recycle(fragment2_ssd_blocks)
@@ -2077,6 +2185,9 @@ class GlobalCacheEngine:
                         DeviceType.SSD, ssd_node_to_unlock, ssd_swa_slot),
             )
         skipped_gpu_blocks = len(cpu_matched_blocks)
+        swa_slots_to_free = [(device_type, slot) for device_type, slot in
+                             ((DeviceType.CPU, cpu_swa_slot),
+                              (DeviceType.SSD, ssd_swa_slot)) if slot >= 0]
         return PutTransferPlan(
             transfer_graph=transfer_graph,
             finished_ops_ids=finished_ops_ids,
@@ -2085,6 +2196,7 @@ class GlobalCacheEngine:
             buffer_to_free={},
             num_gpu_blocks_to_transfer=len(fragment12_gpu_blocks),
             skipped_gpu_blocks=skipped_gpu_blocks,
+            swa_slots_to_free=swa_slots_to_free,
         )
 
     def _transfer_callback(self,
@@ -2123,6 +2235,36 @@ class GlobalCacheEngine:
             if DeviceType.REMOTE in buffer_to_free:
                 assert self.remote_cache_engine is not None
                 self.remote_cache_engine.recycle(buffer_to_free[DeviceType.REMOTE])
+
+    def _abort_transfer_plan(self,
+                             node_to_unlock: Dict[DeviceType, Tuple[RadixNode, int]],
+                             buffer_to_free: Optional[Dict[DeviceType, np.ndarray]] = None,
+                             swa_reservation: Optional[SWAReadReservation] = None,
+                             swa_slots_to_free: Optional[List[Tuple[DeviceType, int]]] = None) -> None:
+        """Roll back a planned get/put whose graph was never launched.
+
+        The completion path (:meth:`_transfer_callback`) unlocks, marks nodes
+        ready and recycles staging. On a cancelled plan no transfer ever ran,
+        so marking ready would publish unfilled blocks as valid cache — instead
+        every node is unlocked and any node this plan inserted unready is
+        removed and its blocks recycled. Nodes that pre-existed (matched, hence
+        ready) are only unlocked; ``rollback_unready_insert`` is a no-op for
+        them, so node_to_unlock can be processed uniformly.
+        """
+        for device_type, (node, _ready_length) in node_to_unlock.items():
+            engine = self.cache_engines[device_type]
+            engine.unlock(node)
+            engine.rollback_unready_insert(node)
+        if buffer_to_free is not None:
+            for device_type, blocks in buffer_to_free.items():
+                if blocks is not None and len(blocks) > 0:
+                    self.cache_engines[device_type].recycle(blocks)
+        if swa_reservation is not None:
+            self._release_swa_read_reservation(swa_reservation)
+        if swa_slots_to_free:
+            for device_type, slot in swa_slots_to_free:
+                if slot >= 0:
+                    self.cache_engines[device_type]._free_swa_slot(slot)
 
     def _op_callback(self, device_type: DeviceType, node_to_ready: RadixNode, ready_length: int) -> None:
         if device_type == DeviceType.CPU:

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -210,7 +210,9 @@ class RadixNode:
         # freed_swa_slots + the SWA-LRU (this node has no back-ref to the tree).
 
 class RadixTreeIndex:
-    def __init__(self, tokens_per_block: int, max_num_blocks: int = 1000000, hit_reward_seconds: int = 0, eviction_policy: str = "lru", protected_threshold: int = 2):
+    def __init__(self, tokens_per_block: int, max_num_blocks: int = 1000000,
+                 hit_reward_seconds: int = 0, eviction_policy: str = "lru",
+                 protected_threshold: int = 2):
         self.root_node: RadixNode = RadixNode(block_hashes=np.array([], dtype=np.int64),
                                               physical_blocks=np.array([], dtype=np.int64),
                                               is_ready=True,
@@ -616,6 +618,42 @@ class RadixTreeIndex:
                     evicted_full_blocks = np.concatenate([evicted_full_blocks, freed_full])
         return evicted_full_blocks, num_swa_freed
 
+    def remove_unready_leaf(self, node: Optional[RadixNode]) -> np.ndarray:
+        """Roll back a not-yet-ready inserted leaf, returning its blocks.
+
+        Used when a planned transfer is aborted before launch: the node was
+        inserted with ``is_ready=False`` and its completion callback (which
+        would have marked it ready) will never run. Left alone it can never be
+        evicted (``in_use`` is true for unready nodes) and it shadows future
+        puts of the same prefix, so the blocks and the prefix are both lost.
+
+        Only removes the node when doing so is unambiguously safe: it must
+        still be an unready, unlocked, SWA-unlocked leaf. If another request
+        split it or inserted below it in the create-to-cancel window, the node
+        is left in place (pre-existing behavior) rather than risk detaching
+        blocks another plan references. Returns the physical blocks to recycle
+        (empty when nothing was removed).
+        """
+        if (node is None or node.is_root() or node.is_ready
+                or node.lock_cnt > 0 or node.swa_lock_ref > 0
+                or not node.is_leaf()):
+            return np.array([], dtype=np.int64)
+        parent = node.parent
+        assert parent is not None
+        parent.children.pop(node.head_hash(), None)
+        self.leaf_nodes.pop(node.head_hash(), None)
+        self.record_freed_swa_slot(node)
+        freed = node.physical_blocks
+        node.parent = None
+        if parent.is_leaf() and not parent.is_root():
+            self.leaf_nodes[parent.head_hash()] = parent
+        if self._swa_enabled:
+            cascade_blocks, _hashes, _survivor = \
+                self._iteratively_delete_tombstone_leaf(parent)
+            if cascade_blocks.size:
+                freed = np.concatenate([freed, cascade_blocks])
+        return freed
+
     def _iteratively_delete_tombstone_leaf(
             self, node: RadixNode) -> Tuple[np.ndarray, np.ndarray, Optional[RadixNode]]:
         """Delete ``node`` and its ancestors while they are tombstone leaves with
@@ -698,11 +736,10 @@ class RadixTreeIndex:
         cur = swa_boundary
         assert cur.swa_lock_ref > 0, "dec_swa_lock_only on an unlocked SWA node"
         cur.swa_lock_ref -= 1
-        if cur.swa_lock_ref == 0 and cur.has_swa():
-            if cur.is_leaf():
-                # Leaf: free SWA now (Full stays until the full lock drops).
-                self.record_freed_swa_slot(cur)
-            # internal: keep SWA, stays evictable on the SWA-LRU
+        if cur.swa_lock_ref == 0 and cur.has_swa() and cur.is_leaf():
+            # Leaf: free SWA now (Full stays until the full lock drops).
+            # An internal node keeps its SWA, staying evictable on the SWA-LRU.
+            self.record_freed_swa_slot(cur)
 
 
     def _get_eviction_priority(self, node: RadixNode):

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -382,6 +382,22 @@ class KVTaskManager:
             return
         task = self.tasks[task_id]
         if not task.is_completed():
+            # A task whose graph never launched still holds everything its
+            # plan acquired at create time: locked radix nodes, CPU staging
+            # blocks, and is_ready=False index nodes that only a completion
+            # callback could publish. Dropping the task without aborting leaks
+            # all of it -- the staging blocks become unreachable (mempool
+            # exhaustion) and the unready nodes are permanently unevictable
+            # holes that also shadow future puts of the same prefix. Abort
+            # rolls those back; RUNNING tasks keep the old behavior (their
+            # graph is in flight and completion callbacks will still fire).
+            if task.status in (TaskStatus.UNREADY, TaskStatus.READY):
+                callbacks = task.callback if isinstance(task.callback, list) \
+                    else [task.callback]
+                for callback in callbacks:
+                    abort = getattr(callback, "abort", None)
+                    if abort is not None:
+                        abort()
             task.status = TaskStatus.CANCELLED
         self._release_task(task_id)
 

--- a/tests/test_cancel_task_rollback.py
+++ b/tests/test_cancel_task_rollback.py
@@ -1,0 +1,328 @@
+"""Cancelling a never-launched task must roll back everything its plan holds.
+
+``create_get_task`` / ``create_put_task`` run the cache engine's planner at
+creation time, which locks matched radix nodes, allocates CPU staging blocks
+for SSD-resident fragments, and inserts ``is_ready=False`` index nodes that
+only a completion callback can publish. The vLLM adapter cancels unlaunched
+tasks routinely (a matched request that is not scheduled this step, and every
+preemption), so dropping those resources on cancel leaks them permanently:
+staging blocks vanish from the mempool, locked/unready nodes can never be
+evicted, and unready nodes shadow future puts of the same prefix.
+
+These tests pin the abort path: the plan handle's ``abort()`` (wired into
+``KVTaskManager._cancel_task``) must restore the mempool, leave no unready
+nodes behind, and be mutually exclusive with the completion callback.
+"""
+import numpy as np
+import pytest
+
+from flexkv import c_ext
+from flexkv.cache.cache_engine import (
+    CacheEngine,
+    CacheEngineAccel,
+    GlobalCacheEngine,
+    TransferPlanHandle,
+)
+from flexkv.common.block import SequenceMeta
+from flexkv.common.config import CacheConfig, ModelConfig, GLOBAL_CONFIG_FROM_ENV
+from flexkv.common.transfer import DeviceType
+from flexkv.kvtask import KVTaskManager, TaskStatus
+
+pytestmark = pytest.mark.unit
+
+TPB = 16
+
+# The compiled extension is required for the Accel variants; the pure-Python
+# variants run anywhere. (A stubbed c_ext module has no __file__.)
+_HAS_REAL_C_EXT = getattr(c_ext, "__file__", None) is not None
+
+ENGINE_CLASSES = [
+    pytest.param(CacheEngine, id="CacheEngine"),
+    pytest.param(CacheEngineAccel, id="CacheEngineAccel",
+                 marks=pytest.mark.skipif(not _HAS_REAL_C_EXT,
+                                          reason="requires compiled c_ext")),
+]
+
+INDEX_ACCEL_MODES = [
+    pytest.param(False, id="python-index"),
+    pytest.param(True, id="accel-index",
+                 marks=pytest.mark.skipif(not _HAS_REAL_C_EXT,
+                                          reason="requires compiled c_ext")),
+]
+
+
+def _tokens(num_blocks: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 50000, num_blocks * TPB, dtype=np.int64)
+
+
+def _seq(tokens: np.ndarray) -> SequenceMeta:
+    return SequenceMeta(token_ids=tokens, tokens_per_block=TPB)
+
+
+# --------------------------------------------------------------------------
+# Tier-engine level: rollback_unready_insert
+# --------------------------------------------------------------------------
+
+@pytest.fixture(params=ENGINE_CLASSES)
+def tier_engine(request):
+    return request.param(device_type=DeviceType.CPU,
+                         num_total_blocks=64,
+                         tokens_per_block=TPB,
+                         evict_ratio=0.05)
+
+
+def test_rollback_removes_unready_leaf_and_recycles(tier_engine):
+    free_before = tier_engine.mempool.num_free_blocks
+    blocks = tier_engine.take(4)
+    node = tier_engine.insert(_seq(_tokens(4, seed=1)), blocks, is_ready=False)
+    assert tier_engine.mempool.num_free_blocks == free_before - 4
+
+    freed = tier_engine.rollback_unready_insert(node)
+
+    assert freed == 4
+    assert tier_engine.mempool.num_free_blocks == free_before
+    assert tier_engine.index.total_unready_blocks() == 0
+    # the prefix is gone: a fresh identical insert allocates fresh blocks
+    blocks2 = tier_engine.take(4)
+    node2 = tier_engine.insert(_seq(_tokens(4, seed=1)), blocks2, is_ready=True)
+    assert node2 is not None
+
+
+def test_rollback_is_noop_on_ready_node(tier_engine):
+    blocks = tier_engine.take(4)
+    node = tier_engine.insert(_seq(_tokens(4, seed=2)), blocks, is_ready=True)
+    free_before = tier_engine.mempool.num_free_blocks
+
+    freed = tier_engine.rollback_unready_insert(node)
+
+    assert freed == 0
+    assert tier_engine.mempool.num_free_blocks == free_before
+    assert tier_engine.index.total_ready_blocks() == 4
+
+
+def test_rollback_is_noop_while_node_is_locked(tier_engine):
+    blocks = tier_engine.take(4)
+    node = tier_engine.insert(_seq(_tokens(4, seed=3)), blocks, is_ready=False)
+    tier_engine.lock_node(node)
+
+    assert tier_engine.rollback_unready_insert(node) == 0
+    assert tier_engine.index.total_unready_blocks() == 4
+
+    tier_engine.unlock(node)
+    assert tier_engine.rollback_unready_insert(node) == 4
+    assert tier_engine.index.total_unready_blocks() == 0
+
+
+def test_rollback_is_noop_when_node_gained_children(tier_engine):
+    """The raced case: another request inserted below the unready node in the
+    create-to-cancel window. The node is no longer a leaf, so rollback must
+    leave it alone rather than detach blocks a descendant depends on."""
+    toks = _tokens(4, seed=4)
+    blocks = tier_engine.take(4)
+    node = tier_engine.insert(_seq(toks), blocks, is_ready=False)
+
+    longer = np.concatenate([toks, _tokens(2, seed=5)])
+    blocks2 = tier_engine.take(2)
+    child = tier_engine.insert(_seq(longer), blocks2, is_ready=True)
+    assert child is not None
+
+    free_before = tier_engine.mempool.num_free_blocks
+    assert tier_engine.rollback_unready_insert(node) == 0
+    assert tier_engine.mempool.num_free_blocks == free_before
+
+
+# --------------------------------------------------------------------------
+# TransferPlanHandle: completion and abort are mutually exclusive
+# --------------------------------------------------------------------------
+
+def test_plan_handle_runs_each_path_at_most_once():
+    calls = []
+    handle = TransferPlanHandle(complete=lambda: calls.append("complete"),
+                                abort=lambda: calls.append("abort"))
+    handle()
+    handle()
+    handle.abort()
+    assert calls == ["complete"]
+
+    calls.clear()
+    handle = TransferPlanHandle(complete=lambda: calls.append("complete"),
+                                abort=lambda: calls.append("abort"))
+    handle.abort()
+    handle.abort()
+    handle()
+    assert calls == ["abort"]
+
+
+# --------------------------------------------------------------------------
+# GlobalCacheEngine plan abort, end to end on the control plane
+# --------------------------------------------------------------------------
+
+NUM_CPU = 128
+NUM_SSD = 1024
+
+
+@pytest.fixture(params=INDEX_ACCEL_MODES)
+def global_engine(request, tmp_path, monkeypatch):
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "index_accel", request.param)
+    model_config = ModelConfig(num_layers=2, num_kv_heads=2, head_size=8,
+                               tp_size=1)
+    cache_config = CacheConfig(tokens_per_block=TPB,
+                               enable_cpu=True,
+                               enable_ssd=True,
+                               num_cpu_blocks=NUM_CPU,
+                               num_ssd_blocks=NUM_SSD,
+                               ssd_cache_dir=str(tmp_path / "ssd"))
+    return GlobalCacheEngine(cache_config, model_config)
+
+
+def _run_put(engine, tokens, request_id, complete=True):
+    mask = np.ones_like(tokens, dtype=bool)
+    slot_mapping = np.arange(tokens.size, dtype=np.int64)
+    _graph, mask_out, callback, op_callbacks, _end = engine.put(
+        request_id, tokens, mask, slot_mapping, dp_client_id=0)
+    if complete:
+        for op_callback in op_callbacks.values():
+            op_callback()
+        callback()
+    return mask_out, callback
+
+
+def _run_get(engine, tokens, request_id):
+    mask = np.ones_like(tokens, dtype=bool)
+    slot_mapping = np.arange(tokens.size, dtype=np.int64)
+    _graph, mask_out, callback, _op_callbacks, _end = engine.get(
+        request_id, tokens, mask, slot_mapping, dp_client_id=0)
+    return mask_out, callback
+
+
+def _seed_ssd_resident_data(engine, num_seqs=6, churn=10):
+    """Fill the CPU tier past capacity so early sequences survive only on SSD,
+    which is what makes a later GET allocate CPU staging blocks."""
+    seqs = [_tokens(TPB // 2, seed=100 + i) for i in range(num_seqs)]
+    request_id = 0
+    for tokens in seqs:
+        _run_put(engine, tokens, request_id)
+        request_id += 1
+    for i in range(churn):
+        _run_put(engine, _tokens(TPB // 2, seed=500 + i), request_id)
+        request_id += 1
+    return seqs
+
+
+def test_aborted_get_restores_cpu_pool(global_engine):
+    engine = global_engine
+    seqs = _seed_ssd_resident_data(engine)
+    cpu = engine.cpu_cache_engine
+
+    free_before = cpu.mempool.num_free_blocks
+    unready_before = cpu.index.total_unready_blocks()
+    aborted = 0
+    for i, tokens in enumerate(seqs * 8):
+        mask_out, callback = _run_get(engine, tokens, request_id=1000 + i)
+        if mask_out.any():
+            callback.abort()   # what _cancel_task now does pre-launch
+            aborted += 1
+    assert aborted > 0, "scenario must produce at least one plan to abort"
+
+    assert cpu.mempool.num_free_blocks == free_before
+    assert cpu.index.total_unready_blocks() == unready_before
+    # the pool is usable: a fresh put both allocates and completes
+    mask_out, _ = _run_put(engine, _tokens(TPB // 2, seed=9000),
+                           request_id=2000)
+    assert mask_out.any()
+
+
+def test_aborted_put_restores_both_tiers(global_engine):
+    engine = global_engine
+    cpu = engine.cpu_cache_engine
+    ssd = engine.ssd_cache_engine
+    cpu_free = cpu.mempool.num_free_blocks
+    ssd_free = ssd.mempool.num_free_blocks
+
+    tokens = _tokens(TPB // 2, seed=42)
+    _mask, callback = _run_put(engine, tokens, request_id=1, complete=False)
+    assert cpu.mempool.num_free_blocks < cpu_free  # plan holds blocks
+
+    callback.abort()
+
+    assert cpu.mempool.num_free_blocks == cpu_free
+    assert ssd.mempool.num_free_blocks == ssd_free
+    assert cpu.index.total_unready_blocks() == 0
+    assert ssd.index.total_unready_blocks() == 0
+    # the prefix was rolled back, so the same put succeeds afterwards
+    mask_out, _ = _run_put(engine, tokens, request_id=2)
+    assert mask_out.any()
+
+
+def test_completed_then_cancelled_plan_does_not_double_release(global_engine):
+    engine = global_engine
+    cpu = engine.cpu_cache_engine
+    tokens = _tokens(TPB // 2, seed=77)
+
+    _mask, callback = _run_put(engine, tokens, request_id=1, complete=True)
+    free_after_complete = cpu.mempool.num_free_blocks
+
+    callback.abort()   # late cancel racing completion: must be a no-op
+
+    assert cpu.mempool.num_free_blocks == free_after_complete
+    assert cpu.index.total_ready_blocks() > 0
+
+
+# --------------------------------------------------------------------------
+# KVTaskManager._cancel_task wiring
+# --------------------------------------------------------------------------
+
+def _make_manager(engine) -> KVTaskManager:
+    manager = KVTaskManager.__new__(KVTaskManager)  # skip transfer subprocess
+    manager.cache_engine = engine
+    manager.tasks = {}
+    manager.graph_to_task = {}
+    return manager
+
+
+def test_cancel_task_aborts_unlaunched_plan(global_engine):
+    engine = global_engine
+    manager = _make_manager(engine)
+    cpu = engine.cpu_cache_engine
+    free_before = cpu.mempool.num_free_blocks
+
+    tokens = _tokens(TPB // 2, seed=11)
+    manager.create_put_task(task_id=1, token_ids=tokens,
+                            slot_mapping=np.arange(tokens.size, dtype=np.int64),
+                            dp_client_id=0,
+                            token_mask=np.ones_like(tokens, dtype=bool))
+    assert cpu.mempool.num_free_blocks < free_before
+
+    manager._cancel_task(1)
+
+    assert 1 not in manager.tasks
+    assert cpu.mempool.num_free_blocks == free_before
+    assert cpu.index.total_unready_blocks() == 0
+
+
+def test_cancel_task_leaves_running_tasks_alone(global_engine):
+    """A RUNNING task's graph is in flight; its completion callbacks will still
+    fire, so cancel must not abort (that would race the real completion)."""
+    engine = global_engine
+    manager = _make_manager(engine)
+    cpu = engine.cpu_cache_engine
+
+    tokens = _tokens(TPB // 2, seed=12)
+    manager.create_put_task(task_id=1, token_ids=tokens,
+                            slot_mapping=np.arange(tokens.size, dtype=np.int64),
+                            dp_client_id=0,
+                            token_mask=np.ones_like(tokens, dtype=bool))
+    task = manager.tasks[1]
+    task.status = TaskStatus.RUNNING
+    held = cpu.mempool.num_free_blocks
+    callback = task.callback
+
+    manager._cancel_task(1)
+
+    assert cpu.mempool.num_free_blocks == held  # nothing rolled back
+    # the in-flight completion still lands normally afterwards
+    for op_callback in task.op_callback_dict.values():
+        op_callback()
+    callback()
+    assert cpu.index.total_ready_blocks() > 0

--- a/tests/test_cancel_task_rollback.py
+++ b/tests/test_cancel_task_rollback.py
@@ -185,15 +185,15 @@ def _run_put(engine, tokens, request_id, complete=True):
         for op_callback in op_callbacks.values():
             op_callback()
         callback()
-    return mask_out, callback
+    return mask_out, callback, op_callbacks
 
 
 def _run_get(engine, tokens, request_id):
     mask = np.ones_like(tokens, dtype=bool)
     slot_mapping = np.arange(tokens.size, dtype=np.int64)
-    _graph, mask_out, callback, _op_callbacks, _end = engine.get(
+    _graph, mask_out, callback, op_callbacks, _end = engine.get(
         request_id, tokens, mask, slot_mapping, dp_client_id=0)
-    return mask_out, callback
+    return mask_out, callback, op_callbacks
 
 
 def _seed_ssd_resident_data(engine, num_seqs=6, churn=10):
@@ -219,7 +219,7 @@ def test_aborted_get_restores_cpu_pool(global_engine):
     unready_before = cpu.index.total_unready_blocks()
     aborted = 0
     for i, tokens in enumerate(seqs * 8):
-        mask_out, callback = _run_get(engine, tokens, request_id=1000 + i)
+        mask_out, callback, _ops = _run_get(engine, tokens, request_id=1000 + i)
         if mask_out.any():
             callback.abort()   # what _cancel_task now does pre-launch
             aborted += 1
@@ -228,8 +228,8 @@ def test_aborted_get_restores_cpu_pool(global_engine):
     assert cpu.mempool.num_free_blocks == free_before
     assert cpu.index.total_unready_blocks() == unready_before
     # the pool is usable: a fresh put both allocates and completes
-    mask_out, _ = _run_put(engine, _tokens(TPB // 2, seed=9000),
-                           request_id=2000)
+    mask_out, _cb, _ops = _run_put(engine, _tokens(TPB // 2, seed=9000),
+                                   request_id=2000)
     assert mask_out.any()
 
 
@@ -241,7 +241,7 @@ def test_aborted_put_restores_both_tiers(global_engine):
     ssd_free = ssd.mempool.num_free_blocks
 
     tokens = _tokens(TPB // 2, seed=42)
-    _mask, callback = _run_put(engine, tokens, request_id=1, complete=False)
+    _mask, callback, _ops = _run_put(engine, tokens, request_id=1, complete=False)
     assert cpu.mempool.num_free_blocks < cpu_free  # plan holds blocks
 
     callback.abort()
@@ -251,7 +251,7 @@ def test_aborted_put_restores_both_tiers(global_engine):
     assert cpu.index.total_unready_blocks() == 0
     assert ssd.index.total_unready_blocks() == 0
     # the prefix was rolled back, so the same put succeeds afterwards
-    mask_out, _ = _run_put(engine, tokens, request_id=2)
+    mask_out, _cb, _ops = _run_put(engine, tokens, request_id=2)
     assert mask_out.any()
 
 
@@ -260,7 +260,7 @@ def test_completed_then_cancelled_plan_does_not_double_release(global_engine):
     cpu = engine.cpu_cache_engine
     tokens = _tokens(TPB // 2, seed=77)
 
-    _mask, callback = _run_put(engine, tokens, request_id=1, complete=True)
+    _mask, callback, _ops = _run_put(engine, tokens, request_id=1, complete=True)
     free_after_complete = cpu.mempool.num_free_blocks
 
     callback.abort()   # late cancel racing completion: must be a no-op
@@ -326,3 +326,76 @@ def test_cancel_task_leaves_running_tasks_alone(global_engine):
         op_callback()
     callback()
     assert cpu.index.total_ready_blocks() > 0
+
+
+# --------------------------------------------------------------------------
+# Raced plans: cancel one while an overlapping plan is pending
+# --------------------------------------------------------------------------
+
+def test_cancel_with_pending_extension_leaves_bounded_hole(global_engine):
+    """The documented residual case, pinned so it is not overstated.
+
+    Put B (prefix + extension) arrives while put A (prefix) is pending; B
+    skips A's blocks because A's unready insert claims them, so A's content
+    is never written by anyone. Cancelling A then backs off the rollback
+    (A's node gained B's child and is no longer a leaf) and the prefix stays
+    an unready hole -- semantically forced, since marking it ready would
+    publish blocks whose transfer never ran. What the fix guarantees here is
+    strictly-no-worse than before: the hole is the same size as upstream's,
+    bounded by A's node, and unlike upstream it is no longer locked.
+    """
+    engine = global_engine
+    cpu = engine.cpu_cache_engine
+    prefix = _tokens(4, seed=61)
+    extension = np.concatenate([prefix, _tokens(2, seed=62)])
+
+    mask_a, callback_a, _ops_a = _run_put(engine, prefix, request_id=1,
+                                          complete=False)
+    assert mask_a.any()
+    _mask_b, callback_b, ops_b = _run_put(engine, extension, request_id=2,
+                                          complete=False)
+
+    callback_a.abort()
+    # B saw A's pending insert and skipped the prefix; complete it normally.
+    for op_callback in ops_b.values():
+        op_callback()
+    callback_b()
+
+    # A's node was extended by B, so the rollback must have backed off: the
+    # hole is exactly A's insert (4 blocks per tier), bounded and no larger.
+    # Upstream leaves the same 4-block hole PLUS a leaked lock on it; here
+    # nothing may stay locked once both plans are resolved.
+    assert cpu.index.total_unready_blocks() == 4
+
+    if hasattr(cpu.index, "root_node"):  # python index exposes the tree
+        stack = [cpu.index.root_node]
+        while stack:
+            node = stack.pop()
+            assert node.lock_cnt == 0, "no plan may leave a lock behind"
+            stack.extend(node.children.values())
+
+
+def test_cancel_get_with_racing_put_leaves_no_residue(global_engine):
+    """A staging GET is cancelled while a put of the same prefix is pending;
+    the put saw the unready staging node and skipped, so after the abort and
+    the put's completion nothing unready may remain and late abort/complete
+    calls on the cancelled handle must be inert."""
+    engine = global_engine
+    seqs = _seed_ssd_resident_data(engine)
+    target = seqs[0]
+
+    mask_get, callback_get, _get_ops = _run_get(engine, target, request_id=900)
+    if not mask_get.any():
+        pytest.skip("scenario needs an SSD-staging GET plan")
+    _mask, callback_put, put_ops = _run_put(engine, target, request_id=901,
+                                            complete=False)
+
+    callback_get.abort()
+    for op_callback in put_ops.values():
+        op_callback()
+    callback_put()
+
+    assert engine.cpu_cache_engine.index.total_unready_blocks() == 0
+    assert engine.ssd_cache_engine.index.total_unready_blocks() == 0
+    callback_get.abort()   # late duplicate: inert
+    callback_get()         # late complete on aborted handle: inert


### PR DESCRIPTION
## Problem

`create_get_task` / `create_put_task` run the cache-engine planner **at creation time**, which already acquires real resources:

- matched radix nodes are **locked** (`get()` / `put()` call `lock_node` on every entry of the plan's `node_to_unlock`),
- **CPU staging blocks** are allocated for SSD-resident fragments (`_get_impl_local`, `take()`),
- new index nodes are inserted with **`is_ready=False`**, and only a completion callback can publish them.

`KVTaskManager._cancel_task`, however, only popped the task from its dicts — it never invoked any release path.

The vLLM adapter cancels never-launched tasks **routinely**: every request that matches but is not scheduled in that step (the auto-cancel path in `_build_connector_meta`), and every preemption (`handle_preemptions` — whose comment says tasks are moved to the cancel list *"to ensure underlying resources are freed"*, an assumption the code did not satisfy).

Each such cancel therefore leaked its staging blocks out of the CPU mempool and left permanently-unevictable locked/unready nodes in the tree. Unready nodes are additionally skipped by later puts of the same prefix (put skips on matched blocks, not ready-matched ones), so those prefixes became lasting hit-rate holes.

**Reproduction** (control-plane only, no GPU): on a 512-block CPU pool with SSD-resident data, 32 cancelled SSD-hit GETs converted the entire CPU pool into unreachable blocks — every subsequent PUT failed permanently (`CPU=0/16`), with 21 locked and 20 forever-unready nodes left in the CPU tree. With this fix the same scenario ends with the pool fully restored, zero locked/unready residue, and all subsequent PUTs succeeding.

## Fix

Thread an abort path from the planner to the cancel site:

- **`get()` / `put()` now return a `TransferPlanHandle`** instead of a bare `partial`. *Calling* it keeps the exact completion behavior — kvtask, benchmarks and the batch-merge list path are unchanged, since the handle is callable. `abort()` rolls the plan back instead. The handle runs at most one of the two, exactly once, so a cancel racing a completion cannot double-release.
- **`_abort_transfer_plan`** unlocks every node the plan locked, removes the nodes this plan inserted unready and recycles their blocks, recycles staging buffers, releases a held SWA read reservation (get) and returns unpublished SWA slots to the host pool (put). Distinguishing inserted-unready nodes from pre-existing matched nodes needs no extra bookkeeping: matched nodes are ready by definition, so the rollback is a guarded no-op for them.
- **`RadixTreeIndex.remove_unready_leaf` / `CRadixTreeIndex::remove_unready_leaf`** implement the rollback at the index level, mirroring `evict()`'s leaf deletion (including the SWA tombstone cascade). The node is removed only while it is still an unready, unlocked, SWA-unlocked **leaf**; if another request split it or inserted below it in the create-to-cancel window, it is left in place — the pre-existing behavior — rather than risk detaching blocks a descendant depends on.
- **`_cancel_task`** aborts tasks whose graph never launched (`UNREADY` / `READY`). `RUNNING` tasks keep the old behavior: their graph is in flight and the completion callbacks will still fire. (Cancelling running transfers is the larger follow-up the adapter TODO already notes.)

## Testing

`tests/test_cancel_task_rollback.py` (marked `unit`, no GPU):

- index-level rollback for **both** engine implementations — the `CacheEngineAccel` variants exercise the new C++ `remove_unready_leaf` wherever the extension is built (they skip locally without it),
- plan-level abort for get and put on both index modes: mempool restored exactly, zero unready residue, and the same prefix is re-insertable afterwards,
- handle complete/abort mutual exclusion (late cancel racing a completion is a no-op),
- `_cancel_task` wiring, and that `RUNNING` tasks are *not* aborted.

Mutation-checked: removing the `_cancel_task` abort call fails the wiring test; making the index rollback a no-op fails four tests.

## Notes for the reviewer

- The lint hunks (line wraps, an unused-name import, one nested-if collapse) are pre-existing `ruff` findings in the touched files; the changed-file lint job fails the PR without them. No behavior change in any of them.
- Residual known gap, unchanged from before: if another request locks or extends the unready node between create and cancel, the rollback backs off and that node stays unready (exactly the pre-fix behavior for a strictly rarer case).
- I could not compile the CUDA extension locally; the C++ `remove_unready_leaf` mirrors the Python implementation line for line and is exercised by the Accel test variants in CI.
