### PR TITLE
feat(transfer): add FLEXKV_TRANSFER_TRACE transfer diagnosis tracing

### DIFF
--- a/benchmarks/benchmark_workers.py
+++ b/benchmarks/benchmark_workers.py
@@ -7,16 +7,24 @@ from argparse import ArgumentParser
 from tqdm import tqdm
 import copy
 
+import numpy as np
 import torch
 
-from flexkv.common.transfer import TransferOp, TransferType
+from flexkv.common.transfer import TransferOp, TransferType, LayerwiseTransferOp
 from flexkv.transfer.worker import GPUCPUTransferWorker, CPUSSDDiskTransferWorker, WorkerHandle, tpGPUCPUTransferWorker, \
     GDSTransferWorker, tpGDSTransferWorker
+from flexkv.transfer.layerwise import LayerwiseTransferWorker, build_layerwise_eventfd_socket_path
 from flexkv.storage.allocator import CPUAllocator, GPUAllocator, SSDAllocator
 from flexkv.common.storage import KVCacheLayoutType, KVCacheLayout
 from flexkv.common.config import ModelConfig, CacheConfig, GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.debug import flexkv_logger
 from utils import load_config
+
+# GDS support is optional (only available when compiled with FLEXKV_ENABLE_GDS=1)
+try:
+    from flexkv.c_ext import transfer_kv_blocks_gds
+except ImportError:
+    transfer_kv_blocks_gds = None
 
 # flexkv_logger.set_level("OFF")
 
@@ -315,6 +323,97 @@ def create_gpu_ssd_worker(
         finished_ops_queue,
     )
 
+def create_layerwise_worker(
+                  model_config: ModelConfig,
+                  cache_config: CacheConfig,
+                  num_gpu_blocks: int,
+                  gpu_layout_type: int = 0) -> Tuple[WorkerHandle, mp.Queue]:
+    """Create a LayerwiseTransferWorker for benchmarking CPU->GPU H2D transfers.
+
+    Uses ``enable_eventfd=False`` so no sglang eventfd session is required —
+    the worker uses an empty eventfd tensor and the benchmark drives transfers
+    purely via ``launch_transfer`` + ``sync_all``.
+    """
+    mp.set_start_method('spawn', force=True)
+    cpu_layout = KVCacheLayout(
+        type=GLOBAL_CONFIG_FROM_ENV.cpu_layout_type,
+        num_layer=model_config.num_layers,
+        num_block=cache_config.num_cpu_blocks,
+        tokens_per_block=cache_config.tokens_per_block,
+        num_head=model_config.num_kv_heads,
+        head_size=model_config.head_size,
+        is_mla=model_config.use_mla,
+    )
+    if gpu_layout_type == 0 or gpu_layout_type == 2:
+        layout_type = KVCacheLayoutType.LAYERFIRST
+    elif gpu_layout_type == 1:
+        layout_type = KVCacheLayoutType.BLOCKFIRST
+    else:
+        raise ValueError(f"Invalid GPU layout type: {gpu_layout_type}")
+
+    if gpu_layout_type == 0:
+        num_chunks = model_config.num_layers
+    elif gpu_layout_type == 1:
+        num_chunks = 1
+    elif gpu_layout_type == 2:
+        num_chunks = model_config.num_layers * 2
+    else:
+        raise ValueError(f"Invalid GPU layout type: {gpu_layout_type}")
+
+    gpu_layout = KVCacheLayout(
+        type=layout_type,
+        num_layer=model_config.num_layers,
+        num_block=num_gpu_blocks,
+        tokens_per_block=cache_config.tokens_per_block,
+        num_head=model_config.num_kv_heads,
+        head_size=model_config.head_size,
+        is_mla=model_config.use_mla,
+    )
+    gpu_layout = gpu_layout.div_head(model_config.tp_size) if not model_config.use_mla else gpu_layout
+    cpu_handle = CPUAllocator.allocate(
+        layout=cpu_layout,
+        dtype=model_config.dtype,
+        pin_memory=True
+    )
+    gpu_handles = []
+    for tp_id in range(model_config.tp_size):
+        torch.cuda.set_device(tp_id)
+        gpu_handles.append(GPUAllocator.allocate(
+            layout=gpu_layout,
+            dtype=model_config.dtype,
+            num_chunks=num_chunks,
+            device_id=tp_id,
+        ))
+    finished_ops_queue = mp.Queue()
+    max_block_num = max(1024, cache_config.num_cpu_blocks)
+    op_buffer_tensor = torch.empty((4, max_block_num), dtype=torch.int64).share_memory_()
+
+    # Build the eventfd socket path (not actually used when enable_eventfd=False,
+    # but __init__ still expects a string).
+    layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
+        dp_client_id=0, pp_rank=0, model_config=model_config)
+
+    worker_handle = LayerwiseTransferWorker.create_worker(
+        mp_ctx=mp.get_context('spawn'),
+        finished_ops_queue=finished_ops_queue,
+        op_buffer_tensor=op_buffer_tensor,
+        gpu_blocks=[handle.get_tensor_handle_list() for handle in gpu_handles],
+        cpu_blocks=cpu_handle.get_tensor(),
+        ssd_files={},
+        gpu_kv_layouts=[gpu_handles[tp_id].kv_layout for tp_id in range(model_config.tp_size)],
+        cpu_kv_layout=cpu_handle.kv_layout,
+        ssd_kv_layout=cpu_handle.kv_layout,
+        dtype=model_config.dtype,
+        tp_group_size=model_config.tp_size,
+        layerwise_eventfd_socket=layerwise_eventfd_socket,
+        num_blocks_per_file=0,
+        enable_eventfd=False,
+    )
+    return (
+        worker_handle,
+        finished_ops_queue,
+    )
+
 def launch_transfer(worker_handle: WorkerHandle,
                     finished_ops_queue: mp.Queue,
                     transfer_op: TransferOp):
@@ -367,7 +466,13 @@ def bench_worker(args):
     elif transfer_type == TransferType.H2DISK or transfer_type == TransferType.DISK2H:
         worker_handle, finished_ops_queue = create_cpu_ssd_worker(model_config, cache_config)
     elif transfer_type == TransferType.DISK2D or transfer_type == TransferType.D2DISK:
+        if transfer_kv_blocks_gds is None:
+            print("[BENCH] GDS not compiled, skipping DISK2D/D2DISK")
+            return []
         worker_handle, finished_ops_queue = create_gpu_ssd_worker(
+            model_config, cache_config, max_blocks, gpu_layout_type)
+    elif transfer_type == TransferType.LAYERWISE:
+        worker_handle, finished_ops_queue = create_layerwise_worker(
             model_config, cache_config, max_blocks, gpu_layout_type)
     else:
         raise ValueError(f"Unsupported transfer type: {transfer_type}")
@@ -380,15 +485,26 @@ def bench_worker(args):
         else:
             block_ids = torch.arange(num_blocks_to_transfer).numpy()
 
-        transfer_op = TransferOp(
-            transfer_type=transfer_type,
-            src_block_ids=block_ids,
-            dst_block_ids=block_ids,
-            graph_id=0,
-            dp_client_id=0,
-            successors=[],
-            predecessors=[],
-        )
+        if transfer_type == TransferType.LAYERWISE:
+            transfer_op = LayerwiseTransferOp(
+                graph_id=0,
+                src_block_ids_h2d=block_ids,
+                dst_block_ids_h2d=block_ids,
+                src_block_ids_disk2h=np.array([], dtype=np.int64),
+                dst_block_ids_disk2h=np.array([], dtype=np.int64),
+                dp_client_id=0,
+                counter_id=0,
+            )
+        else:
+            transfer_op = TransferOp(
+                transfer_type=transfer_type,
+                src_block_ids=block_ids,
+                dst_block_ids=block_ids,
+                graph_id=0,
+                dp_client_id=0,
+                successors=[],
+                predecessors=[],
+            )
 
         if transfer_type == TransferType.DISK2H or transfer_type == TransferType.H2DISK:
             tmp_op = copy.deepcopy(transfer_op)
