### PR TITLE
[bugfix] vllm: derive local_rank from world group so device_id is unique per worker (init hangs at 1/N)

### DIFF
--- a/.github/workflows/vllm-compat-test.yml
+++ b/.github/workflows/vllm-compat-test.yml
@@ -88,6 +88,10 @@ jobs:
           # Config
           check_import("vllm.config", "VllmConfig")
 
+          # Process groups (used to derive tp_rank / local_rank on the worker)
+          check_import("vllm.distributed.parallel_state", "get_tp_group")
+          check_import("vllm.distributed.parallel_state", "get_world_group")
+
           # Logger
           check_import("vllm.logger", "init_logger")
 

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -284,9 +284,12 @@ class FlexKVConfig:
             instance_id=instance_id,
             pp_start_layer=pp_start_layer,
             pp_end_layer=pp_end_layer,
-            # vLLM sets LOCAL_RANK env var (= rank % gpus_per_node) before
-            # launching each worker process.  Use it directly as the
-            # authoritative physical device index.
+            # LOCAL_RANK is only set for launchers that export it (e.g. ray or
+            # torchrun).  The mp executor passes local_rank to the worker as a
+            # constructor kwarg and does NOT export it, so this is -1 there and
+            # RankInfo.__post_init__ falls back to deriving it from tp_rank.
+            # FlexKVConnectorV1Impl overrides it with get_world_group().local_rank
+            # on the worker side; do not rely on this value being correct.
             local_rank=int(os.environ.get('LOCAL_RANK', -1)),
         )
 

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -836,18 +836,33 @@ class FlexKVConnectorV1Impl:
             # Track scheduled requests to detect preemptions in build_connector_meta
             self.previous_scheduled_req_ids: set[str] = set()
         elif role == KVConnectorRole.WORKER:
-            # vllm's ParallelConfig has no ``tensor_parallel_rank`` field, so
-            # the value read in post_init_from_vllm_config is always 0 on every
-            # worker.  Override it here using the initialized TP group rank so
-            # each worker registers a distinct device_id with FlexKV.
+            # Neither rank is knowable from the config on the worker side:
+            #   * vllm's ParallelConfig has no ``tensor_parallel_rank`` field, so
+            #     the tp_rank read in post_init_from_vllm_config is always 0.
+            #   * the mp executor passes ``local_rank`` to the worker as a kwarg
+            #     and never exports LOCAL_RANK, so the
+            #     ``int(os.environ.get('LOCAL_RANK', -1))`` in
+            #     integration/config.py yields -1 and RankInfo.__post_init__
+            #     derives local_rank from tp_rank=0 -> 0.
+            # local_rank is what becomes device_id, so leaving it at 0 makes
+            # every worker register the same device_id and GPU registration
+            # never reaches expected_gpus.  Recover both from the initialized
+            # process groups.  local_rank must be set explicitly:
+            # dataclasses.replace re-runs __post_init__, but by then local_rank
+            # is 0 (not < 0) so it is never re-derived.
             try:
                 import dataclasses
-                from vllm.distributed.parallel_state import get_tp_group
+                from vllm.distributed.parallel_state import (get_tp_group,
+                                                             get_world_group)
                 rank_info = dataclasses.replace(
-                    rank_info, tp_rank=get_tp_group().rank_in_group)
+                    rank_info,
+                    tp_rank=get_tp_group().rank_in_group,
+                    local_rank=get_world_group().local_rank)
             except Exception as _e:
-                logger.warning(
-                    f"FlexKV: could not derive tp_rank from vllm TP group: {_e}")
+                logger.error(
+                    f"FlexKV: could not derive ranks from vllm process groups: "
+                    f"{_e}. device_id will collide across workers and GPU "
+                    f"registration will hang at 1/N.")
             self.connector = FlexKVWorkerConnector(flexkv_config, rank_info)
         else:
             raise ValueError(f"Unrecognized KVConnectorRole: {role}.")

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -82,7 +82,17 @@ class TransferManager:
         device_id = req.device_id
 
         if device_id in self.all_gpu_blocks:
-            flexkv_logger.error(f"GPU {device_id} has already registered.")
+            # A duplicate device_id means the framework adapter handed us the
+            # same id for two different workers.  Registration can then never
+            # reach expected_gpus, so _register_gpu_blocks_via_socket spins
+            # forever printing "Still waiting for GPU registrations: k/N".
+            # Say so explicitly instead of leaving an unexplained hang.
+            flexkv_logger.error(
+                f"GPU {device_id} has already registered. Duplicate device_id "
+                f"from a different worker: registration cannot reach "
+                f"{self.expected_gpus}/{self.expected_gpus} and init will hang. "
+                f"Check that the framework adapter passes a per-worker-unique "
+                f"device_id (registered so far: {sorted(self.all_gpu_blocks)}).")
         else:
             try:
                 self.all_gpu_blocks[device_id] = req.handles


### PR DESCRIPTION
## Summary

On the worker side, **every worker registers `device_id=0`**, so GPU registration never completes and init hangs forever with no error:

```
GPU 0 has already registered.                                    # ×7
Still waiting for GPU registrations: 1/8 registered (registered_device_ids=[0])
```

`_register_gpu_blocks_via_socket` loops `while len(self.all_gpu_blocks) < self.expected_gpus` with no timeout, so this never fails — it just stops. We hit this twice on production bring-up (8-GPU node, vLLM V1, `--distributed-executor-backend mp`).

## Root cause

`FlexKVWorkerConnector` builds `KVTPClient(device_id=rank_info.local_rank, ...)`. On the worker side **neither rank in `RankInfo` is correct**:

