### PR TITLE
docs: refresh README updates with recent milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ FlexKV is released under the **Apache-2.0 License**. See the [LICENSE](LICENSE) 
 
 ## Updates
 
+- **Jul–Aug 2026**: Transfer performance and operability received a broad refresh: [adaptive multi-path GPU↔CPU transfers](https://github.com/taco-project/FlexKV/pull/203), [reliability and operational logging](https://github.com/taco-project/FlexKV/pull/233), [graceful shutdown](https://github.com/taco-project/FlexKV/pull/238), [chunked host-memory registration](https://github.com/taco-project/FlexKV/pull/240), [vectored SSD I/O](https://github.com/taco-project/FlexKV/pull/242), and [per-operation transfer tracing](https://github.com/taco-project/FlexKV/pull/247).
+
+- **Jul 24, 2026**: [Mooncake Store](https://github.com/kvcache-ai/Mooncake) can now serve as FlexKV's key-addressed remote cache tier ([#231](https://github.com/taco-project/FlexKV/pull/231)), enabling cluster-wide KV reuse with zero-copy RDMA and support for DeepSeek-V4 SWA/state sidecars.
+
+- **Jul 21, 2026**: DeepSeek-V4 support landed in FlexKV ([#225](https://github.com/taco-project/FlexKV/pull/225)), covering heterogeneous C4/C128/indexer KV groups, FullKV + SWA dual caches, attention/indexer compress-state sidecars, and layerwise restore. See the [SGLang integration guide](flexkv/integration/sglang/README.md) and [DeepSeek-V4 design notes](docs/dsv4_compress_state_io_zh.md).
+
+- **Jul 7, 2026**: 🎉 The FlexKV connector was merged into [SGLang](https://github.com/sgl-project/sglang) mainline ([PR #29701](https://github.com/sgl-project/sglang/pull/29701)), providing native CPU/SSD KV-cache offloading through `--enable-flexkv`.
+
+- **Jul 7, 2026**: Added byte-exact NVFP4 KV-cache offload and reload for vLLM on Blackwell GPUs ([#204](https://github.com/taco-project/FlexKV/pull/204)).
+
+- **Jun 24, 2026**: Added [layerwise KV transfer with SGLang/Mooncake integration](https://github.com/taco-project/FlexKV/commit/71dfa69), [Pipeline Parallel support](https://github.com/taco-project/FlexKV/commit/1a91e7f), and [HugePage-backed host cache](docs/hugepage/README_en.md).
+
 - **Jun 8, 2026**: Integrate nvcomp into FlexKV.
 
 - **Mar 17, 2026**: 🎉 FlexKV has been officially merged into [vLLM](https://github.com/vllm-project/vllm) mainline ([PR #34328](https://github.com/vllm-project/vllm/pull/34328))! Starting from **vLLM v0.17.2**, `FlexKVConnectorV1` is built in — no patch required. See [docs/vllm_adapter/README_en.md](docs/vllm_adapter/README_en.md) for updated usage.
@@ -34,12 +46,12 @@ Universal:
 - Support construct TensorSharedHandle directly from CUDA IPC Handle ([#44](https://github.com/taco-project/FlexKV/pull/44))
 
 
-Targeting vLLM: 
+Targeting vLLM:
 - Support dp > 1 while integrated with vLLM ([#18](https://github.com/taco-project/FlexKV/pull/18))
 - Add launch scripts for vLLM adaption ([#47](https://github.com/taco-project/FlexKV/pull/47))
 - Support TP16 for vLLM+FlexKV ([#59](https://github.com/taco-project/FlexKV/pull/59))
 
-Targeting TensorRT-LLM 
+Targeting TensorRT-LLM
 - Support using FlexKV on TensorRT-LLM ([#48](https://github.com/taco-project/FlexKV/pull/48))
 - Support TP16 for TensorRT-LLM+FlexKV ([#53](https://github.com/taco-project/FlexKV/pull/53))
 
@@ -161,6 +173,6 @@ Note: Critical fixes discovered in released versions are applied directly to the
 ## Roadmap
 
 - **In-Process Cache Engine Integration**: In the dev branch, the implementation, integration, and invocation of the Cache Engine will be further optimized, along with synchronized updates to related APIs.
-- **Framework Integration**: Support works for vLLM, SGLang, and other acceleration frameworks will be updated soon.
+- **Framework Integration**: Deepen the native vLLM, SGLang, and TensorRT-LLM integrations and expand support to more inference engines.
 - **Distributed Query Support**: Enable scalable, distributed KVCache lookup.
 - **Latency Optimization**: Further reduce *get* latency via smarter prefetching and compression.

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,6 +8,18 @@ FlexKV 采用 **Apache-2.0 开源协议**，详细信息请参见 [LICENSE](LICE
 
 ## Updates
 
+- **2026 年 7–8 月**：传输性能与可运维性全面增强，包括 [GPU↔CPU 自适应多路径传输](https://github.com/taco-project/FlexKV/pull/203)、[可靠性与运行日志增强](https://github.com/taco-project/FlexKV/pull/233)、[优雅退出](https://github.com/taco-project/FlexKV/pull/238)、[分块注册 Host Memory](https://github.com/taco-project/FlexKV/pull/240)、[SSD 向量化 I/O](https://github.com/taco-project/FlexKV/pull/242) 和 [Op 级传输 Trace](https://github.com/taco-project/FlexKV/pull/247)。
+
+- **2026 年 7 月 24 日**：支持将 [Mooncake Store](https://github.com/kvcache-ai/Mooncake) 作为基于 Key 的远端缓存层（[#231](https://github.com/taco-project/FlexKV/pull/231)），通过零拷贝 RDMA 实现集群级 KV 复用，并支持 DeepSeek-V4 的 SWA/state sidecar。
+
+- **2026 年 7 月 21 日**：FlexKV 完成 DeepSeek-V4 适配（[#225](https://github.com/taco-project/FlexKV/pull/225)），支持异构 C4/C128/indexer KV group、FullKV + SWA 双缓存、attention/indexer compress-state sidecar 以及逐层恢复。详见 [SGLang 集成说明](flexkv/integration/sglang/README.md)和 [DeepSeek-V4 设计文档](docs/dsv4_compress_state_io_zh.md)。
+
+- **2026 年 7 月 7 日**：🎉 FlexKV Connector 正式合入 [SGLang](https://github.com/sgl-project/sglang) 主干（[PR #29701](https://github.com/sgl-project/sglang/pull/29701)），可通过 `--enable-flexkv` 原生启用 CPU/SSD KV Cache Offloading。
+
+- **2026 年 7 月 7 日**：新增 vLLM 在 Blackwell GPU 上的 NVFP4 KV Cache 字节级无损卸载与恢复支持（[#204](https://github.com/taco-project/FlexKV/pull/204)）。
+
+- **2026 年 6 月 24 日**：新增 [逐层 KV 传输及 SGLang/Mooncake 集成](https://github.com/taco-project/FlexKV/commit/71dfa69)、[Pipeline Parallel 支持](https://github.com/taco-project/FlexKV/commit/1a91e7f)和 [HugePage Host Cache](docs/hugepage/README_zh.md)。
+
 - **2026 年 3 月 17 日**：🎉 FlexKV 正式合并进入 [vLLM](https://github.com/vllm-project/vllm) 官方主干（[PR #34328](https://github.com/vllm-project/vllm/pull/34328)）！从 **vLLM v0.17.2** 起，`FlexKVConnectorV1` 已内置，**无需再手动打 patch**。详见 [docs/vllm_adapter/README_zh.md](docs/vllm_adapter/README_zh.md)。
 
 - **2026 年 3 月 3 日**：🎉 FlexKV 正式合并进入 [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo)（[PR #5858](https://github.com/ai-dynamo/dynamo/pull/5858)）！FlexKV 成为 Dynamo 原生支持的 KV Cache Offloading 方案，实现 KV 感知路由与多级缓存卸载联合部署。详见 [docs/dynamo_integration/README_zh.md](docs/dynamo_integration/README_zh.md)。
@@ -158,6 +170,6 @@ FlexKV 原生集成了基于 Prometheus 的运行时监控框架，覆盖 Python
 ## Roadmap
 
 - **缓存引擎共进程化**：dev 分支将进一步优化 Cache Engine 的实现、集成和调用，并同步更新相关 API 支持
-- **加速框架支持**：对 vLLM、SGLang 等主流推理框架的适配将陆续发布
+- **加速框架支持**：深化 vLLM、SGLang 和 TensorRT-LLM 原生集成，并扩展更多推理引擎支持
 - **分布式查询支持**：实现可扩展的分布式 KVCache 查询能力
 - **延迟优化**：通过预取、压缩等手段进一步降低 *get* 请求延迟


### PR DESCRIPTION
## Summary

- refresh the English and Chinese `Updates` sections with the latest user-visible milestones
- document the SGLang mainline integration, DeepSeek-V4 support, Mooncake Store backend, NVFP4 support, layerwise/PP/HugePage support, and recent transfer/operability improvements
- replace the stale roadmap wording that described vLLM and SGLang integrations as upcoming

## Why

The README timeline stopped before several major integrations and features landed, so new users could not easily tell which inference engines and cache layouts are supported today.

## Impact

The top-level README now points users directly to the relevant merged PRs, commits, and integration/design guides in both English and Chinese. This is a documentation-only change with no runtime impact.

## Validation

- cross-checked milestone dates and descriptions against merged GitHub PRs and commits
- verified referenced in-repository documentation paths exist
- `pre-commit run --files README.md README_zh.md`