@@ -459,6 +575,8 @@ def bench_worker(args):
                 r["num_blocks"], r["total_gb"],
                 r["avg_time_s"] * 1000, r["bw_gbps"]))
 
+    return results
+
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument("--transfer-type",
@@ -501,8 +619,49 @@ def parse_args():
                         default=None,
                         help="Comma-separated block counts to sweep "
                              "(e.g. '64,128,256,512,1024,2048,4096')")
+    parser.add_argument("--all",
+                        action="store_true",
+                        help="run all local transfer types (H2D/D2H/H2DISK/DISK2H/DISK2D/D2DISK/LAYERWISE) and print summary")
     return parser.parse_args()
 
 if __name__ == "__main__":
     args = parse_args()
-    bench_worker(args)
+    if getattr(args, "all", False):
+        all_types = ["H2D", "D2H", "H2DISK", "DISK2H", "DISK2D", "D2DISK", "LAYERWISE"]
+        summary = []  # [(transfer_type, result_dict_or_None_or_"SKIPPED"), ...]
+        for t in all_types:
+            # GDS not compiled: skip DISK2D/D2DISK
+            if t in ("DISK2D", "D2DISK") and transfer_kv_blocks_gds is None:
+                print(f"\n{'='*70}\n[--all] SKIPPED: {t} (GDS not compiled)\n{'='*70}")
+                summary.append((t, "SKIPPED"))
+                continue
+            args.transfer_type = t
+            print(f"\n{'='*70}\n[--all] running transfer_type={t}\n{'='*70}")
+            try:
+                results = bench_worker(args)
+                last = results[-1] if results else None
+                summary.append((t, last))
+            except Exception as e:
+                import traceback
+                print(f"[--all] case {t} FAILED: {e}")
+                traceback.print_exc()
+                summary.append((t, None))
+        # 汇总表
+        print(f"\n{'='*70}\n[--all] Summary\n{'='*70}")
+        hdr = "{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}".format(
+            "Type", "Blocks", "Total GB", "Avg ms", "BW GB/s")
+        print(hdr)
+        print("-" * len(hdr))
+        for t, r in summary:
+            if r == "SKIPPED":
+                print("{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}".format(
+                    t, "-", "-", "-", "SKIPPED"))
+            elif r is not None:
+                print("{:>10s}  {:>10d}  {:>10.2f}  {:>12.3f}  {:>12.2f}".format(
+                    t, r["num_blocks"], r["total_gb"],
+                    r["avg_time_s"] * 1000, r["bw_gbps"]))
+            else:
+                print("{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}".format(
+                    t, "-", "-", "-", "FAILED"))
+    else:
+        bench_worker(args)

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -64,7 +64,8 @@ void transfer_kv_blocks_binding(
     bool ce_path_opt = false,
     int ce_segment_threshold = 8, int ce_force_path = -1,
     bool ce_enable_memcpy2d = false, bool is_blockfirst = false,
-    int ce_gather_threads = 4, bool ce_gather_nt = true) {
+    int ce_gather_threads = 4, bool ce_gather_nt = true,
+    bool enable_transfer_trace = false) {
   int num_blocks = gpu_block_id_tensor.numel();
 
   int64_t *gpu_block_ids =
@@ -117,7 +118,7 @@ void transfer_kv_blocks_binding(
         cpu_block_stride_in_bytes, /*cpu_startoff_inside_chunks=*/0,
         chunk_size_in_bytes, stream, transfer_num_cta, is_host_to_device,
         use_ce_transfer, is_mla,
-        gpu_block_stride_in_bytes, sync, ce_config);
+        gpu_block_stride_in_bytes, sync, ce_config, enable_transfer_trace);
     break;
   case flexkv::BackendType::TRTLLM:
     flexkv::transfer_kv_blocks<flexkv::BackendType::TRTLLM>(
@@ -127,7 +128,7 @@ void transfer_kv_blocks_binding(
         cpu_block_stride_in_bytes, /*cpu_startoff_inside_chunks=*/0,
         chunk_size_in_bytes, stream, transfer_num_cta, is_host_to_device,
         use_ce_transfer, is_mla,
-        gpu_block_stride_in_bytes, sync, ce_config);
+        gpu_block_stride_in_bytes, sync, ce_config, enable_transfer_trace);
     break;
   case flexkv::BackendType::SGLANG:
     flexkv::transfer_kv_blocks<flexkv::BackendType::SGLANG>(
@@ -137,7 +138,7 @@ void transfer_kv_blocks_binding(
         cpu_block_stride_in_bytes, /*cpu_startoff_inside_chunks=*/0,
         chunk_size_in_bytes, stream, transfer_num_cta, is_host_to_device,
         use_ce_transfer, is_mla,
-        gpu_block_stride_in_bytes, sync, ce_config);
+        gpu_block_stride_in_bytes, sync, ce_config, enable_transfer_trace);
     break;
   }
 
