### PR TITLE
feat(transfer): chunked cudaHostRegister via FLEXKV_CUDAHOST_CHUNK_SI…

### DIFF
--- a/docs/flexkv_config_reference/README_en.md
+++ b/docs/flexkv_config_reference/README_en.md
@@ -55,6 +55,7 @@ If the `FLEXKV_CONFIG_PATH` environment variable is not set, configuration can b
 | `FLEXKV_SSD_CACHE_GB` | int | 0 | SSD cache layer capacity in GB. Recommended to be greater than `FLEXKV_CPU_CACHE_GB` and a multiple of `FLEXKV_MAX_FILE_SIZE_GB`. Set to 0 if only using CPU cache (SSD cache will not be enabled) |
 | `FLEXKV_SSD_CACHE_DIR` | str | "./flexkv_ssd" | Directory where SSD cache data is stored. If multiple SSDs are available, separate multiple mount paths with semicolons `;`. For example, `"/data0/flexkv_ssd/;/data1/flexkv_ssd/"` to improve bandwidth |
 | `FLEXKV_ENABLE_GDS` | bool | 0 | Whether to enable GPU Direct Storage (GDS). If hardware and drivers support it, enabling this can improve SSD to GPU data throughput. Disabled by default, set to 1 to enable |
+| `FLEXKV_CUDAHOST_CHUNK_SIZE_GB` | float | 0 | Chunk size in GB used when calling `cudaHostRegister` on a HugePage host buffer. Default `0` registers the whole buffer in a single call; a value greater than 0 registers (and correspondingly unregisters) the buffer in chunks of this size, which avoids one-shot registration failures on very large buffers. The chunk size is rounded down to a 4 KiB page boundary with a small alignment margin reserved |
 | `FLEXKV_SWA_MULTI_GROUP` | bool | unset (auto-enabled) | For DeepSeek-V4, unset or `1` stores/restores SWA KV with attention/indexer compress states; `0` keeps SWA KV I/O only |
 | `FLEXKV_SWA_MULTI_LAYER` | bool | 1 | `1` fuses SWA/state H2D into layerwise restore; `0` uses the standalone SWA/state H2D predecessor worker |
 

--- a/docs/flexkv_config_reference/README_zh.md
+++ b/docs/flexkv_config_reference/README_zh.md
@@ -58,6 +58,7 @@ swa_multi_group: false
 | `FLEXKV_USE_HUGEPAGE_CPU_BUFFER` | bool | 0 | 是否为通用 CPU KV cache 启用 HugePage。默认关闭，开启请设为 1 |
 | `FLEXKV_USE_HUGEPAGE_TMP_BUFFER` | bool | 0 | 是否为 `enable_p2p_ssd` 场景下的 tmp CPU staging buffer 启用 HugePage。默认关闭，开启请设为 1 |
 | `FLEXKV_HUGEPAGE_SIZE_BYTES` | int | 2097152 | HugePage 大小，默认 2 MiB。如果宿主机准备的是 1 GiB HugePage，可设为 `1073741824` |
+| `FLEXKV_CUDAHOST_CHUNK_SIZE_GB` | float | 0 | HugePage host buffer 执行 `cudaHostRegister` 时的分段大小，单位为 GB。默认 `0` 表示整块一次性注册；设为大于 0 时按该大小分段注册（并对应分段反注册），可避免超大 buffer 一次注册失败。分段大小会自动向下对齐到 4 KiB 页边界，并预留少量对齐余量 |
 | `FLEXKV_SWA_MULTI_GROUP` | bool | 未设置（自动开启） | DeepSeek-V4 下未设置或设为 `1` 时，SWA KV 与 attention/indexer compress state 一起存取；设为 `0` 时只保留 SWA KV 存取 |
 | `FLEXKV_SWA_MULTI_LAYER` | bool | 1 | `1` 表示把 SWA/state H2D 融合进 layerwise restore；`0` 表示使用独立的 SWA/state H2D 前置 worker |
 

--- a/flexkv/transfer/host_buffer.py
+++ b/flexkv/transfer/host_buffer.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import ctypes
+import os
+import time
 import weakref
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 import torch
@@ -48,25 +50,72 @@ CUDA_HOST_ALLOC_PORTABLE = 0x01
 CUDA_HOST_ALLOC_MAPPED = 0x02
 
 
