### PR TITLE
Fix broken quoting for FLEXKV_GIT_COMMIT macro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -358,7 +358,7 @@ print(f"TORCH_CUDA_ARCH_LIST = {os.environ['TORCH_CUDA_ARCH_LIST']}")
 extra_compile_args = [
     "-std=c++17",
     "-O3",
-    f'-DFLEXKV_GIT_COMMIT=\\"{build_git_commit}\\"',
+    f'-DFLEXKV_GIT_COMMIT=\"{build_git_commit}\"',
 ]
 if enable_metrics:
     extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")

--- a/setup.py
+++ b/setup.py
@@ -358,7 +358,7 @@ print(f"TORCH_CUDA_ARCH_LIST = {os.environ['TORCH_CUDA_ARCH_LIST']}")
 extra_compile_args = [
     "-std=c++17",
     "-O3",
-    f'-DFLEXKV_GIT_COMMIT=\"{build_git_commit}\"',
+    f'-DFLEXKV_GIT_COMMIT="{build_git_commit}"',
 ]
 if enable_metrics:
     extra_compile_args.append("-DFLEXKV_ENABLE_MONITORING")


### PR DESCRIPTION
Compilation of the dev branch fails due to incorrect quote escaping in the FLEXKV_GIT_COMMIT macro definition. The current build command passes an invalid string literal to the preprocessor, causing quote errors. This patch fixes the quoting logic so the macro is correctly parsed and the build succeeds.


```
DEBUG [3/11] c++ -MMD -MF /tmp/tmp8zs9vcuq.build-temp/csrc/bindings.o.d -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -fPIC -I/home/lwn/20260612_mooncaketrace/FlexKV/build/include -I/home/lwn/20260612_mooncaketrace/FlexKV/csrc -I/home/lwn/20260612_mooncaketrace/FlexKV/third_party/spdlog/include -I/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/torch/include -I/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/torch/include/torch/csrc/api/include -I/usr/local/cuda/include -I/home/lwn/.venv/env/kvcache/include -I/home/lwn/.local/share/uv/python/cpython-3.10.19-linux-x86_64-gnu/include/python3.10 -c -c /home/lwn/20260612_mooncaketrace/FlexKV/csrc/bindings.cpp -o /tmp/tmp8zs9vcuq.build-temp/csrc/bindings.o -std=c++17 -O3 '-DFLEXKV_GIT_COMMIT=\"5f7fe1541ac3\"' -DCUDA_AVAILABLE -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=c_ext
DEBUG FAILED: [code=1] /tmp/tmp8zs9vcuq.build-temp/csrc/bindings.o 
DEBUG c++ -MMD -MF /tmp/tmp8zs9vcuq.build-temp/csrc/bindings.o.d -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -fPIC -I/home/lwn/20260612_mooncaketrace/FlexKV/build/include -I/home/lwn/20260612_mooncaketrace/FlexKV/csrc -I/home/lwn/20260612_mooncaketrace/FlexKV/third_party/spdlog/include -I/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/torch/include -I/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/torch/include/torch/csrc/api/include -I/usr/local/cuda/include -I/home/lwn/.venv/env/kvcache/include -I/home/lwn/.local/share/uv/python/cpython-3.10.19-linux-x86_64-gnu/include/python3.10 -c -c /home/lwn/20260612_mooncaketrace/FlexKV/csrc/bindings.cpp -o /tmp/tmp8zs9vcuq.build-temp/csrc/bindings.o -std=c++17 -O3 '-DFLEXKV_GIT_COMMIT=\"5f7fe1541ac3\"' -DCUDA_AVAILABLE -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=c_ext
DEBUG <command-line>: warning: missing terminating " character
DEBUG <command-line>: error: stray ‘\’ in program
DEBUG /home/lwn/20260612_mooncaketrace/FlexKV/csrc/bindings.cpp:425:30: note: in expansion of macro ‘FLEXKV_GIT_COMMIT’
DEBUG   425 |   m.attr("__git_commit__") = FLEXKV_GIT_COMMIT;
DEBUG       |                              ^~~~~~~~~~~~~~~~~
DEBUG <command-line>: error: missing terminating " character
DEBUG <command-line>: note: in definition of macro ‘FLEXKV_GIT_COMMIT’

```