@@ -447,7 +448,8 @@ PYBIND11_MODULE(c_ext, m) {
         py::arg("ce_enable_memcpy2d") = false,
         py::arg("is_blockfirst") = false,
         py::arg("ce_gather_threads") = 4,
-        py::arg("ce_gather_nt") = true);
+        py::arg("ce_gather_nt") = true,
+        py::arg("enable_transfer_trace") = false);
   m.def("transfer_kv_blocks_ssd", &transfer_kv_blocks_ssd_binding,
         "Transfer KV blocks between SSD and CPU memory", py::arg("ioctx"),
         py::arg("cpu_layer_id_list"), py::arg("cpu_tensor_ptr"),
@@ -676,7 +678,8 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("swa_ssd_kv_stride_in_bytes") = 0,
            py::arg("swa_num_blocks_per_file") = 0,
            py::arg("mla_d2h_mode") = "sharded",
-           py::arg("notify_mode") = "hostfunc")
+           py::arg("notify_mode") = "hostfunc",
+           py::arg("enable_trace") = false)
       .def("layerwise_transfer_multi_group",
            &flexkv::LayerwiseTransferGroup::layerwise_transfer_multi_group,
            py::arg("ssd_block_ids"), py::arg("cpu_block_ids_d2h"),
@@ -700,7 +703,8 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("swa_ssd_kv_stride_in_bytes") = 0,
            py::arg("swa_num_blocks_per_file") = 0,
            py::arg("mla_d2h_mode") = "sharded",
-           py::arg("notify_mode") = "hostfunc");
+           py::arg("notify_mode") = "hostfunc",
+           py::arg("enable_trace") = false);
 
 #ifdef FLEXKV_ENABLE_CFS
   m.def("transfer_kv_blocks_remote", &transfer_kv_blocks_remote,

--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -968,7 +968,7 @@ void LayerwiseTransferGroup::layerwise_transfer(
     const int64_t swa_ssd_layer_stride_in_bytes,
     const int64_t swa_ssd_kv_stride_in_bytes,
     const int swa_num_blocks_per_file, const std::string &mla_d2h_mode,
-    const std::string &notify_mode) {
+    const std::string &notify_mode, const bool enable_trace) {
 
   if (has_multi_group_) {
     throw std::runtime_error(
@@ -1253,6 +1253,29 @@ void LayerwiseTransferGroup::layerwise_transfer(
     }
   }
 
+  if (enable_trace && log_timing) {
+    cudaSetDevice(gpu_device_ids_[0]);
+    for (int i = 0; i < num_batches; ++i) {
+      // event-level sync
+      cudaEventSynchronize(timing_events[i + 1]);
+      float sync_ms = 0.0f;
+      cudaEventElapsedTime(&sync_ms, timing_events[i], timing_events[i + 1]);
+      int layers_this_batch = batch_layers_count[i];
+      int64_t h2d_bytes = 0;
+      for (int g = 0; g < num_gpus_; ++g) {
+        h2d_bytes +=
+            gpu_chunk_sizes_in_bytes_[g] * 2 * layers_this_batch * num_blocks;
+      }
+      double data_mb = h2d_bytes / (1024.0 * 1024.0);
+      double bw_mbs = (sync_ms > 0.0f) ? data_mb / (sync_ms / 1000.0) : 0.0;
+      int sl = i * layer_granularity;
+      FLEXKV_LOG_INFO(
+          "[XFER] type=layerwise_h2d layer_range=[%d,%d) blocks=%d "
+          "data=%.2fMB sync_ms=%.3f bw=%.0fMB/s",
+          sl, sl + layers_this_batch, num_blocks, data_mb, sync_ms, bw_mbs);
+    }
+  }
+
   if (log_timing) {
     float total_time_ms = 0.0f;
     int64_t total_bytes = 0;
@@ -1302,7 +1325,7 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
     const int64_t swa_ssd_layer_stride_in_bytes,
     const int64_t swa_ssd_kv_stride_in_bytes,
     const int swa_num_blocks_per_file, const std::string &mla_d2h_mode,
-    const std::string &notify_mode) {
+    const std::string &notify_mode, const bool enable_trace) {
   (void)swa_cpu_tp_stride_in_bytes;
 
   if (!has_multi_group_) {
@@ -1462,10 +1485,38 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
     h2d_range_ids[first] = nvtxRangeStartA(h2d_range_names[first].c_str());
   }
 
+  const bool mg_trace = enable_trace &&
+                        notify_mode_ != NotifyMode::POLLING &&
+                        logging::IsEnabled(logging::Level::Debug) &&
+                        !work_origs.empty();
+  std::vector<std::vector<cudaEvent_t>> trace_begin_events(
+      mg_trace ? work_origs.size() : 0,
+      std::vector<cudaEvent_t>(mg_trace ? num_gpus_ : 0));
+  std::vector<std::vector<cudaEvent_t>> trace_end_events(
+      mg_trace ? work_origs.size() : 0,
+      std::vector<cudaEvent_t>(mg_trace ? num_gpus_ : 0));
+  std::vector<int64_t> data_bytes_per_orig(work_origs.size(), 0);
+  if (mg_trace) {
+    for (size_t ai = 0; ai < work_origs.size(); ++ai) {
+      for (int d = 0; d < num_gpus_; ++d) {
+        cudaSetDevice(gpu_device_ids_[d]);
+        cudaEventCreate(&trace_begin_events[ai][d]);
+        cudaEventCreate(&trace_end_events[ai][d]);
+      }
+    }
+  }
+
   for (size_t ai = 0; ai < work_origs.size(); ++ai) {
     int orig = work_origs[ai];
     const auto &members = layer_members_[orig];
     int members_this_layer = static_cast<int>(members.size());
+
+    if (mg_trace) {
+      for (int d = 0; d < num_gpus_; ++d) {
+        cudaSetDevice(gpu_device_ids_[d]);
+        cudaEventRecord(trace_begin_events[ai][d], streams_[d]);
+      }
+    }
 
     for (const auto &member : members) {
       int gi = member.first;
@@ -1514,6 +1565,21 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
           break;
         }
       }
+    }
+
+    if (mg_trace) {
+      for (int d = 0; d < num_gpus_; ++d) {
+        cudaSetDevice(gpu_device_ids_[d]);
+        cudaEventRecord(trace_end_events[ai][d], streams_[d]);
+      }
+      int64_t per_orig_bytes = 0;
+      for (const auto &m : members) {
+        const GroupParams &gp = groups_[m.first];
+        for (int d = 0; d < num_gpus_; ++d) {
+          per_orig_bytes += gp.gpu_chunk_sizes[d] * 2 * num_blocks;
+        }
+      }
+      data_bytes_per_orig[ai] = per_orig_bytes;
     }
 
     if (swa_active) {
@@ -1566,6 +1632,39 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
         throw std::runtime_error(
             "layerwise_transfer_multi_group failed on GPU " +
             std::to_string(d) + ": " + cudaGetErrorString(err));
+      }
+    }
+    if (mg_trace) {
+      for (size_t ai = 0; ai < work_origs.size(); ++ai) {
+        int orig = work_origs[ai];
+        float max_ms = 0.0f;
+        for (int d = 0; d < num_gpus_; ++d) {
+          cudaEventSynchronize(trace_end_events[ai][d]);
+          float ms = 0.0f;
+          cudaEventElapsedTime(&ms, trace_begin_events[ai][d],
+                               trace_end_events[ai][d]);
+          if (ms > max_ms) {
+            max_ms = ms;
+          }
+        }
+        double data_mb = data_bytes_per_orig[ai] / (1024.0 * 1024.0);
+        double bw_mbs = (max_ms > 0.0f) ? data_mb / (max_ms / 1000.0) : 0.0;
+        FLEXKV_LOG_INFO(
+            "[XFER] type=layerwise_mg_h2d orig=%d members=%zu gpus=%d "
+            "sync_ms=%.3f data=%.2fMB bw=%.0fMB/s",
+            orig, layer_members_[orig].size(), num_gpus_, max_ms, data_mb,
+            bw_mbs);
+      }
+    }
+  }
+
+  // destroy trace timing events
+  if (mg_trace) {
+    for (size_t ai = 0; ai < work_origs.size(); ++ai) {
+      for (int d = 0; d < num_gpus_; ++d) {
+        cudaSetDevice(gpu_device_ids_[d]);
+        cudaEventDestroy(trace_begin_events[ai][d]);
+        cudaEventDestroy(trace_end_events[ai][d]);
       }
     }
   }

--- a/csrc/layerwise.h
+++ b/csrc/layerwise.h
@@ -172,7 +172,8 @@ public:
       const int swa_num_blocks_per_file = 0,
       // ---- MLA D2H mode (#192) + polling notification (#199) ----
       const std::string &mla_d2h_mode = "sharded",
-      const std::string &notify_mode = "hostfunc");
+      const std::string &notify_mode = "hostfunc",
+      const bool enable_trace = false);
 
   // Multi-group layerwise transfer: SSD->CPU per group, CPU->GPU per original
   // layer (expanding the CSR to fire one transfer kernel per group member).
@@ -201,7 +202,8 @@ public:
       const int64_t swa_ssd_kv_stride_in_bytes = 0,
       const int swa_num_blocks_per_file = 0,
       const std::string &mla_d2h_mode = "sharded",
-      const std::string &notify_mode = "hostfunc");
+      const std::string &notify_mode = "hostfunc",
+      const bool enable_trace = false);
 
   // Bind heterogeneous SWA/state sidecars (SWA KV + compress states) onto the
   // same LayerwiseTransferGroup.  Mutually exclusive with the uniform

--- a/csrc/transfer.cu
+++ b/csrc/transfer.cu
@@ -17,9 +17,12 @@
 #include <cuda_runtime.h>
 #include <torch/extension.h>
 
+#include <chrono>
+
 #include "monitoring/metrics_manager.h"
 #include "transfer.cuh"
 #include "ce_transfer.h"
