### PR TITLE
docs: clarify SGLang FlexKV version guidance

### DIFF
--- a/flexkv/integration/sglang/README.md
+++ b/flexkv/integration/sglang/README.md
@@ -1,101 +1,87 @@
-# SGLang FlexKV Connector Integration
+# Using FlexKV with SGLang
 
-> **WARNING: THIS INTEGRATION IS NOT YET COMPLETE AND HAS NOT BEEN TESTED.**
->
-> The patch was mechanically ported from the development branch and conflicts
-> were resolved manually. It has NOT been validated with runtime tests.
-> Please do NOT use in production until full testing is completed.
+[中文文档](README_zh.md)
 
-## Overview
+## Version compatibility
 
-This directory contains the patch to integrate FlexKV connector into SGLang. The patch adds KV cache sharing capabilities via FlexKV, supporting cross-node Tensor Parallelism (TP) and Pipeline Parallelism (PP).
+There are two different SGLang integration paths. Choose the one that matches
+your model.
 
-## Target SGLang Version
+> Status last checked: August 6, 2026.
 
-- **Repository**: https://github.com/sgl-project/sglang.git
-- **Branch**: `deepseek_v4`
-- **Base Commit**: `b69485ff4272b5a306045fa0cf7fc2c5692d391f` (small fix h200 docker)
-- **Based on Release**: v0.5.12.post1 + 68 commits (deepseek_v4 branch)
+| Use case | SGLang version | Patch required? |
+| --- | --- | --- |
+| Standard models | SGLang `v0.5.16` or later, or a recent `main` | No |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781), pinned to commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | No local patch; use the pinned SGLang commit |
 
-## Patch File
+### Standard models: use upstream SGLang directly
 
