### PR TITLE
ci: fix wheel build, run CPU tests, and document CI/SGLang

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
-# This workflow will upload a Python Package to Release asset
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
-# Copied from vLLM github actions https://github.com/vllm-project/vllm/blob/main/.github/workflows/publish.yml
+# Build a release wheel for pull requests and protected-branch pushes.
+# Wheels from protected-branch pushes are also uploaded to COS.
 name: flexkv ci
 
 on:
@@ -9,9 +8,8 @@ on:
   push:
     branches: [ "main", "dev"]
 
-# Needed to create wheel and upload assets
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -57,12 +55,44 @@ jobs:
         run: |
           ./build.sh --release
 
+      - name: Install wheel and test dependencies
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install --force-reinstall --no-deps dist/*.whl
+
+      - name: Run CPU unit tests
+        shell: bash
+        run: |
+          mapfile -t unit_test_files < <(
+            python - <<'PY'
+          import os
+          from pathlib import Path
+
+          tests_dir = Path(os.environ["GITHUB_WORKSPACE"]) / "tests"
+          marker = "pytestmark = pytest.mark.unit"
+          for path in sorted(tests_dir.rglob("test_*.py")):
+              if marker in path.read_text():
+                  print(path)
+          PY
+          )
+
+          if [ "${#unit_test_files[@]}" -eq 0 ]; then
+            echo "No unit test files found."
+            exit 1
+          fi
+
+          echo "Running ${#unit_test_files[@]} CPU unit test files against the built wheel."
+          cd "$RUNNER_TEMP"
+          timeout 10m python -m pytest -q --maxfail=1 "${unit_test_files[@]}"
+
       - name: Get Date and Time
+        if: github.event_name == 'push'
         run: |
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
           echo "time=$(date +'%H-%M-%S')" >> $GITHUB_ENV
 
       - name: Upload to cos
+        if: github.event_name == 'push'
         uses: shallwefootball/s3-upload-action@master
         with:
           aws_key_id: ${{ secrets.COS_SECRET_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Feature
+
+Targeting SGLang:
+- The native FlexKV backend is available in upstream SGLang `v0.5.16` and later; no patch is required ([sglang#29701](https://github.com/sgl-project/sglang/pull/29701))
+- Add DeepSeek-V4 support for heterogeneous C4/C128/indexer KV groups, FullKV + SWA dual caches, attention/indexer compress-state sidecars, and layerwise restore ([#225](https://github.com/taco-project/FlexKV/pull/225))
+- The matching DeepSeek-V4 SGLang adaptation is not merged yet. Use [sglang#31781](https://github.com/sgl-project/sglang/pull/31781) pinned to [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) until it is merged
+
+### Documentation
+
+- Replace the legacy SGLang patch workflow with version-specific English and Chinese integration instructions
+
 ## [1.2.0] - 2025-11-25
 ### Feature
 Universal:
@@ -75,4 +86,3 @@ Targeting TensorRT-LLM:
 ### Init
 - init version
 - add license
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Targeting SGLang:
 ### Documentation
 
 - Replace the legacy SGLang patch workflow with version-specific English and Chinese integration instructions
+- Add English and Chinese CI guides covering the runner, release-wheel build, CPU unit-test scope, reference timing, local reproduction, and COS upload policy
 
 ## [1.2.0] - 2025-11-25
 ### Feature

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Targeting vLLM:
 - Add launch scripts for vLLM adaption ([#47](https://github.com/taco-project/FlexKV/pull/47))
 - Support TP16 for vLLM+FlexKV ([#59](https://github.com/taco-project/FlexKV/pull/59))
 
+Targeting SGLang:
+- The native FlexKV backend is available in upstream SGLang `v0.5.16` and later; no patch is required ([sglang#29701](https://github.com/sgl-project/sglang/pull/29701))
+- Support DeepSeek-V4 heterogeneous C4/C128/indexer KV groups, FullKV + SWA dual caches, compress-state sidecars, and layerwise restore ([#225](https://github.com/taco-project/FlexKV/pull/225)). Until the matching SGLang adaptation is merged, use [sglang#31781](https://github.com/sgl-project/sglang/pull/31781) pinned to [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac). See the [SGLang integration guide](flexkv/integration/sglang/README.md)
+
 Targeting TensorRT-LLM
 - Support using FlexKV on TensorRT-LLM ([#48](https://github.com/taco-project/FlexKV/pull/48))
 - Support TP16 for TensorRT-LLM+FlexKV ([#53](https://github.com/taco-project/FlexKV/pull/53))

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ FlexKV natively integrates a Prometheus-based runtime monitoring framework that 
 
 For the full list of supported metrics, environment variable configuration, deployment guide for the monitoring stack (Prometheus + Grafana), see [docs/monitoring/README_en.md](docs/monitoring/README_en.md).
 
+## Continuous Integration
+
+Pull requests and protected-branch pushes build the release wheel and run the
+CPU unit-test tier on GitHub Actions. See the
+[CI guide](docs/ci/README_en.md) for the runner configuration, test scope,
+reference duration, local reproduction steps, and artifact-upload policy.
+
 ## Branching Strategy
 
 The branch management strategy of this project is as follows:

--- a/README_zh.md
+++ b/README_zh.md
@@ -161,6 +161,12 @@ FlexKV 原生集成了基于 Prometheus 的运行时监控框架，覆盖 Python
 
 完整的指标列表、环境变量配置、监控栈（Prometheus + Grafana）部署指南，请参阅 [docs/monitoring/README_zh.md](docs/monitoring/README_zh.md)。
 
+## 持续集成
+
+Pull Request 和受保护分支 push 会在 GitHub Actions 中构建 release wheel，并运行 CPU
+单元测试。Runner 配置、测试范围、参考耗时、本地复现步骤和产物上传规则详见
+[CI 文档](docs/ci/README_zh.md)。
+
 ## 分支策略
 
 本项目的分支管理策略如下：

--- a/README_zh.md
+++ b/README_zh.md
@@ -49,6 +49,10 @@ FlexKV 采用 **Apache-2.0 开源协议**，详细信息请参见 [LICENSE](LICE
 - 添加 vLLM 适配的启动脚本 ([#47](https://github.com/taco-project/FlexKV/pull/47))
 - 支持 vLLM+FlexKV 的 TP16 ([#59](https://github.com/taco-project/FlexKV/pull/59))
 
+针对 SGLang:
+- SGLang `v0.5.16` 及以上版本已原生内置 FlexKV backend，无需再应用 patch（[sglang#29701](https://github.com/sgl-project/sglang/pull/29701)）
+- 支持 DeepSeek-V4 异构 C4/C128/indexer KV group、FullKV + SWA 双缓存、compress-state sidecar 和逐层恢复（[#225](https://github.com/taco-project/FlexKV/pull/225)）。在配套的 SGLang 适配合入前，请使用 [sglang#31781](https://github.com/sgl-project/sglang/pull/31781) 并固定到 [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac)。详见 [SGLang 集成说明](flexkv/integration/sglang/README_zh.md)
+
 针对 TensorRT-LLM
 - 在 TensorRT-LLM 上支持使用 FlexKV ([#48](https://github.com/taco-project/FlexKV/pull/48))
 - 支持 TensorRT-LLM+FlexKV 的 TP16 ([#53](https://github.com/taco-project/FlexKV/pull/53))

--- a/docs/ci/README_en.md
+++ b/docs/ci/README_en.md
@@ -1,0 +1,169 @@
+# FlexKV Continuous Integration
+
+[中文文档](README_zh.md)
+
+This document describes the GitHub Actions workflow in
+[`publish.yml`](../../.github/workflows/publish.yml), including where it runs,
+what it validates, and what it deliberately leaves to GPU or integration
+testing.
+
+## When the workflow runs
+
+The `flexkv ci` workflow runs for:
+
+- pull requests targeting `main` or `dev`;
+- pushes to `main` or `dev`.
+
+The workflow has read-only repository permission (`contents: read`). Pull
+requests build and test the package but do not receive COS credentials and do
+not upload artifacts. Protected-branch pushes run the same validation and then
+upload the generated wheel to COS.
+
+## Runner and version matrix
+
+| Item | Current value |
+| --- | --- |
+| Runner | GitHub-hosted `ubuntu-22.04` |
+| Python | `3.10` |
+| PyTorch | `2.6.0` |
+| CUDA toolkit | `12.4` |
+| CUDA architectures | `8.9`, `9.0+PTX` |
+| Parallel build jobs | `4` |
+
+This is currently a single build configuration, not a multi-version matrix.
+The GitHub-hosted runner is a CPU runner: CUDA is installed to compile the
+wheel, but the unit-test stage does not require a GPU.
+
+## What the CI validates
+
+The `Build Wheel` job performs these steps in order:
+
+1. Checks out the pull request or protected-branch commit.
+2. Installs the Linux build dependencies.
+3. Installs Python 3.10, CUDA 12.4, and PyTorch 2.6.0.
+4. Runs `./build.sh --release`, including release-mode Cython compilation.
+5. Installs `requirements.txt` and then force-installs the newly built wheel.
+6. Changes to the runner's temporary directory and runs the CPU unit tests.
+7. On `main` or `dev` pushes only, uploads `dist/` to COS.
+
+Running tests outside the source tree is intentional: imports must resolve to
+the installed wheel, so the job validates the built artifact rather than the
+checkout's Python files.
+
+## CPU unit-test selection
+
+CI discovers every `tests/**/test_*.py` file containing this module-level
+marker:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.unit
+```
+
+If no matching files are found, the workflow fails. The selected files run
+with:
+
+```bash
+timeout 10m python -m pytest -q --maxfail=1 <selected-test-files>
+```
+
+To add a test to this CI tier:
+
+1. Keep it CPU-only and independent of GPUs, network services, storage
+   devices, and repository secrets.
+2. Add `pytestmark = pytest.mark.unit` at module scope.
+3. Confirm it passes against an installed release wheel from outside the
+   repository directory.
+
+## Local reproduction on Ubuntu 22.04
+
+Run the following from the FlexKV repository root. The environment setup
+scripts install system packages and may require `sudo` access.
+
+```bash
+bash -x .github/workflows/scripts/env.sh
+bash -x .github/workflows/scripts/cuda-install.sh 12.4 ubuntu-22.04
+bash -x .github/workflows/scripts/pytorch-install.sh 3.10 2.6.0 12.4
+
+TORCH_CUDA_ARCH_LIST="8.9 9.0+PTX" MAX_JOBS=4 ./build.sh --release
+python -m pip install -r requirements.txt
+python -m pip install --force-reinstall --no-deps dist/*.whl
+
+mapfile -t unit_test_files < <(
+  python - <<'PY'
+from pathlib import Path
+
+marker = "pytestmark = pytest.mark.unit"
+for path in sorted(Path("tests").resolve().rglob("test_*.py")):
+    if marker in path.read_text():
+        print(path)
+PY
+)
+
+ci_test_dir=$(mktemp -d)
+cd "$ci_test_dir"
+timeout 10m python -m pytest -q --maxfail=1 "${unit_test_files[@]}"
+```
+
+`timeout` and `mapfile` are GNU/Linux commands. Use an Ubuntu environment when
+reproducing the workflow exactly.
+
+## Reference duration
+
+[GitHub Actions run #31087143283](https://github.com/taco-project/FlexKV/actions/runs/31087143283)
+completed successfully on August 6, 2026. Rounded step durations were:
+
+| Stage | Duration |
+| --- | ---: |
+| Linux environment setup | 1m 31s |
+| Python setup | 30s |
+| CUDA installation | 5m 06s |
+| PyTorch installation | 2m 10s |
+| Release-wheel build | 6m 49s |
+| Wheel/dependency installation | 5s |
+| CPU unit-test step | 4s |
+| Complete job | **17m 05s** |
+
+That run discovered 12 unit-test modules and reported `198 passed, 1 skipped in
+1.01s`. The total duration is a reference, not an SLA; runner availability and
+dependency caches can change it substantially.
+
+## Artifact upload
+
+The COS upload step runs only for pushes to `main` or `dev`. It requires these
+repository secrets:
+
+- `COS_SECRET_ID`;
+- `COS_SECRET_KEY`;
+- `COS_BUCKET`;
+- `COS_ENDPOINT`.
+
+The workflow uploads `dist/` to `flexkv/<date>/<time>`. Pull requests always
+skip the date/time and upload steps, so missing COS secrets in a pull request
+must not be treated as a build or test failure.
+
+## What this workflow does not cover
+
+The current workflow does not validate:
+
+- GPU runtime correctness or CUDA kernel execution;
+- multi-GPU, TP, DP, PP, or cross-node behavior;
+- SSD, GDS, RDMA, Mooncake, Redis, or COS round trips;
+- vLLM, SGLang, Dynamo, or TensorRT-LLM end-to-end serving;
+- performance or soak regressions;
+- other Python, PyTorch, CUDA, or Ubuntu versions.
+
+Those paths require separate GPU and integration testing before release.
+
+## Checking a pull request
+
+Use the GitHub pull-request page, or query it with the GitHub CLI:
+
+```bash
+gh pr checks <pr-number> --repo taco-project/FlexKV
+```
+
+For a failure, inspect the first failed step and its complete log. In
+particular, distinguish build or unit-test failures from secret-dependent
+artifact upload failures; upload is expected to be skipped for pull requests.

--- a/docs/ci/README_zh.md
+++ b/docs/ci/README_zh.md
@@ -1,0 +1,157 @@
+# FlexKV 持续集成说明
+
+[English](README_en.md)
+
+本文介绍 GitHub Actions 工作流
+[`publish.yml`](../../.github/workflows/publish.yml) 的执行环境、检查范围和明确不覆盖的
+GPU/集成测试。
+
+## 触发条件
+
+`flexkv ci` 工作流在以下情况触发：
+
+- 目标分支为 `main` 或 `dev` 的 Pull Request；
+- 向 `main` 或 `dev` 分支推送代码。
+
+工作流只有仓库只读权限（`contents: read`）。Pull Request 会构建并测试安装包，但拿不到
+COS 凭据，也不会上传产物。受保护分支的 push 完成相同检查后，会将生成的 wheel 上传到
+COS。
+
+## Runner 和版本矩阵
+
+| 项目 | 当前配置 |
+| --- | --- |
+| Runner | GitHub-hosted `ubuntu-22.04` |
+| Python | `3.10` |
+| PyTorch | `2.6.0` |
+| CUDA toolkit | `12.4` |
+| CUDA 架构 | `8.9`、`9.0+PTX` |
+| 并行编译任务数 | `4` |
+
+当前只有这一套构建配置，并不是真正的多版本矩阵。该 GitHub-hosted runner 是 CPU
+runner：安装 CUDA 是为了编译 wheel，unit-test 阶段不依赖 GPU。
+
+## CI 检查内容
+
+`Build Wheel` job 按顺序执行：
+
+1. Checkout Pull Request 或受保护分支的 commit。
+2. 安装 Linux 编译依赖。
+3. 安装 Python 3.10、CUDA 12.4 和 PyTorch 2.6.0。
+4. 执行 `./build.sh --release`，其中包含 release 模式的 Cython 编译。
+5. 安装 `requirements.txt`，然后强制安装刚构建出的 wheel。
+6. 切换到 runner 临时目录并运行 CPU 单元测试。
+7. 仅在 push 到 `main` 或 `dev` 时，将 `dist/` 上传至 COS。
+
+测试刻意在源码目录外运行，使 Python import 指向已经安装的 wheel，确保 CI 验证的是
+实际构建产物，而不是 checkout 目录中的 Python 源文件。
+
+## CPU 单元测试筛选规则
+
+CI 会查找所有包含以下模块级 marker 的 `tests/**/test_*.py` 文件：
+
+```python
+import pytest
+
+pytestmark = pytest.mark.unit
+```
+
+如果一个匹配文件都没有，工作流会直接失败。筛选出的测试通过以下命令执行：
+
+```bash
+timeout 10m python -m pytest -q --maxfail=1 <selected-test-files>
+```
+
+要把新测试加入这个 CI 层级，需要：
+
+1. 保证测试只依赖 CPU，不依赖 GPU、网络服务、存储设备或仓库 secrets。
+2. 在模块级添加 `pytestmark = pytest.mark.unit`。
+3. 确认测试可以在仓库目录外、使用已安装的 release wheel 运行通过。
+
+## 在 Ubuntu 22.04 本地复现
+
+在 FlexKV 仓库根目录执行以下命令。环境初始化脚本会安装系统依赖，可能需要 `sudo`
+权限。
+
+```bash
+bash -x .github/workflows/scripts/env.sh
+bash -x .github/workflows/scripts/cuda-install.sh 12.4 ubuntu-22.04
+bash -x .github/workflows/scripts/pytorch-install.sh 3.10 2.6.0 12.4
+
+TORCH_CUDA_ARCH_LIST="8.9 9.0+PTX" MAX_JOBS=4 ./build.sh --release
+python -m pip install -r requirements.txt
+python -m pip install --force-reinstall --no-deps dist/*.whl
+
+mapfile -t unit_test_files < <(
+  python - <<'PY'
+from pathlib import Path
+
+marker = "pytestmark = pytest.mark.unit"
+for path in sorted(Path("tests").resolve().rglob("test_*.py")):
+    if marker in path.read_text():
+        print(path)
+PY
+)
+
+ci_test_dir=$(mktemp -d)
+cd "$ci_test_dir"
+timeout 10m python -m pytest -q --maxfail=1 "${unit_test_files[@]}"
+```
+
+`timeout` 和 `mapfile` 是 GNU/Linux 命令。如需完全复现工作流，请使用 Ubuntu 环境。
+
+## 参考耗时
+
+2026 年 8 月 6 日的
+[GitHub Actions run #31087143283](https://github.com/taco-project/FlexKV/actions/runs/31087143283)
+执行成功，各阶段耗时取整后如下：
+
+| 阶段 | 耗时 |
+| --- | ---: |
+| Linux 环境初始化 | 1 分 31 秒 |
+| Python 初始化 | 30 秒 |
+| 安装 CUDA | 5 分 06 秒 |
+| 安装 PyTorch | 2 分 10 秒 |
+| 构建 release wheel | 6 分 49 秒 |
+| 安装 wheel 和测试依赖 | 5 秒 |
+| CPU 单元测试步骤 | 4 秒 |
+| Job 总耗时 | **17 分 05 秒** |
+
+该次运行发现 12 个单元测试模块，结果为 `198 passed, 1 skipped in 1.01s`。总耗时只是
+参考值，不是 SLA；runner 调度和依赖缓存状态都可能导致明显变化。
+
+## 产物上传
+
+COS 上传步骤只在 push 到 `main` 或 `dev` 时执行，需要配置以下仓库 secrets：
+
+- `COS_SECRET_ID`；
+- `COS_SECRET_KEY`；
+- `COS_BUCKET`；
+- `COS_ENDPOINT`。
+
+工作流会把 `dist/` 上传到 `flexkv/<date>/<time>`。Pull Request 始终跳过日期生成和上传
+步骤，因此 PR 中缺少 COS secrets 不应被判断为构建或测试失败。
+
+## 当前未覆盖范围
+
+当前工作流不验证：
+
+- GPU 运行时正确性或 CUDA kernel 执行；
+- 多 GPU、TP、DP、PP 或跨节点行为；
+- SSD、GDS、RDMA、Mooncake、Redis 或 COS 数据往返；
+- vLLM、SGLang、Dynamo 或 TensorRT-LLM 端到端服务；
+- 性能回归或长稳测试；
+- 其他 Python、PyTorch、CUDA 或 Ubuntu 版本。
+
+这些路径在发布前仍需单独执行 GPU 和集成测试。
+
+## 查看 Pull Request 状态
+
+可以直接查看 GitHub Pull Request 页面，或使用 GitHub CLI：
+
+```bash
+gh pr checks <pr-number> --repo taco-project/FlexKV
+```
+
+发生失败时，应先定位第一个失败步骤并检查完整日志，尤其要区分构建/单元测试失败和依赖
+secret 的产物上传失败；Pull Request 中跳过上传属于预期行为。

--- a/flexkv/external/mooncake_store_utils.py
+++ b/flexkv/external/mooncake_store_utils.py
@@ -604,7 +604,7 @@ class MooncakeStoreCacheEngine:
     def match_swa_from_result(self, match_result, sequence_meta, upper_bound_blocks: int,
                               lock_for_load: bool = False):
         """Mooncake REMOTE tier: SWA is keyed by tail hash, not a mounted slot."""
-        del lock_for_load
+        # lock_for_load is unused: Mooncake SWA is hash-keyed, so no slot lock is needed.
         swa_hit = int(getattr(match_result, "swa_hit_blocks", 0) or 0) if match_result else 0
         if swa_hit <= 0 or upper_bound_blocks <= 0:
             return 0, -1, None

--- a/flexkv/integration/sglang/README.md
+++ b/flexkv/integration/sglang/README.md
@@ -1,101 +1,87 @@
-# SGLang FlexKV Connector Integration
+# Using FlexKV with SGLang
 
-> **WARNING: THIS INTEGRATION IS NOT YET COMPLETE AND HAS NOT BEEN TESTED.**
->
-> The patch was mechanically ported from the development branch and conflicts
-> were resolved manually. It has NOT been validated with runtime tests.
-> Please do NOT use in production until full testing is completed.
+[中文文档](README_zh.md)
 
-## Overview
+## Version compatibility
 
-This directory contains the patch to integrate FlexKV connector into SGLang. The patch adds KV cache sharing capabilities via FlexKV, supporting cross-node Tensor Parallelism (TP) and Pipeline Parallelism (PP).
+There are two different SGLang integration paths. Choose the one that matches
+your model.
 
-## Target SGLang Version
+> Status last checked: August 6, 2026.
 
-- **Repository**: https://github.com/sgl-project/sglang.git
-- **Branch**: `deepseek_v4`
-- **Base Commit**: `b69485ff4272b5a306045fa0cf7fc2c5692d391f` (small fix h200 docker)
-- **Based on Release**: v0.5.12.post1 + 68 commits (deepseek_v4 branch)
+| Use case | SGLang version | Patch required? |
+| --- | --- | --- |
+| Standard models | SGLang `v0.5.16` or later, or a recent `main` | No |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781), pinned to commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | No local patch; use the pinned SGLang commit |
 
-## Patch File
+### Standard models: use upstream SGLang directly
 
-- `sglang_flexkv_connector.patch` — Combined patch containing all FlexKV connector changes
-
-## How to Apply
+The base FlexKV integration was merged into upstream SGLang by
+[sglang#29701](https://github.com/sgl-project/sglang/pull/29701) and is included
+in SGLang `v0.5.16` and later. Do **not** apply
+`sglang_flexkv_connector.patch` to these versions.
 
 ```bash
-# Clone and checkout the target branch
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-git checkout deepseek_v4
-git reset --hard b69485ff4272b5a306045fa0cf7fc2c5692d391f
-
-# Apply the patch
-git apply sglang_flexkv_connector.patch
-
-# Verify
-git status
+git checkout v0.5.16  # or use a newer release/main
 ```
 
-## Changes Included
+### DeepSeek V4: pin the unmerged SGLang adaptation
 
-### New Files (7)
-
-| File | Description |
-|------|-------------|
-| `python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py` | FlexKV connector main implementation (KV get/put, cross-node TP/PP) |
-| `python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py` | FlexKV communication layer (RankInfo, sync groups, async reaper) |
-| `python/sglang/srt/mem_cache/extended_radix_cache.py` | Extended radix cache wrapping base cache with connector support |
-| `python/sglang/srt/mem_cache/kv_connector.py` | KV connector abstract base class and factory |
-| `python/sglang/srt/mem_cache/session_aware_cache.py` | Session-aware cache decorator for streaming session KV management |
-| `python/sglang/srt/mem_cache/allocator_ascend.py` | Ascend NPU allocator support |
-| `docs/advanced_features/kv_connector.md` | User-facing documentation for KV connector configuration |
-
-### Modified Files (9)
-
-| File | Change Summary |
-|------|----------------|
-| `python/sglang/srt/server_args.py` | Add `--kv-connector-cls` argument and related config |
-| `python/sglang/srt/managers/scheduler.py` | Integrate connector lifecycle: init, prefetch check, event loop, abort handling |
-| `python/sglang/srt/managers/scheduler_output_processor_mixin.py` | Add cache breakdown metrics (device/storage/connector) |
-| `python/sglang/srt/managers/schedule_batch.py` | Add `cached_tokens_extended_device` field and `update_connector_state` param |
-| `python/sglang/srt/managers/schedule_policy.py` | Adapt `init_load_back` call for connector integration |
-| `python/sglang/srt/mem_cache/base_prefix_cache.py` | Change `init_load_back` signature, rename `check_hicache_events` -> `check_kv_events` |
-| `python/sglang/srt/mem_cache/hiradix_cache.py` | Rename `check_hicache_events` -> `check_kv_events` |
-| `python/sglang/srt/layers/attention/nsa_backend.py` | Add FA3 import guard for FlexKV+Blackwell compatibility |
-| `python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format` | Clang format config |
-
-## Features
-
-- KV cache prefix matching and sharing across SGLang instances via FlexKV
-- Cross-node Tensor Parallelism (TP) support
-- Pipeline Parallelism (PP) support with decentralized control plane
-- Async prefetch with adaptive work reaper
-- Observability: cache hit metrics per request (device/storage breakdown)
-- Compatible with HiCache hierarchical caching
-
-## Configuration
+FlexKV's DeepSeek V4 support is present on FlexKV `main` (merged by
+[FlexKV#225](https://github.com/taco-project/FlexKV/pull/225)), but the matching
+SGLang adaptation has **not** been merged upstream yet. Until
+[sglang#31781](https://github.com/sgl-project/sglang/pull/31781) is merged, fetch
+the PR and pin the commit below instead of using an SGLang release or `main`
+alone:
 
 ```bash
-# Launch SGLang with FlexKV connector
-python -m sglang.launch_server \
-    --model-path <model> \
-    --kv-connector-cls FlexKVConnector \
-    # ... other args
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git fetch origin pull/31781/head
+git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
 ```
 
-See `docs/advanced_features/kv_connector.md` (in the patched repo) for full configuration details.
+Use this with the current FlexKV `main` branch:
 
-## Source Reference
+```bash
+git clone https://github.com/taco-project/FlexKV.git
+cd FlexKV
+git checkout main
+```
 
-- **Development Repo**: https://github.com/zhuofan1123/sglang.git (branch: `taco_sglang`)
-- **Patch derived from**: 23 commits after `ac84702b6186bbcc2c92a8d8356af624a8c39bcc`
+The PR is still under development, so check its status before updating the
+pinned SGLang commit. DeepSeek V4's unified-KV layout and `--enable-hisparse`
+are not supported by that commit.
 
-## TODO
+## Launch
 
-- [ ] Runtime smoke test: single-node TP launch with FlexKV connector
-- [ ] Cross-node TP correctness validation
-- [ ] PP mode validation
-- [ ] Prefetch / async reaper stress test
-- [ ] Compatibility test with HiCache enabled
-- [ ] Performance regression check vs. baseline (no connector)
+After installing SGLang and FlexKV, create a FlexKV configuration file. For
+example:
+
+```yaml
+# flexkv_config.yaml
+cpu_cache_gb: 16
+```
+
+Launch SGLang with the built-in FlexKV backend:
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --enable-flexkv \
+  --flexkv-config-file /path/to/flexkv_config.yaml \
+  # ... other SGLang arguments
+```
+
+The equivalent explicit backend option is
+`--radix-cache-backend flexkv`. See SGLang's
+[`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)
+for detailed configuration and validation instructions.
+
+## About the patch in this directory
+
+`sglang_flexkv_connector.patch` is retained only as a legacy reference for the
+old pre-upstream integration. It is not required for supported SGLang releases,
+and it must not be used for the DeepSeek V4 path above.

--- a/flexkv/integration/sglang/README_zh.md
+++ b/flexkv/integration/sglang/README_zh.md
@@ -1,0 +1,81 @@
+# 在 SGLang 中使用 FlexKV
+
+[English](README.md)
+
+## 版本兼容性
+
+SGLang 目前有两条不同的 FlexKV 集成路径，请根据模型选择。
+
+> 状态最后确认日期：2026 年 8 月 6 日。
+
+| 使用场景 | SGLang 版本 | 是否需要 patch |
+| --- | --- | --- |
+| 普通模型 | SGLang `v0.5.16` 及以上版本，或较新的 `main` | 不需要 |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781)，固定到 commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | 不需要本地 patch；使用指定的 SGLang commit |
+
+### 普通模型：直接使用 SGLang 官方版本
+
+基础 FlexKV 集成已通过
+[sglang#29701](https://github.com/sgl-project/sglang/pull/29701) 合入 SGLang
+官方主干，并从 SGLang `v0.5.16` 开始随版本发布。使用这些版本时，**不要**再应用
+`sglang_flexkv_connector.patch`。
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git checkout v0.5.16  # 也可以使用更新的正式版本或 main
+```
+
+### DeepSeek V4：固定使用尚未合入的 SGLang 适配
+
+FlexKV 侧的 DeepSeek V4 支持已经通过
+[FlexKV#225](https://github.com/taco-project/FlexKV/pull/225) 合入 FlexKV
+`main`，但配套的 SGLang 适配**尚未合入**官方主干。在
+[sglang#31781](https://github.com/sgl-project/sglang/pull/31781) 合入之前，不要只使用
+SGLang 正式版本或 `main`，而应拉取该 PR 并固定到下面的 commit：
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git fetch origin pull/31781/head
+git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
+```
+
+同时使用当前 FlexKV `main` 分支：
+
+```bash
+git clone https://github.com/taco-project/FlexKV.git
+cd FlexKV
+git checkout main
+```
+
+该 PR 仍在开发中，更新固定的 SGLang commit 前请先检查 PR 状态。这个 commit
+暂不支持 DeepSeek V4 unified-KV layout 和 `--enable-hisparse`。
+
+## 启动方式
+
+安装 SGLang 和 FlexKV 后，先创建 FlexKV 配置文件。例如：
+
+```yaml
+# flexkv_config.yaml
+cpu_cache_gb: 16
+```
+
+使用 SGLang 内置的 FlexKV backend 启动服务：
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --enable-flexkv \
+  --flexkv-config-file /path/to/flexkv_config.yaml \
+  # ... 其他 SGLang 参数
+```
+
+也可以使用等价的显式参数 `--radix-cache-backend flexkv`。更详细的配置和验证方法请参考
+SGLang 官方的
+[`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)。
+
+## 关于本目录中的 patch
+
+`sglang_flexkv_connector.patch` 仅作为 FlexKV 尚未合入 SGLang 主干前的历史参考保留。
+受支持的 SGLang 正式版本不需要它，上述 DeepSeek V4 路径也不能使用它。

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest>=6.0.0
 pytest-benchmark>=3.0.0
 expiring-dict==1.1.2
 redis>=4.0.0
+requests>=2.0.0


### PR DESCRIPTION
## Summary

- remove the Cython-invalid deletion of a bool-annotated parameter that currently breaks every release-wheel build
- install the built wheel and run the CPU unit-test modules in CI
- skip COS credential-dependent steps on pull requests and reduce workflow permissions to read-only
- update the English SGLang integration README and add a matching Chinese README
- update the top-level English and Chinese feature lists and populate the SGLang entries in `CHANGELOG.md`
- clarify that standard SGLang releases no longer require a FlexKV patch, while DeepSeek V4 must currently use SGLang PR #31781 at the pinned commit
- add bilingual CI documentation covering the runner, version matrix, workflow stages, unit-test selection, local reproduction, reference timing, COS policy, and coverage gaps

## Root cause

Release-mode Cython treats `lock_for_load: bool` as a native value, so `del lock_for_load` fails with `Deletion of non-Python, non-C++ object`. An existing proof build showed that removing this line completes the wheel build, but fork pull requests then fail because the workflow unconditionally attempts a COS upload without repository secrets.

The SGLang integration README also still described the old `deepseek_v4` branch and manually ported patch workflow. The base FlexKV integration has since been merged into upstream SGLang, while the separate DeepSeek V4 adaptation remains unmerged.

## CI behavior

The workflow discovers the 12 test modules carrying the module-level `pytest.mark.unit` marker, installs the newly built wheel, runs those tests outside the source tree, and enforces a 10-minute unit-test timeout. COS upload remains enabled for pushes to `main` and `dev` only.

The new CI guide documents the GitHub-hosted Ubuntu runner and fixed Python/PyTorch/CUDA matrix, explains how to add CPU unit tests, records the per-stage duration from a green reference run, and explicitly lists GPU and integration paths that remain outside this workflow.

## SGLang version guidance

- standard models: use SGLang `v0.5.16` or later (or a recent `main`) without applying `sglang_flexkv_connector.patch`
- DeepSeek V4: use the unmerged SGLang PR #31781 pinned to `ee0465a09196421a6e4d53a3103eccdef1dd32ac`
- the patch in `flexkv/integration/sglang/` is retained only as a legacy reference

## Validation

- workflow structure assertions passed
- embedded Bash syntax check passed
- all 12 unit-test modules were discovered
- all 56 release-mode modules Cythonized successfully with Cython 3.2.9
- verified that SGLang `v0.5.16` contains the upstream FlexKV integration
- verified that SGLang PR #31781 remains open at the documented commit
- verified the English README, Chinese README, integration guides, and changelog use the same version guidance
- verified the documented unit-test selector currently discovers 12 modules and matches the workflow implementation
- `git diff --check` passed