+#include "logging.h"
 
 namespace flexkv {
 
@@ -168,7 +171,7 @@ void transfer_kv_blocks(
     cudaStream_t stream, int transfer_num_cta, bool is_host_to_device,
     bool use_ce_transfer, bool is_mla,
     int64_t gpu_block_stride_in_bytes, bool sync,
-    const CETransferConfig &ce_config) {
+    const CETransferConfig &ce_config, bool enable_trace) {
 
   int block_size = 1024;
   int block_count = transfer_num_cta;
@@ -298,7 +301,16 @@ void transfer_kv_blocks(
     }
   }
   if (sync) {
+    auto sync_t0 = std::chrono::steady_clock::now();
     cudaStreamSynchronize(stream);
+    if (enable_trace) {
+      auto sync_t1 = std::chrono::steady_clock::now();
+      double sync_ms =
+          std::chrono::duration<double, std::milli>(sync_t1 - sync_t0).count();
+      FLEXKV_LOG_INFO(
+          "[XFER] type=%s blocks=%d sync_ms=%.3f",
+          is_host_to_device ? "H2D" : "D2H", num_blocks, sync_ms);
+    }
   }
 }
 
@@ -306,16 +318,16 @@ void transfer_kv_blocks(
 template void transfer_kv_blocks<BackendType::VLLM>(
     int, int, int, int64_t *, GTensorHandler, int64_t, int64_t *, void *,
     int64_t, int64_t, int64_t, int64_t, int64_t, cudaStream_t, int, bool, bool,
-    bool, int64_t, bool, const CETransferConfig &);
+    bool, int64_t, bool, const CETransferConfig &, bool);
 
 template void transfer_kv_blocks<BackendType::TRTLLM>(
     int, int, int, int64_t *, GTensorHandler, int64_t, int64_t *, void *,
     int64_t, int64_t, int64_t, int64_t, int64_t, cudaStream_t, int, bool, bool,
-    bool, int64_t, bool, const CETransferConfig &);
+    bool, int64_t, bool, const CETransferConfig &, bool);
 
 template void transfer_kv_blocks<BackendType::SGLANG>(
     int, int, int, int64_t *, GTensorHandler, int64_t, int64_t *, void *,
     int64_t, int64_t, int64_t, int64_t, int64_t, cudaStream_t, int, bool, bool,
-    bool, int64_t, bool, const CETransferConfig &);
+    bool, int64_t, bool, const CETransferConfig &, bool);
 
 } // namespace flexkv

--- a/csrc/transfer.cuh
+++ b/csrc/transfer.cuh
@@ -33,6 +33,7 @@ void transfer_kv_blocks(
     int64_t chunk_size_in_bytes, cudaStream_t stream, int transfer_num_cta,
     bool is_host_to_device, bool use_ce_transfer, bool is_mla,
     int64_t gpu_block_stride_in_bytes = 0,
-    bool sync = true, const CETransferConfig &ce_config = CETransferConfig{});
+    bool sync = true, const CETransferConfig &ce_config = CETransferConfig{},
+    bool enable_trace = false);
 
 } // namespace flexkv

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -782,6 +782,8 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     trace_max_files=int(os.getenv('FLEXKV_TRACE_MAX_FILES', 5)),
     trace_flush_interval_ms=int(os.getenv('FLEXKV_TRACE_FLUSH_INTERVAL_MS', 1000)),
 
+    enable_transfer_trace=bool(int(os.getenv('FLEXKV_TRANSFER_TRACE', 0))),
+
     lt_pool_initial_capacity=int(os.getenv('FLEXKV_LT_POOL_INITIAL_CAPACITY', 10000000)),
     refresh_batch_size=int(os.getenv('FLEXKV_REFRESH_BATCH_SIZE', 256)),
     rebuild_interval_ms=int(os.getenv('FLEXKV_REBUILD_INTERVAL_MS', 2000)),

--- a/flexkv/transfer/layerwise.py
+++ b/flexkv/transfer/layerwise.py
@@ -289,6 +289,8 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                 tp_group_size=tp_group_size,
             )
 
+        self._bytes_per_block = getattr(self, "cpu_chunk_size_in_bytes", 0) * self.num_layers * self.kv_dim
+
         if self.has_swa_multi_group:
             self._bind_swa_multi_group(tp_group_size)
 
@@ -960,6 +962,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
                 counter_id=counter_id,
                 mla_d2h_mode=self.mla_d2h_mode,
                 notify_mode=self.layerwise_notify_mode,
+                enable_trace=GLOBAL_CONFIG_FROM_ENV.enable_transfer_trace,
                 **swa_kwargs,
             )
             return
@@ -989,6 +992,7 @@ class LayerwiseTransferWorker(TransferWorkerBase):
             counter_id,
             mla_d2h_mode=self.mla_d2h_mode,
             notify_mode=self.layerwise_notify_mode,
+            enable_trace=GLOBAL_CONFIG_FROM_ENV.enable_transfer_trace,
             **swa_kwargs,
         )
 