-- `sglang_flexkv_connector.patch` — Combined patch containing all FlexKV connector changes
-
-## How to Apply
+The base FlexKV integration was merged into upstream SGLang by
+[sglang#29701](https://github.com/sgl-project/sglang/pull/29701) and is included
+in SGLang `v0.5.16` and later. Do **not** apply
+`sglang_flexkv_connector.patch` to these versions.
 
 ```bash
-# Clone and checkout the target branch
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-git checkout deepseek_v4
-git reset --hard b69485ff4272b5a306045fa0cf7fc2c5692d391f
-
-# Apply the patch
-git apply sglang_flexkv_connector.patch
-
-# Verify
-git status
+git checkout v0.5.16  # or use a newer release/main
 ```
 
-## Changes Included
+### DeepSeek V4: pin the unmerged SGLang adaptation
 
-### New Files (7)
-
-| File | Description |
-|------|-------------|
-| `python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py` | FlexKV connector main implementation (KV get/put, cross-node TP/PP) |
-| `python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py` | FlexKV communication layer (RankInfo, sync groups, async reaper) |
-| `python/sglang/srt/mem_cache/extended_radix_cache.py` | Extended radix cache wrapping base cache with connector support |
-| `python/sglang/srt/mem_cache/kv_connector.py` | KV connector abstract base class and factory |
-| `python/sglang/srt/mem_cache/session_aware_cache.py` | Session-aware cache decorator for streaming session KV management |
-| `python/sglang/srt/mem_cache/allocator_ascend.py` | Ascend NPU allocator support |
-| `docs/advanced_features/kv_connector.md` | User-facing documentation for KV connector configuration |
-
-### Modified Files (9)
-
-| File | Change Summary |
-|------|----------------|
-| `python/sglang/srt/server_args.py` | Add `--kv-connector-cls` argument and related config |
-| `python/sglang/srt/managers/scheduler.py` | Integrate connector lifecycle: init, prefetch check, event loop, abort handling |
-| `python/sglang/srt/managers/scheduler_output_processor_mixin.py` | Add cache breakdown metrics (device/storage/connector) |
-| `python/sglang/srt/managers/schedule_batch.py` | Add `cached_tokens_extended_device` field and `update_connector_state` param |
-| `python/sglang/srt/managers/schedule_policy.py` | Adapt `init_load_back` call for connector integration |
-| `python/sglang/srt/mem_cache/base_prefix_cache.py` | Change `init_load_back` signature, rename `check_hicache_events` -> `check_kv_events` |
-| `python/sglang/srt/mem_cache/hiradix_cache.py` | Rename `check_hicache_events` -> `check_kv_events` |
-| `python/sglang/srt/layers/attention/nsa_backend.py` | Add FA3 import guard for FlexKV+Blackwell compatibility |
-| `python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format` | Clang format config |
-
-## Features
-
-- KV cache prefix matching and sharing across SGLang instances via FlexKV
-- Cross-node Tensor Parallelism (TP) support
-- Pipeline Parallelism (PP) support with decentralized control plane
-- Async prefetch with adaptive work reaper
-- Observability: cache hit metrics per request (device/storage breakdown)
-- Compatible with HiCache hierarchical caching
-
-## Configuration
+FlexKV's DeepSeek V4 support is present on FlexKV `main` (merged by
+[FlexKV#225](https://github.com/taco-project/FlexKV/pull/225)), but the matching
+SGLang adaptation has **not** been merged upstream yet. Until
+[sglang#31781](https://github.com/sgl-project/sglang/pull/31781) is merged, fetch
+the PR and pin the commit below instead of using an SGLang release or `main`
+alone:
 
 ```bash
-# Launch SGLang with FlexKV connector
-python -m sglang.launch_server \
-    --model-path <model> \
-    --kv-connector-cls FlexKVConnector \
-    # ... other args
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git fetch origin pull/31781/head
+git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
 ```
 
-See `docs/advanced_features/kv_connector.md` (in the patched repo) for full configuration details.
+Use this with the current FlexKV `main` branch:
 
-## Source Reference
+```bash
+git clone https://github.com/taco-project/FlexKV.git
+cd FlexKV
+git checkout main
+```
 
-- **Development Repo**: https://github.com/zhuofan1123/sglang.git (branch: `taco_sglang`)
-- **Patch derived from**: 23 commits after `ac84702b6186bbcc2c92a8d8356af624a8c39bcc`
+The PR is still under development, so check its status before updating the
+pinned SGLang commit. DeepSeek V4's unified-KV layout and `--enable-hisparse`
+are not supported by that commit.
 
-## TODO
+## Launch
 
-- [ ] Runtime smoke test: single-node TP launch with FlexKV connector
-- [ ] Cross-node TP correctness validation
-- [ ] PP mode validation
-- [ ] Prefetch / async reaper stress test
-- [ ] Compatibility test with HiCache enabled
-- [ ] Performance regression check vs. baseline (no connector)
+After installing SGLang and FlexKV, create a FlexKV configuration file. For
+example:
+
+```yaml
+# flexkv_config.yaml
+cpu_cache_gb: 16
+```
+
+Launch SGLang with the built-in FlexKV backend:
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --enable-flexkv \
+  --flexkv-config-file /path/to/flexkv_config.yaml \
+  # ... other SGLang arguments
+```
+
+The equivalent explicit backend option is
+`--radix-cache-backend flexkv`. See SGLang's
+[`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)
+for detailed configuration and validation instructions.
+
+## About the patch in this directory
+
+`sglang_flexkv_connector.patch` is retained only as a legacy reference for the
+old pre-upstream integration. It is not required for supported SGLang releases,
+and it must not be used for the DeepSeek V4 path above.

--- a/flexkv/integration/sglang/README_zh.md
+++ b/flexkv/integration/sglang/README_zh.md
@@ -1,0 +1,81 @@
+# 在 SGLang 中使用 FlexKV
+
+[English](README.md)
+
+## 版本兼容性
+
+SGLang 目前有两条不同的 FlexKV 集成路径，请根据模型选择。
+
+> 状态最后确认日期：2026 年 8 月 6 日。
+
+| 使用场景 | SGLang 版本 | 是否需要 patch |
+| --- | --- | --- |
+| 普通模型 | SGLang `v0.5.16` 及以上版本，或较新的 `main` | 不需要 |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781)，固定到 commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | 不需要本地 patch；使用指定的 SGLang commit |
+
+### 普通模型：直接使用 SGLang 官方版本
+
+基础 FlexKV 集成已通过
+[sglang#29701](https://github.com/sgl-project/sglang/pull/29701) 合入 SGLang
+官方主干，并从 SGLang `v0.5.16` 开始随版本发布。使用这些版本时，**不要**再应用
+`sglang_flexkv_connector.patch`。
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git checkout v0.5.16  # 也可以使用更新的正式版本或 main
+```
+
+### DeepSeek V4：固定使用尚未合入的 SGLang 适配
+
+FlexKV 侧的 DeepSeek V4 支持已经通过
+[FlexKV#225](https://github.com/taco-project/FlexKV/pull/225) 合入 FlexKV
+`main`，但配套的 SGLang 适配**尚未合入**官方主干。在
+[sglang#31781](https://github.com/sgl-project/sglang/pull/31781) 合入之前，不要只使用
+SGLang 正式版本或 `main`，而应拉取该 PR 并固定到下面的 commit：
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git fetch origin pull/31781/head
+git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
+```
+
+同时使用当前 FlexKV `main` 分支：
+
+```bash
+git clone https://github.com/taco-project/FlexKV.git
+cd FlexKV
+git checkout main
+```
+
+该 PR 仍在开发中，更新固定的 SGLang commit 前请先检查 PR 状态。这个 commit
+暂不支持 DeepSeek V4 unified-KV layout 和 `--enable-hisparse`。
+
+## 启动方式
+
+安装 SGLang 和 FlexKV 后，先创建 FlexKV 配置文件。例如：
+
+```yaml
+# flexkv_config.yaml
+cpu_cache_gb: 16
+```
+
+使用 SGLang 内置的 FlexKV backend 启动服务：
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --enable-flexkv \
+  --flexkv-config-file /path/to/flexkv_config.yaml \
+  # ... 其他 SGLang 参数
+```
+
+也可以使用等价的显式参数 `--radix-cache-backend flexkv`。更详细的配置和验证方法请参考
+SGLang 官方的
+[`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)。
+
+## 关于本目录中的 patch
+
+`sglang_flexkv_connector.patch` 仅作为 FlexKV 尚未合入 SGLang 主干前的历史参考保留。
+受支持的 SGLang 正式版本不需要它，上述 DeepSeek V4 路径也不能使用它。


### PR DESCRIPTION
## Summary

- document that the base FlexKV integration is available in upstream SGLang starting from v0.5.16 and no longer requires a patch
- document that DeepSeek V4 support still requires the unmerged SGLang PR #31781, pinned to commit `ee0465a09196421a6e4d53a3103eccdef1dd32ac`
- add a Chinese version of the SGLang integration README
- mark `sglang_flexkv_connector.patch` as a legacy reference that should not be used with supported releases or the DeepSeek V4 path

## Why

The existing README still instructed users to check out the old `deepseek_v4` branch and apply a manually ported patch. That workflow became stale after the base integration was merged upstream, while the separate DeepSeek V4 adaptation has not yet been merged.

## Validation

- `git diff --check`
- verified that the SGLang `v0.5.16` tag contains the base FlexKV integration
- verified that SGLang PR #31781 remains open and its current head is `ee0465a09196421a6e4d53a3103eccdef1dd32ac`