+_FLEXKV_CUDAHOST_REGISTER_PORTABLE = 1  # cudaHostRegisterPortable
+_FLEXKV_CUDAHOST_CHUNK_SAFETY_MARGIN_BYTES = 4 * 1024  # 4 KiB cushion for CUDA internal alignment
+
+
+def _get_cudahost_chunk_bytes() -> int:
+    chunk_gb = float(os.getenv("FLEXKV_CUDAHOST_CHUNK_SIZE_GB", "0"))
+    if chunk_gb <= 0:
+        return 0  # no chunking
+    chunk = int(chunk_gb * (1024 ** 3)) - _FLEXKV_CUDAHOST_CHUNK_SAFETY_MARGIN_BYTES
+    # Round down to 4 KiB page boundary
+    return chunk & ~0xFFF
+
+
 def cudaHostRegister(tensor: torch.Tensor) -> None:
+    """Register a CPU tensor with CUDA, optionally in chunks of FLEXKV_CUDAHOST_CHUNK_SIZE_GB.
+
+    Chunked registration keeps each cudaHostRegister call under the configured size,
+    which avoids failures on very large buffers. When the chunk size is 0 (default)
+    the whole tensor is registered in a single call.
+    """
     cudart = _get_cudart()
-    ptr = tensor.data_ptr()
-    size = tensor.numel() * tensor.element_size()
+    ptr_base = tensor.data_ptr()
+    total_size = tensor.numel() * tensor.element_size()
     flags = CUDA_HOST_REGISTER_PORTABLE | CUDA_HOST_REGISTER_MAPPED
-    ret = cudart.cudaHostRegister(
-        ctypes.c_void_p(ptr), ctypes.c_size_t(size), ctypes.c_uint(flags)
-    )
-    if ret != 0:
-        raise RuntimeError(f"cudaHostRegister failed with error code {ret}")
+    chunk_size = _get_cudahost_chunk_bytes()
+
+    if chunk_size == 0 or total_size <= chunk_size:
+        ret = cudart.cudaHostRegister(
+            ctypes.c_void_p(ptr_base), ctypes.c_size_t(total_size), ctypes.c_uint(flags)
+        )
+        if ret != 0:
+            raise RuntimeError(f"cudaHostRegister failed with error code {ret}")
+        return
+
+    for offset in range(0, total_size, chunk_size):
+        size = min(chunk_size, total_size - offset)
+        ret = cudart.cudaHostRegister(
+            ctypes.c_void_p(ptr_base + offset), ctypes.c_size_t(size), ctypes.c_uint(flags)
+        )
+        if ret != 0:
+            # Roll back already-registered chunks so we don't leak registrations.
+            for done in range(0, offset, chunk_size):
+                cudart.cudaHostUnregister(ctypes.c_void_p(ptr_base + done))
+            raise RuntimeError(
+                f"cudaHostRegister failed at offset={offset} bytes with error code {ret}"
+            )
 
 
 def cudaHostUnregister(tensor: torch.Tensor) -> None:
+    """Unregister a CPU tensor from CUDA, matching the chunked register layout."""
     cudart = _get_cudart()
-    ptr = tensor.data_ptr()
-    ret = cudart.cudaHostUnregister(ctypes.c_void_p(ptr))
-    if ret != 0:
-        raise RuntimeError(f"cudaHostUnregister failed with error code {ret}")
+    ptr_base = tensor.data_ptr()
+    total_size = tensor.numel() * tensor.element_size()
+    chunk_size = _get_cudahost_chunk_bytes()
 
+    if chunk_size == 0 or total_size <= chunk_size:
+        cudart.cudaHostUnregister(ctypes.c_void_p(ptr_base))
+        return
+
+    for offset in range(0, total_size, chunk_size):
+        ret = cudart.cudaHostUnregister(ctypes.c_void_p(ptr_base + offset))
+        if ret != 0:
+            flexkv_logger.warning(
+                f"cudaHostUnregister failed at offset={offset} bytes, "
+                f"error code {ret} (ignored)"
+            )
 
 @dataclass
 class HostBufferHandle:


### PR DESCRIPTION
Register HugePage host buffers in segments matching the existing chunked unregister layout. chunk=0 (default) registers the whole buffer in one call; chunk>0 splits registration to avoid one-shot failures on very large buffers, with rollback of already-registered chunks on error.

Document the new env var in the zh/en config references.