--- a/flexkv/transfer/trace.py
+++ b/flexkv/transfer/trace.py
@@ -1,0 +1,206 @@
+"""Transfer diagnosis tracing (single switch, raw-data only).
+
+One switch: FLEXKV_TRANSFER_TRACE. When on, every transfer prints one
+[XFER] line (lifecycle timing + backlog) plus a periodic [XFER-SUMMARY].
+No verdict; raw data for the operator to grep. Uses flexkv_logger.info,
+so it also obeys FLEXKV_LOG_LEVEL (default INFO => on).
+"""
+import time
+import threading
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from flexkv.common.debug import flexkv_logger
+
+# Set by configure(); caller reads GLOBAL_CONFIG_FROM_ENV.
+_TRACE_ON = False
+
+# Summary window in seconds (hardcoded).
+_SUMMARY_INTERVAL_S = 10.0
+
+# Scheduler-side state (parent process).
+_submit_lock = threading.Lock()
+_submit_ns: Dict[int, int] = {}
+
+_inflight_lock = threading.Lock()
+_inflight = 0
+_inflight_max_window = 0
+
+# Summary accumulators (reset each window).
+_sum_lock = threading.Lock()
+_win_start = time.monotonic()
+_wait_ms: List[float] = []
+_xfer_ms: List[float] = []
+_type_counts: Dict[str, int] = defaultdict(int)
+
+
+def configure(enabled: bool) -> None:
+    """Enable/disable tracing. Call once at startup from GLOBAL_CONFIG_FROM_ENV."""
+    global _TRACE_ON
+    _TRACE_ON = bool(enabled)
+
+
+def set_submit_ns(op_id: int, submitted_ns: int) -> None:
+    """Record submit time (scheduler side)."""
+    if not _TRACE_ON:
+        return
+    with _submit_lock:
+        _submit_ns[op_id] = submitted_ns
+
+
+def consume_submit_ns(op_id: int) -> float:
+    """e2e ms from submit to now; 0.0 if unknown."""
+    if not _TRACE_ON:
+        return 0.0
+    with _submit_lock:
+        t = _submit_ns.pop(op_id, None)
+    if t is None:
+        return 0.0
+    return (time.perf_counter_ns() - t) / 1e6
+
+
+def inc_inflight() -> None:
+    """One op submitted to a worker."""
+    if not _TRACE_ON:
+        return
+    global _inflight, _inflight_max_window
+    with _inflight_lock:
+        _inflight += 1
+        if _inflight > _inflight_max_window:
+            _inflight_max_window = _inflight
+
+
+def dec_inflight() -> int:
+    """One op finished; return current inflight."""
+    if not _TRACE_ON:
+        return 0
+    global _inflight
+    with _inflight_lock:
+        _inflight = max(0, _inflight - 1)
+        return _inflight
+
+
+def inflight_value() -> int:
+    if not _TRACE_ON:
+        return 0
+    with _inflight_lock:
+        return _inflight
+
+
+def build_worker_metrics(
+    op,
+    submitted_ns: int,
+    received_ns: int,
+    launch_ns: int,
+    launched_ns: int,
+    worker_id: int,
+    bytes_per_block: int,
+    is_mla: bool,
+    is_h2d: bool,
+) -> Optional[dict]:
+    """Worker-side: ipc / wait / xfer + op metadata. None when off.
+
+    bytes = bytes_per_block * num_blocks; backends without a block byte
+    size pass 0 (bytes=0, bandwidth omitted).
+    """
+    if not _TRACE_ON:
+        return None
+    transfer_type = getattr(op, "transfer_type", None)
+    type_name = transfer_type.name if transfer_type is not None else "UNKNOWN"
+
+    nb = getattr(op, "valid_block_num", 0)
+    if not nb:
+        sb = getattr(op, "src_block_ids_h2d", None)
+        nb = int(sb.size) if sb is not None else 0
+
+    ipc_ms = max(0.0, (received_ns - submitted_ns) / 1e6)
+    wait_ms = max(0.0, (launch_ns - received_ns) / 1e6)
+    xfer_ms = max(0.0, (launched_ns - launch_ns) / 1e6)
+
+    return {
+        "type": type_name,
+        "nb": int(nb),
+        "graph_id": getattr(op, "transfer_graph_id", -1),
+        "worker_id": worker_id,
+        "is_h2d": bool(is_h2d),
+        "is_mla": bool(is_mla),
+        "bytes": int(bytes_per_block) * int(nb),
+        "ipc_ms": ipc_ms,
+        "wait_ms": wait_ms,
+        "xfer_ms": xfer_ms,
+    }
+
+
+def record_xfer(op_id: int, metrics: Optional[dict], e2e_ms: float) -> None:
+    """Engine-side: print one [XFER] line + update the summary window."""
+    if not _TRACE_ON or metrics is None:
+        return
+    backlog = inflight_value()
+    bytes_ = metrics.get("bytes", 0)
+    xfer_ms = metrics.get("xfer_ms", 0.0)
+    bw = (bytes_ / (xfer_ms / 1000.0) / 1e6) if (bytes_ > 0 and xfer_ms > 0) else 0.0
+
+    flexkv_logger.info(
+        "[XFER] op=%d type=%s nb=%d bytes=%d h2d=%d mla=%d "
+        "ipc=%.3fms wait=%.3fms xfer=%.3fms e2e=%.3fms bw=%.0fMB/s "
+        "worker=%d graph=%d backlog=%d",
+        op_id,
+        metrics["type"],
+        metrics["nb"],
+        bytes_,
+        int(metrics["is_h2d"]),
+        int(metrics["is_mla"]),
+        metrics["ipc_ms"],
+        metrics["wait_ms"],
+        xfer_ms,
+        e2e_ms,
+        bw,
+        metrics["worker_id"],
+        metrics["graph_id"],
+        backlog,
+    )
+    _accumulate(metrics)
+
+
+def _accumulate(metrics: dict) -> None:
+    global _win_start
+    with _sum_lock:
+        _wait_ms.append(metrics["wait_ms"])
+        _xfer_ms.append(metrics["xfer_ms"])
+        _type_counts[metrics["type"]] += 1
+        now = time.monotonic()
+        if now - _win_start >= _SUMMARY_INTERVAL_S:
+            _flush_locked(now)
+
+
+def _flush_locked(now: float) -> None:
+    global _win_start, _inflight_max_window
+    w_p50, w_p99 = _pct(_wait_ms), _pct(_wait_ms, 99)
+    x_p50, x_p99 = _pct(_xfer_ms), _pct(_xfer_ms, 99)
+    types = " ".join(f"{k}={v}" for k, v in sorted(_type_counts.items()))
+    flexkv_logger.info(
+        "[XFER-SUMMARY] window=%.0fs ops=%d inflight_max=%d "
+        "wait_p50=%.3fms wait_p99=%.3fms xfer_p50=%.3fms xfer_p99=%.3fms "
+        "type: %s",
+        now - _win_start,
+        len(_wait_ms),
+        _inflight_max_window,
+        w_p50,
+        w_p99,
+        x_p50,
+        x_p99,
+        types,
+    )
+    _win_start = now
+    _wait_ms.clear()
+    _xfer_ms.clear()
+    _type_counts.clear()
+    _inflight_max_window = inflight_value()
+
+
+def _pct(vals: List[float], p: float = 50.0) -> float:
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    k = max(0, min(len(s) - 1, int(round((p / 100.0) * (len(s) - 1)))))
+    return s[k]

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -30,6 +30,7 @@ from flexkv.common.storage import StorageHandle
 from flexkv.common.transfer import TransferOp, TransferOpGraph, TransferType, CompletedOp, WorkerKey
 from flexkv.common.transfer import get_nvtx_range_color
 from flexkv.transfer.scheduler import TransferScheduler