* **`tp_rank`** — read from `vllm_config.parallel_config` in `post_init_from_vllm_config`, but vLLM's `ParallelConfig` has no `tensor_parallel_rank` field, so it is always `0`.
* **`local_rank`** — `flexkv/integration/config.py` does `local_rank=int(os.environ.get('LOCAL_RANK', -1))`. The comment there states that vLLM "sets LOCAL_RANK env var before launching each worker process". That is **not true for the mp executor**: `multiproc_executor.py` passes `local_rank` to the worker as a **constructor kwarg** and never exports it. So the lookup yields `-1`, and `RankInfo.__post_init__` derives `local_rank` from `tp_rank=0` → `0`.

Verified on a live 8-worker run — none of the worker processes has `LOCAL_RANK` in its environment:

```
$ for p in $(pgrep -f 'VLLM::Worker'); do tr '\0' '\n' < /proc/$p/environ | grep -c '^LOCAL_RANK='; done
0 0 0 0 0 0 0 0
```

and the run's own startup log prints `RankInfo(tp_rank=0, ..., local_rank=0` **8 times**, once per worker.

## Fix

Recover both ranks from the already-initialized process groups:

```python
rank_info = dataclasses.replace(
    rank_info,
    tp_rank=get_tp_group().rank_in_group,
    local_rank=get_world_group().local_rank)
```

`get_world_group().local_rank` is the physical device index, and is what vLLM's own in-tree `p2p_nccl_connector` and `moriio_connector` use for exactly this purpose. FlexKV's sglang integration already uses the sglang equivalent, so the pattern isn't new here either.

Two subtleties worth a reviewer's attention:

* **`local_rank` must be overridden explicitly.** `dataclasses.replace` re-runs `RankInfo.__post_init__`, but that method only re-derives `local_rank` `if self.local_rank < 0` — and by then it is already `0`, not `< 0`. **This is why the existing `tp_rank`-only override does not actually make `device_id` distinct**, despite its comment saying "so each worker registers a distinct device_id". The `tp_rank` it sets is genuinely used elsewhere; it just never reaches `device_id`.

* **Why not `device_id=rank_info.tp_rank`?** That is the patch we originally carried downstream, and it is only correct when TP == world size. `device_id` is not merely a dict key — it flows `register_gpu_blocks` → `GPUAllocator.from_raw_data` → `StorageHandle.gpu_device_id` → `transfer_engine` → `ensure_cuda_device(gpu_device_id)`, i.e. it is used as a **physical CUDA device index**. Under DP it collides again. Checked against the real `RankInfo` on one 8-GPU node:

  | topology | current (`local_rank`) | `tp_rank` swap | this PR |
  |---|---|---|---|
  | TP8 / DP1 | `0,0,0,0,0,0,0,0` — hangs at 1/8 | `0..7` ok | `0..7` ok |
  | TP4 / DP2 | `0,0,0,0,4,4,4,4` — hangs at 2/8 | `0,1,2,3,0,1,2,3` — **still collides**, hangs at 4/8 | `0..7` ok |
  | TP2 / DP4 | `0,0,2,2,4,4,6,6` — hangs at 4/8 | — | `0..7` ok |

  So this makes `local_rank` *correct* rather than changing which field `device_id` reads.

Note the same collapsed `local_rank` also mis-gates the multi-node remote transfer-manager branch (`rank_info.model_config.nnodes > 1 and rank_info.node_rank > 0 and rank_info.local_rank == 0`) — fixed by the same change.

Two small companion changes:

* **`integration/config.py`** — corrected the `LOCAL_RANK` comment, which asserted the env var is always set. That assumption is what made this bug easy to write.
* **`transfer_manager.py`** — the duplicate-`device_id` path already logs at error level, but says only `"GPU 0 has already registered."` and then returns into an untimed spin. It now names the consequence and lists the ids seen so far, so a future collision fails legibly instead of silently. No behaviour change.

## Verification

Same node, same config, before vs after:

| | before | after |
|---|---|---|
| distinct `device_id`s registered | 1 (`[0]`) | 8 (`0`–`7`, each exactly once) |
| `"has already registered"` lines | 7 | 0 |
| outcome | hangs on `Still waiting for GPU registrations: 1/8` | `All 8 GPUs registered successfully` |

## Test plan

* 8-GPU node, vLLM V1 `mp` executor, TP8, `FlexKVConnectorV1`: init completes with `All 8 GPUs registered successfully`; served traffic plus KV offload/reload verified end-to-end.
* Rank derivation checked against the real `RankInfo` class for TP8/DP1, TP4/DP2, TP2/DP4 (table above) — 8 distinct ids in every case.
* `get_tp_group` was already imported from `vllm.distributed.parallel_state` in this file; `get_world_group` comes from the same module. Both confirmed importable via the same `getattr`-on-module pattern the compat workflow uses.
* The import stays inside the existing `try`, so a vLLM lacking the symbol degrades to a loud error rather than an import-time failure.
* **CI**: added `check_import` entries for `get_tp_group` / `get_world_group` to `vllm-compat-test.yml`. Check 1 did not cover `vllm.distributed.parallel_state` at all, even though `get_tp_group` was already imported unguarded — so a rename there would have surfaced only on a real multi-GPU bring-up.

## Notes

Found while running FlexKV on a non-NVIDIA backend, but nothing here is vendor-specific — the collapse comes from vLLM's mp executor not exporting `LOCAL_RANK`, and reproduces on `main` as-is. Vendor-specific fixes from that work are kept out of this PR.
