### PR TITLE
fix(sglang): auto-derive dp_rank for dp_attention mode

### DIFF
--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -329,10 +329,10 @@ class FlexKVConfig:
             dp_rank: logical DP shard index for this worker.
                 - plain DP (``enable_dp_attention=False``): the regular
                   ``dp_rank`` passed to the scheduler process (0, 1, …).
-                - DP Attention (``enable_dp_attention=True``): the
-                  ``attn_dp_rank`` derived from ``tp_rank`` via
-                  ``compute_dp_attention_world_info`` (already converted
-                  by the sglang scheduler before calling this method).
+                - DP Attention (``enable_dp_attention=True``): auto-derived
+                  from ``tp_rank`` via the same decomposition sglang uses
+                  in ``compute_dp_attention_world_info``.  The caller may
+                  pass ``None`` or 0; it will be overridden.
                 In both cases this value is stored directly as
                 ``RankInfo.dp_rank`` and ``ModelConfig.dp_size`` is set
                 to the true ``sglang_dp_size`` so that
@@ -361,6 +361,12 @@ class FlexKVConfig:
         attn_tp_size = max(1, sglang_tp_size // (attn_dp_size * attn_cp_size))
         # attn_tp_rank: derived from physical tp_rank
         attn_tp_rank = int(tp_rank) % attn_tp_size
+
+        if enable_dp_attention:
+            # sglang's _flexkv_factory passes dp_rank=None (the factory does
+            # not carry dp_rank on TreeCacheBuildContext).  Derive it from
+            # tp_rank using the same formula as compute_dp_attention_world_info.
+            dp_rank = int(tp_rank) // (attn_tp_size * attn_cp_size)
 
         # cache config: use page_size as tokens_per_block so that FlexKV's
         # CPU radix tree manages blocks at page granularity, ensuring that


### PR DESCRIPTION
sglang's _flexkv_factory passes dp_rank=None because TreeCacheBuildContext does not carry dp_rank. With dp_attention enabled (e.g. tp_size=8, dp_size=8, 8 physical GPUs), every worker gets dp_rank=0 → dp_client_id=0 → all 8 try to spawn a KVServer on the same IPC port → port conflict and hang.

Fix: when enable_dp_attention is True, derive dp_rank from tp_rank using the same formula as sglang's compute_dp_attention_world_info:
  dp_rank = tp_rank // (attn_tp_size * attn_cp_size)

This gives each worker a unique dp_client_id so only dp_client_id=0 creates the KVServer, and the rest connect as clients.