+from flexkv.transfer import trace
 from flexkv.transfer.worker import (
     WorkerHandle,
     CPUSSDDiskTransferWorker,
@@ -1165,13 +1166,22 @@ class TransferEngine:
                         # Get all available ops in one go to reduce system calls
                         while True:
                             try:
-                                op_id = self.finished_ops_queue.get_nowait()
-                                # A bare int means success; a (op_id, False)
-                                # tuple is a worker-reported transfer failure.
+                                payload = self.finished_ops_queue.get_nowait()
+                                # Payload: int (legacy) | (op_id, ok) |
+                                #          (op_id, ok, metrics_dict from worker).
                                 op_succeeded = True
-                                if isinstance(op_id, tuple):
-                                    op_id, op_succeeded = op_id
+                                metrics = None
+                                if isinstance(payload, tuple):
+                                    if len(payload) >= 3:
+                                        op_id, op_succeeded, metrics = payload[0], payload[1], payload[2]
+                                    else:
+                                        op_id, op_succeeded = payload
+                                else:
+                                    op_id = payload
                                 if not op_succeeded:
+                                    # Keep trace state consistent even on failure.
+                                    trace.dec_inflight()
+                                    trace.consume_submit_ns(op_id)
                                     self._handle_failed_op(op_id)
                                     continue
                                 if op_id in self._child_to_parent_op_id:
@@ -1182,6 +1192,7 @@ class TransferEngine:
                                     free_op_from_buffer(child_op, self.pin_buffer)
                                     if op_id in self.op_id_to_nvtx_range:
                                         nvtx.end_range(self.op_id_to_nvtx_range.pop(op_id))
+                                    self._emit_xfer_trace(op_id, metrics)
                                     parent_op = self.op_id_to_op[parent_op_id]
                                     parent_op.pending_count -= 1
                                     if parent_op.pending_count == 0:
@@ -1192,6 +1203,7 @@ class TransferEngine:
                                 else:
                                     op = self.op_id_to_op[op_id]
                                     op.pending_count -= 1
+                                    self._emit_xfer_trace(op_id, metrics)
                                     if op.pending_count == 0:
                                         self._finalize_or_discard(op, finished_ops)
                             except queue.Empty:
@@ -1273,6 +1285,18 @@ class TransferEngine:
             self._discard_failed_op(op)
         else:
             self._finalize_op(op, finished_ops)
+
+    def _emit_xfer_trace(self, op_id: int, metrics) -> None:
+        """Print one ``[XFER]`` line for a completed op (transfer tracing).
+
+        Combines the worker-computed timing metrics with the scheduler-side
+        e2e (submit -> detect) and current backlog. All trace.* calls no-op
+        when ``FLEXKV_TRANSFER_TRACE`` is unset, so this is safe to call
+        unconditionally on every finished op.
+        """
+        e2e_ms = trace.consume_submit_ns(op_id)
+        trace.dec_inflight()
+        trace.record_xfer(op_id, metrics, e2e_ms)
 
     def _handle_failed_op(self, op_id: int) -> None:
         """A worker reported a failed transfer for ``op_id``.

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -79,6 +79,8 @@ from flexkv.transfer.compression.common.strategy import (
     NullCompressionStrategy,
 )
 from flexkv.transfer.worker_op import WorkerTransferOp, WorkerLayerwiseTransferOp
+from flexkv.transfer import trace
+trace.configure(GLOBAL_CONFIG_FROM_ENV.enable_transfer_trace)
 
 from flexkv.mooncakeEngineWrapper import MoonCakeTransferEngineWrapper
 from flexkv.external.mooncake_store_keys import PoolKind, build_key
@@ -490,6 +492,7 @@ class TransferWorkerBase(ABC):
                 op = self.transfer_conn.recv()
                 if op is None:
                     return
+                op._received_ns = time.perf_counter_ns()
 
                 batch_ops = [op]
                 shutdown_after_batch = False
@@ -498,60 +501,75 @@ class TransferWorkerBase(ABC):
                     if op is None:
                         shutdown_after_batch = True
                         break
-                    batch_ops = [op]
-                    for op in batch_ops:
-                        transfer_status = False
-                        transfer_start_ns = time.perf_counter_ns()
-                        nvtx_pushed = False
+                    op._received_ns = time.perf_counter_ns()
+                    batch_ops.append(op)
+                for op in batch_ops:
+                    transfer_status = False
+                    transfer_start_ns = time.perf_counter_ns()
+                    nvtx_pushed = False
+                    try:
+                        nvtx.push_range(f"launch {op.transfer_type.name} op_id: {op.transfer_op_id}, "
+                                            f"graph_id: {op.transfer_graph_id}",
+                                            color=get_nvtx_range_color(op.transfer_graph_id))
+                        nvtx_pushed = True
+                        transfer_status = self.launch_transfer(op)
+                    except Exception as e:
+                        is_layerwise = op.transfer_type == TransferType.LAYERWISE
+                        direction = "H2D" if is_layerwise else op.transfer_type.value
+                        blocks = (
+                            len(op.src_block_ids_h2d)
+                            if is_layerwise
+                            else op.valid_block_num
+                        )
+                        flexkv_logger.error(
+                            "[FlexKV-IO] operation=transfer act=complete "
+                            "status=failed direction=%s blocks=%d op_id=%d "
+                            "graph_id=%d mode=%s transfer_time=%.4fs "
+                            "error=%r",
+                            direction,
+                            blocks,
+                            op.transfer_op_id,
+                            op.transfer_graph_id,
+                            "layerwise" if is_layerwise else "no-layerwise",
+                            (time.perf_counter_ns() - transfer_start_ns) / 1e9,
+                            str(e),
+                            exc_info=True,
+                        )
+                    finally:
+                        if nvtx_pushed:
+                            nvtx.pop_range()
+                    launched_ns = time.perf_counter_ns()
+                    is_h2d = (op.transfer_type == TransferType.H2D
+                              or op.transfer_type == TransferType.LAYERWISE)
+                    metrics = trace.build_worker_metrics(
+                        op,
+                        getattr(op, "prof_submitted_ns", 0),
+                        getattr(op, "_received_ns", launched_ns),
+                        transfer_start_ns,
+                        launched_ns,
+                        self.worker_id,
+                        getattr(self, "_bytes_per_block", 0),
+                        getattr(self, "is_mla", False),
+                        is_h2d,
+                    )
+                    if transfer_status:
+                        self.finished_ops_queue.put(
+                            (op.transfer_op_id, True, metrics))
+                    else:
+                        # Report the failure instead of dropping it: a
+                        # dropped op leaves its graph incomplete forever
+                        # and leaks every resource its plan holds. A bare
+                        # int still means success, so the queue format
+                        # stays compatible.
+                        self.finished_ops_queue.put(
+                            (op.transfer_op_id, False, None))
+                if shutdown_after_batch:
+                    if hasattr(self, "shutdown") and callable(self.shutdown):
                         try:
-                            nvtx.push_range(f"launch {op.transfer_type.name} op_id: {op.transfer_op_id}, "
-                                                f"graph_id: {op.transfer_graph_id}",
-                                                color=get_nvtx_range_color(op.transfer_graph_id))
-                            nvtx_pushed = True
-                            transfer_status = self.launch_transfer(op)
+                            self.shutdown()
                         except Exception as e:
-                            is_layerwise = op.transfer_type == TransferType.LAYERWISE
-                            direction = "H2D" if is_layerwise else op.transfer_type.value
-                            blocks = (
-                                len(op.src_block_ids_h2d)
-                                if is_layerwise
-                                else op.valid_block_num
-                            )
-                            flexkv_logger.error(
-                                "[FlexKV-IO] operation=transfer act=complete "
-                                "status=failed direction=%s blocks=%d op_id=%d "
-                                "graph_id=%d mode=%s transfer_time=%.4fs "
-                                "error=%r",
-                                direction,
-                                blocks,
-                                op.transfer_op_id,
-                                op.transfer_graph_id,
-                                "layerwise" if is_layerwise else "no-layerwise",
-                                (time.perf_counter_ns() - transfer_start_ns) / 1e9,
-                                str(e),
-                                exc_info=True,
-                            )
-                        finally:
-                            if nvtx_pushed:
-                                nvtx.pop_range()
-                        if transfer_status:
-                            self.finished_ops_queue.put(op.transfer_op_id)
-                        else:
-                            # Report the failure instead of dropping it: a
-                            # dropped op leaves its graph incomplete forever
-                            # and leaks every resource its plan holds. A bare
-                            # int still means success, so the queue format
-                            # stays compatible.
-                            self.finished_ops_queue.put((op.transfer_op_id, False))
-                    if shutdown_after_batch:
-                        if hasattr(self, "shutdown") and callable(self.shutdown):
-                            try:
-                                self.shutdown()
-                            except Exception as e:
-                                flexkv_logger.error(f"Error when shut down worker: {e}")
-                        break
-                else:
-                    continue
+                            flexkv_logger.error(f"Error when shut down worker: {e}")
+                    break
             except EOFError:
                 flexkv_logger.warning(
                     f"[worker {self.worker_id}] transfer pipe EOF; exiting run loop"
@@ -573,6 +591,11 @@ class WorkerHandle:
             worker_op = WorkerLayerwiseTransferOp(op)
         else:
             worker_op = WorkerTransferOp(op)
+        if trace._TRACE_ON:
+            submitted_ns = time.perf_counter_ns()
+            worker_op.prof_submitted_ns = submitted_ns
+            trace.set_submit_ns(op.op_id, submitted_ns)
+            trace.inc_inflight()
         self.transfer_conn.send(worker_op)
 
     def shutdown(self) -> None:
@@ -628,13 +651,16 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                  gpu_layouts_per_group: Optional[List[KVCacheLayout]] = None) -> None:
         # initialize worker in a new process
         super().__init__(worker_id, transfer_conn, finished_ops_queue, op_buffer_tensor)
+
         # Bind CUDA device BEFORE host-register / IPC import / Stream creation.
         ensure_cuda_device(gpu_device_id)
+
         self._pin_op_buffer()
         # Register CPU tensors with CUDA
         cpu_blocks = materialize_worker_tensor(cpu_blocks)
         flexkv_logger.info(f"Pinning CPU Memory: {cpu_blocks.numel() * cpu_blocks.element_size() / (1024 ** 3):.2f} GB")
         self._register_host_tensor(cpu_blocks, "cpu_kv_pool")
+
         self.gpu_blocks = import_tensor_handles(gpu_blocks)
         # Get pointers first
         self.gpu_blocks_ptrs = self._get_layer_ptrs(self.gpu_blocks)
@@ -664,6 +690,8 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
 
             # a chunk can be located by layer_id * layer_stride + kv_id * kv_stride + block_id * block_stride
             self.chunk_size_in_bytes = gpu_kv_layout.get_chunk_size() * self.dtype.itemsize
+            # Bytes per KV block (all layers); used by transfer tracing for bw.
+            self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
 
             # Compute GPU strides from actual tensor to handle different attention
             # backend layouts (flash_attn: [2,N,B,H,D], triton: [N,2,B,H,D]).
@@ -881,6 +909,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                     -1,  # ce_force_path
                     self.ce_enable_memcpy2d,
                     self.cpu_is_blockfirst,
+                    enable_transfer_trace=GLOBAL_CONFIG_FROM_ENV.enable_transfer_trace,
                 )
         else:
             # Uniform transfer: single call (whole-model)
@@ -909,6 +938,7 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
                 -1,  # ce_force_path
                 self.ce_enable_memcpy2d,
                 self.cpu_is_blockfirst,
+                enable_transfer_trace=GLOBAL_CONFIG_FROM_ENV.enable_transfer_trace,
             )
 
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
@@ -1043,6 +1073,8 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             self.cpu_block_stride_in_bytes = cpu_kv_layout.get_block_stride() * self.dtype.itemsize
             self.cpu_chunk_size_in_bytes = cpu_kv_layout.get_chunk_size() * self.dtype.itemsize
             self.chunk_size_in_bytes = self.cpu_chunk_size_in_bytes
+            # Bytes per KV block (all layers); used by transfer tracing for bw.
+            self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
             # tp has effect on the layout of the cpu tensor
             # the tp dim should always be right after the block dim
             # on both blockfirst layout and layerfirst layout
@@ -1378,6 +1410,8 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
             self.cpu_layer_stride_in_bytes = cpu_kv_layout.get_layer_stride() * self.dtype.itemsize
             self.ssd_kv_stride_in_bytes = ssd_kv_layout_per_file.get_kv_stride() * self.dtype.itemsize
             self.ssd_layer_stride_in_bytes = ssd_kv_layout_per_file.get_layer_stride() * self.dtype.itemsize
+            # Bytes per KV block (all layers); used by transfer tracing for bw.
+            self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
 
         try:
             self.ioctx = c_ext.SSDIOCTX(ssd_files, len(ssd_files), GLOBAL_CONFIG_FROM_ENV.iouring_entries,
@@ -1588,6 +1622,8 @@ class CPURemoteTransferWorker(TransferWorkerBase):
         self.cpu_block_stride_in_bytes = self.block_size * self.dtype.itemsize
 
         self.chunk_size_in_bytes = self.block_size * self.dtype.itemsize
+        # Bytes per KV block (all layers); used by transfer tracing for bw.
+        self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
         # 144115188075855883 only use int not c_types.u_int64
         if not remote_config_custom:
             raise RuntimeError("remote_config_custom is not provided")
@@ -1801,6 +1837,8 @@ class GDSTransferWorker(TransferWorkerBase):
             # GPU layout calculations — compute strides from actual tensor to handle
             # different attention backend layouts (flash_attn vs triton/flashinfer).
             self.chunk_size_in_bytes = gpu_kv_layout_per_layer.get_chunk_size() * self.dtype.itemsize
+            # Bytes per KV block (all layers); used by transfer tracing for bw.
+            self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
             gpu_strides = self._get_gpu_strides_from_tensor(
                 self.gpu_blocks[0], gpu_kv_layout.tokens_per_block,
                 self.dtype.itemsize, self.is_mla,
@@ -2103,7 +2141,10 @@ class tpGDSTransferWorker(TransferWorkerBase):
         else:
             ssd_kv_layout_per_file = ssd_kv_layout.div_block(self.num_files, padding=True)
             self.ssd_chunk_size_in_bytes = ssd_kv_layout_per_file.get_chunk_size() * self.dtype.itemsize
+            self.chunk_size_in_bytes = self.ssd_chunk_size_in_bytes
             self.ssd_block_stride_in_bytes = ssd_kv_layout_per_file.get_block_stride() * self.dtype.itemsize
+            # Bytes per KV block (all layers); used by transfer tracing for bw.
+            self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
             if not self.is_mla:
                 ssd_kv_layout_per_file = ssd_kv_layout_per_file.div_head(self.tp_group_size)
 
@@ -2441,6 +2482,7 @@ class NixlTransferWorker(TransferWorkerBase):
 
         self.num_layers = gpu_kv_layout.num_layer
         self.is_mla = gpu_kv_layout.is_mla
+        self.kv_dim = gpu_kv_layout.kv_dim
 
         # SSD / file-side layout (same for every NIXL FILE backend).
         ssd_pf = ssd_kv_layout.div_block(self.num_files, padding=True)
@@ -2516,6 +2558,9 @@ class NixlTransferWorker(TransferWorkerBase):
                 raise RuntimeError("NIXL: prepare_all_ssd_files failed")
             if not self._session.prepare_dram_cpu(self.cpu_blocks):
                 raise RuntimeError("NIXL: prepare_dram_cpu failed")
+
+        # Bytes per KV block (all layers); used by transfer tracing for bw.
+        self._bytes_per_block = self.chunk_size_in_bytes * self.num_layers * self.kv_dim
 
     def _transfer_impl(
         self,
@@ -2730,6 +2775,8 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
 
         self.is_mla = cpu_kv_layout.is_mla
         self.kv_dim = cpu_kv_layout.kv_dim
+        # Bytes per KV block (all layers); used by transfer tracing for bw.
+        self._bytes_per_block = self.block_size * self.dtype.itemsize * self.num_layers * self.kv_dim
 
         self.cpu_blocks = cpu_blocks  ## shared memory
         self.cache_config = cache_config
@@ -3687,6 +3734,8 @@ class MooncakeStoreTransferWorker(TransferWorkerBase):
         # Opaque whole-block I/O: multi-group CPU layout is byte-flat
         # ([num_block, bytes_per_block]); get_chunk_size() is invalid there.
         self.block_size_bytes = self._block_size_bytes(cpu_kv_layout, dtype)
+        # Bytes per KV block (all layers); used by transfer tracing for bw.
+        self._bytes_per_block = self.block_size_bytes
 
         from flexkv.external.mooncake_store_utils import MooncakeStoreClient, MooncakeStoreConfig
         store_config = MooncakeStoreConfig.from_file(

--- a/flexkv/transfer/worker_op.py
+++ b/flexkv/transfer/worker_op.py
@@ -19,6 +19,7 @@ class WorkerTransferOp:
     src_block_node_ids: Optional[np.ndarray]
     mooncake_store_block_hashes: Optional[np.ndarray] = None
     mooncake_store_swa_block_hashes: Optional[list] = None
+    prof_submitted_ns: int = 0
 
     def __init__(self, transfer_op: TransferOp):
         self.transfer_op_id = transfer_op.op_id
@@ -61,6 +62,7 @@ class WorkerLayerwiseTransferOp:
     swa_src_block_ids_disk2h: np.ndarray
     swa_dst_block_ids_disk2h: np.ndarray
     counter_id: int  # Counter set index for triple buffering eventfd notification
+    prof_submitted_ns: int = 0
 
     def __init__(self, transfer_op: LayerwiseTransferOp):
         self.transfer_op_id = transfer_op.op_id

--- a/tests/test_transfer_trace.py
+++ b/tests/test_transfer_trace.py
@@ -1,0 +1,128 @@
+"""Unit tests for flexkv.transfer.trace (transfer diagnosis tracing).
+
+Run with: pytest tests/test_transfer_trace.py -s
+"""
+import importlib
+import logging
+import os
+
+import pytest
+
+
+class _CaptureHandler(logging.Handler):
+    # Collect formatted messages from the FLEXKV logger (propagate is off,
+    # so caplog on the root logger never sees them).
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+def _reload_with_env(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("FLEXKV_TRANSFER_TRACE", raising=False)
+    else:
+        monkeypatch.setenv("FLEXKV_TRANSFER_TRACE", value)
+    import flexkv.transfer.trace as trace
+    trace = importlib.reload(trace)
+    trace.configure(os.getenv("FLEXKV_TRANSFER_TRACE") is not None)
+    return trace
+
+
+class _FakeType:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeOp:
+    def __init__(self, valid_block_num=10, graph_id=7, type_name="H2D"):
+        self.prof_submitted_ns = 0
+        self.valid_block_num = valid_block_num
+        self.transfer_graph_id = graph_id
+        self.transfer_type = _FakeType(type_name)
+
+
+def test_trace_off_returns_none(monkeypatch):
+    trace = _reload_with_env(monkeypatch, None)
+    assert trace._TRACE_ON is False
+    op = _FakeOp()
+    assert trace.build_worker_metrics(op, 1_000_000, 2_000_000,
+                                       3_000_000, 4_000_000, 0, 0, False,
+                                       True) is None
+
+
+def test_build_worker_metrics_timing(monkeypatch):
+    trace = _reload_with_env(monkeypatch, "1")
+    assert trace._TRACE_ON is True
+    # 1e6 ns == 1 ms
+    op = _FakeOp()
+    m = trace.build_worker_metrics(
+        op,
+        submitted_ns=0,        # submit at 0
+        received_ns=1_000_000,    # +1 ms ipc
+        launch_ns=3_000_000,    # +2 ms wait
+        launched_ns=8_000_000,    # +5 ms xfer
+        worker_id=2,
+        bytes_per_block=4096,
+        is_mla=True,
+        is_h2d=True,
+    )
+    assert m["ipc_ms"] == pytest.approx(1.0)
+    assert m["wait_ms"] == pytest.approx(2.0)
+    assert m["xfer_ms"] == pytest.approx(5.0)
+    assert m["type"] == "H2D"
+    assert m["nb"] == 10
+    assert m["bytes"] == 4096 * 10
+    assert m["is_h2d"] is True
+    assert m["is_mla"] is True
+    assert m["graph_id"] == 7
+    assert m["worker_id"] == 2
+
+
+def test_record_xfer_and_summary(monkeypatch):
+    trace = _reload_with_env(monkeypatch, "1")
+    # Force the summary window stale so the flush triggers within this test.
+    with trace._sum_lock:
+        trace._win_start = trace._win_start - trace._SUMMARY_INTERVAL_S - 1
+        trace._wait_ms.clear()
+        trace._xfer_ms.clear()
+        trace._type_counts.clear()
+        trace._inflight_max_window = 0
+
+    cap = _CaptureHandler()
+    target = trace.flexkv_logger.logger  # logging.getLogger("FLEXKV")
+    prev_level = target.level
+    target.setLevel(logging.INFO)
+    target.addHandler(cap)
+    try:
+        trace.set_submit_ns(100, 0)
+        trace.inc_inflight()  # inflight == 1 before record_xfer prints backlog
+        metrics = trace.build_worker_metrics(
+            _FakeOp(valid_block_num=4, type_name="D2H"),
+            submitted_ns=0, received_ns=500_000, launch_ns=1_500_000,
+            launched_ns=6_500_000,
+            worker_id=0, bytes_per_block=1024, is_mla=False, is_h2d=False)
+        trace.record_xfer(100, metrics, e2e_ms=7.0)
+    finally:
+        target.removeHandler(cap)
+        target.setLevel(prev_level)
+
+    lines = "\n".join(cap.messages)
+    assert "[XFER] op=100" in lines
+    assert "type=D2H" in lines
+    assert "bytes=4096" in lines
+    assert "backlog=1" in lines   # inflight not yet decremented at print time
+    # Summary should have flushed (window forced stale).
+    assert "[XFER-SUMMARY]" in lines
+    assert "inflight_max=" in lines
+    assert "type: D2H=1" in lines
+
+
+def test_pct(monkeypatch):
+    trace = _reload_with_env(monkeypatch, "1")
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert trace._pct(vals, 50) == 3.0
+    assert trace._pct(vals, 99) == 5.0
+    assert trace._pct([], 50) == 0.0


### PR DESCRIPTION
# feat(transfer): add FLEXKV_TRANSFER_TRACE transfer diagnosis tracing
## Summary

Adds an **opt-in, zero-overhead** diagnosis tracing subsystem for FlexKV's KV cache migration path. With `FLEXKV_TRANSFER_TRACE=1` **and Debug logging enabled**, every transfer emits one structured `[XFER]` log line (ipc / wait / xfer / e2e lifecycle timing + inflight backlog + bandwidth) and a periodic `[XFER-SUMMARY]` (p50 / p99) every 10s. When disabled (or Debug off), all hooks early-return at the entry, so performance is identical to having no such feature.

Operators can `grep "[XFER]"` to locate whether a migration bottleneck is in IPC, worker wait, or the GPU copy itself — no code changes, no profiler attached.

## Motivation

KV cache migration between CPU / GPU / SSD is FlexKV's critical path, yet it has long lacked observability. When something slows down ("copies got slow", "requests stall", "concurrency piles up"), there was no way to tell whether the bottleneck was:

- scheduler → worker IPC,
- worker-internal queuing / resource prep,
- the actual GPU/CPU copy,
- or the engine polling latency to reap completion.

This PR turns that guesswork into a `grep` by quantifying each segment with a single switch and a four-segment timing model.

## How It Works

Each transfer op's lifecycle is split into four segments:

```
submit ──ipc──> receive ──wait──> launch ──xfer──> launched ──(poll)──> detect
|_______________________________ e2e ________________________________|
```

- `ipc_ms`: scheduler → worker process IPC cost
- `wait_ms`: worker receive → actual copy start (internal queue)
- `xfer_ms`: actual copy time (CUDA kernel / CE / cudaMemcpy)
- `e2e_ms`: submit → engine detects completion (includes poll interval)
- `inflight` / `backlog`: concurrency backlog
- `bw`: copy bandwidth (MB/s)

Timestamps use `perf_counter_ns`; the submit timestamp travels with the op across processes to the worker, and metrics travel back to the engine via the completion queue, so all `[XFER]` lines are emitted sequentially from the engine process (no interleaving across workers). The C++ layer additionally measures CUDA stream sync time with `cudaEvent` / `steady_clock`, complementing the Python layer to distinguish "slow CPU submission" vs "slow GPU copy".

## Usage

```bash
# Enable tracing (BOTH flags required)
FLEXKV_TRANSFER_TRACE=1 FLEXKV_LOG_LEVEL=DEBUG python -m your_server

# Disabled (default, zero overhead)
python -m your_server
```

## Log Samples

**Per-op line**:

```
[XFER] op=42 type=H2D nb=64 bytes=8388608 h2d=1 mla=0 \
       ipc=0.120ms wait=0.450ms xfer=1.234ms e2e=2.345ms \
       bw=6794MB/s worker=0 graph=3 backlog=2
```

**Window summary** (every 10s):

```
[XFER-SUMMARY] window=10s ops=1234 inflight_max=8 \
               wait_p50=0.100ms wait_p99=2.000ms \
               xfer_p50=0.500ms xfer_p99=3.000ms \
               type: H2D=1000 D2H=234
```

**C++ layer (CUDA stream view)**:

```
[XFER] type=H2D blocks=64 sync_ms=1.180
[XFER] type=layerwise_h2d layer_range=[0,4) blocks=64 data=32.00MB sync_ms=1.234 bw=25932MB/s
[XFER] type=layerwise_mg_h2d orig=7 members=2 gpus=4 sync_ms=1.452 data=64.00MB bw=44077MB/s
```