### PR TITLE
feat: extract sglang connector to FlexKV + config improvements

### DIFF
--- a/docs/flexkv_config_reference/README_en.md
+++ b/docs/flexkv_config_reference/README_en.md
@@ -189,3 +189,13 @@ Some configurations can only be set through environment variables.
 | `FLEXKV_EVICT_RATIO` | float | 0.05 | CPU and SSD eviction ratio for proactive eviction per cycle (0.0 = only evict the minimal necessary blocks). Recommended to keep at `0.05`, i.e., evict 5% of least recently used blocks per cycle |
 | `FLEXKV_EVICT_START_THRESHOLD` | float | 0.7 | Memory utilization threshold to trigger proactive eviction. When the cache utilization reaches this ratio, FlexKV starts evicting nodes proactively. For example, `0.7` means eviction begins when 70% of the cache is occupied. Set to `1.0` to only evict when the cache is full |
 | `FLEXKV_HIT_REWARD_SECONDS` | int | 0 | Number of bonus seconds added to a node's effective access time on each cache hit, enhancing LRU with frequency awareness. When set to `0` (default), standard LRU behavior applies. When set to a positive value, frequently hit nodes accumulate extra protection time, making them harder to evict. See [Eviction Policy Guide](../eviction_policy/README_en.md) for details |
+
+---
+
+### SGLang Integration
+
+> Note: The following configuration only takes effect when using the SGLang integration (`flexkv.integration.sglang.connector`).
+
+| Environment Variable | Type | Default | Description |
+|---------------------|------|---------|-------------|
+| `FLEXKV_ENABLE_COLLECTIVE_SYNC` | bool | 1 | Whether to enable cross-rank collective sync (scatter/barrier/all_reduce). This sync is primarily used for coordination between Pipeline Parallelism (PP) stages. Can be set to 0 to disable in non-PP deployments to reduce sync overhead and improve performance |

--- a/docs/flexkv_config_reference/README_zh.md
+++ b/docs/flexkv_config_reference/README_zh.md
@@ -187,3 +187,13 @@ swa_multi_group: false
 | `FLEXKV_EVICT_RATIO` | float | 0.05 | cpu，ssd一次evict主动淘汰比例（0.0 = 只淘汰最小的必要的block数）。建议保持 `0.05`，即每一次淘汰5%的最久未使用的block |
 | `FLEXKV_EVICT_START_THRESHOLD` | float | 0.7 | 触发主动淘汰的内存利用率阈值。当缓存利用率达到该比例时，FlexKV 开始主动淘汰节点。例如 `0.7` 表示缓存占用达到 70% 时即开始淘汰。设为 `1.0` 则仅在缓存满时才淘汰 |
 | `FLEXKV_HIT_REWARD_SECONDS` | int | 0 | 每次缓存命中时向节点的有效访问时间叠加的额外秒数，为 LRU 增加频率感知能力。设为 `0`（默认值）时为标准 LRU 行为。设为正数时，频繁命中的节点会累积额外的保护时间，使其更难被驱逐。详见[驱逐策略指南](../eviction_policy/README_zh.md) |
+
+---
+
+### SGLang 集成
+
+> 注：以下配置仅在使用 SGLang 集成（`flexkv.integration.sglang.connector`）时生效。
+
+| 环境变量 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `FLEXKV_ENABLE_COLLECTIVE_SYNC` | bool | 1 | 是否启用跨 rank 集合同步（scatter/barrier/all_reduce）。该同步主要用于 Pipeline Parallelism (PP) 场景下各 stage 间的协调。在不使用 PP 的部署中可设为 0 关闭以减少同步开销、提升性能 |

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -500,15 +500,9 @@ class RankInfo:
     def effective_tp_rank(self) -> int:
         """Effective tp-rank in the *data-plane* segmentation space.
 
-        For MLA models, every CP rank holds the same KV pages (the MLA latent
-        is not split along the sequence axis from a KV perspective), so
-        ``cp_rank`` must NOT participate in slice indexing — otherwise a CP rank
-        would write to a non-existent CPU slice and corrupt block accounting.
-        For non-MLA models, CP shards along the sequence dimension and each
-        ``(cp_rank, tp_rank)`` pair owns a unique slice.
+        Each ``(cp_rank, tp_rank)`` pair owns a unique slice in the combined
+        CP×TP segmentation space.
         """
-        if self.model_config.use_mla:
-            return self.tp_rank
         return self.cp_rank * max(1, self.model_config.tp_size) + self.tp_rank
 
     @property
@@ -785,6 +779,8 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     slru_protected_threshold=int(os.getenv('FLEXKV_SLRU_PROTECTED_THRESHOLD', 2)),
 
     enable_mps=bool(int(os.getenv('FLEXKV_ENABLE_MPS', 1))),
+
+    enable_collective_sync=bool(int(os.getenv('FLEXKV_ENABLE_COLLECTIVE_SYNC', 1))),
 
     enable_trace=bool(int(os.getenv('FLEXKV_ENABLE_TRACE', 0))),
     trace_file_path=os.getenv('FLEXKV_TRACE_FILE_PATH', './flexkv_trace.log'),
@@ -1220,6 +1216,7 @@ def update_default_config_from_user_config(rank_info: RankInfo,
             else:
                 raise ValueError(f"Unknown config name: {global_attr_name} in config file, "
                                  f"available config names: {global_config_attrs}")
+
 
 @dataclass
 class MooncakeTransferEngineConfig:

--- a/flexkv/integration/sglang/README.md
+++ b/flexkv/integration/sglang/README.md
@@ -80,6 +80,24 @@ The equivalent explicit backend option is
 [`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)
 for detailed configuration and validation instructions.
 
+## Integration boundary
+
+The core FlexKV connector logic (`FlexKVComm` and `FlexKVConnector`) lives in
+this directory:
+
+| File | Description |
+|------|-------------|
+| `comm.py` | 3-axis (PP × CP × TP) cross-rank communication layer |
+| `connector.py` | `FlexKVConnector` wrapping `KVManager` for SGLang |
+
+SGLang's `storage/flexkv/__init__.py` dynamically loads the connector from
+`flexkv.integration.sglang.connector` via `importlib`, so future FlexKV logic
+changes typically only require updating the FlexKV repo.
+
+Set `FLEXKV_ENABLE_COLLECTIVE_SYNC=0` to disable cross-rank sync
+(scatter/barrier/all_reduce). In deployments without Pipeline Parallelism (PP),
+disabling it reduces sync overhead and improves performance.
+
 ## About the patch in this directory
 
 `sglang_flexkv_connector.patch` is retained only as a legacy reference for the

--- a/flexkv/integration/sglang/README_zh.md
+++ b/flexkv/integration/sglang/README_zh.md
@@ -75,6 +75,21 @@ python -m sglang.launch_server \
 SGLang 官方的
 [`flexkv/README.md`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/flexkv/README.md)。
 
+## 集成边界
+
+FlexKV connector 的核心逻辑（`FlexKVComm` 和 `FlexKVConnector`）位于本目录：
+
+| 文件 | 职责 |
+|------|------|
+| `comm.py` | 3-axis（PP × CP × TP）跨 rank 通信层 |
+| `connector.py` | `FlexKVConnector`，封装 `KVManager` 供 SGLang 调用 |
+
+SGLang 侧的 `storage/flexkv/__init__.py` 通过 `importlib` 从 `flexkv.integration.sglang.connector`
+动态加载 connector，后续 FlexKV 逻辑改动通常只需更新 FlexKV 仓库。
+
+设置环境变量 `FLEXKV_ENABLE_COLLECTIVE_SYNC=0` 可禁用跨 rank 同步（scatter/barrier/all_reduce），
+在不使用 Pipeline Parallelism (PP) 的部署中关闭可减少同步开销、提升性能。
+
 ## 关于本目录中的 patch
 
 `sglang_flexkv_connector.patch` 仅作为 FlexKV 尚未合入 SGLang 主干前的历史参考保留。

--- a/flexkv/integration/sglang/comm.py
+++ b/flexkv/integration/sglang/comm.py
@@ -1,0 +1,981 @@
+"""Communication helpers for the FlexKV connector.
+
+FlexKV runs a single KVManager per DP group (typically the TP/CP/PP
+sync leader's process). Every other rank in the same KV-cache-sharing
+fan-out must be told the leader's decisions: which prefix matched in
+FlexKV, which task id the leader allocated, which slot mappings to
+send, etc.
+
+This file provides:
+
+* ``FlexKVComm`` — a 3-axis (PP × CP × TP) hierarchical sync context
+  built on torch.distributed (gloo CPU groups). Exposes ``scatter``,
+  ``scatter_pp``, ``barrier`` and ``all_reduce_min`` plus role flags
+  (``is_sync_leader`` etc.) that the connector branches on.
+* libc / ``eventfd`` shims used by the layerwise transfer worker
+  socket handshake.
+* ``FlexKVLayerLoadingEvent`` and ``FlexKVLayerDoneCounter`` — the
+  eventfd-backed per-layer completion structures that the FlexKV
+  layerwise transfer worker signals into. Hooked into sglang's
+  ``register_layer_transfer_counter`` so each layer's forward waits
+  for its own host→device copy.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import logging
+import os
+import pickle
+import socket
+import struct
+import time
+from datetime import timedelta
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+# PP-channel command tags (used by ``scatter_pp`` payloads). Sender and
+# receiver assert on these to catch protocol drift early.
+CMD_PUT_META = 2
+CMD_LAYERWISE = 3
+CMD_STORE_COMPLETE = 5
+
+
+class FlexKVScatterChannel(str, Enum):
+    """Logical channels multiplexed over the hierarchical P2P fan-out."""
+
+    LOOKUP = "lookup"
+    LAYERWISE_MANIFEST = "layerwise_manifest"
+    STORE_COMPLETION = "store_completion"
+    PREFETCH_START = "prefetch_start"
+    PREFETCH_PROGRESS = "prefetch_progress"
+    RESET = "reset"
+
+
+_SCATTER_CHANNEL_OFFSETS = {
+    FlexKVScatterChannel.LOOKUP: 1,
+    FlexKVScatterChannel.LAYERWISE_MANIFEST: 2,
+    FlexKVScatterChannel.STORE_COMPLETION: 3,
+    FlexKVScatterChannel.PREFETCH_START: 4,
+    FlexKVScatterChannel.PREFETCH_PROGRESS: 5,
+    FlexKVScatterChannel.RESET: 6,
+}
+_SCATTER_CHANNEL_TYPES = {
+    FlexKVScatterChannel.LOOKUP: dict,
+    FlexKVScatterChannel.LAYERWISE_MANIFEST: dict,
+    FlexKVScatterChannel.STORE_COMPLETION: list,
+    FlexKVScatterChannel.PREFETCH_START: dict,
+    FlexKVScatterChannel.PREFETCH_PROGRESS: dict,
+    FlexKVScatterChannel.RESET: dict,
+}
+
+
+class FlexKVComm:
+    """3-axis (PP × CP × TP) hierarchical sync for the FlexKV connector.
+
+    Notation:
+      * "sync leader" is the unique rank that talks to the FlexKV
+        KVManager: pp_rank=0, attn_cp_rank=0, attn_tp_rank=0.
+      * "PP stage leader" is the (cp=0, tp=0) rank within a PP stage —
+        it does cross-PP P2P (``scatter_pp``).
+      * Every rank participates in collective layers it belongs to.
+
+    Communication strategy:
+      * P2P (send/recv/isend/irecv) on CPU tensors → ``world_cpu_group``
+        (the global gloo group). Sub-group cpu_groups have unreliable
+        TCP pairs for direct P2P.
+      * Collectives (all_reduce / barrier) → sglang's sub-group
+        cpu_groups (fine for collectives).
+    """
+
+    # P2P tags. World group is shared with sglang's own P2P, so we pick
+    # 4-byte tags that won't collide.
+    _TAG_SCATTER = int.from_bytes(b"FxSc", byteorder="big")
+    _TAG_PP = int.from_bytes(b"FxPP", byteorder="big")
+    _TAG_CP = int.from_bytes(b"FxCP", byteorder="big")
+    _TAG_TP = int.from_bytes(b"FxTP", byteorder="big")
+    _TAG_PP_AR_MIN = int.from_bytes(b"FxA2", byteorder="big")
+    _TAG_PP_BARRIER = int.from_bytes(b"FxB2", byteorder="big")
+    _TAG_PP_BARRIER_BCAST = int.from_bytes(b"FxB3", byteorder="big")
+    _TAG_AR_BCAST = int.from_bytes(b"FxAR", byteorder="big")
+
+    # Adaptive async-work reaper. gloo's isend Work objects do not auto-
+    # advance their "completed" state on poll, so a pure poll-based reaper
+    # leaks. We actively wait() the oldest works with a tiny timeout;
+    # the watermark grows on stuck reaps (slow / asymmetric peer) and
+    # shrinks back on clean reaps.
+    _REAP_HIGH_BASE = 1024
+    _REAP_HIGH_MAX = 32768
+    _REAP_MAX_DRAIN = 512
+    _REAP_PROBE = timedelta(milliseconds=1)
+    _REAP_LOG_EVERY = 64
+
+    def __init__(
+        self,
+        rank_info,
+        world_rank: int,
+        pp_group=None,
+        attn_tp_group=None,
+        attn_cp_group=None,
+        world_group=None,
+    ):
+        model_config = rank_info.model_config
+        self.world_rank = world_rank
+        self._world_group = world_group
+        self._async_works: List = []
+        self._reap_high: int = self._REAP_HIGH_BASE
+        self._reap_calls: int = 0
+        self._reap_stuck_total: int = 0
+        self._reap_drained_total: int = 0
+
+        # Accept either GroupCoordinator wrappers (has ``.cpu_group``) or
+        # raw ProcessGroups.
+        self.pp_cpu_group = (
+            getattr(pp_group, "cpu_group", pp_group) if pp_group is not None else None
+        )
+        self.attn_tp_cpu_group = (
+            getattr(attn_tp_group, "cpu_group", attn_tp_group)
+            if attn_tp_group is not None
+            else None
+        )
+        self.attn_cp_cpu_group = (
+            getattr(attn_cp_group, "cpu_group", attn_cp_group)
+            if attn_cp_group is not None
+            else None
+        )
+
+        self.pp_size = model_config.pp_size
+        self.attn_tp_size = model_config.attn_tp_size
+        self.attn_cp_size = model_config.attn_cp_size
+
+        self.pp_rank = rank_info.pp_rank
+        self.attn_tp_rank = rank_info.attn_tp_rank
+        self.attn_cp_rank = rank_info.attn_cp_rank
+
+        self.is_pp_stage_leader = self.attn_tp_rank == 0 and self.attn_cp_rank == 0
+        self.is_sync_leader = self.pp_rank == 0 and self.is_pp_stage_leader
+        self.is_pp_leader = self.pp_rank == 0 and self.is_pp_stage_leader
+        self.is_cp_leader = self.attn_cp_rank == 0
+        self.is_tp_leader = self.attn_tp_rank == 0
+
+        # P2P routing tables (computed once).
+        stride = self.attn_tp_size * self.attn_cp_size
+        self._pp_stage_leader_ranks = [s * stride for s in range(self.pp_size)]
+        pp_stage_offset = self.pp_rank * stride
+        self._cp_leader_ranks = (
+            [
+                pp_stage_offset + cp * self.attn_tp_size
+                for cp in range(self.attn_cp_size)
+            ]
+            if self.attn_cp_size > 1
+            else []
+        )
+        if self.attn_tp_size > 1:
+            if self.attn_tp_cpu_group is None:
+                raise RuntimeError(
+                    f"[FlexKV] attn_tp_size={self.attn_tp_size} > 1 but "
+                    f"attn_tp_cpu_group is None — TP CPU group is required "
+                    f"for scatter/collectives."
+                )
+            self._tp_group_ranks = [
+                dist.get_global_rank(self.attn_tp_cpu_group, i)
+                for i in range(self.attn_tp_cpu_group.size())
+            ]
+        else:
+            self._tp_group_ranks = []
+        self._pp_group_global_ranks = (
+            [
+                dist.get_global_rank(self.pp_cpu_group, i)
+                for i in range(self.pp_cpu_group.size())
+            ]
+            if self.pp_size > 1 and self.pp_cpu_group is not None
+            else []
+        )
+        self._pp_stage_member_ranks = list(
+            range(pp_stage_offset, pp_stage_offset + stride)
+        )
+
+        self.needs_sync = (
+            self.pp_size > 1 or self.attn_tp_size > 1 or self.attn_cp_size > 1
+        )
+
+        self._world_cpu_group = self._resolve_world_cpu_group()
+
+        self.pp_group = (
+            self.pp_cpu_group
+            if (self.pp_size > 1 and self.is_pp_stage_leader)
+            else None
+        )
+        self.is_pp_active = self.pp_size > 1
+        self.is_pp_sender = self.is_pp_leader
+        self.is_pp_receiver = self.is_pp_stage_leader and not self.is_pp_leader
+
+        self.is_cross_node_pp = self.pp_size > rank_info.pp_size_per_node
+        self.should_send_slot_mapping_to_remote = (
+            self.is_pp_receiver and self.is_cross_node_pp
+        )
+
+        logger.info(
+            "[FlexKV] Comm init: rank=%d, pp=%d/%d, tp=%d/%d, cp=%d/%d, "
+            "sync_leader=%s, stage_leader=%s, cross_node_pp=%s",
+            world_rank,
+            self.pp_rank,
+            self.pp_size,
+            self.attn_tp_rank,
+            self.attn_tp_size,
+            self.attn_cp_rank,
+            self.attn_cp_size,
+            self.is_sync_leader,
+            self.is_pp_stage_leader,
+            self.is_cross_node_pp,
+        )
+
+    # ------------------------------------------------------------------
+    # World CPU group resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_world_cpu_group(self):
+        """Return the world CPU group, preferring the injected ``world_group``.
+
+        When ``world_group`` is not injected by the caller (legacy sglang
+        path), fall back to sglang's ``get_world_group()`` via a delayed
+        import so this module does not require sglang at import time.
+        """
+        world_group = self._world_group
+        if world_group is None:
+            from sglang.srt.distributed.parallel_state import get_world_group
+
+            world_group = get_world_group()
+        return getattr(world_group, "cpu_group", world_group)
+
+    # ------------------------------------------------------------------
+    # Public collectives
+    # ------------------------------------------------------------------
+
+    def scatter(
+        self,
+        data: Any,
+        *,
+        channel: FlexKVScatterChannel,
+        blocking: bool = False,
+    ) -> Any:
+        """Hierarchical fan-out: sync_leader → PP stage leaders →
+        CP leaders → TP ranks. Returns the leader's payload on every rank.
+
+        Logical operations use distinct P2P tags. Scheduler ticks are not a
+        collective clock: for example, one CP rank can poll store completion
+        before another rank enters prefix lookup. Sharing one tag for both
+        operations lets the lookup receive a pending completion list instead
+        of its task-id dictionary.
+
+        ``blocking=False`` queues isends and reaps later — fine for the
+        hot path; ``True`` blocks until the leader's sends drain (used
+        on shutdown / barriers).
+        """
+        channel = self._normalize_scatter_channel(channel)
+        self._validate_scatter_payload(data, channel, source="local")
+        if self.pp_size > 1 and self.is_pp_stage_leader:
+            data = self._scatter_group(
+                data,
+                self._pp_stage_leader_ranks,
+                self.is_pp_leader,
+                self._scatter_tag(self._TAG_PP, channel),
+                blocking,
+            )
+        if self._cp_leader_ranks:
+            data = self._scatter_group(
+                data,
+                self._cp_leader_ranks,
+                self.is_cp_leader,
+                self._scatter_tag(self._TAG_CP, channel),
+                blocking,
+            )
+        if self._tp_group_ranks:
+            data = self._scatter_group(
+                data,
+                self._tp_group_ranks,
+                self.is_tp_leader,
+                self._scatter_tag(self._TAG_TP, channel),
+                blocking,
+            )
+        self._validate_scatter_payload(data, channel, source="received")
+        return data
+
+    @staticmethod
+    def _normalize_scatter_channel(channel: Any) -> FlexKVScatterChannel:
+        try:
+            return FlexKVScatterChannel(channel)
+        except (TypeError, ValueError) as exc:
+            valid = ", ".join(item.value for item in FlexKVScatterChannel)
+            raise ValueError(
+                f"Unknown FlexKV scatter channel {channel!r}; expected one of {valid}"
+            ) from exc
+
+    @staticmethod
+    def _scatter_tag(base_tag: int, channel: FlexKVScatterChannel) -> int:
+        return base_tag + _SCATTER_CHANNEL_OFFSETS[channel]
+
+    def _validate_scatter_payload(
+        self,
+        data: Any,
+        channel: FlexKVScatterChannel,
+        *,
+        source: str,
+    ) -> None:
+        expected_type = _SCATTER_CHANNEL_TYPES[channel]
+        if isinstance(data, expected_type):
+            return
+        raise TypeError(
+            "[FlexKV] scatter protocol mismatch: "
+            f"rank={self.world_rank} channel={channel.value} source={source} "
+            f"expected={expected_type.__name__} got={type(data).__name__}"
+        )
+
+    def scatter_pp(self, data: Any) -> Any:
+        """PP-only fan-out across PP stages (only stage leaders participate)."""
+        if not self._pp_group_global_ranks:
+            return data
+        is_leader = self._pp_group_global_ranks[0] == self.world_rank
+        return self._scatter_group(
+            data,
+            self._pp_group_global_ranks,
+            is_leader,
+            self._TAG_SCATTER,
+            blocking=False,
+        )
+
+    def all_reduce_min(self, value: int) -> int:
+        """Hierarchical all_reduce(MIN) across TP, CP, PP.
+
+        Used to align FlexKV block-count limits across all ranks that
+        will register GPU buffers (each rank computes the maximum it can
+        support, and we take the MIN to land on a value everyone can
+        honor).
+        """
+        tensor = torch.tensor(value, dtype=torch.int64)
+        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
+            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_tp_cpu_group)
+        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
+            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_cp_cpu_group)
+        if self.pp_size > 1 and self.is_pp_stage_leader:
+            self._pp_all_reduce_min_p2p(tensor)
+        if self.pp_size > 1:
+            self._bcast_to_stage_members(tensor, self._TAG_AR_BCAST)
+        return int(tensor.item())
+
+    def barrier(self) -> None:
+        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
+            dist.barrier(group=self.attn_tp_cpu_group)
+        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
+            dist.barrier(group=self.attn_cp_cpu_group)
+        if self.pp_size > 1 and self.is_pp_stage_leader:
+            self._pp_barrier_p2p()
+        if self.pp_size > 1:
+            dummy = torch.tensor([0], dtype=torch.int64)
+            self._bcast_to_stage_members(dummy, self._TAG_PP_BARRIER_BCAST)
+
+    # ------------------------------------------------------------------
+    # Internal scatter helper
+    # ------------------------------------------------------------------
+
+    def _scatter_group(
+        self,
+        data: Any,
+        group_ranks: List[int],
+        is_leader: bool,
+        tag: int,
+        blocking: bool = False,
+    ) -> Any:
+        if not group_ranks or self.world_rank not in group_ranks:
+            return data
+        if is_leader:
+            dsts = [r for r in group_ranks if r != self.world_rank]
+            works = []
+            for dst in dsts:
+                works.extend(self._isend(dst, data, tag, self._world_cpu_group))
+            if blocking:
+                for w in works:
+                    w.wait()
+            else:
+                self._reap_completed_async_works()
+                self._async_works.extend(works)
+            return data
+        return self._recv(group_ranks[0], tag, self._world_cpu_group)
+
+    def _reap_completed_async_works(self) -> None:
+        n = len(self._async_works)
+        if n <= self._reap_high:
+            return
+
+        drained = 0
+        stuck = False
+        for _ in range(self._REAP_MAX_DRAIN):
+            if not self._async_works:
+                break
+            w = self._async_works[0]
+            try:
+                w.wait(self._REAP_PROBE)
+            except RuntimeError:
+                stuck = True
+                break
+            self._async_works.pop(0)
+            drained += 1
+
+        self._reap_calls += 1
+        self._reap_drained_total += drained
+        if stuck:
+            self._reap_stuck_total += 1
+
+        prev_high = self._reap_high
+        if stuck:
+            self._reap_high = min(self._REAP_HIGH_MAX, self._reap_high * 2)
+        else:
+            self._reap_high = max(self._REAP_HIGH_BASE, self._reap_high // 2)
+        if self._reap_high != prev_high:
+            logger.debug(
+                "[FlexKV] reap watermark rank=%d %d->%d "
+                "(stuck=%s drained=%d backlog=%d)",
+                self.world_rank,
+                prev_high,
+                self._reap_high,
+                stuck,
+                drained,
+                n,
+            )
+        if self._reap_calls % self._REAP_LOG_EVERY == 0:
+            logger.debug(
+                "[FlexKV] reap stats rank=%d calls=%d drained=%d stuck=%d "
+                "backlog=%d high=%d",
+                self.world_rank,
+                self._reap_calls,
+                self._reap_drained_total,
+                self._reap_stuck_total,
+                len(self._async_works),
+                self._reap_high,
+            )
+
+    # ------------------------------------------------------------------
+    # Low-level send / recv on the world cpu group
+    # ------------------------------------------------------------------
+
+    def _isend(self, dst: int, data: Any, tag: int = 0, group=None) -> list:
+        serialized = bytearray(pickle.dumps(data))
+        t_size = torch.tensor([len(serialized)], dtype=torch.long)
+        t_data = torch.frombuffer(serialized, dtype=torch.uint8)
+        return [
+            dist.isend(t_size, dst=dst, tag=tag, group=group),
+            dist.isend(t_data, dst=dst, tag=tag, group=group),
+        ]
+
+    def _recv(self, src: int, tag: int = 0, group=None) -> Any:
+        t_size = torch.tensor([0], dtype=torch.long)
+        dist.irecv(t_size, src=src, tag=tag, group=group).wait()
+        size = int(t_size.item())
+        if size <= 0:
+            raise RuntimeError(
+                "[FlexKV] received invalid serialized payload size: "
+                f"rank={self.world_rank} src={src} tag={tag} size={size}"
+            )
+        t_data = torch.empty(size, dtype=torch.uint8)
+        dist.irecv(t_data, src=src, tag=tag, group=group).wait()
+        return pickle.loads(t_data.numpy().tobytes())
+
+    def _send_tensor(
+        self, tensor: torch.Tensor, dst: int, tag: int = 0, group=None
+    ) -> None:
+        dist.send(tensor, dst=dst, tag=tag, group=group)
+
+    def _recv_tensor(
+        self, tensor: torch.Tensor, src: int, tag: int = 0, group=None
+    ) -> None:
+        dist.recv(tensor, src=src, tag=tag, group=group)
+
+    def _bcast_to_stage_members(self, tensor: torch.Tensor, tag: int) -> None:
+        if not self.is_pp_stage_leader:
+            self._recv_tensor(
+                tensor,
+                src=self._pp_stage_leader_ranks[self.pp_rank],
+                tag=tag,
+                group=self._world_cpu_group,
+            )
+            return
+        for rank in self._pp_stage_member_ranks:
+            if rank != self.world_rank:
+                self._send_tensor(
+                    tensor, dst=rank, tag=tag, group=self._world_cpu_group
+                )
+
+    def _pp_all_reduce_min_p2p(self, tensor: torch.Tensor) -> None:
+        leader_rank = self._pp_stage_leader_ranks[0]
+        other_leaders = self._pp_stage_leader_ranks[1:]
+        tag = self._TAG_PP_AR_MIN
+        if self.world_rank == leader_rank:
+            result = int(tensor.item())
+            for src in other_leaders:
+                other = torch.tensor(0, dtype=torch.int64)
+                self._recv_tensor(other, src=src, tag=tag, group=self._world_cpu_group)
+                result = min(result, int(other.item()))
+            tensor.fill_(result)
+            for dst in other_leaders:
+                self._send_tensor(tensor, dst=dst, tag=tag, group=self._world_cpu_group)
+        else:
+            self._send_tensor(
+                tensor, dst=leader_rank, tag=tag, group=self._world_cpu_group
+            )
+            self._recv_tensor(
+                tensor, src=leader_rank, tag=tag, group=self._world_cpu_group
+            )
+
+    def _pp_barrier_p2p(self) -> None:
+        leader_rank = self._pp_stage_leader_ranks[0]
+        other_leaders = self._pp_stage_leader_ranks[1:]
+        tag = self._TAG_PP_BARRIER
+        dummy = torch.tensor([1], dtype=torch.int64)
+        if self.world_rank == leader_rank:
+            for src in other_leaders:
+                self._recv_tensor(dummy, src=src, tag=tag, group=self._world_cpu_group)
+            for dst in other_leaders:
+                self._send_tensor(dummy, dst=dst, tag=tag, group=self._world_cpu_group)
+        else:
+            self._send_tensor(
+                dummy, dst=leader_rank, tag=tag, group=self._world_cpu_group
+            )
+            self._recv_tensor(
+                dummy, src=leader_rank, tag=tag, group=self._world_cpu_group
+            )
+
+
+# ----------------------------------------------------------------------
+# libc / eventfd / SCM_RIGHTS shims for the layerwise UDS handshake
+# ----------------------------------------------------------------------
+
+_libc = ctypes.CDLL("libc.so.6", use_errno=True)
+_libc.eventfd.argtypes = [ctypes.c_uint, ctypes.c_int]
+_libc.eventfd.restype = ctypes.c_int
+_libc.read.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+_libc.read.restype = ctypes.c_ssize_t
+_libc.write.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+_libc.write.restype = ctypes.c_ssize_t
+
+EFD_SEMAPHORE = 0x1
+EFD_NONBLOCK = 0x800
+
+
+def eventfd(initval: int = 0, flags: int = 0) -> int:
+    fd = _libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
+    if fd == -1:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return fd
+
+
+def eventfd_write(fd: int, val: int) -> None:
+    v = ctypes.c_uint64(val)
+    n = _libc.write(fd, ctypes.byref(v), ctypes.sizeof(v))
+    if n != ctypes.sizeof(v):
+        err = ctypes.get_errno()
+        raise OSError(err, f"eventfd write failed: {os.strerror(err)}")
+
+
+def eventfd_read(fd: int) -> int:
+    v = ctypes.c_uint64()
+    n = _libc.read(fd, ctypes.byref(v), ctypes.sizeof(v))
+    if n != ctypes.sizeof(v):
+        err = ctypes.get_errno()
+        if err == errno.EAGAIN:
+            return 0
+        raise OSError(err, f"eventfd read failed: {os.strerror(err)}")
+    return v.value
+
+
+def send_fds(sock: socket.socket, fds: list, extra_data: bytes = b"x") -> None:
+    """SCM_RIGHTS-send a list of file descriptors over a UDS socket."""
+    fds_packed = struct.pack(f"{len(fds)}i", *fds)
+    ancdata = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds_packed)]
+    sock.sendmsg([extra_data], ancdata)
+
+
+# ----------------------------------------------------------------------
+# Layerwise transfer signaling (eventfd-backed)
+# ----------------------------------------------------------------------
+
+
+class FlexKVLayerLoadingEvent:
+    """One per producer slot. Holds ``num_layers`` semaphore eventfds —
+    the FlexKV layerwise worker writes 1 to each as the corresponding
+    layer's H2D copy completes; the consumer (sglang's
+    ``register_layer_transfer_counter`` hook) reads to wait for them."""
+
+    def __init__(self, num_layers: int):
+        self._num_layers = num_layers
+        # Semaphore mode so each read consumes exactly one signal. NONBLOCK
+        # lets ``reset_for_new_transfer`` drain leftover counter values
+        # without blocking; ``wait`` re-arms the fd to blocking before
+        # reading so consumers still get the desired blocking semantics.
+        self.load_event_fds: List[int] = [
+            eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK) for _ in range(num_layers)
+        ]
+        self._finished = True
+        self._wait_started = False
+        self.wait_remaining: List[int] = [0] * num_layers
+
+    def _drain(self) -> None:
+        """Consume all pending eventfd signals without blocking."""
+        import os
+
+        for fd in self.load_event_fds:
+            while True:
+                try:
+                    if not os.read(fd, 8):
+                        break
+                except BlockingIOError:
+                    break
+                except OSError:
+                    break
+
+    def reset_for_new_transfer(self) -> None:
+        """Drain any leftover signals from prior transfers, then arm.
+
+        Without this drain, a previous transfer that wrote N eventfd
+        signals but only had N-K reads (e.g. because the attention
+        backend skipped a layer's ``get_key_buffer`` call) leaves K
+        pending. The next transfer's first ``wait(layer)`` returns
+        immediately reading one of those stale signals, even though
+        the FlexKV worker hasn't actually finished that layer's H2D
+        yet — and forward proceeds with wrong KV data.
+        """
+        self._drain()
+        self._finished = False
+        self._wait_started = False
+        self.wait_remaining = [0] * self._num_layers
+
+    def add_transfer(self) -> None:
+        """Add one load to the current prefill batch.
+
+        Several requests may restore into the same SGLang prefill batch. They
+        share one eventfd set, and the layer hook consumes one signal per load
+        before allowing that layer's forward to proceed.
+        """
+        if self._finished or self._wait_started:
+            raise RuntimeError("Cannot add a transfer after layer waits have started")
+        for layer_index in range(self._num_layers):
+            self.wait_remaining[layer_index] += 1
+
+    def mark_reusable(self) -> None:
+        """Return this slot to the producer ring after transfer quiescence.
+
+        The caller must first ensure that the FlexKV worker can no longer write
+        to this event set. This method is used by the connector's flush path
+        after it has completely waited for every launched layerwise task.
+        """
+        self._drain()
+        self._finished = True
+        self._wait_started = False
+        self.wait_remaining = [0] * self._num_layers
+
+    def pending_transfers(self) -> int:
+        """Return the number of signals still expected for every layer."""
+        if self._wait_started:
+            raise RuntimeError("Layer waits have already started")
+        counts = set(self.wait_remaining)
+        if len(counts) != 1:
+            raise RuntimeError(
+                "Layerwise event has inconsistent per-layer transfer counts"
+            )
+        return self.wait_remaining[0]
+
+    def remove_transfer(self) -> None:
+        """Undo one pre-launch ``add_transfer`` during coordinated rollback."""
+        if self._wait_started:
+            raise RuntimeError(
+                "Cannot remove a transfer after layer waits have started"
+            )
+        if self.pending_transfers() <= 0:
+            raise RuntimeError("Layerwise event has no transfer to remove")
+        self.wait_remaining = [count - 1 for count in self.wait_remaining]
+
+    def wait(
+        self,
+        layer_index: int,
+        count: int = 1,
+        timeout_s: Optional[float] = None,
+    ) -> None:
+        """Block until the FlexKV worker signals layer ``layer_index``.
+
+        The fd was created with EFD_NONBLOCK so reset can drain it. We
+        re-introduce the blocking semantics with ``select.select`` on a
+        NONBLOCK fd: the read after select is guaranteed to consume one
+        signal.
+        """
+        import os
+        import select
+
+        assert 0 <= layer_index < self._num_layers
+        assert count > 0
+        self._wait_started = True
+        fd = self.load_event_fds[layer_index]
+        deadline = time.monotonic() + timeout_s if timeout_s is not None else None
+        for _ in range(count):
+            while True:
+                timeout = None
+                if deadline is not None:
+                    timeout = max(0.0, deadline - time.monotonic())
+                readable, _, _ = select.select([fd], [], [], timeout)
+                if not readable:
+                    raise TimeoutError(
+                        "Timed out waiting for a FlexKV layerwise eventfd signal"
+                    )
+                try:
+                    buf = os.read(fd, 8)
+                    if buf:
+                        break
+                except BlockingIOError:
+                    # Spurious wakeup; loop and re-select.
+                    continue
+        if layer_index == self._num_layers - 1:
+            self._finished = True
+
+    def close(self) -> None:
+        for fd in self.load_event_fds:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+        self.load_event_fds.clear()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class FlexKVLayerDoneCounter:
+    """Triple-buffered slot-based layerwise counter.
+
+    The KV pool calls ``wait_until(layer_id)`` once per layer during forward.
+    All restores collected while SGLang builds one prefill batch share a
+    producer slot. The layer hook consumes one eventfd signal per restore for
+    each layer. Producer rotation therefore happens per prefill batch, not per
+    request, and the fixed-size ring remains sufficient for large batches.
+    """
+
+    def __init__(self, num_layers: int, num_counters: int = 3, world_rank: int = -1):
+        self.num_layers = num_layers
+        self.num_counters = num_counters
+        self.world_rank = world_rank
+        timeout_raw = os.environ.get("FLEXKV_LAYERWISE_WAIT_TIMEOUT_S", "240")
+        try:
+            timeout_s = float(timeout_raw)
+        except ValueError:
+            logger.warning(
+                "[FlexKV] Invalid FLEXKV_LAYERWISE_WAIT_TIMEOUT_S=%r; using 240s",
+                timeout_raw,
+            )
+            timeout_s = 240.0
+        self.wait_timeout_s: Optional[float] = timeout_s if timeout_s > 0 else None
+        self.events: List[FlexKVLayerLoadingEvent] = [
+            FlexKVLayerLoadingEvent(num_layers) for _ in range(num_counters)
+        ]
+        self.producer_index = -1
+        self.consumer_index = -1
+        self._task_to_producer: Dict[int, int] = {}
+        self._consumer_task_ids: List[int] = []
+
+    def register_task(self, task_id: int, producer_id: int) -> None:
+        if task_id in self._task_to_producer:
+            raise RuntimeError(f"Task {task_id} is already registered")
+        self._task_to_producer[task_id] = producer_id
+
+    def expected_transfer_count(
+        self, counter_id: int, *, allow_unclaimed_active: bool = False
+    ) -> int:
+        """Validate a counter selection without mutating local state.
+
+        The sync leader may have just armed a fresh producer event, while
+        followers only accept either their current open batch or a reusable
+        event.  Returning the next signal count lets the connector detect
+        rank-skewed batch boundaries before launching FlexKV.
+        """
+        if not 0 <= counter_id < self.num_counters:
+            raise ValueError(
+                f"Invalid counter_id={counter_id}, must be in [0, {self.num_counters})"
+            )
+        event = self.events[counter_id]
+        if self.consumer_index == counter_id:
+            if event._finished:
+                raise RuntimeError(
+                    f"Counter {counter_id} is marked finished but is still the consumer"
+                )
+            if event._wait_started:
+                raise RuntimeError(
+                    f"Counter {counter_id} has already started layer waits"
+                )
+            return event.pending_transfers() + 1
+
+        if self.consumer_index >= 0:
+            raise RuntimeError(
+                f"Counter {self.consumer_index} is still the active consumer; "
+                f"cannot select counter {counter_id}"
+            )
+
+        if event._finished:
+            return 1
+
+        if event._wait_started:
+            raise RuntimeError(f"Counter {counter_id} has already started layer waits")
+
+        if allow_unclaimed_active and self.producer_index == counter_id:
+            pending = event.pending_transfers()
+            if pending != 0:
+                raise RuntimeError(
+                    f"Unclaimed counter {counter_id} unexpectedly has {pending} transfers"
+                )
+            return 1
+
+        raise RuntimeError(f"Counter {counter_id} is still active on a previous batch")
+
+    def register_task_with_explicit_counter_id(
+        self, task_id: int, counter_id: int
+    ) -> None:
+        self.expected_transfer_count(counter_id)
+        if task_id in self._task_to_producer:
+            raise RuntimeError(f"Task {task_id} is already registered")
+        event = self.events[counter_id]
+        if event._finished:
+            event.reset_for_new_transfer()
+        self._task_to_producer[task_id] = counter_id
+
+    def update_producer(self) -> int:
+        if self.consumer_index >= 0:
+            event = self.events[self.consumer_index]
+            if not event._finished and not event._wait_started:
+                return self.consumer_index
+
+        self.producer_index = (self.producer_index + 1) % self.num_counters
+        assert self.events[
+            self.producer_index
+        ]._finished, "Producer event should be finished before reuse"
+        self.events[self.producer_index].reset_for_new_transfer()
+        return self.producer_index
+
+    def set_consumer(self, task_id: int) -> None:
+        if task_id < 0:
+            return
+        producer_id = self._task_to_producer.pop(task_id, None)
+        if producer_id is None:
+            return
+        if self.consumer_index < 0:
+            self.consumer_index = producer_id
+        elif self.consumer_index != producer_id:
+            raise RuntimeError(
+                "FlexKV restores from different producer slots cannot share "
+                "one prefill batch"
+            )
+        self.events[producer_id].add_transfer()
+        self._consumer_task_ids.append(task_id)
+
+    def rollback_prepared_transfer(
+        self, task_id: int, producer_id: int, *, transfer_added: bool
+    ) -> None:
+        """Undo local counter state when an all-rank preflight fails."""
+        if not 0 <= producer_id < self.num_counters:
+            raise ValueError(
+                f"Invalid producer_id={producer_id}, must be in "
+                f"[0, {self.num_counters})"
+            )
+        self._task_to_producer.pop(task_id, None)
+        event = self.events[producer_id]
+        if transfer_added:
+            event.remove_transfer()
+            try:
+                self._consumer_task_ids.remove(task_id)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Task {task_id} is missing from the active consumer batch"
+                ) from exc
+
+        if not event._wait_started and event.pending_transfers() == 0:
+            if self.consumer_index == producer_id:
+                self.consumer_index = -1
+            event.mark_reusable()
+
+    def abort_unregistered_selection(self, producer_id: int) -> None:
+        """Release a freshly selected leader counter before registration."""
+        if not 0 <= producer_id < self.num_counters:
+            raise ValueError(
+                f"Invalid producer_id={producer_id}, must be in "
+                f"[0, {self.num_counters})"
+            )
+        event = self.events[producer_id]
+        if self.consumer_index == producer_id or event._wait_started:
+            raise RuntimeError(f"Counter {producer_id} is already being consumed")
+        if event.pending_transfers() != 0:
+            raise RuntimeError(
+                f"Counter {producer_id} already has registered transfers"
+            )
+        event.mark_reusable()
+
+    def wait_until(self, threshold: int) -> None:
+        if self.consumer_index < 0:
+            return
+        event = self.events[self.consumer_index]
+        wait_count = event.wait_remaining[threshold]
+        if wait_count <= 0:
+            return
+        event.wait_remaining[threshold] = 0
+        try:
+            event.wait(
+                threshold,
+                wait_count,
+                timeout_s=getattr(self, "wait_timeout_s", None),
+            )
+        except TimeoutError as exc:
+            task_ids = list(getattr(self, "_consumer_task_ids", []))
+            rank = getattr(self, "world_rank", -1)
+            timeout_s = getattr(self, "wait_timeout_s", None)
+            logger.error(
+                "[ERROR][FlexKV-SGLang] operation=load act=wait "
+                "status=timeout direction=H2D flexkv_task_ids=%s "
+                "mode=layerwise rank=%d counter_id=%d layer=%d "
+                "wait_count=%d timeout=%s",
+                task_ids,
+                rank,
+                self.consumer_index,
+                threshold,
+                wait_count,
+                "-" if timeout_s is None else f"{timeout_s}s",
+            )
+            raise TimeoutError(
+                "FlexKV layerwise wait timed out: "
+                f"rank={rank}, task_ids={task_ids}, counter_id={self.consumer_index}, "
+                f"layer={threshold}, wait_count={wait_count}"
+            ) from exc
+        if threshold == self.num_layers - 1:
+            self.consumer_index = -1
+            self._consumer_task_ids.clear()
+
+    def reset(self) -> None:
+        # FlexKVConnector.reset() completely waits for every launched transfer
+        # before calling this method, so no worker can signal these eventfds
+        # after they are drained and returned to the producer ring.
+        for event in self.events:
+            event.mark_reusable()
+        self.producer_index = -1
+        self.consumer_index = -1
+        self._task_to_producer.clear()
+        self._consumer_task_ids.clear()
+
+    def __del__(self) -> None:
+        try:
+            for event in self.events:
+                event.close()
+            self.events.clear()
+        except Exception:
+            pass

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -1,0 +1,2209 @@
+"""Wrapper around FlexKV ``KVManager`` for sglang.
+
+The public surface is small (see "Public API" below). The class owns:
+
+* the FlexKV ``KVManager`` (server-client mode when ``dp_size > 1`` or
+  multi-instance; in-process otherwise — handled by FlexKV itself);
+* the per-rank ``KVTPClient`` that registers this rank's GPU KV cache
+  with the FlexKV TransferManager;
+* an optional ``FlexKVLayerDoneCounter`` plus the UDS-side handshake
+  that wires its eventfds into the FlexKV layerwise transfer worker.
+
+Cross-rank sync uses :class:`FlexKVComm`. Only the **sync leader**
+(rank 0 of every PP × CP × TP axis) talks to ``KVManager``; other
+ranks block on broadcast / barrier.
+
+Modes:
+  * **MP / synchronous** (default): ``retrieve_kv`` fires ``launch``
+    and blocks on ``wait`` so the device slots are ready by the time
+    sglang's prefill runs.
+  * **Layerwise** (``FLEXKV_ENABLE_LAYERWISE_TRANSFER=1``): ``launch``
+    is fired with ``layerwise_transfer=True`` and the per-layer hook
+    registered via ``register_layer_transfer_counter`` blocks each
+    forward layer on its own eventfd.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import signal
+import socket
+import struct
+import time
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from flexkv.integration.sglang.comm import (
+    CMD_LAYERWISE,
+    CMD_PUT_META,
+    CMD_STORE_COMPLETE,
+    FlexKVComm,
+    FlexKVLayerDoneCounter,
+    FlexKVScatterChannel,
+    send_fds,
+)
+
+from flexkv.common.config import (
+    GLOBAL_CONFIG_FROM_ENV,
+    LayerGroupSpec,
+    recompute_cache_block_counts,
+)
+from flexkv.common.request import KVResponseStatus
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.integration.config import FlexKVConfig
+from flexkv.kvmanager import KVManager
+from flexkv.server.client import KVTPClient
+from flexkv.transfer.layerwise import build_layerwise_eventfd_socket_path
+from flexkv.transfer_manager import TransferManagerOnRemote
+
+logger = logging.getLogger(__name__)
+
+_SGLANG_REQ_ID_UNSET = object()
+_INFO_STATUSES = {"hit", "miss", "skipped", "success"}
+_WARNING_STATUSES = {"cancelled", "failed", "missing", "not_found", "timeout"}
+
+
+@dataclass
+class _CacheOpContext:
+    operation: str
+    sglang_req_id: Optional[str]
+    start_ns: int
+    task_id: int = -1
+
+
+def _status_value(response: Any) -> str:
+    status = getattr(response, "status", None)
+    value = getattr(status, "value", status)
+    return str(value).lower() if value is not None else "missing"
+
+
+def _is_terminal_status(status: str) -> bool:
+    return status in {"success", "failed", "cancelled", "not_found"}
+
+
+class FlexKVHostReleaseShim:
+    """HiCache-compatible host-release hook for ``release_host_resources``.
+
+    Scheduler already does::
+
+        host_pool = getattr(tree_cache, "token_to_kv_pool_host", None)
+        if host_pool is not None:
+            host_pool.destroy()
+
+    FlexKV has no local pinned HostKVCache; ``destroy()`` forwards to
+    ``FlexKVConnector.shutdown()`` so unpin stays on that same path.
+    """
+
+    def __init__(self, connector: "FlexKVConnector") -> None:
+        self._connector = connector
+
+    def destroy(self) -> None:
+        print(
+            f"[FLEXKV] HostReleaseShim.destroy begin {self._connector._label}",
+            flush=True,
+        )
+        self._connector.shutdown()
+        print(
+            f"[FLEXKV] HostReleaseShim.destroy done {self._connector._label}",
+            flush=True,
+        )
+
+
+class FlexKVConnector:
+    """A FlexKV-side façade used by :class:`FlexKVRadixCache`.
+
+    This class manages connection lifecycle and provides a small,
+    sgl-friendly contract over FlexKV's task-based API:
+
+      * ``lookup_kv`` — page-aligned hit count + a held task id.
+      * ``retrieve_kv`` — synchronous load (launch + wait).
+      * ``start_load_kv_layerwise`` — layerwise async load.
+      * ``store_kv`` — page-aligned write back.
+      * ``check_completed_stores`` — drain async store completions.
+      * ``prefetch_async`` / ``check_prefetch_progress`` /
+        ``pop_prefetch_loaded_tokens`` / ``cancel_prefetch`` —
+        opportunistic SSD/Remote → CPU staging (wired from the scheduler
+        when ``--enable-flexkv`` is set).
+      * ``release_pending`` — cancel a held task whose load won't run.
+      * ``reset`` / ``shutdown``.
+    """
+
+    def __init__(
+        self,
+        *,
+        sgl_model_config: Any,
+        server_args: Any,
+        page_size: int,
+        kvcache: Any,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        pp_rank: int,
+        attn_cp_rank: int,
+        pp_group: Any = None,
+        attn_tp_group: Any = None,
+        attn_cp_group: Any = None,
+    ) -> None:
+        self.page_size = int(page_size)
+
+        # 1. Resolve FlexKV config from env + sglang server args.
+        self.flexkv_config = FlexKVConfig.from_env()
+        self.rank_info = self.flexkv_config.post_init_from_sglang_config(
+            sglang_config=sgl_model_config,
+            server_args=server_args,
+            page_size=self.page_size,
+            tp_rank=tp_rank,
+            pp_rank=pp_rank,
+            dp_rank=dp_rank if dp_rank is not None else 0,
+            attn_cp_rank=attn_cp_rank,
+        )
+        self.model_config = self.flexkv_config.model_config
+        self.cache_config = self.flexkv_config.cache_config
+        self._label = f"[model_config={self.model_config}, rank_info={self.rank_info}]"
+
+        # 2. Cross-rank sync context.
+        world_rank = (
+            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        )
+        self._sync_ctx = FlexKVComm(
+            rank_info=self.rank_info,
+            world_rank=world_rank,
+            pp_group=pp_group,
+            attn_tp_group=attn_tp_group,
+            attn_cp_group=attn_cp_group,
+        )
+        # Master switch: FLEXKV_ENABLE_COLLECTIVE_SYNC=0 disables all
+        # cross-rank scatter/barrier/all_reduce. Every rank then acts
+        # independently (TP-only deployments that share one FlexKV
+        # instance per rank do not need collective sync).
+        if not GLOBAL_CONFIG_FROM_ENV.enable_collective_sync:
+            self._sync_ctx.needs_sync = False
+            logger.info(
+                "[FlexKV] Collective sync disabled "
+                "(FLEXKV_ENABLE_COLLECTIVE_SYNC=0): "
+                "scatter/barrier/all_reduce are skipped."
+            )
+
+        # 3. Align block counts across all ranks (MIN reduce) so each
+        # rank's KVManager registers compatible sizes.
+        for attr in ("num_cpu_blocks", "num_ssd_blocks", "num_remote_blocks"):
+            orig = getattr(self.cache_config, attr, None)
+            if orig is None or orig <= 0:
+                continue
+            aligned = self._sync_ctx.all_reduce_min(int(orig))
+            if aligned != orig:
+                logger.info(
+                    "[FlexKV] Block count MIN alignment '%s': %d -> %d",
+                    attr,
+                    orig,
+                    aligned,
+                )
+            setattr(self.cache_config, attr, aligned)
+
+        # 4. Extract GPU buffers. DeepSeek V4 uses heterogeneous compressed
+        # pools and is registered through FlexKV's multi-group API; regular
+        # MLA/MHA models keep the single-layout path.
+        self._kvcache = kvcache
+        self._swa_kv_pool = getattr(kvcache, "swa_kv_pool", None)
+        self._is_dsv4 = hasattr(kvcache, "c4_kv_pool")
+        self._dsv4_layer_groups: List[Dict[str, Any]] = []
+        self._dsv4_state_groups: List[Dict[str, Any]] = []
+        kv_caches, indexer_buffers = self._resolve_kv_buffers(kvcache)
+
+        # Heterogeneous groups change the bytes represented by one logical
+        # FlexKV block. Recompute CPU/SSD capacities before KVManager starts.
+        self._apply_layer_groups_for_cache_sizing(kv_caches, indexer_buffers)
+        self._label = f"[model_config={self.model_config}, rank_info={self.rank_info}]"
+
+        # 5. On multi-node setups, every node beyond node 0 needs a
+        # TransferManagerOnRemote process (FlexKV side) before any rank
+        # on that node can register GPU buffers.
+        self._remote_process = None
+        if (
+            self.model_config.nnodes > 1
+            and self.rank_info.node_rank > 0
+            and self.rank_info.local_rank == 0
+        ):
+            self._remote_process = TransferManagerOnRemote.create_process(
+                master_host=self.model_config.master_host,
+                master_ports=self.model_config.master_ports,
+            )
+            logger.info(
+                "[FlexKV] Launched TransferManagerOnRemote on node_rank=%d %s",
+                self.rank_info.node_rank,
+                self._label,
+            )
+
+        # 6. Bring up KVManager on the sync leader only.
+        self.kv_manager: Optional[KVManager] = None
+        if self._sync_ctx.is_sync_leader:
+            self.kv_manager = KVManager(
+                model_config=self.model_config,
+                cache_config=self.cache_config,
+                dp_client_id=self.rank_info.dp_client_id,
+                server_recv_port=self.flexkv_config.server_recv_port,
+                gpu_register_port=self.flexkv_config.gpu_register_port,
+            )
+            self.kv_manager.start()
+
+        # 7. Per-rank TP client registers this rank's GPU buffers.
+        self.tp_client = KVTPClient(
+            self.flexkv_config.gpu_register_port,
+            dp_client_id=self.rank_info.dp_client_id,
+            pp_rank=self.rank_info.pp_rank,
+            device_id=self.rank_info.local_rank,
+        )
+        self._register_with_retry(kv_caches, indexer_buffers)
+
+        # 8. Layerwise transfer plumbing.
+        self.enable_layerwise = bool(
+            int(os.environ.get("FLEXKV_ENABLE_LAYERWISE_TRANSFER", "0"))
+        )
+        self._layerwise_socket = build_layerwise_eventfd_socket_path(
+            dp_client_id=self.rank_info.dp_client_id,
+            pp_rank=self.rank_info.pp_rank,
+            model_config=self.model_config,
+        )
+        self._layerwise_eventfd_connect_max_retries = max(
+            360,
+            int(os.environ.get("FLEXKV_LAYERWISE_EVENTFD_CONNECT_MAX_RETRIES", "0")),
+        )
+        self.layer_done_counter: Optional[FlexKVLayerDoneCounter] = None
+        if self.enable_layerwise:
+            self.layer_done_counter = FlexKVLayerDoneCounter(
+                self.rank_info.num_layers_per_pp_stage,
+                world_rank=world_rank,
+            )
+            self._send_eventfds_to_worker()
+        self._layerwise_generation = 0
+
+        # 9. Wait for the KVManager (and its remote subprocess) to be ready.
+        if self._sync_ctx.is_sync_leader:
+            self._wait_kv_manager_ready()
+
+        # 10. Per-rank in-flight tracking.
+        # Loads
+        self._pending_lookups: Dict[str, int] = {}  # rid -> fkv_task_id
+        self._pending_lookup_contexts: Dict[str, _CacheOpContext] = {}
+        self._inflight_loads: Dict[int, int] = {}  # producer_id -> rid hashlike
+        self._completed_layerwise: List[int] = []
+        self._launched_load_tids: List[int] = []  # leader-only, for periodic drain
+        self._launched_load_contexts: Dict[int, _CacheOpContext] = {}
+        # Stores
+        self._inflight_stores: Dict[str, int] = {}  # rid -> fkv_task_id
+        self._inflight_store_contexts: Dict[str, _CacheOpContext] = {}
+        # Prefetches
+        self._ongoing_prefetches: Dict[str, int] = {}  # rid -> fkv_task_id
+        self._prefetch_contexts: Dict[str, _CacheOpContext] = {}
+        self._prefetch_enabled = bool(
+            self.cache_config.enable_ssd
+            or self.cache_config.enable_remote
+            or self.cache_config.enable_kv_sharing
+        )
+        self._shutdown_done = False
+
+        # Keep FlexKV lifecycle self-contained (avoid scattering hooks in
+        # scheduler / tokenizer / http_server):
+        #   * Ignore process-group Ctrl+C so this scheduler process stays
+        #     alive until ShutdownReq → process exit → atexit unpin.
+        #   * atexit runs kv_manager.shutdown() (cudaHostUnregister).
+        #   * Stretch the parent's scheduler-exit wait so kill_process_tree
+        #     does not SIGKILL mid-unpin (generic env, not FlexKV-named in TM).
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except Exception:  # noqa: BLE001
+            pass
+        # Graceful shutdown timeout hierarchy (see FlexKV config.py):
+        #   tokenizer wait (this env)                   = 1200s
+        #     > TM parent-side wait (FLEXKV_TRANSFER_MANAGER_SHUTDOWN_TIMEOUT_S) = 900s
+        #       > per-worker wait   (FLEXKV_WORKER_SHUTDOWN_TIMEOUT_S)           = 600s
+        # If you tune one, keep the ordering: worker < TM < scheduler-wait.
+        # This must be >= FLEXKV_TRANSFER_MANAGER_SHUTDOWN_TIMEOUT_S + buffer,
+        # otherwise tokenizer's kill_process_tree fires mid-unpin.
+        os.environ.setdefault("SGLANG_SCHEDULER_SHUTDOWN_WAIT_S", "1200")
+        # Compat with older server.sh / docs.
+        os.environ.setdefault(
+            "SGLANG_FLEXKV_SHUTDOWN_WAIT_S",
+            os.environ["SGLANG_SCHEDULER_SHUTDOWN_WAIT_S"],
+        )
+        atexit.register(self.shutdown)
+
+        logger.info(
+            "[FlexKV] Connector ready %s: layerwise=%s, prefetch=%s",
+            self._label,
+            self.enable_layerwise,
+            self._prefetch_enabled,
+        )
+
+    def _new_op_context(
+        self,
+        operation: str,
+        tracking_key: Optional[str],
+        sglang_req_id: Any = _SGLANG_REQ_ID_UNSET,
+        task_id: int = -1,
+    ) -> _CacheOpContext:
+        if sglang_req_id is _SGLANG_REQ_ID_UNSET:
+            sglang_req_id = tracking_key
+        return _CacheOpContext(
+            operation=operation,
+            sglang_req_id=sglang_req_id,
+            start_ns=time.perf_counter_ns(),
+            task_id=task_id,
+        )
+
+    def _pop_context(
+        self,
+        attr: str,
+        key: Any,
+        operation: str,
+        task_id: int,
+    ) -> _CacheOpContext:
+        context = getattr(self, attr, {}).pop(key, None)
+        if context is None:
+            context = self._new_op_context(operation, str(key), task_id=task_id)
+        context.operation = operation
+        context.task_id = task_id
+        return context
+
+    def _log_cache_op(
+        self,
+        context: _CacheOpContext,
+        action: str,
+        status: str,
+        *,
+        task_id: Optional[int] = None,
+        start_ns: Optional[int] = None,
+        **fields: Any,
+    ) -> None:
+        if not self._sync_ctx.is_sync_leader:
+            return
+        if status in _WARNING_STATUSES:
+            level = logging.WARNING
+        elif action == "launch" or status in _INFO_STATUSES:
+            level = logging.INFO
+        else:
+            level = logging.DEBUG
+        if not logger.isEnabledFor(level):
+            return
+
+        if start_ns is None and action == "complete":
+            start_ns = context.start_ns
+        elapsed_s = (
+            (time.perf_counter_ns() - start_ns) / 1e9 if start_ns is not None else None
+        )
+
+        values = [
+            ("operation", context.operation),
+            ("act", action),
+            ("status", status),
+        ]
+        for name in ("direction", "blocks", "op_id", "graph_id"):
+            if name in fields:
+                values.append((name, fields.pop(name)))
+        values.extend(
+            [
+                ("sglang_req_id", context.sglang_req_id),
+                (
+                    "flexkv_task_id",
+                    context.task_id if task_id is None else task_id,
+                ),
+            ]
+        )
+        for name in (
+            "child_task_ids",
+            "flexkv_batch_task_id",
+            "flexkv_batch_task_ids",
+            "flexkv_task_ids",
+        ):
+            if name in fields:
+                values.append((name, fields.pop(name)))
+        if "transfer_mode" in fields:
+            values.append(("mode", fields.pop("transfer_mode")))
+        error = fields.pop("error", None)
+        values.extend((name, value) for name, value in fields.items())
+        if elapsed_s is not None:
+            values.append((f"{context.operation}_time", elapsed_s))
+        if error is not None:
+            values.append(("error", error))
+
+        formatted = []
+        for name, value in values:
+            if value is None:
+                continue
+            if name in {"sglang_req_id", "error"}:
+                value = json.dumps(str(value), ensure_ascii=True)
+            elif isinstance(value, bool):
+                value = str(value).lower()
+            elif name.endswith("_time"):
+                value = f"{value:.4f}s"
+            elif isinstance(value, float):
+                value = f"{value:.3f}"
+            elif isinstance(value, (list, tuple)):
+                value = ",".join(str(item) for item in value) or "-"
+            formatted.append(f"{name}={value}")
+
+        logger.log(
+            level,
+            "[%s][FlexKV-SGLang] %s",
+            logging.getLevelName(level),
+            " ".join(formatted),
+        )
+
+    # ------------------------------------------------------------------
+    # Public API — lookup / load
+    # ------------------------------------------------------------------
+
+    def lookup_kv(
+        self,
+        token_ids: List[int],
+        token_mask: torch.Tensor,
+        rid: Optional[str] = None,
+        sglang_req_id: Any = _SGLANG_REQ_ID_UNSET,
+    ) -> Tuple[int, int]:
+        """Page-aligned prefix lookup against FlexKV.
+
+        Args:
+          token_ids: full token id sequence we'd like to check.
+          token_mask: 1-D bool tensor or array, True for "this token is
+            *not* already on GPU and is a candidate for load-back".
+          rid: if set and hit > 0, the held FlexKV task id is stashed
+            under this key so a later ``retrieve_kv(rid, slots)`` call
+            can resolve it. If not set, the held task is cancelled when
+            hit > 0 and the caller didn't ask to track it.
+          sglang_req_id: business request ID used only for logs. This can be
+            ``None`` when ``rid`` is an internal tracking key.
+
+        Returns:
+          ``(fkv_task_id, hit_count)``. ``hit_count`` is page-aligned
+          and may be smaller than the raw FlexKV match if the page
+          floor truncated it.
+        """
+        context = self._new_op_context("lookup", rid, sglang_req_id)
+        fkv_task_id = -1
+        hit_length = 0
+        lookup_error: Optional[Exception] = None
+
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            tids_np = np.asarray(token_ids, dtype=np.int64)
+            mask_np = self._as_numpy_mask(token_mask)
+            try:
+                # A DSv4 prefix is reusable only when the same host node also
+                # owns its SWA window and compress-state sidecars.
+                res = self.kv_manager.get_match(
+                    token_ids=tids_np,
+                    token_mask=mask_np,
+                    swa_aware=self._swa_kv_pool is not None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                lookup_error = exc
+                res = None
+            if res is None:
+                fkv_task_id = -1
+                hit_length = 0
+            else:
+                fkv_task_id, matched_mask = res
+                hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
+
+        if self._sync_ctx.needs_sync:
+            payload = self._sync_ctx.scatter(
+                {
+                    "task_id": fkv_task_id,
+                    "hit": hit_length,
+                },
+                channel=FlexKVScatterChannel.LOOKUP,
+            )
+            fkv_task_id = payload["task_id"]
+            hit_length = payload["hit"]
+
+        # Page-align: FlexKV transfers whole pages.
+        if hit_length > 0 and self.page_size > 1:
+            aligned = (hit_length // self.page_size) * self.page_size
+            if aligned < hit_length:
+                logger.debug(
+                    "[FlexKV] lookup_kv: page-aligning hit %d -> %d (page=%d)",
+                    hit_length,
+                    aligned,
+                    self.page_size,
+                )
+            hit_length = aligned
+
+        context.task_id = fkv_task_id
+        lookup_status = (
+            "failed"
+            if lookup_error is not None
+            else ("hit" if hit_length > 0 else "miss")
+        )
+        self._log_cache_op(
+            context,
+            "complete",
+            lookup_status,
+            tokens=len(token_ids),
+            hit_tokens=hit_length,
+            hit_blocks=hit_length // self.page_size,
+            error=str(lookup_error) if lookup_error is not None else None,
+        )
+
+        # Decide what to do with the held task. Three cases:
+        #   1. hit_length > 0 and rid given → stash for retrieve_kv later.
+        #   2. hit_length > 0 and rid is None → cancel; caller can't use it.
+        #   3. hit_length == 0 → no work to do; FlexKV already marked the
+        #      empty graph COMPLETED inside get_match, cancel would warn.
+        if hit_length > 0 and rid is not None and fkv_task_id >= 0:
+            self._pending_lookups[rid] = fkv_task_id
+            self._pending_lookup_contexts[rid] = context
+        elif hit_length > 0 and fkv_task_id >= 0 and self._sync_ctx.is_sync_leader:
+            assert self.kv_manager is not None
+            self.kv_manager.cancel([fkv_task_id])
+
+        return fkv_task_id, hit_length
+
+    def release_pending(self, rid: str) -> None:
+        """Cancel the task held by an earlier ``lookup_kv(rid=...)`` that
+        won't be followed by a ``retrieve_kv`` (e.g. allocation failed)."""
+        fkv_task_id = self._pending_lookups.pop(rid, -1)
+        context = getattr(self, "_pending_lookup_contexts", {}).pop(rid, None)
+        if fkv_task_id >= 0 and self._sync_ctx.is_sync_leader:
+            assert self.kv_manager is not None
+            self.kv_manager.cancel([fkv_task_id])
+        if context is not None:
+            context.operation = "load"
+            self._log_cache_op(
+                context,
+                "complete",
+                "cancelled",
+                reason="lookup_released",
+            )
+
+    def retrieve_kv(
+        self,
+        rid: str,
+        slot_mapping: torch.Tensor,
+    ) -> int:
+        """Synchronous load: ``launch`` + ``wait``.
+
+        Returns the number of slots actually loaded. The caller is
+        responsible for having allocated ``slot_mapping`` of length
+        equal to ``hit_length`` from a prior ``lookup_kv``.
+        """
+        fkv_task_id = self._pending_lookups.pop(rid, -1)
+        if fkv_task_id < 0:
+            return 0
+        context = self._pop_context(
+            "_pending_lookup_contexts", rid, "load", fkv_task_id
+        )
+        load_start_ns = time.perf_counter_ns()
+
+        slot_mapping_cpu = self._to_cpu_int64(slot_mapping)
+        swa_slot_mapping = self._build_swa_slot_mapping(slot_mapping)
+        swa_slots = 0 if swa_slot_mapping is None else int(swa_slot_mapping.numel())
+
+        # Cross-node PP receivers must send their slot mapping back to
+        # the TransferManagerOnRemote so the remote side knows where to
+        # land the H2D copies on its own GPUs.
+        if self._sync_ctx.should_send_slot_mapping_to_remote:
+            self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+
+        n = slot_mapping_cpu.numel()
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            try:
+                self.kv_manager.launch(
+                    task_ids=[fkv_task_id],
+                    slot_mappings=[slot_mapping_cpu],
+                    swa_slot_mappings=[swa_slot_mapping],
+                    as_batch=True,
+                    layerwise_transfer=False,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    "failed",
+                    start_ns=load_start_ns,
+                    direction="H2D",
+                    transfer_mode="no-layerwise",
+                    stage="launch",
+                    error=str(exc),
+                )
+                raise
+            self._log_cache_op(
+                context,
+                "launch",
+                "running",
+                direction="H2D",
+                transfer_mode="no-layerwise",
+                slots=n,
+                swa_slots=swa_slots,
+            )
+            try:
+                resp = self.kv_manager.wait([fkv_task_id], timeout=30.0) or {}
+            except Exception as exc:  # noqa: BLE001
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    "failed",
+                    start_ns=load_start_ns,
+                    direction="H2D",
+                    transfer_mode="no-layerwise",
+                    error=str(exc),
+                )
+                raise
+            status = _status_value(resp.get(fkv_task_id))
+            success = status == KVResponseStatus.SUCCESS.value
+            self._log_cache_op(
+                context,
+                "complete",
+                status,
+                start_ns=load_start_ns,
+                direction="H2D",
+                transfer_mode="no-layerwise",
+                slots=n,
+                swa_slots=swa_slots,
+            )
+            if not success:
+                n = 0
+        if self._sync_ctx.needs_sync:
+            self._sync_ctx.barrier()
+        return n
+
+    def start_load_kv_layerwise(
+        self,
+        rid: str,
+        slot_mapping: torch.Tensor,
+    ) -> Tuple[int, int]:
+        """Layerwise load. Fires ``launch(layerwise_transfer=True)`` and
+        returns ``(n_slots, producer_id)`` after registering the producer
+        with the layer hook so the KV pool blocks on the right eventfds."""
+        assert self.enable_layerwise and self.layer_done_counter is not None, (
+            "start_load_kv_layerwise called but layerwise transfer is "
+            "disabled. Set FLEXKV_ENABLE_LAYERWISE_TRANSFER=1."
+        )
+        fkv_task_id = self._pending_lookups.pop(rid, -1)
+        context = self._pop_context(
+            "_pending_lookup_contexts", rid, "load", fkv_task_id
+        )
+        load_start_ns = time.perf_counter_ns()
+
+        slot_mapping_cpu = self._to_cpu_int64(slot_mapping)
+        swa_slot_mapping = self._build_swa_slot_mapping(slot_mapping)
+        swa_slots = 0 if swa_slot_mapping is None else int(swa_slot_mapping.numel())
+        n = slot_mapping_cpu.numel()
+
+        # Counter selection must be a single global decision.  Choosing from
+        # local timing state lets CP ranks cross a batch boundary at different
+        # moments under overlap scheduling, so they can wait on eventfds that
+        # the leader's FlexKV launch will never signal.
+        generation = getattr(self, "_layerwise_generation", 0)
+        producer_id = -1
+        expected_signal_count = -1
+        selected_new_counter = False
+        selection_error = None
+        if self._sync_ctx.is_sync_leader:
+            try:
+                if fkv_task_id < 0:
+                    raise RuntimeError(f"No pending FlexKV lookup for rid={rid}")
+                producer_id = self.layer_done_counter.update_producer()
+                selected_new_counter = (
+                    self.layer_done_counter.consumer_index != producer_id
+                )
+                expected_signal_count = self.layer_done_counter.expected_transfer_count(
+                    producer_id,
+                    allow_unclaimed_active=selected_new_counter,
+                )
+            except Exception as exc:  # noqa: BLE001
+                selection_error = str(exc)
+
+        manifest = {
+            "cmd": CMD_LAYERWISE,
+            "task_id": fkv_task_id,
+            "producer_id": producer_id,
+            "generation": generation,
+            "slot_count": n,
+            "expected_signal_count": expected_signal_count,
+            "error": selection_error,
+        }
+        if self._sync_ctx.needs_sync:
+            manifest = self._sync_ctx.scatter(
+                manifest,
+                channel=FlexKVScatterChannel.LAYERWISE_MANIFEST,
+            )
+
+        local_ok = 1
+        local_error = None
+        registered = False
+        transfer_added = False
+        try:
+            if not isinstance(manifest, dict) or manifest.get("cmd") != CMD_LAYERWISE:
+                raise RuntimeError("Invalid FlexKV layerwise manifest")
+            if manifest.get("error"):
+                raise RuntimeError(str(manifest["error"]))
+            if int(manifest["generation"]) != generation:
+                raise RuntimeError(
+                    "FlexKV layerwise generation mismatch: "
+                    f"local={generation}, leader={manifest.get('generation')}"
+                )
+            if int(manifest["task_id"]) != fkv_task_id or fkv_task_id < 0:
+                raise RuntimeError(
+                    "FlexKV layerwise task mismatch: "
+                    f"local={fkv_task_id}, leader={manifest.get('task_id')}"
+                )
+            if int(manifest["slot_count"]) != n:
+                raise RuntimeError(
+                    "FlexKV layerwise slot-count mismatch: "
+                    f"local={n}, leader={manifest.get('slot_count')}"
+                )
+            producer_id = int(manifest["producer_id"])
+            expected_signal_count = int(manifest["expected_signal_count"])
+            if not 0 <= producer_id < self.layer_done_counter.num_counters:
+                raise RuntimeError(f"Invalid FlexKV producer_id={producer_id}")
+            if expected_signal_count <= 0:
+                raise RuntimeError(
+                    f"Invalid FlexKV expected signal count {expected_signal_count}"
+                )
+            if not self._sync_ctx.is_sync_leader:
+                local_expected = self.layer_done_counter.expected_transfer_count(
+                    producer_id
+                )
+                if local_expected != expected_signal_count:
+                    raise RuntimeError(
+                        "FlexKV layerwise batch boundary differs across ranks: "
+                        f"local_expected={local_expected}, "
+                        f"leader_expected={expected_signal_count}"
+                    )
+        except Exception as exc:  # noqa: BLE001
+            local_ok = 0
+            local_error = str(exc)
+
+        # Include remote slot metadata and local counter registration in the
+        # same all-rank preflight. Nothing reaches KVManager.launch until every
+        # rank reports that it is ready to consume the leader's counter.
+        if local_ok and self._sync_ctx.should_send_slot_mapping_to_remote:
+            try:
+                self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+            except Exception as exc:  # noqa: BLE001
+                local_ok = 0
+                local_error = f"remote slot metadata failed: {exc}"
+
+        if local_ok:
+            try:
+                if self._sync_ctx.is_sync_leader:
+                    self.layer_done_counter.register_task(fkv_task_id, producer_id)
+                else:
+                    self.layer_done_counter.register_task_with_explicit_counter_id(
+                        fkv_task_id, producer_id
+                    )
+                registered = True
+                self.layer_done_counter.set_consumer(fkv_task_id)
+                transfer_added = True
+                local_signal_count = self.layer_done_counter.events[
+                    producer_id
+                ].pending_transfers()
+                if local_signal_count != expected_signal_count:
+                    raise RuntimeError(
+                        "FlexKV layerwise signal-count changed during registration: "
+                        f"local={local_signal_count}, leader={expected_signal_count}"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                local_ok = 0
+                local_error = f"counter registration failed: {exc}"
+
+        self._layerwise_generation = generation + 1
+        all_ranks_ok = (
+            self._sync_ctx.all_reduce_min(local_ok)
+            if self._sync_ctx.needs_sync
+            else local_ok
+        )
+        if all_ranks_ok == 0:
+            cleanup_ok = 1
+            cleanup_error = None
+            try:
+                if registered or transfer_added:
+                    self.layer_done_counter.rollback_prepared_transfer(
+                        fkv_task_id,
+                        producer_id,
+                        transfer_added=transfer_added,
+                    )
+                elif self._sync_ctx.is_sync_leader and selected_new_counter:
+                    self.layer_done_counter.abort_unregistered_selection(producer_id)
+            except Exception as exc:  # noqa: BLE001
+                cleanup_ok = 0
+                cleanup_error = str(exc)
+            all_cleanup_ok = (
+                self._sync_ctx.all_reduce_min(cleanup_ok)
+                if self._sync_ctx.needs_sync
+                else cleanup_ok
+            )
+            if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+                try:
+                    if fkv_task_id >= 0:
+                        self.kv_manager.cancel([fkv_task_id])
+                except Exception as exc:  # noqa: BLE001
+                    self._log_cache_op(
+                        context,
+                        "cleanup",
+                        "failed",
+                        start_ns=load_start_ns,
+                        direction="H2D",
+                        transfer_mode="layerwise",
+                        stage="prelaunch_cancel",
+                        error=str(exc),
+                    )
+            if all_cleanup_ok == 0:
+                raise RuntimeError(
+                    "FlexKV layerwise counter rollback failed on at least one rank: "
+                    f"{cleanup_error or 'remote rank failure'}"
+                )
+            self._log_cache_op(
+                context,
+                "complete",
+                "failed",
+                start_ns=load_start_ns,
+                direction="H2D",
+                transfer_mode="layerwise",
+                stage="preflight",
+                rank=self._sync_ctx.world_rank,
+                generation=generation,
+                producer_id=producer_id,
+                error=local_error or "another rank rejected the pre-launch state",
+            )
+            return 0, -1
+
+        self._log_cache_op(
+            context,
+            "register",
+            "ready",
+            direction="H2D",
+            transfer_mode="layerwise",
+            rank=self._sync_ctx.world_rank,
+            generation=generation,
+            producer_id=producer_id,
+            expected_signal_count=expected_signal_count,
+        )
+
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            try:
+                launched_task_ids = self.kv_manager.launch(
+                    task_ids=[fkv_task_id],
+                    slot_mappings=[slot_mapping_cpu],
+                    swa_slot_mappings=[swa_slot_mapping],
+                    as_batch=True,
+                    layerwise_transfer=True,
+                    counter_id=producer_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    "failed",
+                    start_ns=load_start_ns,
+                    direction="H2D",
+                    transfer_mode="layerwise",
+                    stage="launch",
+                    error=str(exc),
+                )
+                raise
+            # A layerwise launch is always merged into a batch task. Track the
+            # IDs returned by launch(), not the lookup task ID that the merge
+            # removes from FlexKV's task table.
+            self._launched_load_tids.extend(launched_task_ids)
+            for launched_task_id in launched_task_ids:
+                self._launched_load_contexts[launched_task_id] = replace(
+                    context,
+                    task_id=launched_task_id,
+                    start_ns=load_start_ns,
+                )
+            self._log_cache_op(
+                context,
+                "launch",
+                "running",
+                direction="H2D",
+                flexkv_batch_task_ids=launched_task_ids,
+                transfer_mode="layerwise",
+                slots=n,
+                swa_slots=swa_slots,
+                producer_id=producer_id,
+            )
+
+        return n, producer_id
+
+    def drain_launched_loads(self, threshold: int = 100) -> None:
+        """Periodic non-blocking sweep on long-lived launched tasks so the
+        FlexKV pipe doesn't accumulate. No-op on non-leader ranks."""
+        if not self._sync_ctx.is_sync_leader or self.kv_manager is None:
+            return
+        if len(self._launched_load_tids) < threshold:
+            return
+        task_ids = list(dict.fromkeys(self._launched_load_tids))
+        contexts = getattr(self, "_launched_load_contexts", {})
+        try:
+            responses = (
+                self.kv_manager.wait(task_ids, timeout=0.0, completely=True) or {}
+            )
+        except Exception as exc:  # noqa: BLE001
+            context = next(
+                (contexts[task_id] for task_id in task_ids if task_id in contexts),
+                None,
+            )
+            context = context or self._new_op_context("load", "-")
+            self._log_cache_op(
+                context,
+                "poll",
+                "failed",
+                task_id=-1,
+                direction="H2D",
+                flexkv_batch_task_ids=task_ids,
+                transfer_mode="layerwise",
+                error=str(exc),
+            )
+            return
+        for task_id, response in responses.items():
+            status = _status_value(response)
+            if not _is_terminal_status(status):
+                continue
+            context = self._pop_context(
+                "_launched_load_contexts", task_id, "load", task_id
+            )
+            self._log_cache_op(
+                context,
+                "complete",
+                status,
+                direction="H2D",
+                transfer_mode="layerwise",
+            )
+        self._launched_load_tids = [
+            task_id
+            for task_id in task_ids
+            if task_id not in responses
+            or not _is_terminal_status(_status_value(responses[task_id]))
+        ]
+
+    # ------------------------------------------------------------------
+    # Public API — store
+    # ------------------------------------------------------------------
+
+    def store_kv(
+        self,
+        rid: str,
+        token_ids: List[int],
+        kv_indices: torch.Tensor,
+        sglang_req_id: Any = _SGLANG_REQ_ID_UNSET,
+    ) -> int:
+        """Schedule a write back from GPU into FlexKV.
+
+        On the sync leader this runs ``put_match`` to discover which
+        tokens are NOT yet in FlexKV's CPU cache (= the "unmatched"
+        slice), then ``launch`` on those. On non-leaders the unmatched
+        mask is received over the PP fan-out so cross-node PP can
+        forward its slot mappings.
+
+        Returns the FlexKV task id of the in-flight store, or -1 if
+        nothing needed to be written.
+        """
+        context = self._new_op_context("store", rid, sglang_req_id)
+        token_ids_np = np.asarray(token_ids, dtype=np.int64)
+        n = len(token_ids_np)
+        if n != len(kv_indices):
+            raise ValueError(
+                f"store_kv: token_ids has {n} entries but kv_indices "
+                f"has {len(kv_indices)} entries"
+            )
+
+        # Page-align inputs *before* put_match so the FlexKV allocator
+        # only reserves slots that line up with the slot_mapping we send.
+        if self.page_size > 1:
+            aligned_len = (n // self.page_size) * self.page_size
+            if aligned_len == 0:
+                self._send_pp_put_meta(-1, [])
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    "skipped",
+                    direction="D2H",
+                    reason="partial_block",
+                    tokens=0,
+                )
+                return -1
+            if aligned_len < n:
+                token_ids_np = token_ids_np[:aligned_len]
+                kv_indices = kv_indices[:aligned_len]
+
+        fkv_task_id = -1
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            match_error: Optional[Exception] = None
+            try:
+                res = self.kv_manager.put_match(token_ids=token_ids_np, token_mask=None)
+            except Exception as exc:  # noqa: BLE001
+                match_error = exc
+                res = None
+            if res is None:
+                self._send_pp_put_meta(-1, [])
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    "failed",
+                    direction="D2H",
+                    stage="put_match",
+                    reason="no_response" if match_error is None else None,
+                    error=str(match_error) if match_error is not None else None,
+                )
+                return -1
+            fkv_task_id, unmatched_mask = res
+            context.task_id = fkv_task_id
+
+            self._send_pp_put_meta(fkv_task_id, unmatched_mask)
+
+            unmatched_count = int(unmatched_mask.sum())
+            if unmatched_count > 0:
+                filtered = kv_indices[unmatched_mask]
+                slot_mapping_cpu = self._to_cpu_int64(filtered)
+                swa_slot_mapping = self._build_swa_slot_mapping(filtered)
+                swa_slots = (
+                    0 if swa_slot_mapping is None else int(swa_slot_mapping.numel())
+                )
+                try:
+                    self.kv_manager.launch(
+                        task_ids=[fkv_task_id],
+                        slot_mappings=[slot_mapping_cpu],
+                        swa_slot_mappings=[swa_slot_mapping],
+                        as_batch=False,
+                        layerwise_transfer=False,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    self._log_cache_op(
+                        context,
+                        "complete",
+                        "failed",
+                        direction="D2H",
+                        transfer_mode="no-layerwise",
+                        stage="launch",
+                        error=str(exc),
+                    )
+                    raise
+                self._log_cache_op(
+                    context,
+                    "launch",
+                    "running",
+                    direction="D2H",
+                    transfer_mode="no-layerwise",
+                    tokens=unmatched_count,
+                    slots=int(slot_mapping_cpu.numel()),
+                    swa_slots=swa_slots,
+                )
+                self._inflight_stores[rid] = fkv_task_id
+                self._inflight_store_contexts[rid] = context
+                return fkv_task_id
+            self._log_cache_op(
+                context,
+                "complete",
+                "skipped",
+                direction="D2H",
+                reason="already_cached",
+                tokens=0,
+            )
+            return -1
+
+        # Non-leader path: receive the unmatched mask + maybe forward
+        # slot_mapping to the remote-side TransferManager.
+        if self._sync_ctx.is_pp_receiver:
+            payload = self._sync_ctx.scatter_pp(None)
+            if payload.get("cmd") != CMD_PUT_META:
+                raise RuntimeError(
+                    f"Tag mismatch: expected CMD_PUT_META, got {payload.get('cmd')}"
+                )
+            fkv_task_id = int(payload["fkv_task_id"])
+            mask_list = payload.get("unmatched_mask", [])
+            unmatched_mask = torch.tensor(mask_list, dtype=torch.bool)
+            if (
+                int(unmatched_mask.sum()) > 0
+                and fkv_task_id >= 0
+                and self._sync_ctx.should_send_slot_mapping_to_remote
+            ):
+                filtered = kv_indices[unmatched_mask]
+                slot_mapping_cpu = self._to_cpu_int64(filtered)
+                self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+                self._inflight_stores[rid] = fkv_task_id
+                context.task_id = fkv_task_id
+                self._inflight_store_contexts[rid] = context
+        return fkv_task_id
+
+    def check_completed_stores(self) -> List[str]:
+        """Return rids whose stores have completed since the last call."""
+        completed_rids: List[str] = []
+        completed_dict: Dict[int, Any] = {}
+
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            if self._inflight_stores:
+                fk_to_rid = {v: k for k, v in self._inflight_stores.items()}
+                try:
+                    completed_dict = (
+                        self.kv_manager.try_wait(task_ids=list(fk_to_rid.keys())) or {}
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    rid = next(iter(self._inflight_stores))
+                    context = getattr(self, "_inflight_store_contexts", {}).get(rid)
+                    context = context or self._new_op_context(
+                        "store", rid, task_id=self._inflight_stores[rid]
+                    )
+                    self._log_cache_op(
+                        context,
+                        "poll",
+                        "failed",
+                        task_id=-1,
+                        flexkv_task_ids=list(fk_to_rid),
+                        error=str(exc),
+                    )
+                    completed_dict = {}
+                for fk_tid, response in completed_dict.items():
+                    rid = fk_to_rid[fk_tid]
+                    completed_rids.append(rid)
+                    self._inflight_stores.pop(rid, None)
+                    context = self._pop_context(
+                        "_inflight_store_contexts", rid, "store", fk_tid
+                    )
+                    status = _status_value(response)
+                    self._log_cache_op(
+                        context,
+                        "complete",
+                        status,
+                        direction="D2H",
+                        transfer_mode="no-layerwise",
+                    )
+
+        if self._sync_ctx.is_pp_sender:
+            self._sync_ctx.scatter_pp(
+                {
+                    "cmd": CMD_STORE_COMPLETE,
+                    "completed_fk_ids": list(completed_dict),
+                }
+            )
+        elif self._sync_ctx.is_pp_receiver:
+            payload = self._sync_ctx.scatter_pp(None)
+            if payload.get("cmd") != CMD_STORE_COMPLETE:
+                raise RuntimeError(
+                    f"Tag mismatch: expected CMD_STORE_COMPLETE, got "
+                    f"{payload.get('cmd')}"
+                )
+            fk_ids = payload.get("completed_fk_ids", [])
+            if fk_ids and self._inflight_stores:
+                fk_to_rid = {v: k for k, v in self._inflight_stores.items()}
+                for fk_tid in fk_ids:
+                    if fk_tid in fk_to_rid:
+                        rid = fk_to_rid[fk_tid]
+                        completed_rids.append(rid)
+                        self._inflight_stores.pop(rid, None)
+                        getattr(self, "_inflight_store_contexts", {}).pop(rid, None)
+
+        if self._sync_ctx.needs_sync:
+            completed_rids = self._sync_ctx.scatter(
+                completed_rids,
+                channel=FlexKVScatterChannel.STORE_COMPLETION,
+            )
+        return completed_rids
+
+    def wait_store(self, rid: str, timeout: float = 30.0) -> bool:
+        """Block until a single store task identified by ``rid`` finishes."""
+        fkv_task_id = self._inflight_stores.pop(rid, -1)
+        if fkv_task_id < 0:
+            return True
+        context = self._pop_context(
+            "_inflight_store_contexts", rid, "store", fkv_task_id
+        )
+        if not self._sync_ctx.is_sync_leader or self.kv_manager is None:
+            return True
+        try:
+            resp = self.kv_manager.wait([fkv_task_id], timeout=timeout) or {}
+        except Exception as exc:  # noqa: BLE001
+            self._log_cache_op(
+                context,
+                "complete",
+                "failed",
+                direction="D2H",
+                transfer_mode="no-layerwise",
+                error=str(exc),
+            )
+            return False
+        status = _status_value(resp.get(fkv_task_id))
+        success = status == KVResponseStatus.SUCCESS.value
+        self._log_cache_op(
+            context,
+            "complete",
+            status,
+            direction="D2H",
+            transfer_mode="no-layerwise",
+        )
+        return success
+
+    # ------------------------------------------------------------------
+    # Public API — prefetch
+    # ------------------------------------------------------------------
+
+    def prefetch_async(
+        self,
+        rid: str,
+        token_ids: List[int],
+        sglang_req_id: Any = _SGLANG_REQ_ID_UNSET,
+    ) -> int:
+        if not self._prefetch_enabled or not rid:
+            return -1
+        context = self._new_op_context("prefetch", rid, sglang_req_id)
+        task_id = -1
+        prefetch_error: Optional[Exception] = None
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            try:
+                task_id = self.kv_manager.prefetch_async(
+                    token_ids=np.asarray(token_ids, dtype=np.int64)
+                )
+            except Exception as exc:  # noqa: BLE001
+                prefetch_error = exc
+                task_id = -1
+        if self._sync_ctx.needs_sync:
+            payload = self._sync_ctx.scatter(
+                {"task_id": task_id},
+                channel=FlexKVScatterChannel.PREFETCH_START,
+            )
+            task_id = payload["task_id"]
+        if task_id >= 0:
+            context.task_id = task_id
+            self._ongoing_prefetches[rid] = task_id
+            self._prefetch_contexts[rid] = context
+            self._log_cache_op(
+                context,
+                "launch",
+                "running",
+                tokens=len(token_ids),
+            )
+        elif self._sync_ctx.is_sync_leader:
+            self._log_cache_op(
+                context,
+                "complete",
+                "failed",
+                reason="task_not_created" if prefetch_error is None else None,
+                error=str(prefetch_error) if prefetch_error is not None else None,
+            )
+        return task_id
+
+    def check_prefetch_progress(self, rid: str) -> bool:
+        if not self._prefetch_enabled:
+            return True
+        task_id = self._ongoing_prefetches.get(rid, -1)
+        if task_id < 0:
+            return True
+        done = False
+        status = "running"
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            try:
+                completed = self.kv_manager.try_wait(task_ids=[task_id]) or {}
+            except Exception as exc:  # noqa: BLE001
+                context = getattr(self, "_prefetch_contexts", {}).get(rid)
+                context = context or self._new_op_context(
+                    "prefetch", rid, task_id=task_id
+                )
+                self._log_cache_op(
+                    context,
+                    "poll",
+                    "failed",
+                    error=str(exc),
+                )
+                completed = {}
+            if task_id in completed:
+                status = _status_value(completed[task_id])
+                done = _is_terminal_status(status)
+        if self._sync_ctx.needs_sync:
+            payload = self._sync_ctx.scatter(
+                {"done": done, "status": status},
+                channel=FlexKVScatterChannel.PREFETCH_PROGRESS,
+            )
+            done = payload["done"]
+            status = payload["status"]
+        if done:
+            self._ongoing_prefetches.pop(rid, None)
+            context = self._pop_context("_prefetch_contexts", rid, "prefetch", task_id)
+            self._log_cache_op(
+                context,
+                "complete",
+                status,
+            )
+        return done
+
+    def cancel_prefetch(self, rid: str) -> None:
+        self._pending_lookups.pop(rid, None)
+        lookup_context = getattr(self, "_pending_lookup_contexts", {}).pop(rid, None)
+        if lookup_context is not None:
+            lookup_context.operation = "load"
+            self._log_cache_op(
+                lookup_context,
+                "complete",
+                "cancelled",
+                reason="caller_cancelled",
+            )
+        # FlexKV doesn't currently support prefetch cancellation, but
+        # we still drop our tracking entry.
+        task_id = self._ongoing_prefetches.pop(rid, -1)
+        context = getattr(self, "_prefetch_contexts", {}).pop(rid, None)
+        if context is not None:
+            self._log_cache_op(
+                context,
+                "complete",
+                "cancelled",
+                task_id=task_id,
+                reason="caller_cancelled_tracking",
+            )
+
+    # ------------------------------------------------------------------
+    # Layerwise transfer hooks
+    # ------------------------------------------------------------------
+
+    def register_layer_transfer_counter(self, kvcache: Any) -> None:
+        """Register the FlexKVLayerDoneCounter onto sglang's KV pool so
+        each forward layer blocks on its eventfd. No-op when layerwise
+        is disabled."""
+        if (
+            self.layer_done_counter is None
+            or kvcache is None
+            or not hasattr(kvcache, "register_layer_transfer_counter")
+        ):
+            return
+        kvcache.register_layer_transfer_counter(self.layer_done_counter)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
+        # Layerwise launch merges the lookup task into a new batch task. Wait
+        # for those returned batch task IDs before the scheduler clears GPU
+        # slot ownership or the eventfd producer ring is reused. ``completely``
+        # is required: an early task-end response is not sufficient to prove
+        # that the worker has stopped writing layer completion eventfds.
+        load_reset_status = {"ok": True, "error": ""}
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            launched = list(dict.fromkeys(self._launched_load_tids))
+            if launched:
+                try:
+                    responses = self.kv_manager.wait(
+                        launched, timeout=30.0, completely=True
+                    )
+                    responses = responses or {}
+                    for task_id, response in responses.items():
+                        status = _status_value(response)
+                        context = self._pop_context(
+                            "_launched_load_contexts", task_id, "load", task_id
+                        )
+                        self._log_cache_op(
+                            context,
+                            "complete",
+                            status,
+                            direction="H2D",
+                            transfer_mode="layerwise",
+                            source="reset",
+                        )
+                    failed = [
+                        task_id
+                        for task_id in launched
+                        if task_id not in responses
+                        or responses[task_id].status != KVResponseStatus.SUCCESS
+                    ]
+                    if failed:
+                        load_reset_status = {
+                            "ok": False,
+                            "error": (
+                                "layerwise load tasks did not finish during reset: "
+                                f"{failed}"
+                            ),
+                        }
+                except Exception as exc:  # noqa: BLE001
+                    load_reset_status = {
+                        "ok": False,
+                        "error": f"waiting for layerwise loads during reset failed: {exc}",
+                    }
+        if self._sync_ctx.needs_sync:
+            load_reset_status = self._sync_ctx.scatter(
+                load_reset_status,
+                channel=FlexKVScatterChannel.RESET,
+                blocking=True,
+            )
+        if not load_reset_status["ok"]:
+            raise RuntimeError(f"[FlexKV] {load_reset_status['error']}")
+
+        # Drop pending lookups (cancel their held tasks on the leader).
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            pending = [tid for tid in self._pending_lookups.values() if tid >= 0]
+            if pending:
+                try:
+                    self.kv_manager.cancel(pending)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("[FlexKV] reset cancel: %s", exc)
+        for context in self._pending_lookup_contexts.values():
+            context.operation = "load"
+            self._log_cache_op(
+                context, "complete", "cancelled", reason="connector_reset"
+            )
+        self._pending_lookup_contexts.clear()
+        self._pending_lookups.clear()
+        for context in self._prefetch_contexts.values():
+            self._log_cache_op(
+                context, "complete", "cancelled", reason="connector_reset"
+            )
+        self._prefetch_contexts.clear()
+        self._ongoing_prefetches.clear()
+        self._inflight_loads.clear()
+        self._completed_layerwise.clear()
+        self._launched_load_tids.clear()
+        getattr(self, "_launched_load_contexts", {}).clear()
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            for rid, fk_tid in list(self._inflight_stores.items()):
+                if fk_tid >= 0:
+                    context = self._pop_context(
+                        "_inflight_store_contexts", rid, "store", fk_tid
+                    )
+                    error = None
+                    try:
+                        responses = self.kv_manager.wait([fk_tid], timeout=20.0) or {}
+                        status = _status_value(responses.get(fk_tid))
+                    except Exception as exc:  # noqa: BLE001
+                        status = "failed"
+                        error = str(exc)
+                    self._log_cache_op(
+                        context,
+                        "complete",
+                        status,
+                        direction="D2H",
+                        transfer_mode="no-layerwise",
+                        source="reset",
+                        error=error,
+                    )
+        self._inflight_stores.clear()
+        getattr(self, "_inflight_store_contexts", {}).clear()
+        if self.layer_done_counter is not None:
+            self.layer_done_counter.reset()
+
+    def shutdown(self) -> None:
+        """Idempotent: unpin FlexKV CPU host buffers via kv_manager.shutdown()."""
+        if getattr(self, "_shutdown_done", False):
+            return
+        self._shutdown_done = True
+        # print+flush: survives abrupt exit better than logger buffering into | tee.
+        logger.info("[FlexKV] connector shutdown begin %s", self._label)
+        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+            logger.info(
+                f"[FLEXKV] kv_manager.shutdown begin {self._label}",
+            )
+            try:
+                self.kv_manager.shutdown()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[FlexKV] kv_manager.shutdown: %s", exc)
+            self.kv_manager = None
+        else:
+            logger.info(
+                f"[FLEXKV] connector shutdown skip kv_manager "
+                f"(leader={self._sync_ctx.is_sync_leader}) {self._label}",
+            )
+        if self._remote_process is not None:
+            try:
+                self._remote_process.terminate()
+                self._remote_process.join(timeout=5.0)
+                if self._remote_process.is_alive():
+                    self._remote_process.kill()
+                    self._remote_process.join()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[FlexKV] remote process shutdown: %s", exc)
+            self._remote_process = None
+        logger.info("[FlexKV] connector shutdown done %s", self._label)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_kv_buffers(
+        self, kvcache: Any
+    ) -> Tuple[List[torch.Tensor], Optional[List[torch.Tensor]]]:
+        """Resolve the GPU buffers and describe heterogeneous DSv4 pools."""
+        indexer_buffers = getattr(kvcache, "index_k_with_scale_buffer", None)
+        if not self._is_dsv4:
+            if hasattr(kvcache, "kv_buffer"):
+                return list(kvcache.kv_buffer), indexer_buffers
+            if hasattr(kvcache, "k_buffer"):
+                return (
+                    list(kvcache.k_buffer) + list(kvcache.v_buffer),
+                    indexer_buffers,
+                )
+            raise AttributeError(
+                f"Unsupported KV cache type {type(kvcache).__name__}: "
+                "expected kv_buffer, k_buffer/v_buffer, or DSv4 multi-pools."
+            )
+
+        if getattr(kvcache, "_unified_kv", False):
+            raise NotImplementedError(
+                "FlexKV DSv4 integration currently requires the split "
+                "c4/c128/SWA GPU layout; unified_kv is not supported yet."
+            )
+
+        compression_ratios = list(kvcache.compression_ratios)
+        stage_start = int(getattr(kvcache, "_stage_start", 0))
+        stage_end = int(getattr(kvcache, "_stage_end", len(compression_ratios)))
+        c4_global_layer_ids = [
+            i for i in range(stage_start, stage_end) if compression_ratios[i] == 4
+        ]
+        c128_global_layer_ids = [
+            i for i in range(stage_start, stage_end) if compression_ratios[i] == 128
+        ]
+        # FlexKV's transfer workers and layerwise eventfds use PP-stage-local
+        # layer coordinates. Keep the global ids only for indexing SGLang's
+        # full-model state-pool arrays.
+        c4_layer_ids = [i - stage_start for i in c4_global_layer_ids]
+        c128_layer_ids = [i - stage_start for i in c128_global_layer_ids]
+
+        def add_kv_group(
+            name: str,
+            ratio: int,
+            layer_ids: List[int],
+            buffers: List[torch.Tensor],
+            sub_page_size: int,
+            bytes_per_token: int,
+        ) -> None:
+            if buffers:
+                self._dsv4_layer_groups.append(
+                    {
+                        "name": name,
+                        "ratio": ratio,
+                        "layer_ids": layer_ids,
+                        "buffers": list(buffers),
+                        "sub_page_size": int(sub_page_size),
+                        "bytes_per_token": int(bytes_per_token),
+                        "dtype": buffers[0].dtype,
+                    }
+                )
+
+        c4_pool = getattr(kvcache, "c4_kv_pool", None)
+        c128_pool = getattr(kvcache, "c128_kv_pool", None)
+        if c4_pool is not None:
+            add_kv_group(
+                "c4",
+                4,
+                c4_layer_ids,
+                c4_pool.kv_buffer,
+                c4_pool.page_size,
+                c4_pool.get_bytes_per_token(),
+            )
+        if c128_pool is not None:
+            add_kv_group(
+                "c128",
+                128,
+                c128_layer_ids,
+                c128_pool.kv_buffer,
+                c128_pool.page_size,
+                c128_pool.get_bytes_per_token(),
+            )
+
+        indexer_pool = getattr(kvcache, "c4_indexer_kv_pool", None)
+        dsv4_indexer_buffers = (
+            list(getattr(indexer_pool, "index_k_with_scale_buffer", []))
+            if indexer_pool is not None
+            else []
+        )
+        if dsv4_indexer_buffers:
+            sample = dsv4_indexer_buffers[0]
+            add_kv_group(
+                "c4_indexer",
+                4,
+                list(c4_layer_ids),
+                dsv4_indexer_buffers,
+                indexer_pool.page_size,
+                sample.shape[1] // indexer_pool.page_size,
+            )
+
+        # Compress states share the SWA physical-page mapping. The FlexKV
+        # user option is intentionally tri-state: omitted/None enables the
+        # correctness-preserving default; explicit false keeps SWA-only I/O.
+        swa_multi_group = getattr(
+            getattr(self.flexkv_config, "user_config", None),
+            "swa_multi_group",
+            None,
+        )
+        if swa_multi_group is not False:
+            self._append_dsv4_state_group(
+                "c4_attention_state",
+                c4_layer_ids,
+                [kvcache.compress_state_pools[i] for i in c4_global_layer_ids],
+            )
+            self._append_dsv4_state_group(
+                "c4_indexer_state",
+                c4_layer_ids,
+                [kvcache.indexer_compress_state_pools[i] for i in c4_global_layer_ids],
+            )
+        else:
+            logger.info(
+                "[FlexKV-DSv4] swa_multi_group=false; registering SWA without "
+                "compress-state sidecars"
+            )
+
+        if self._dsv4_state_groups:
+            if self.cache_config.swa is None:
+                raise RuntimeError(
+                    "FlexKV DSv4 state sidecars require an SWA cache config"
+                )
+            self.cache_config.swa.multi_group = True
+
+        if not self._dsv4_layer_groups:
+            raise RuntimeError("DSv4 KV cache has no buffers on this PP stage")
+        flat_buffers = [
+            buffer for group in self._dsv4_layer_groups for buffer in group["buffers"]
+        ]
+        logger.info(
+            "[FlexKV-DSv4] resolved groups=%s state_groups=%s",
+            [group["name"] for group in self._dsv4_layer_groups],
+            [group["name"] for group in self._dsv4_state_groups],
+        )
+        return flat_buffers, None
+
+    def _append_dsv4_state_group(
+        self,
+        name: str,
+        layer_ids: List[int],
+        pools: List[Any],
+    ) -> None:
+        if not pools or any(pool is None for pool in pools):
+            return
+        ring_sizes = {int(pool.ring_size) for pool in pools}
+        if len(ring_sizes) != 1:
+            raise RuntimeError(
+                f"FlexKV DSv4 state group {name!r} has mixed ring sizes: "
+                f"{sorted(ring_sizes)}"
+            )
+        ring_size = ring_sizes.pop()
+        swa_page_size = int(getattr(self._kvcache, "swa_page_size", self.page_size))
+        if swa_page_size != self.page_size or swa_page_size % ring_size != 0:
+            raise RuntimeError(
+                f"FlexKV DSv4 state group {name!r} has incompatible "
+                f"page_size={swa_page_size}, ring_size={ring_size}"
+            )
+        buffers = [pool.kv_score_buffer.kv_score for pool in pools]
+        sample = buffers[0]
+        if sample.ndim != 2 or not sample.is_contiguous():
+            raise RuntimeError(
+                f"FlexKV DSv4 state group {name!r} expects contiguous 2D "
+                f"buffers, got shape={tuple(sample.shape)}"
+            )
+        if any(
+            buf.shape != sample.shape or buf.dtype != sample.dtype for buf in buffers
+        ):
+            raise RuntimeError(
+                f"FlexKV DSv4 state group {name!r} has inconsistent buffers"
+            )
+        self._dsv4_state_groups.append(
+            {
+                "name": name,
+                "layer_ids": list(layer_ids),
+                "buffers": buffers,
+                "ratio": swa_page_size // ring_size,
+                "sub_page_size": ring_size,
+                "head_size": int(sample.shape[1]),
+                "dtype": sample.dtype,
+            }
+        )
+
+    def _build_dsv4_layer_group_specs(self) -> List[LayerGroupSpec]:
+        specs = []
+        for group in self._dsv4_layer_groups:
+            sample = group["buffers"][0]
+            sub_page_size = group["sub_page_size"]
+            if sample.shape[1] % sub_page_size != 0:
+                raise RuntimeError(
+                    f"FlexKV DSv4 group {group['name']!r} has page bytes "
+                    f"{sample.shape[1]} not divisible by {sub_page_size}"
+                )
+            specs.append(
+                LayerGroupSpec(
+                    num_layers=len(group["layer_ids"]),
+                    num_kv_heads=1,
+                    head_size=sample.shape[1] // sub_page_size,
+                    layer_indices=list(group["layer_ids"]),
+                    compress_ratio=group["ratio"],
+                    dtype=group["dtype"],
+                )
+            )
+        return specs
+
+    def _build_indexer_layer_group_specs(
+        self,
+        kv_caches: List[torch.Tensor],
+        indexer_buffers: List[torch.Tensor],
+    ) -> List[LayerGroupSpec]:
+        _, num_kv_heads, head_size = kv_caches[0].shape
+        return [
+            LayerGroupSpec(
+                num_layers=self.rank_info.num_layers_per_pp_stage,
+                num_kv_heads=num_kv_heads,
+                head_size=head_size,
+                layer_indices=list(range(self.rank_info.num_layers_per_pp_stage)),
+                compress_ratio=1,
+                dtype=kv_caches[0].dtype,
+            ),
+            LayerGroupSpec(
+                num_layers=len(indexer_buffers),
+                num_kv_heads=1,
+                head_size=indexer_buffers[0].shape[1],
+                layer_indices=list(range(len(indexer_buffers))),
+                compress_ratio=1,
+                dtype=indexer_buffers[0].dtype,
+            ),
+        ]
+
+    def _apply_layer_groups_for_cache_sizing(
+        self,
+        kv_caches: List[torch.Tensor],
+        indexer_buffers: Optional[List[torch.Tensor]],
+    ) -> None:
+        if self.model_config.layer_groups is None:
+            layer_groups = None
+            if self._is_dsv4:
+                layer_groups = self._build_dsv4_layer_group_specs()
+            elif indexer_buffers:
+                layer_groups = self._build_indexer_layer_group_specs(
+                    kv_caches, indexer_buffers
+                )
+            else:
+                return
+
+            # FlexKV freezes ModelConfig at the end of its SGLang adapter.
+            # Preserve that immutability contract by replacing the config
+            # rather than mutating the frozen instance in place.
+            model_config = replace(self.model_config, layer_groups=layer_groups)
+            model_config.freeze()
+            self.model_config = model_config
+            self.flexkv_config.model_config = model_config
+            self.rank_info = replace(self.rank_info, model_config=model_config)
+
+        old_cpu_blocks = self.cache_config.num_cpu_blocks
+        if not recompute_cache_block_counts(self.model_config, self.cache_config):
+            return
+        logger.info(
+            "[FlexKV] recomputed cache capacity for %d groups: %s -> %s CPU blocks",
+            len(self.model_config.layer_groups),
+            old_cpu_blocks,
+            self.cache_config.num_cpu_blocks,
+        )
+        for attr in ("num_cpu_blocks", "num_ssd_blocks", "num_remote_blocks"):
+            value = getattr(self.cache_config, attr, None)
+            if value is not None and value > 0:
+                setattr(
+                    self.cache_config,
+                    attr,
+                    self._sync_ctx.all_reduce_min(int(value)),
+                )
+
+    def _build_swa_slot_mapping(
+        self, full_indices: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        """Translate full-pool indices and keep only the mapped SWA tail."""
+        if self._swa_kv_pool is None:
+            return None
+        translate = getattr(self._kvcache, "translate_loc_from_full_to_swa", None)
+        if translate is None:
+            return None
+        swa_indices = translate(full_indices).to(device="cpu", dtype=torch.int64)
+        mapped = swa_indices > 0
+        if not bool(mapped.any()):
+            return None
+        unmapped = (~mapped).nonzero(as_tuple=False)
+        if unmapped.numel() > 0:
+            swa_indices = swa_indices[int(unmapped[-1].item()) + 1 :]
+        if swa_indices.numel() == 0:
+            return None
+        if not bool((swa_indices > 0).all()):
+            raise RuntimeError("SWA slot mapping contains the reserved slot 0")
+        return swa_indices
+
+    @staticmethod
+    def _as_numpy_mask(mask) -> np.ndarray:
+        if mask is None:
+            return None
+        if isinstance(mask, torch.Tensor):
+            return mask.detach().cpu().numpy()
+        return np.asarray(mask)
+
+    @staticmethod
+    def _to_cpu_int64(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.is_cuda:
+            tensor = tensor.cpu()
+        return tensor.to(torch.int64)
+
+    def _wait_kv_manager_ready(self, poll_interval: float = 10.0) -> None:
+        assert self.kv_manager is not None
+        wait_count = 0
+        while not self.kv_manager.is_ready():
+            time.sleep(poll_interval)
+            wait_count += 1
+            logger.info(
+                "[FlexKV] Waiting for FlexKV ready %s (waited %.0fs)",
+                self._label,
+                wait_count * poll_interval,
+            )
+        logger.info("[FlexKV] FlexKV is ready %s", self._label)
+
+    def _register_with_retry(
+        self,
+        kv_caches: List[torch.Tensor],
+        indexer_buffers: Optional[List[torch.Tensor]] = None,
+        max_retries: int = 360,
+    ) -> None:
+        """Retry GPU registration. On node_rank>0, the
+        TransferManagerOnRemote may not be ready immediately; retry up
+        to ~6 minutes."""
+        for attempt in range(max_retries):
+            try:
+                self._register_to_server(kv_caches, indexer_buffers)
+                return
+            except Exception as exc:  # noqa: BLE001
+                if attempt == max_retries - 1:
+                    raise
+                if attempt % 30 == 0:
+                    logger.info(
+                        "[FlexKV] GPU register retry %s attempt=%d/%d error=%s",
+                        self._label,
+                        attempt + 1,
+                        max_retries,
+                        exc,
+                    )
+                time.sleep(1.0)
+
+    def _register_to_server(
+        self,
+        kv_caches: List[torch.Tensor],
+        indexer_buffers: Optional[List[torch.Tensor]] = None,
+    ) -> None:
+        assert len(kv_caches) > 0
+        if self._is_dsv4:
+            self._register_dsv4_to_server(kv_caches)
+            return
+        assert (
+            kv_caches[0].ndim == 3
+        ), f"Expected 3D KV cache tensor, got shape={kv_caches[0].shape}"
+
+        is_mla = self.model_config.use_mla
+        num_blocks, num_kv_heads, head_size = kv_caches[0].shape
+
+        gpu_layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=self.rank_info.num_layers_per_pp_stage,
+            num_block=num_blocks // self.page_size,
+            tokens_per_block=self.page_size,
+            num_head=num_kv_heads,
+            head_size=head_size,
+            is_mla=is_mla,
+        )
+
+        indexer_layout = None
+        if indexer_buffers is not None and len(indexer_buffers) > 0:
+            indexer_tensor = indexer_buffers[0]
+            assert indexer_tensor.ndim == 2, (
+                f"Expected 2D indexer tensor (num_pages, page_stride_size), "
+                f"got shape={indexer_tensor.shape}"
+            )
+            indexer_layout = KVCacheLayout(
+                type=KVCacheLayoutType.LAYERFIRST,
+                num_layer=len(indexer_buffers),
+                num_block=indexer_tensor.shape[0],
+                tokens_per_block=1,
+                num_head=1,
+                head_size=indexer_tensor.shape[1],
+                is_mla=True,
+            )
+
+        if indexer_buffers and indexer_layout is not None:
+            self.tp_client.register_to_server(
+                kv_caches=list(kv_caches) + list(indexer_buffers),
+                kv_layout=gpu_layout,
+                layer_groups=self._build_indexer_layer_group_specs(
+                    kv_caches, indexer_buffers
+                ),
+                gpu_layouts=[gpu_layout, indexer_layout],
+                handles_per_group=[list(kv_caches), list(indexer_buffers)],
+            )
+        else:
+            self.tp_client.register_to_server(
+                kv_caches=kv_caches,
+                kv_layout=gpu_layout,
+            )
+        logger.info("[FlexKV] Registered KV caches to server %s", self._label)
+
+    def _register_dsv4_to_server(self, kv_caches: List[torch.Tensor]) -> None:
+        """Register DSv4 main KV groups plus SWA/state sidecars."""
+        layer_groups: List[LayerGroupSpec] = []
+        gpu_layouts: List[KVCacheLayout] = []
+        handles_per_group: List[List[torch.Tensor]] = []
+        all_buffers: List[torch.Tensor] = []
+
+        for group in self._dsv4_layer_groups:
+            buffers = group["buffers"]
+            sample = buffers[0]
+            if sample.ndim != 2:
+                raise RuntimeError(
+                    f"FlexKV DSv4 group {group['name']!r} expects 2D page "
+                    f"buffers, got shape={tuple(sample.shape)}"
+                )
+            if any(buf.shape != sample.shape for buf in buffers):
+                raise RuntimeError(
+                    f"FlexKV DSv4 group {group['name']!r} has mixed shapes"
+                )
+            sub_page_size = int(group["sub_page_size"])
+            if self.page_size % int(group["ratio"]) != 0:
+                raise RuntimeError(
+                    f"FlexKV page_size={self.page_size} is not divisible by "
+                    f"DSv4 ratio={group['ratio']}"
+                )
+            if sample.shape[1] % sub_page_size != 0:
+                raise RuntimeError(
+                    f"FlexKV DSv4 group {group['name']!r} page stride "
+                    f"{sample.shape[1]} is not divisible by {sub_page_size}"
+                )
+            head_size = sample.shape[1] // sub_page_size
+            layer_groups.append(
+                LayerGroupSpec(
+                    num_layers=len(group["layer_ids"]),
+                    num_kv_heads=1,
+                    head_size=head_size,
+                    layer_indices=list(group["layer_ids"]),
+                    compress_ratio=int(group["ratio"]),
+                    dtype=group["dtype"],
+                )
+            )
+            gpu_layouts.append(
+                KVCacheLayout(
+                    type=KVCacheLayoutType.LAYERFIRST,
+                    num_layer=len(group["layer_ids"]),
+                    num_block=sample.shape[0],
+                    tokens_per_block=sub_page_size,
+                    num_head=1,
+                    head_size=head_size,
+                    is_mla=True,
+                )
+            )
+            handles_per_group.append(list(buffers))
+            all_buffers.extend(buffers)
+
+        if len(all_buffers) != len(kv_caches):
+            raise RuntimeError(
+                f"FlexKV DSv4 flattened {len(all_buffers)} buffers, expected "
+                f"{len(kv_caches)}"
+            )
+
+        # The primary layout owns the full PP-stage layer-id namespace. Group
+        # layouts remain local because several groups cover disjoint layer sets.
+        first_layout = gpu_layouts[0]
+        primary_layout = KVCacheLayout(
+            type=first_layout.type,
+            num_layer=self.rank_info.num_layers_per_pp_stage,
+            num_block=first_layout.num_block,
+            tokens_per_block=first_layout.tokens_per_block,
+            num_head=first_layout.num_head,
+            head_size=first_layout.head_size,
+            is_mla=first_layout.is_mla,
+        )
+
+        swa_caches = None
+        swa_layout = None
+        swa_layer_groups = None
+        swa_gpu_layouts = None
+        swa_handles_per_group = None
+        swa_pool = self._swa_kv_pool
+        swa_buffers = list(getattr(swa_pool, "kv_buffer", []))
+        if swa_buffers:
+            sample = swa_buffers[0]
+            sub_page_size = int(swa_pool.page_size)
+            if sample.ndim != 2 or sample.shape[1] % sub_page_size != 0:
+                raise RuntimeError(
+                    "FlexKV DSv4 SWA buffers must be 2D with a page-aligned stride"
+                )
+            head_size = sample.shape[1] // sub_page_size
+            swa_layout = KVCacheLayout(
+                type=KVCacheLayoutType.LAYERFIRST,
+                num_layer=len(swa_buffers),
+                num_block=sample.shape[0],
+                tokens_per_block=sub_page_size,
+                num_head=1,
+                head_size=head_size,
+                is_mla=True,
+            )
+            swa_caches = list(swa_buffers)
+
+            if self._dsv4_state_groups:
+                swa_layer_ids = list(range(len(swa_buffers)))
+                swa_layer_groups = [
+                    LayerGroupSpec(
+                        num_layers=len(swa_buffers),
+                        num_kv_heads=1,
+                        head_size=head_size,
+                        layer_indices=swa_layer_ids,
+                        compress_ratio=1,
+                        dtype=sample.dtype,
+                    )
+                ]
+                swa_gpu_layouts = [swa_layout]
+                swa_handles_per_group = [list(swa_buffers)]
+
+                for state_group in self._dsv4_state_groups:
+                    state_buffers = state_group["buffers"]
+                    ring_size = int(state_group["sub_page_size"])
+                    state_pages = min(
+                        int(buffer.shape[0]) // ring_size for buffer in state_buffers
+                    )
+                    if state_pages < sample.shape[0]:
+                        raise RuntimeError(
+                            f"FlexKV DSv4 state group {state_group['name']!r} "
+                            f"has {state_pages} pages, SWA has {sample.shape[0]}"
+                        )
+                    state_layout = KVCacheLayout(
+                        type=KVCacheLayoutType.LAYERFIRST,
+                        num_layer=len(state_group["layer_ids"]),
+                        num_block=state_pages,
+                        tokens_per_block=ring_size,
+                        num_head=1,
+                        head_size=int(state_group["head_size"]),
+                        is_mla=True,
+                    )
+                    swa_layer_groups.append(
+                        LayerGroupSpec(
+                            num_layers=len(state_group["layer_ids"]),
+                            num_kv_heads=1,
+                            head_size=int(state_group["head_size"]),
+                            layer_indices=list(state_group["layer_ids"]),
+                            compress_ratio=int(state_group["ratio"]),
+                            dtype=state_group["dtype"],
+                        )
+                    )
+                    swa_gpu_layouts.append(state_layout)
+                    swa_handles_per_group.append(list(state_buffers))
+                    swa_caches.extend(state_buffers)
+
+        self.tp_client.register_to_server(
+            kv_caches=all_buffers,
+            kv_layout=primary_layout,
+            layer_groups=layer_groups,
+            gpu_layouts=gpu_layouts,
+            handles_per_group=handles_per_group,
+            swa_caches=swa_caches,
+            swa_layout=swa_layout,
+            swa_layer_groups=swa_layer_groups,
+            swa_gpu_layouts=swa_gpu_layouts,
+            swa_handles_per_group=swa_handles_per_group,
+        )
+        logger.info(
+            "[FlexKV-DSv4] registered %d main groups, SWA=%s, state_groups=%d",
+            len(layer_groups),
+            bool(swa_buffers),
+            len(self._dsv4_state_groups),
+        )
+
+    def _send_pp_put_meta(self, fkv_task_id: int, unmatched_mask) -> None:
+        if not self._sync_ctx.is_pp_active:
+            return
+        if hasattr(unmatched_mask, "tolist"):
+            mask_list = unmatched_mask.tolist()
+        else:
+            mask_list = list(unmatched_mask)
+        self._sync_ctx.scatter_pp(
+            {
+                "cmd": CMD_PUT_META,
+                "fkv_task_id": fkv_task_id,
+                "unmatched_mask": mask_list,
+            }
+        )
+
+    def _send_slot_mapping_to_remote(
+        self, task_id: int, slot_mapping_cpu: torch.Tensor
+    ) -> None:
+        np_arr = slot_mapping_cpu.numpy()
+        self.tp_client.set_slot_mapping(task_id, np_arr)
+
+    def _send_eventfds_to_worker(self, retry_interval: float = 1.0) -> None:
+        """UDS handshake with the FlexKV layerwise transfer worker.
+
+        Sends per-counter eventfd FDs over a unix domain socket using
+        ``SCM_RIGHTS``. Retries connect (worker may not yet be up) and
+        retries the whole connect+send sequence on send error.
+        """
+        max_retries = self._layerwise_eventfd_connect_max_retries
+        max_send_retries = 3
+        last_error: Optional[BaseException] = None
+
+        assert self.layer_done_counter is not None
+
+        for send_attempt in range(max_send_retries):
+            sock: Optional[socket.socket] = None
+            try:
+                # Phase 1: connect (worker may not yet be up).
+                for attempt in range(max_retries):
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    try:
+                        sock.connect(self._layerwise_socket)
+                        logger.info(
+                            "[FlexKV] Eventfd connected %s socket=%s attempts=%d",
+                            self._label,
+                            self._layerwise_socket,
+                            attempt + 1,
+                        )
+                        break
+                    except (FileNotFoundError, ConnectionRefusedError) as exc:
+                        sock.close()
+                        sock = None
+                        if attempt == max_retries - 1:
+                            raise RuntimeError(
+                                f"[FlexKV] Failed to connect to eventfd socket "
+                                f"{self._layerwise_socket} after {max_retries} attempts"
+                            ) from exc
+                        time.sleep(retry_interval)
+                assert sock is not None
+
+                # Phase 2: send 16-byte metadata + per-counter FDs + read ACK.
+                num_counters = self.layer_done_counter.num_counters
+                metadata = struct.pack(
+                    "iiii",
+                    self.rank_info.effective_tp_rank,
+                    self.model_config.effective_tp_size_per_node,
+                    self.rank_info.num_layers_per_pp_stage,
+                    num_counters,
+                )
+                sock.sendall(metadata)
+                for counter_id in range(num_counters):
+                    fds = self.layer_done_counter.events[counter_id].load_event_fds
+                    send_fds(sock, fds, struct.pack("i", counter_id))
+                sock.settimeout(30.0)
+                try:
+                    ack = sock.recv(1)
+                except socket.timeout as exc:
+                    raise RuntimeError(
+                        "Timed out waiting for ACK from FlexKV layerwise worker"
+                    ) from exc
+                if not ack or ack[0] != 1:
+                    raise RuntimeError(
+                        f"FlexKV layerwise worker NACK'd eventfd transfer (ack={ack!r})"
+                    )
+                logger.info(
+                    "[FlexKV] Eventfd handshake complete %s counters=%d layers=%d",
+                    self._label,
+                    num_counters,
+                    self.rank_info.num_layers_per_pp_stage,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                logger.warning(
+                    "[FlexKV] Eventfd handshake send_attempt=%d/%d failed: %s",
+                    send_attempt + 1,
+                    max_send_retries,
+                    exc,
+                )
+            finally:
+                if sock is not None:
+                    sock.close()
+                time.sleep(retry_interval)
+
+        raise RuntimeError(
+            f"[FlexKV] Failed to send eventfds to {self._layerwise_socket} "
+            f"after {max_send_retries} attempts: {last_error}"
+        )

--- a/flexkv/integration/sglang/sglang_flexkv_connector.patch
+++ b/flexkv/integration/sglang/sglang_flexkv_connector.patch
@@ -1,1173 +1,2125 @@
-diff --git a/docs/advanced_features/kv_connector.md b/docs/advanced_features/kv_connector.md
-new file mode 100644
-index 000000000..8d5598008
---- /dev/null
-+++ b/docs/advanced_features/kv_connector.md
-@@ -0,0 +1,89 @@
-+# KV Connector Guide
-+
-+Implement `BaseKVConnector` (`sglang/srt/mem_cache/kv_connector.py`) to integrate an external KV cache offloading framework into SGLang.
-+
-+## Architecture
-+
-+```
-+Scheduler
-+    │
-+    v
-+ExtendedRadixCache  ───>  RadixCache (manage GPU KV pool)
-+    │
-+    v
-+BaseKVConnector (your impl)  ───>  External Storage (CPU/SSD/remote)
-+```
-+
-+`ExtendedRadixCache` wraps `RadixCache` via composition. It intercepts
-+`match_prefix`, `cache_finished_req` etc. to coordinate with the connector.
-+GPU memory allocation and radix tree operations are handled by the inner
-+`RadixCache`; the connector only manages external storage and async transfers.
-+
-+## How It Works
-+
-+Each scheduler iteration:
-+
-+1. **Poll completions** — `check_completed_store_tasks()` / `check_completed_load_tasks()`
-+   release GPU radix tree node locks so GPU nodes become evictable, otherwise tree nodes stay locked and GPU memory leaks.
-+2. **Match prefix** — `get_new_hit_length()`: query external storage for tokens
-+   beyond the GPU radix cache hit.
-+3. **Prepare load** — `init_load_back`: pre-allocate GPU slots, create locked
-+   TreeNode, enqueue `LoadOperation`.
-+4. **Dispatch load** — `start_load_kv()`: async transfer from external storage into pre-allocated GPU slots.
-+5. **Request completes** — `start_store_kv()`: async transfer of new KV data to external storage; node locked until done.
-+
-+## Constructor
-+
-+```python
-+class BaseKVConnector(ABC):
-+    def __init__(self, params, server_args, tp_group, tp_rank, kvcache):
-+```
-+
-+| Parameter     | Key Contents                                                       |
-+|---------------|--------------------------------------------------------------------|
-+| `params`      | `page_size`, `token_to_kv_pool_allocator`                          |
-+| `server_args` | Model path, `tp_size`, dtype, `kv_connector_extra_config`          |
-+| `tp_group`    | `torch.distributed` process group (`None` if tp=1)                 |
-+| `tp_rank`     | 0-based TP rank                                                    |
-+| `kvcache`     | `k_buffer` / `v_buffer`: list of per-layer GPU tensors `[num_slots, num_kv_heads, head_dim]` |
-+
-+## Methods to Implement
-+
-+### Abstract (required)
-+
-+| Method | Signature | Purpose |
-+|--------|-----------|---------|
-+| `get_new_hit_length` | `(token_ids, token_mask, update_state_for_load, rid) -> int` | Query external storage for cached tokens. `token_mask[i]=True` for positions not on GPU. When `update_state_for_load=True`, reserve state keyed by `rid` for the upcoming load. |
-+| `release_load_state` | `(rid) -> None` | Release state reserved by `get_new_hit_length` (called when GPU alloc fails). |
-+| `start_load_kv` | `(task_id, load_ops: List[LoadOperation]) -> None` | Begin async KV cache transfer from storage to GPU. Each `LoadOperation` has `rid`, `device_indices` (pre-allocated GPU slots), and `node` (opaque). |
-+| `check_completed_load_tasks` | `() -> List[int]` | Non-blocking poll. Return completed load `task_id`s. |
-+| `start_store_kv` | `(task_id, token_ids, kv_indices: Tensor) -> None` | Begin async KV cache transfer from GPU to storage. `kv_indices[i]` is the GPU pool slot for `token_ids[i]`. |
-+| `check_completed_store_tasks` | `() -> List[int]` | Non-blocking poll. Return completed store `task_id`s. |
-+
-+### Optional (default no-ops)
-+
-+| Method | Purpose |
-+|--------|---------|
-+| `prefetch(rid, token_ids)` | Pre-stage data from slow to fast tier before scheduling. |
-+| `check_prefetch_progress(rid) -> bool` | Gate scheduling (default `True`). |
-+| `pop_prefetch_loaded_tokens(rid) -> int` | Pop and return the number of tokens loaded from storage for a request. Returns 0 if no prefetch was done or was revoked. This should be called after check_prefetch_progress() returns True. |
-+| `cancel_prefetch(rid)` | Cancel prefetch on request abort. |
-+| `layer_done_counter` (property) | Layer-wise sync counter for overlapped load+compute. |
-+| `reset()` | Clear all state on cache flush. |
-+| `shutdown()` | Cleanup resources. |
-+
-+## Example
-+
-+Reference implementation: `FlexKVConnector` (`sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py`).
-+
-+## Launch
-+
-+```bash
-+# Full module path
-+python -m sglang.launch_server --model ... \
-+    --kv-connector-cls my_package.my_module.MyConnector
-+
-+# Built-in alias
-+python -m sglang.launch_server --model ... \
-+    --kv-connector-cls flexkv
-+```
-diff --git a/python/sglang/srt/layers/attention/nsa_backend.py b/python/sglang/srt/layers/attention/nsa_backend.py
-index 0e95c28d2..5b235e916 100644
---- a/python/sglang/srt/layers/attention/nsa_backend.py
-+++ b/python/sglang/srt/layers/attention/nsa_backend.py
-@@ -57,7 +57,15 @@ if _is_hip:
-             "aiter is AMD specific kernel library. Please make sure aiter is installed on your AMD device."
-         )
- else:
--    from sgl_kernel.flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
-+    try:
-+        from sgl_kernel.flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
-+        _fa3_import_error = None
-+    except ImportError as e:
-+        # Blackwell-only sgl-kernel builds may intentionally omit FA3/flash_ops.
-+        # NSA backends that use FlashMLA/TRTLLM should still initialize successfully.
-+        flash_attn_varlen_func = None
-+        flash_attn_with_kvcache = None
-+        _fa3_import_error = e
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index 7b3ca52e5..78fbc9b11 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -518,6 +518,9 @@ def run_detokenizer_process(
+     setproctitle.setproctitle("sglang::detokenizer")
+     configure_logger(server_args)
+     parent_process = psutil.Process().parent()
++    # Parent owns Ctrl+C → ShutdownReq; ignore SIGINT so process-group interrupt
++    # does not KeyboardInterrupt this child into a false SIGQUIT crash path.
++    signal.signal(signal.SIGINT, signal.SIG_IGN)
  
- 
- # Reuse this workspace buffer across all NSA backend instances
-@@ -1504,6 +1512,12 @@ class NativeSparseAttnBackend(
-         logit_cap: float,
-         page_size: int,
-     ) -> torch.Tensor:
-+        if flash_attn_with_kvcache is None:
-+            raise ImportError(
-+                "NSA backend requested FA3, but FA3 kernels are unavailable in "
-+                "the installed sgl-kernel."
-+            ) from _fa3_import_error
-+
-         k_rope_cache = kv_cache[:, :, v_head_dim:]
-         c_kv_cache = kv_cache[:, :, :v_head_dim]
-         qk_rope_dim = k_rope_cache.shape[-1]
-@@ -1673,6 +1687,11 @@ class NativeSparseAttnBackend(
-             )
- 
-         # Use FA3 for SM90 (Hopper/H200)
-+        if flash_attn_varlen_func is None:
-+            raise ImportError(
-+                "NSA standard MHA fell back to FA3, but FA3 kernels are unavailable "
-+                "in the installed sgl-kernel."
-+            ) from _fa3_import_error
-         fa_version = 3
- 
-         return flash_attn_varlen_func(
+     manager = None
+     try:
 diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
-index 674f27f74..1249a938f 100644
+index 97a3dceb6..a7faf6a03 100755
 --- a/python/sglang/srt/managers/schedule_batch.py
 +++ b/python/sglang/srt/managers/schedule_batch.py
-@@ -643,6 +643,8 @@ class Req:
+@@ -888,6 +888,12 @@ class Req(ReqDllmMixin):
+         # Prefix info
+         # The indices to kv cache for the shared prefix.
+         self.prefix_indices: torch.Tensor = torch.empty((0,), dtype=torch.int64)
++        # A storage load-back remains request-owned until cache_finished_req or
++        # cache_unfinished_req transfers those slots into the prefix cache.
++        # Keep that ownership separate from prefix_indices: the latter is
++        # rebuilt on every prefix match and cannot identify an in-flight restore.
++        self.pending_restore_generation: Optional[int] = None
++        self.pending_restore_slots: Optional[torch.Tensor] = None
+         # TODO(ispobock): rename to last_device_node
          self.last_node: Any = None
          self.last_host_node: Any = None
-         self.host_hit_length = 0
-+        # Tokens matched by KV connector (e.g., FlexKV) for this request.
-+        self.cached_tokens_extended_device = 0
-         # The node to lock until for swa radix tree lock ref
-         self.swa_uuid_for_lock: Optional[int] = None
-         # Whether the prefill-time SWA tree lock has been released early
-@@ -884,6 +886,7 @@ class Req:
-                     key=RadixKey(token_ids=token_ids, extra_key=self.extra_key),
-                     req=self if tree_cache.supports_mamba() else None,
-                     cow_mamba=tree_cache.supports_mamba(),
-+                    update_connector_state=True,
-                 )
-             )
-             (
 diff --git a/python/sglang/srt/managers/schedule_policy.py b/python/sglang/srt/managers/schedule_policy.py
-index 62223abd6..5d8433655 100644
+index 0e6d0f214..7da23e207 100644
 --- a/python/sglang/srt/managers/schedule_policy.py
 +++ b/python/sglang/srt/managers/schedule_policy.py
-@@ -774,10 +774,10 @@ class PrefillAdder:
-                     return AddReqResult.NO_TOKEN
+@@ -682,6 +682,32 @@ class PrefillAdder:
+     def ceil_paged_tokens(self, tokens: int) -> int:
+         return -(-tokens // self.page_size) * self.page_size
  
-             if req.host_hit_length > 0:
--                new_indices, req.last_node = self.tree_cache.init_load_back(
-+                self.tree_cache.init_load_back(
-                     req.last_host_node, req.host_hit_length
++    def _get_chunked_prefill_len(
++        self,
++        prefix_len: int,
++        chunk_tokens_limit: int,
++        truncation_align_size: Optional[int],
++    ) -> int:
++        """Return the schedulable chunk length, or 0 when admission must stop.
++
++        This calculation is intentionally side-effect free so storage load-back
++        can run only after every chunk admission check has passed. Otherwise a
++        waiting request can allocate and launch an H2D restore, be rejected by
++        one of these checks, and leak the restored slots on its next retry.
++        """
++        trunc_len = chunk_tokens_limit // self.page_size * self.page_size
++        if trunc_len <= 0:
++            return 0
++
++        if truncation_align_size is not None:
++            if trunc_len < truncation_align_size:
++                return 0
++            trunc_len = truncation_align_size * (trunc_len // truncation_align_size)
++
++        now_input_len = trunc_len + prefix_len
++        now_input_len = now_input_len // self.page_size * self.page_size
++        return max(0, now_input_len - prefix_len)
++
+     def budget_state(self):
+         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
+         if not no_token and self.is_hybrid_swa:
+@@ -1086,6 +1112,33 @@ class PrefillAdder:
+                         return AddReqResult.NO_TOKEN
+                     chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
+ 
++            # Do every deterministic admission check before init_load_back.
++            # Storage restore allocates GPU slots and may launch asynchronous
++            # H2D. A request rejected after that point remains in waiting_queue;
++            # its next prefix match overwrites req.prefix_indices and used to
++            # orphan the restored slots.
++            projected_prefix_len = prefix_len + req.host_hit_length
++            projected_input_tokens = self.ceil_paged_tokens(
++                len(req.full_untruncated_fill_ids) - projected_prefix_len
++            )
++            if self.dllm_config is not None:
++                if self.rem_dllm_tokens <= 0:
++                    return AddReqResult.OTHER
++                assert (
++                    truncation_align_size is None
++                ), "truncation_align_size is not supported for dllm prefill"
++            elif (
++                chunk_tokens_limit is not None
++                and projected_input_tokens > chunk_tokens_limit
++                and self._get_chunked_prefill_len(
++                    projected_prefix_len,
++                    chunk_tokens_limit,
++                    truncation_align_size,
++                )
++                <= 0
++            ):
++                return AddReqResult.OTHER
++
+             if req.needs_host_load_back():
+                 new_indices, req.last_node = self.tree_cache.init_load_back(
+                     InitLoadBackParams(
+@@ -1096,7 +1149,12 @@ class PrefillAdder:
                  )
--                req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
-+                # req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
-                 req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
+                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                  prefix_len = len(req.prefix_indices)
-                 req.cache_protected_len = prefix_len
+-                req.cache_protected_len = prefix_len
++                # FlexKV hybrid restores are request-owned until the normal
++                # cache completion path inserts them. Keep the pre-restore
++                # protection boundary so the inner radix cache can deduplicate
++                # and free those slots correctly.
++                if not getattr(req, "_flexkv_uncached_restore", False):
++                    req.cache_protected_len = prefix_len
+ 
+             input_tokens = self.ceil_paged_tokens(
+                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+@@ -1113,13 +1171,6 @@ class PrefillAdder:
+                 return AddReqResult.OTHER
+ 
+             if self.dllm_config is not None:
+-                if self.rem_dllm_tokens <= 0:
+-                    return AddReqResult.OTHER
+-
+-                assert (
+-                    truncation_align_size is None
+-                ), "truncation_align_size is not supported for dllm prefill"
+-
+                 self._add_dllm_req(req, prefix_len)
+                 self._req_inc_lock_ref(req)
+             elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
+@@ -1141,26 +1192,11 @@ class PrefillAdder:
+                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
+                 )
+             else:
+-                # Make sure at least one page is available
+-                trunc_len = chunk_tokens_limit // self.page_size * self.page_size
+-
+-                if trunc_len <= 0:
+-                    return AddReqResult.OTHER
+-
+-                # When truncation align size is set, we want to assert that the prefill prefix length is multiple of truncation align size
+-                # A typical use case is when deterministic inference is enabled with flashinfer attention backend,
+-                # we need the prefill prefix length to be multiple of attention split size
+-                if truncation_align_size is not None:
+-                    if trunc_len < truncation_align_size:
+-                        return AddReqResult.OTHER
+-                    else:
+-                        trunc_len = truncation_align_size * (
+-                            trunc_len // truncation_align_size
+-                        )
+-
+-                now_input_len = trunc_len + len(req.prefix_indices)
+-                now_input_len = now_input_len // self.page_size * self.page_size
+-                trunc_len = now_input_len - len(req.prefix_indices)
++                trunc_len = self._get_chunked_prefill_len(
++                    len(req.prefix_indices),
++                    chunk_tokens_limit,
++                    truncation_align_size,
++                )
+ 
+                 if trunc_len <= 0:
+                     return AddReqResult.OTHER
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index 09642cd9a..898aae0c6 100644
+index baa191862..b63fd3b19 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -309,6 +309,7 @@ class Scheduler(
-         self.page_size = server_args.page_size
-         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
-         self.enable_hicache_storage = server_args.hicache_storage_backend is not None
-+        self.enable_kv_connector = server_args.kv_connector_cls is not None
-         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
-         self.enable_hisparse = server_args.enable_hisparse
-         self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
-@@ -679,6 +680,42 @@ class Scheduler(
-                 from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
- 
-                 self.tree_cache = MambaRadixCache(params)
-+            elif server_args.kv_connector_cls is not None:
-+                import importlib
-+
-+                from sglang.srt.mem_cache.extended_radix_cache import ExtendedRadixCache
-+                from sglang.srt.mem_cache.kv_connector import BaseKVConnector
-+
-+                _KV_CONNECTOR_ALIASES = {
-+                    "flexkv": "sglang.srt.mem_cache.storage.flexkv.flexkv_connector.FlexKVConnector",
-+                }
-+                connector_cls_path = _KV_CONNECTOR_ALIASES.get(
-+                    server_args.kv_connector_cls, server_args.kv_connector_cls
-+                )
-+                module_path, class_name = connector_cls_path.rsplit(".", 1)
-+                module = importlib.import_module(module_path)
-+                connector_cls = getattr(module, class_name)
-+                if not issubclass(connector_cls, BaseKVConnector):
-+                    raise TypeError(
-+                        f"Connector class {class_name} must inherit from "
-+                        "sglang.srt.mem_cache.kv_connector.BaseKVConnector"
-+                    )
-+                connector = connector_cls(
-+                    params=params,
-+                    server_args=server_args,
-+                    tp_rank=self.tp_rank,
-+                    dp_rank=self.dp_rank,
-+                    attn_cp_rank=self.attn_cp_rank,
-+                    pp_group=self.pp_group,
-+                    attn_tp_group=self.attn_tp_group,
-+                    attn_cp_group=self.attn_cp_group,
-+                )
-+                self.tree_cache = ExtendedRadixCache(params=params, connector=connector)
-+
-+                if getattr(self.tree_cache, "layer_done_counter", None) is not None:
-+                    self.tp_worker.register_hicache_layer_transfer_counter(
-+                        self.tree_cache.layer_done_counter
-+                    )
-             elif server_args.enable_lmcache:
-                 from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
-                     LMCRadixCache,
-@@ -1686,7 +1723,10 @@ class Scheduler(
-                 direction * recv_req.priority < direction * candidate_req.priority
-             )
-             if abort_existing_req:
--                if self.enable_hierarchical_cache:
-+                if self.enable_hicache_storage or self.enable_kv_connector:
-+                    # Release prefetch/load state associated with the request
-+                    self.tree_cache.release_aborted_request(candidate_req.rid)
-+                elif self.enable_hierarchical_cache:
-                     self.tree_cache.terminate_prefetch(candidate_req.rid)
-                 self.waiting_queue.pop(idx)
-                 req_to_abort = candidate_req
-@@ -1933,6 +1973,7 @@ class Scheduler(
-                 self.running_batch = self.update_running_batch(self.running_batch)
-                 ret = self.running_batch if not self.running_batch.is_empty() else None
-             else:
-+                self.running_batch.batch_is_full = False
-                 ret = None
- 
-         # Handle DP attention and log stats
-@@ -2000,8 +2041,8 @@ class Scheduler(
-             self.running_batch.batch_is_full = True
-             return None
- 
--        if self.enable_hierarchical_cache:
--            self.tree_cache.check_hicache_events()
-+        if self.enable_hierarchical_cache or self.enable_kv_connector:
-+            self.tree_cache.check_kv_events()
- 
-         # Get priority queue
-         self.policy.calc_priority(self.waiting_queue, self.running_batch)
-@@ -2092,7 +2133,7 @@ class Scheduler(
-                 ):
-                     break
- 
--            if self.enable_hicache_storage:
-+            if self.enable_hicache_storage or self.enable_kv_connector:
-                 prefetch_done = self.tree_cache.check_prefetch_progress(req.rid)
-                 if not prefetch_done:
-                     # skip staging requests that are ongoing prefetch
-@@ -2191,7 +2232,7 @@ class Scheduler(
-             dllm_staging_reqs=self.dllm_staging_reqs,
-             dllm_config=self.dllm_config,
+@@ -2946,7 +2946,14 @@ class Scheduler(
+             waiting_queue_len=len(self.waiting_queue),
          )
--        if self.enable_hierarchical_cache:
-+        if self.enable_hierarchical_cache or self.enable_kv_connector:
-             # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
-             new_batch.hicache_consumer_index = (
-                 self.tree_cache.ready_to_load_host_cache()
-@@ -2655,7 +2696,7 @@ class Scheduler(
-             # This only works for requests that have not started anything.
-             # We still need to send something back to TokenizerManager to clean up the state.
-             req = self.waiting_queue.pop(i)
--            if self.enable_hicache_storage:
-+            if self.enable_hicache_storage or self.enable_kv_connector:
-                 # to release prefetch events associated with the request
-                 self.tree_cache.release_aborted_request(req.rid)
-             self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
-diff --git a/python/sglang/srt/managers/scheduler_output_processor_mixin.py b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
-index 1b8e8b308..29359027c 100644
---- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
-+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
-@@ -47,6 +47,61 @@ class SchedulerOutputProcessorMixin:
-     We put them into a separate file to make the `scheduler.py` shorter.
-     """
  
-+    def _get_storage_backend_type(self) -> str:
-+        """Get storage backend type from tree_cache."""
-+        storage_backend_type = "none"
-+        cache_controller = getattr(self.tree_cache, "cache_controller", None)
-+        if cache_controller and hasattr(cache_controller, "storage_backend"):
-+            storage_backend = cache_controller.storage_backend
-+            if storage_backend is not None:
-+                storage_backend_type = type(storage_backend).__name__
-+        return storage_backend_type
+-        if self.chunked_req is not None:
++        has_uncommitted_restore = getattr(
++            self.tree_cache, "has_uncommitted_restore", None
++        )
 +
-+    def _get_kv_connector_backend_type(self) -> str:
-+        """Get KV connector backend type from extended radix cache."""
-+        connector = getattr(self.tree_cache, "_connector", None)
-+        if connector is None:
-+            return "none"
-+        return type(connector).__name__
++        if self.chunked_req is not None and not (
++            has_uncommitted_restore is not None
++            and has_uncommitted_restore(self.chunked_req)
++        ):
+             self.chunked_req.init_next_round_input()
+             self.chunked_req = adder.add_chunked_req(self.chunked_req)
+ 
+@@ -2968,6 +2975,13 @@ class Scheduler(
+             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
+         # Get requests from the waiting queue to a new prefill batch
+         for req in self.waiting_queue:
++            # A FlexKV restore owns request-local GPU slots until the previous
++            # batch commits them to the radix cache. Do not rematch the request
++            # in that window: match_prefix would otherwise replace the only
++            # request-side reference before cache completion.
++            if has_uncommitted_restore is not None and has_uncommitted_restore(req):
++                continue
 +
-+    def _get_cached_tokens_details(self, req: Req) -> Optional[dict]:
-+        """Get detailed cache breakdown for a request, if available.
-+
-+        Returns:
-+            - None if no detailed cache info is available
-+            - {"device": X, "host": Y} if HiCache enabled but L3 storage is not
-+            - {"device": X, "host": Y, "storage": Z, "storage_backend": "..."} if L3 enabled
-+            - {"device": X, "storage": Y} when KV connector (e.g., FlexKV) matched Y tokens
-+        """
-+        details = None
-+
-+        if getattr(self, "enable_hierarchical_cache", False):
-+            if (
-+                req.cached_tokens_device > 0
-+                or req.cached_tokens_host > 0
-+                or req.cached_tokens_storage > 0
-+            ):
-+                details = {
-+                    "device": req.cached_tokens_device,
-+                    "host": req.cached_tokens_host,
-+                }
-+                # Only include storage fields if L3 storage is enabled
-+                if getattr(self, "enable_hicache_storage", False):
-+                    details["storage"] = req.cached_tokens_storage
-+                    details["storage_backend"] = self._get_storage_backend_type()
-+
-+        if getattr(self, "enable_kv_connector", False):
-+            if (
-+                req.cached_tokens_device > 0
-+                or req.cached_tokens_extended_device > 0
-+            ):
-+                details = {
-+                    "device": req.cached_tokens_device,
-+                    "storage": req.cached_tokens_extended_device,
-+                    "storage_backend": self._get_kv_connector_backend_type(),
-+                }
-+        return details
-+
-     def process_batch_result_prebuilt(self: Scheduler, batch: ScheduleBatch):
-         assert self.disaggregation_mode == DisaggregationMode.DECODE
-         for req in batch.reqs:
-diff --git a/python/sglang/srt/mem_cache/allocator_ascend.py b/python/sglang/srt/mem_cache/allocator_ascend.py
-new file mode 100644
-index 000000000..74ac8983d
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
-@@ -0,0 +1,186 @@
-+from __future__ import annotations
-+
-+from typing import TYPE_CHECKING
-+
-+import torch
-+
-+if TYPE_CHECKING:
-+    from sglang.srt.mem_cache.memory_pool import KVCache
-+
-+from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
-+from sglang.srt.utils import get_num_new_pages, next_power_of_2
-+
-+
-+def alloc_extend_kernel_ascend(
-+    prefix_lens,
-+    seq_lens,
-+    last_loc,
-+    free_pages,
-+    out_indices,
-+    page_size,
-+    device,
+             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
+                 continue
+ 
+@@ -3022,6 +3036,17 @@ class Scheduler(
+                 # lifecycle and freeing them here causes double-free.
+                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
+                 if not added:
++                    # A successful storage restore must be followed by batch
++                    # admission in this same pass. Freeing a layerwise restore
++                    # here would race its asynchronous H2D writer, so fail loud
++                    # if a future admission check violates that ordering.
++                    if has_uncommitted_restore is not None and has_uncommitted_restore(
++                        req
++                    ):
++                        raise RuntimeError(
++                            "Request was rejected after storage load-back: "
++                            f"rid={req.rid}"
++                        )
+                     # init_next_round_input() may stage deferred Mamba COW/clear
+                     # metadata before add_one_req() rejects the request.
+                     req.mamba_cow_src_index = None
+diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
+index 60b35ea02..e21aaf68e 100644
+--- a/python/sglang/srt/managers/tokenizer_manager.py
++++ b/python/sglang/srt/managers/tokenizer_manager.py
+@@ -1872,6 +1872,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+         if threading.current_thread() is threading.main_thread():
+             signal_handler = self.signal_handler_class(self)
+             loop.add_signal_handler(signal.SIGTERM, signal_handler.sigterm_handler)
++            # Ctrl+C (SIGINT): uvicorn also stops HTTP on SIGINT; set gracefully_exit
++            # so sigterm_watchdog (and lifespan) can ShutdownReq + wait for FlexKV unpin.
++            # Schedulers ignore SIGINT so process-group Ctrl+C does not kill them first.
++            try:
++                loop.add_signal_handler(signal.SIGINT, signal_handler.sigterm_handler)
++            except (NotImplementedError, RuntimeError, ValueError):
++                pass
+             # Update the signal handler for the process. It overrides the sigquit handler in the launch phase.
+             loop.add_signal_handler(
+                 signal.SIGQUIT, signal_handler.running_phase_sigquit_handler
+@@ -2762,7 +2769,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+         # Ask schedulers to release resources in userspace and exit (see
+         # ShutdownReq), then wait for them before hard-killing the rest.
+         self._dispatch_to_scheduler(ShutdownReq())
+-        deadline = time.monotonic() + 15
++        # FlexKV requires the scheduler to have time to unpin large CPU pools
++        # (worker join up to FLEXKV_WORKER_SHUTDOWN_TIMEOUT_S=600s, TM parent
++        # wait up to FLEXKV_TRANSFER_MANAGER_SHUTDOWN_TIMEOUT_S=900s, so
++        # scheduler-wait must be >= 900s + buffer). Default now covers this;
++        # override via env for non-FlexKV setups.
++        wait_s = float(os.getenv("SGLANG_SCHEDULER_SHUTDOWN_WAIT_S", "1200"))
++        deadline = time.monotonic() + wait_s
+         while time.monotonic() < deadline and collect_scheduler_processes():
+             time.sleep(0.1)
+         kill_process_tree(os.getpid(), include_parent=True)
+@@ -3255,6 +3268,10 @@ class SignalHandler:
+         logger.warning(
+             f"SIGTERM received. {signum=} {frame=}. Draining requests and shutting down..."
+         )
++        # Stop watchdog immediately: process-group Ctrl+C may SIGINT children
++        # (e.g. detokenizer) before ShutdownReq; their exit must not become SIGQUIT.
++        if self.tokenizer_manager._subprocess_watchdog is not None:
++            self.tokenizer_manager._subprocess_watchdog.stop()
+         self.tokenizer_manager.gracefully_exit = True
+ 
+     def running_phase_sigquit_handler(self, signum=None, frame=None):
+diff --git a/python/sglang/srt/mem_cache/common.py b/python/sglang/srt/mem_cache/common.py
+index 7a3e1c39d..44261fe20 100644
+--- a/python/sglang/srt/mem_cache/common.py
++++ b/python/sglang/srt/mem_cache/common.py
+@@ -58,9 +58,9 @@ def free_swa_out_of_window_slots(
+         return
+ 
+     # For swa radix cache, we need to evict the tokens that are not in the tree cache and also not in the sliding window
+-    assert (
+-        req.cache_protected_len % page_size == 0
+-    ), "cache_protected_len must be page aligned"
++    assert req.cache_protected_len % page_size == 0, (
++        "cache_protected_len must be page aligned"
++    )
+     evict_floor = max(req.cache_protected_len, getattr(req, "swa_evict_floor", 0))
+     if page_size > 1 and evict_floor > req.cache_protected_len:
+         evict_floor = -(-evict_floor // page_size) * page_size
+@@ -102,7 +102,19 @@ def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
+     tree_cache.cache_unfinished_req(req, **kwargs)
+ 
+ 
+-def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
++def evict_from_tree_cache(
++    tree_cache: BasePrefixCache | None,
++    num_tokens: int,
++    *,
++    swa_num_tokens: int | None = None,
 +):
-+    extend_lens = seq_lens - prefix_lens
-+    end_pos = torch.cumsum(extend_lens, 0)
-+    start_pos = end_pos - extend_lens
-+    num_new_pages = (seq_lens + page_size - 1) // page_size - (
-+        prefix_lens + page_size - 1
-+    ) // page_size
-+    num_full_new_pages = (seq_lens) // page_size - (
-+        prefix_lens + page_size - 1
-+    ) // page_size
-+    need_page = num_new_pages - num_full_new_pages
-+    end_new_pages = torch.cumsum(num_new_pages, 0)
-+    start_new_pages = end_new_pages - num_new_pages
-+    pos_in_page = torch.arange(page_size, device=device, dtype=torch.int32)
-+    for i in range(len(prefix_lens)):
-+        num1 = (
-+            min(
-+                seq_lens[i],
-+                (prefix_lens[i] + page_size - 1) // page_size * page_size,
-+            )
-+            - prefix_lens[i]
-+        )
-+        if num1:
-+            out_indices[start_pos[i] : start_pos[i] + num1] = (
-+                last_loc[i] + 1 + pos_in_page[:num1].view(-1)
-+            )
++    """Evict enough radix-cache entries to satisfy an allocation.
 +
-+        num2 = (
-+            seq_lens[i] // page_size - (prefix_lens[i] + page_size - 1) // page_size
-+        ) * page_size
-+        if num2:
-+            pages = (
-+                free_pages[start_new_pages[i] : end_new_pages[i] - need_page[i]]
-+                * page_size
-+            )
-+            out_indices[start_pos[i] + num1 : start_pos[i] + num1 + num2] = (
-+                pages.view(-1, 1) + pos_in_page.view(1, -1)
-+            ).view(-1)
-+
-+        num3 = seq_lens[i] - seq_lens[i] // page_size * page_size
-+        if num3:
-+            out_indices[end_pos[i] - num3 : end_pos[i]] = (
-+                free_pages[end_new_pages[i] - 1] * page_size + pos_in_page[:num3]
-+            ).view(-1)
-+
-+
-+class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
-+    def __init__(
-+        self,
-+        size: int,
-+        page_size: int,
-+        dtype: torch.dtype,
-+        device: str,
-+        kvcache: KVCache,
-+        need_sort: bool,
-+    ):
-+        super().__init__(size, page_size, dtype, device, kvcache, need_sort)
-+        self.roundup = page_size - 1
-+
-+    def alloc_extend(
-+        self,
-+        prefix_lens: torch.Tensor,
-+        prefix_lens_cpu: torch.Tensor,
-+        seq_lens: torch.Tensor,
-+        seq_lens_cpu: torch.Tensor,
-+        last_loc: torch.Tensor,
-+        extend_num_tokens: int,
-+    ):
-+        if self.debug_mode:
-+            assert torch.all(
-+                (last_loc + 1) % self.page_size == prefix_lens % self.page_size
-+            )
-+
-+        num_new_pages = (
-+            (seq_lens + self.roundup) // self.page_size
-+            - (prefix_lens + self.roundup) // self.page_size
-+        ).sum()
-+        num_new_pages_item = num_new_pages.item()
-+        if self.need_sort and num_new_pages_item > len(self.free_pages):
-+            self.merge_and_sort_free()
-+
-+        if num_new_pages_item > len(self.free_pages):
-+            return None
-+
-+        if num_new_pages_item < 200:
-+            from sgl_kernel_npu.mem_cache.allocator import alloc_extend_kernel
-+
-+            out_indices = torch.empty(
-+                (extend_num_tokens,),
-+                dtype=torch.int64,
-+                device=self.device,
-+            )
-+            max_num_extend_tokens = next_power_of_2(extend_num_tokens)
-+            bs = prefix_lens.shape[0]
-+            alloc_extend_kernel[(bs,)](
-+                prefix_lens,
-+                seq_lens,
-+                last_loc,
-+                self.free_pages,
-+                out_indices,
-+                next_power_of_2(bs),
-+                self.page_size,
-+                max_num_extend_tokens,
-+            )
-+
-+        else:
-+            out_indices = torch.empty(
-+                (extend_num_tokens,),
-+                dtype=torch.int32,
-+                device=self.device,
-+            )
-+            alloc_extend_kernel_ascend(
-+                prefix_lens,
-+                seq_lens,
-+                last_loc,
-+                self.free_pages,
-+                out_indices,
-+                self.page_size,
-+                self.device,
-+            )
-+
-+        if self.debug_mode:
-+            assert len(torch.unique(out_indices)) == len(out_indices)
-+
-+        self.free_pages = self.free_pages[num_new_pages_item:]
-+        return out_indices.int()
-+
-+    def alloc_decode(
-+        self,
-+        seq_lens: torch.Tensor,
-+        seq_lens_cpu: torch.Tensor,
-+        last_loc: torch.Tensor,
-+    ):
-+        if self.debug_mode:
-+            assert torch.all(
-+                (last_loc + 2) % self.page_size == seq_lens % self.page_size
-+            )
-+
-+        num_new_pages = get_num_new_pages(
-+            seq_lens=seq_lens_cpu,
-+            page_size=self.page_size,
-+            decode=True,
-+        )
-+
-+        if num_new_pages > len(self.free_pages):
-+            self.merge_and_sort_free()
-+
-+        if num_new_pages > len(self.free_pages):
-+            return None
-+
-+        need_new_pages = (seq_lens % self.page_size == 1).int()
-+        end_new_pages = torch.cumsum(need_new_pages, 0)
-+        start_new_pages = end_new_pages - need_new_pages
-+        if num_new_pages == 0:
-+            out_indices = last_loc + 1
-+        else:
-+            out_indices = (last_loc + 1) * (1 - need_new_pages) + self.free_pages[
-+                start_new_pages
-+            ] * self.page_size * need_new_pages
-+
-+        if self.debug_mode:
-+            assert len(torch.unique(out_indices)) == len(out_indices)
-+
-+        self.free_pages = self.free_pages[num_new_pages:]
-+        return out_indices.int()
-diff --git a/python/sglang/srt/mem_cache/base_prefix_cache.py b/python/sglang/srt/mem_cache/base_prefix_cache.py
-index e01f98dcb..6c03b7079 100644
---- a/python/sglang/srt/mem_cache/base_prefix_cache.py
-+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
-@@ -42,6 +42,11 @@ class MatchPrefixParams:
-     cow_mamba: bool = False
-     req: Optional[Req] = None
++    For a hybrid SWA allocator, ``num_tokens`` is the full-attention demand and
++    ``swa_num_tokens`` is the independent SWA demand. The latter defaults to
++    ``num_tokens`` for existing callers that allocate both pools symmetrically.
++    Tail-only restore paths may request less SWA capacity than full capacity.
++    """
+     if tree_cache is None:
+         return
  
-+    # External KV connector specific
-+    # When True, the cache may update per-request connector state (e.g. reserve
-+    # load-back metadata keyed by rid) as part of match_prefix.
-+    update_connector_state: bool = False
+@@ -110,18 +122,35 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
+         return
+ 
+     allocator = tree_cache.token_to_kv_pool_allocator
++    swa_need = num_tokens if swa_num_tokens is None else swa_num_tokens
+ 
+     if isinstance(allocator, SWATokenToKVPoolAllocator):
+         # Hybrid allocator
+-        full_available_size = allocator.full_available_size()
+-        swa_available_size = allocator.swa_available_size()
++        while True:
++            full_available_size = allocator.full_available_size()
++            swa_available_size = allocator.swa_available_size()
++            if full_available_size >= num_tokens and swa_available_size >= swa_need:
++                break
+ 
+-        if full_available_size < num_tokens or swa_available_size < num_tokens:
+             full_num_tokens = max(0, num_tokens - full_available_size)
+-            swa_num_tokens = max(0, num_tokens - swa_available_size)
++            swa_to_evict = max(0, swa_need - swa_available_size)
++            if full_num_tokens == 0 and swa_to_evict == 0:
++                break
++
+             tree_cache.evict(
+-                EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
++                EvictParams(
++                    num_tokens=full_num_tokens,
++                    swa_num_tokens=swa_to_evict,
++                )
+             )
++
++            new_full_available_size = allocator.full_available_size()
++            new_swa_available_size = allocator.swa_available_size()
++            if (
++                new_full_available_size == full_available_size
++                and new_swa_available_size == swa_available_size
++            ):
++                break
+     else:
+         # Standard allocator
+         if allocator.available_size() < num_tokens:
+@@ -133,9 +162,9 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
+     assert (req.req_pool_idx is None) == (req.kv is None)
+     # MambaRadixCache may alloc mamba state before alloc KV cache
+     if req.req_pool_idx is None:
+-        assert (
+-            tree_cache.supports_mamba()
+-        ), "Only MambaRadixCache allow freeing before alloc"
++        assert tree_cache.supports_mamba(), (
++            "Only MambaRadixCache allow freeing before alloc"
++        )
+         # TODO (csy, hanming): clean up this early allocation logic
+         if req.mamba_pool_idx is not None:
+             tree_cache.req_to_token_pool.mamba_allocator.free(
+@@ -164,9 +193,9 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
+     if isinstance(tree_cache.req_to_token_pool, HybridReqToTokenPool) and (
+         not tree_cache.supports_mamba()
+     ):
+-        assert (
+-            req.mamba_pool_idx is not None
+-        ), "mamba state is freed while the tree cache does not manage mamba states"
++        assert req.mamba_pool_idx is not None, (
++            "mamba state is freed while the tree cache does not manage mamba states"
++        )
+         tree_cache.req_to_token_pool.free_mamba_cache(req)
+     # The DSV4-NPU ReqToTokenPool subclass's free() additionally releases the
+     # c4/c128 state pages; other ReqToTokenPool subclasses are a no-op here.
+@@ -184,9 +213,9 @@ def _release_overallocated_kv_indices(
+     # strip_thinking_cache intentionally reports output tokens as overallocated
+     # so they fall into the free path below (#22373).
+     if spec_algo is None and not global_server_args.strip_thinking_cache:
+-        assert (
+-            start_p == end_p
+-        ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv.kv_allocated_len=}"
++        assert start_p == end_p, (
++            f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv.kv_allocated_len=}"
++        )
+ 
+     if page_size > 1:
+         start_p = ceil_align(start_p, page_size)
+diff --git a/python/sglang/srt/mem_cache/registry.py b/python/sglang/srt/mem_cache/registry.py
+index 744134e01..996c8e32c 100644
+--- a/python/sglang/srt/mem_cache/registry.py
++++ b/python/sglang/srt/mem_cache/registry.py
+@@ -101,6 +101,18 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
+         logger.info("Using experimental C++ radix tree implementation.")
+         return RadixCacheCpp(params=params, server_args=server_args)
+ 
++    if server_args.enable_flexkv:
++        # FlexKV supplies its own host-tier path and composes with the unified
++        # radix cache for SWA models. Select it before the built-in hybrid
++        # cache branches so --enable-flexkv works for DeepSeek V4 as well.
++        import os
++
++        from sglang.srt.mem_cache.storage.flexkv import _flexkv_factory
++
++        if server_args.flexkv_config_file and not os.environ.get("FLEXKV_CONFIG_PATH"):
++            os.environ["FLEXKV_CONFIG_PATH"] = server_args.flexkv_config_file
++        return _flexkv_factory(ctx)
++
+     if envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.get() or use_mlx():
+         return _create_unified_radix_cache(ctx, server_args, params)
+ 
+@@ -141,20 +153,6 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
+             tp_group=ctx.tp_group,
+         )
+ 
+-    if server_args.enable_flexkv:
+-        # Importing the package side-effect registers the explicit
+-        # ``--radix-cache-backend=flexkv`` factory; we then call the
+-        # factory directly so --enable-flexkv stands on its own.
+-        import os
+-
+-        from sglang.srt.mem_cache.storage.flexkv import _flexkv_factory
+-
+-        # Honor a CLI --flexkv-config-file by forwarding it via the env
+-        # var that FlexKV's config loader actually reads.
+-        if server_args.flexkv_config_file and not os.environ.get("FLEXKV_CONFIG_PATH"):
+-            os.environ["FLEXKV_CONFIG_PATH"] = server_args.flexkv_config_file
+-        return _flexkv_factory(ctx)
+-
+     from sglang.srt.mem_cache.radix_cache import RadixCache
+ 
+     return RadixCache(params)
+diff --git a/python/sglang/srt/mem_cache/storage/flexkv/__init__.py b/python/sglang/srt/mem_cache/storage/flexkv/__init__.py
+index a2bd129b6..a21806e40 100644
+--- a/python/sglang/srt/mem_cache/storage/flexkv/__init__.py
++++ b/python/sglang/srt/mem_cache/storage/flexkv/__init__.py
+@@ -27,6 +27,20 @@ def _flexkv_factory(ctx):
+     needs them to fan out lookup/store decisions across the full TP × CP
+     × PP topology.
+     """
++    try:
++        from flexkv.integration.sglang.connector import FlexKVConnector  # noqa: F401
++    except ImportError as exc:
++        try:
++            import flexkv  # noqa: F401
++        except ImportError:
++            raise RuntimeError(
++                "FlexKV is not installed. Please install the FlexKV package "
++                "to use --enable-flexkv."
++            ) from exc
++        raise RuntimeError(
++            f"FlexKV is installed but incompatible version: {exc}."
++        ) from exc
++
+     from sglang.srt.distributed.parallel_state import (
+         get_attn_cp_group,
+         get_attn_tp_group,
+@@ -58,17 +72,18 @@ def _flexkv_factory(ctx):
+     # fall back to 0 for single-rank dims.
+     pp_rank = pp_group.rank_in_group if pp_group is not None else 0
+     attn_cp_rank = attn_cp_group.rank_in_group if attn_cp_group is not None else 0
++    parallel_state = getattr(ctx.tp_worker, "ps", None)
++    if server_args.enable_dp_attention:
++        dp_rank = getattr(parallel_state, "attn_dp_rank", 0)
++    else:
++        dp_rank = getattr(parallel_state, "dp_rank", 0) or 0
+ 
+-    return FlexKVRadixCache(
++    common_kwargs = dict(
+         params=ctx.params,
+         model_config=ctx.model_config,
+         server_args=server_args,
+         tp_rank=ctx.tp_rank,
+-        tp_size=ctx.tp_size,
+-        # ``dp_rank`` isn't carried on TreeCacheBuildContext or ServerArgs
+-        # at construction time; the connector normalizes ``None`` to 0
+-        # for the single-DP-rank case that this factory targets.
+-        dp_rank=None,
++        dp_rank=dp_rank,
+         pp_rank=pp_rank,
+         attn_cp_rank=attn_cp_rank,
+         tp_group=ctx.tp_group,
+@@ -77,6 +92,28 @@ def _flexkv_factory(ctx):
+         attn_cp_group=attn_cp_group,
+     )
+ 
++    if ctx.is_hybrid_ssm:
++        raise NotImplementedError("FlexKV does not support Mamba/SSM pools yet")
++
++    if ctx.is_hybrid_swa:
++        from sglang.srt.mem_cache.storage.flexkv.flexkv_hybrid_radix_cache import (
++            FlexKVHybridRadixCache,
++        )
++        from sglang.srt.mem_cache.unified_cache_components import ComponentType
++        from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
++
++        ctx.params.tree_components = (ComponentType.FULL, ComponentType.SWA)
++        inner_cache = UnifiedRadixCache(ctx.params)
++        return FlexKVHybridRadixCache(
++            inner_cache=inner_cache,
++            **common_kwargs,
++        )
++
++    return FlexKVRadixCache(
++        tp_size=ctx.tp_size,
++        **common_kwargs,
++    )
 +
  
- @dataclasses.dataclass
- class InsertParams:
-diff --git a/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format b/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format
-deleted file mode 120000
-index 5a7a8cea7..000000000
---- a/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format
+ try:
+     register_radix_cache_backend("flexkv", _flexkv_factory)
+diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py
+deleted file mode 100644
+index 00cabf6ae..000000000
+--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py
 +++ /dev/null
-@@ -1 +0,0 @@
--../../../../../sgl-kernel/.clang-format
-\ No newline at end of file
-diff --git a/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format b/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format
+@@ -1,662 +0,0 @@
+-"""Communication helpers for the FlexKV connector.
+-
+-FlexKV runs a single KVManager per DP group (typically the TP/CP/PP
+-sync leader's process). Every other rank in the same KV-cache-sharing
+-fan-out must be told the leader's decisions: which prefix matched in
+-FlexKV, which task id the leader allocated, which slot mappings to
+-send, etc.
+-
+-This file provides:
+-
+-* ``FlexKVComm`` — a 3-axis (PP × CP × TP) hierarchical sync context
+-  built on torch.distributed (gloo CPU groups). Exposes ``scatter``,
+-  ``scatter_pp``, ``barrier`` and ``all_reduce_min`` plus role flags
+-  (``is_sync_leader`` etc.) that the connector branches on.
+-* libc / ``eventfd`` shims used by the layerwise transfer worker
+-  socket handshake.
+-* ``FlexKVLayerLoadingEvent`` and ``FlexKVLayerDoneCounter`` — the
+-  eventfd-backed per-layer completion structures that the FlexKV
+-  layerwise transfer worker signals into. Hooked into sglang's
+-  ``register_layer_transfer_counter`` so each layer's forward waits
+-  for its own host→device copy.
+-"""
+-
+-from __future__ import annotations
+-
+-import ctypes
+-import errno
+-import logging
+-import os
+-import pickle
+-import socket
+-import struct
+-from datetime import timedelta
+-from typing import Any, Dict, List
+-
+-import torch
+-import torch.distributed as dist
+-
+-from sglang.srt.distributed.parallel_state import get_world_group
+-
+-logger = logging.getLogger(__name__)
+-
+-# PP-channel command tags (used by ``scatter_pp`` payloads). Sender and
+-# receiver assert on these to catch protocol drift early.
+-CMD_PUT_META = 2
+-CMD_LAYERWISE = 3
+-CMD_STORE_COMPLETE = 5
+-
+-
+-class FlexKVComm:
+-    """3-axis (PP × CP × TP) hierarchical sync for the FlexKV connector.
+-
+-    Notation:
+-      * "sync leader" is the unique rank that talks to the FlexKV
+-        KVManager: pp_rank=0, attn_cp_rank=0, attn_tp_rank=0.
+-      * "PP stage leader" is the (cp=0, tp=0) rank within a PP stage —
+-        it does cross-PP P2P (``scatter_pp``).
+-      * Every rank participates in collective layers it belongs to.
+-
+-    Communication strategy:
+-      * P2P (send/recv/isend/irecv) on CPU tensors → ``world_cpu_group``
+-        (the global gloo group). Sub-group cpu_groups have unreliable
+-        TCP pairs for direct P2P.
+-      * Collectives (all_reduce / barrier) → sglang's sub-group
+-        cpu_groups (fine for collectives).
+-    """
+-
+-    # P2P tags. World group is shared with sglang's own P2P, so we pick
+-    # 4-byte tags that won't collide.
+-    _TAG_SCATTER = int.from_bytes(b"FxSc", byteorder="big")
+-    _TAG_PP = int.from_bytes(b"FxPP", byteorder="big")
+-    _TAG_CP = int.from_bytes(b"FxCP", byteorder="big")
+-    _TAG_TP = int.from_bytes(b"FxTP", byteorder="big")
+-    _TAG_PP_AR_MIN = int.from_bytes(b"FxA2", byteorder="big")
+-    _TAG_PP_BARRIER = int.from_bytes(b"FxB2", byteorder="big")
+-    _TAG_PP_BARRIER_BCAST = int.from_bytes(b"FxB3", byteorder="big")
+-    _TAG_AR_BCAST = int.from_bytes(b"FxAR", byteorder="big")
+-
+-    # Adaptive async-work reaper. gloo's isend Work objects do not auto-
+-    # advance their "completed" state on poll, so a pure poll-based reaper
+-    # leaks. We actively wait() the oldest works with a tiny timeout;
+-    # the watermark grows on stuck reaps (slow / asymmetric peer) and
+-    # shrinks back on clean reaps.
+-    _REAP_HIGH_BASE = 1024
+-    _REAP_HIGH_MAX = 32768
+-    _REAP_MAX_DRAIN = 512
+-    _REAP_PROBE = timedelta(milliseconds=1)
+-    _REAP_LOG_EVERY = 64
+-
+-    def __init__(
+-        self,
+-        rank_info,
+-        world_rank: int,
+-        pp_group=None,
+-        attn_tp_group=None,
+-        attn_cp_group=None,
+-    ):
+-        model_config = rank_info.model_config
+-        self.world_rank = world_rank
+-        self._async_works: List = []
+-        self._reap_high: int = self._REAP_HIGH_BASE
+-        self._reap_calls: int = 0
+-        self._reap_stuck_total: int = 0
+-        self._reap_drained_total: int = 0
+-
+-        # Accept either GroupCoordinator wrappers (has ``.cpu_group``) or
+-        # raw ProcessGroups.
+-        self.pp_cpu_group = (
+-            getattr(pp_group, "cpu_group", pp_group) if pp_group is not None else None
+-        )
+-        self.attn_tp_cpu_group = (
+-            getattr(attn_tp_group, "cpu_group", attn_tp_group)
+-            if attn_tp_group is not None
+-            else None
+-        )
+-        self.attn_cp_cpu_group = (
+-            getattr(attn_cp_group, "cpu_group", attn_cp_group)
+-            if attn_cp_group is not None
+-            else None
+-        )
+-
+-        self.pp_size = model_config.pp_size
+-        self.attn_tp_size = model_config.attn_tp_size
+-        self.attn_cp_size = model_config.attn_cp_size
+-
+-        self.pp_rank = rank_info.pp_rank
+-        self.attn_tp_rank = rank_info.attn_tp_rank
+-        self.attn_cp_rank = rank_info.attn_cp_rank
+-
+-        self.is_pp_stage_leader = self.attn_tp_rank == 0 and self.attn_cp_rank == 0
+-        self.is_sync_leader = self.pp_rank == 0 and self.is_pp_stage_leader
+-        self.is_pp_leader = self.pp_rank == 0 and self.is_pp_stage_leader
+-        self.is_cp_leader = self.attn_cp_rank == 0
+-        self.is_tp_leader = self.attn_tp_rank == 0
+-
+-        # P2P routing tables (computed once).
+-        stride = self.attn_tp_size * self.attn_cp_size
+-        self._pp_stage_leader_ranks = [s * stride for s in range(self.pp_size)]
+-        pp_stage_offset = self.pp_rank * stride
+-        self._cp_leader_ranks = (
+-            [
+-                pp_stage_offset + cp * self.attn_tp_size
+-                for cp in range(self.attn_cp_size)
+-            ]
+-            if self.attn_cp_size > 1
+-            else []
+-        )
+-        if self.attn_tp_size > 1:
+-            if self.attn_tp_cpu_group is None:
+-                raise RuntimeError(
+-                    f"[FlexKV] attn_tp_size={self.attn_tp_size} > 1 but "
+-                    f"attn_tp_cpu_group is None — TP CPU group is required "
+-                    f"for scatter/collectives."
+-                )
+-            self._tp_group_ranks = [
+-                dist.get_global_rank(self.attn_tp_cpu_group, i)
+-                for i in range(self.attn_tp_cpu_group.size())
+-            ]
+-        else:
+-            self._tp_group_ranks = []
+-        self._pp_group_global_ranks = (
+-            [
+-                dist.get_global_rank(self.pp_cpu_group, i)
+-                for i in range(self.pp_cpu_group.size())
+-            ]
+-            if self.pp_size > 1 and self.pp_cpu_group is not None
+-            else []
+-        )
+-        self._pp_stage_member_ranks = list(
+-            range(pp_stage_offset, pp_stage_offset + stride)
+-        )
+-
+-        self.needs_sync = (
+-            self.pp_size > 1 or self.attn_tp_size > 1 or self.attn_cp_size > 1
+-        )
+-
+-        self._world_cpu_group = get_world_group().cpu_group
+-
+-        self.pp_group = (
+-            self.pp_cpu_group
+-            if (self.pp_size > 1 and self.is_pp_stage_leader)
+-            else None
+-        )
+-        self.is_pp_active = self.pp_size > 1
+-        self.is_pp_sender = self.is_pp_leader
+-        self.is_pp_receiver = self.is_pp_stage_leader and not self.is_pp_leader
+-
+-        self.is_cross_node_pp = self.pp_size > rank_info.pp_size_per_node
+-        self.should_send_slot_mapping_to_remote = (
+-            self.is_pp_receiver and self.is_cross_node_pp
+-        )
+-
+-        logger.info(
+-            "[FlexKV] Comm init: rank=%d, pp=%d/%d, tp=%d/%d, cp=%d/%d, "
+-            "sync_leader=%s, stage_leader=%s, cross_node_pp=%s",
+-            world_rank,
+-            self.pp_rank,
+-            self.pp_size,
+-            self.attn_tp_rank,
+-            self.attn_tp_size,
+-            self.attn_cp_rank,
+-            self.attn_cp_size,
+-            self.is_sync_leader,
+-            self.is_pp_stage_leader,
+-            self.is_cross_node_pp,
+-        )
+-
+-    # ------------------------------------------------------------------
+-    # Public collectives
+-    # ------------------------------------------------------------------
+-
+-    def scatter(self, data: Any, blocking: bool = False) -> Any:
+-        """Hierarchical fan-out: sync_leader → PP stage leaders →
+-        CP leaders → TP ranks. Returns the leader's payload on every rank.
+-
+-        ``blocking=False`` queues isends and reaps later — fine for the
+-        hot path; ``True`` blocks until the leader's sends drain (used
+-        on shutdown / barriers).
+-        """
+-        if self.pp_size > 1 and self.is_pp_stage_leader:
+-            data = self._scatter_group(
+-                data,
+-                self._pp_stage_leader_ranks,
+-                self.is_pp_leader,
+-                self._TAG_PP,
+-                blocking,
+-            )
+-        if self._cp_leader_ranks:
+-            data = self._scatter_group(
+-                data,
+-                self._cp_leader_ranks,
+-                self.is_cp_leader,
+-                self._TAG_CP,
+-                blocking,
+-            )
+-        if self._tp_group_ranks:
+-            data = self._scatter_group(
+-                data,
+-                self._tp_group_ranks,
+-                self.is_tp_leader,
+-                self._TAG_TP,
+-                blocking,
+-            )
+-        return data
+-
+-    def scatter_pp(self, data: Any) -> Any:
+-        """PP-only fan-out across PP stages (only stage leaders participate)."""
+-        if not self._pp_group_global_ranks:
+-            return data
+-        is_leader = self._pp_group_global_ranks[0] == self.world_rank
+-        return self._scatter_group(
+-            data,
+-            self._pp_group_global_ranks,
+-            is_leader,
+-            self._TAG_SCATTER,
+-            blocking=False,
+-        )
+-
+-    def all_reduce_min(self, value: int) -> int:
+-        """Hierarchical all_reduce(MIN) across TP, CP, PP.
+-
+-        Used to align FlexKV block-count limits across all ranks that
+-        will register GPU buffers (each rank computes the maximum it can
+-        support, and we take the MIN to land on a value everyone can
+-        honor).
+-        """
+-        tensor = torch.tensor(value, dtype=torch.int64)
+-        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
+-            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_tp_cpu_group)
+-        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
+-            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_cp_cpu_group)
+-        if self.pp_size > 1 and self.is_pp_stage_leader:
+-            self._pp_all_reduce_min_p2p(tensor)
+-        if self.pp_size > 1:
+-            self._bcast_to_stage_members(tensor, self._TAG_AR_BCAST)
+-        return int(tensor.item())
+-
+-    def barrier(self) -> None:
+-        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
+-            dist.barrier(group=self.attn_tp_cpu_group)
+-        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
+-            dist.barrier(group=self.attn_cp_cpu_group)
+-        if self.pp_size > 1 and self.is_pp_stage_leader:
+-            self._pp_barrier_p2p()
+-        if self.pp_size > 1:
+-            dummy = torch.tensor([0], dtype=torch.int64)
+-            self._bcast_to_stage_members(dummy, self._TAG_PP_BARRIER_BCAST)
+-
+-    # ------------------------------------------------------------------
+-    # Internal scatter helper
+-    # ------------------------------------------------------------------
+-
+-    def _scatter_group(
+-        self,
+-        data: Any,
+-        group_ranks: List[int],
+-        is_leader: bool,
+-        tag: int,
+-        blocking: bool = False,
+-    ) -> Any:
+-        if not group_ranks or self.world_rank not in group_ranks:
+-            return data
+-        if is_leader:
+-            dsts = [r for r in group_ranks if r != self.world_rank]
+-            works = []
+-            for dst in dsts:
+-                works.extend(self._isend(dst, data, tag, self._world_cpu_group))
+-            if blocking:
+-                for w in works:
+-                    w.wait()
+-            else:
+-                self._reap_completed_async_works()
+-                self._async_works.extend(works)
+-            return data
+-        return self._recv(group_ranks[0], tag, self._world_cpu_group)
+-
+-    def _reap_completed_async_works(self) -> None:
+-        n = len(self._async_works)
+-        if n <= self._reap_high:
+-            return
+-
+-        drained = 0
+-        stuck = False
+-        for _ in range(self._REAP_MAX_DRAIN):
+-            if not self._async_works:
+-                break
+-            w = self._async_works[0]
+-            try:
+-                w.wait(self._REAP_PROBE)
+-            except RuntimeError:
+-                stuck = True
+-                break
+-            self._async_works.pop(0)
+-            drained += 1
+-
+-        self._reap_calls += 1
+-        self._reap_drained_total += drained
+-        if stuck:
+-            self._reap_stuck_total += 1
+-
+-        prev_high = self._reap_high
+-        if stuck:
+-            self._reap_high = min(self._REAP_HIGH_MAX, self._reap_high * 2)
+-        else:
+-            self._reap_high = max(self._REAP_HIGH_BASE, self._reap_high // 2)
+-        if self._reap_high != prev_high:
+-            logger.debug(
+-                "[FlexKV] reap watermark rank=%d %d->%d "
+-                "(stuck=%s drained=%d backlog=%d)",
+-                self.world_rank,
+-                prev_high,
+-                self._reap_high,
+-                stuck,
+-                drained,
+-                n,
+-            )
+-        if self._reap_calls % self._REAP_LOG_EVERY == 0:
+-            logger.debug(
+-                "[FlexKV] reap stats rank=%d calls=%d drained=%d stuck=%d "
+-                "backlog=%d high=%d",
+-                self.world_rank,
+-                self._reap_calls,
+-                self._reap_drained_total,
+-                self._reap_stuck_total,
+-                len(self._async_works),
+-                self._reap_high,
+-            )
+-
+-    # ------------------------------------------------------------------
+-    # Low-level send / recv on the world cpu group
+-    # ------------------------------------------------------------------
+-
+-    def _isend(self, dst: int, data: Any, tag: int = 0, group=None) -> list:
+-        serialized = bytearray(pickle.dumps(data))
+-        t_size = torch.tensor([len(serialized)], dtype=torch.long)
+-        t_data = torch.frombuffer(serialized, dtype=torch.uint8)
+-        return [
+-            dist.isend(t_size, dst=dst, tag=tag, group=group),
+-            dist.isend(t_data, dst=dst, tag=tag, group=group),
+-        ]
+-
+-    def _recv(self, src: int, tag: int = 0, group=None) -> Any:
+-        t_size = torch.tensor([0], dtype=torch.long)
+-        dist.irecv(t_size, src=src, tag=tag, group=group).wait()
+-        size = int(t_size.item())
+-        if size == 0:
+-            return []
+-        t_data = torch.empty(size, dtype=torch.uint8)
+-        dist.irecv(t_data, src=src, tag=tag, group=group).wait()
+-        return pickle.loads(t_data.numpy().tobytes())
+-
+-    def _send_tensor(
+-        self, tensor: torch.Tensor, dst: int, tag: int = 0, group=None
+-    ) -> None:
+-        dist.send(tensor, dst=dst, tag=tag, group=group)
+-
+-    def _recv_tensor(
+-        self, tensor: torch.Tensor, src: int, tag: int = 0, group=None
+-    ) -> None:
+-        dist.recv(tensor, src=src, tag=tag, group=group)
+-
+-    def _bcast_to_stage_members(self, tensor: torch.Tensor, tag: int) -> None:
+-        if not self.is_pp_stage_leader:
+-            self._recv_tensor(
+-                tensor,
+-                src=self._pp_stage_leader_ranks[self.pp_rank],
+-                tag=tag,
+-                group=self._world_cpu_group,
+-            )
+-            return
+-        for rank in self._pp_stage_member_ranks:
+-            if rank != self.world_rank:
+-                self._send_tensor(
+-                    tensor, dst=rank, tag=tag, group=self._world_cpu_group
+-                )
+-
+-    def _pp_all_reduce_min_p2p(self, tensor: torch.Tensor) -> None:
+-        leader_rank = self._pp_stage_leader_ranks[0]
+-        other_leaders = self._pp_stage_leader_ranks[1:]
+-        tag = self._TAG_PP_AR_MIN
+-        if self.world_rank == leader_rank:
+-            result = int(tensor.item())
+-            for src in other_leaders:
+-                other = torch.tensor(0, dtype=torch.int64)
+-                self._recv_tensor(other, src=src, tag=tag, group=self._world_cpu_group)
+-                result = min(result, int(other.item()))
+-            tensor.fill_(result)
+-            for dst in other_leaders:
+-                self._send_tensor(tensor, dst=dst, tag=tag, group=self._world_cpu_group)
+-        else:
+-            self._send_tensor(
+-                tensor, dst=leader_rank, tag=tag, group=self._world_cpu_group
+-            )
+-            self._recv_tensor(
+-                tensor, src=leader_rank, tag=tag, group=self._world_cpu_group
+-            )
+-
+-    def _pp_barrier_p2p(self) -> None:
+-        leader_rank = self._pp_stage_leader_ranks[0]
+-        other_leaders = self._pp_stage_leader_ranks[1:]
+-        tag = self._TAG_PP_BARRIER
+-        dummy = torch.tensor([1], dtype=torch.int64)
+-        if self.world_rank == leader_rank:
+-            for src in other_leaders:
+-                self._recv_tensor(dummy, src=src, tag=tag, group=self._world_cpu_group)
+-            for dst in other_leaders:
+-                self._send_tensor(dummy, dst=dst, tag=tag, group=self._world_cpu_group)
+-        else:
+-            self._send_tensor(
+-                dummy, dst=leader_rank, tag=tag, group=self._world_cpu_group
+-            )
+-            self._recv_tensor(
+-                dummy, src=leader_rank, tag=tag, group=self._world_cpu_group
+-            )
+-
+-
+-# ----------------------------------------------------------------------
+-# libc / eventfd / SCM_RIGHTS shims for the layerwise UDS handshake
+-# ----------------------------------------------------------------------
+-
+-_libc = ctypes.CDLL("libc.so.6", use_errno=True)
+-_libc.eventfd.argtypes = [ctypes.c_uint, ctypes.c_int]
+-_libc.eventfd.restype = ctypes.c_int
+-_libc.read.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+-_libc.read.restype = ctypes.c_ssize_t
+-_libc.write.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+-_libc.write.restype = ctypes.c_ssize_t
+-
+-EFD_SEMAPHORE = 0x1
+-EFD_NONBLOCK = 0x800
+-
+-
+-def eventfd(initval: int = 0, flags: int = 0) -> int:
+-    fd = _libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
+-    if fd == -1:
+-        err = ctypes.get_errno()
+-        raise OSError(err, os.strerror(err))
+-    return fd
+-
+-
+-def eventfd_write(fd: int, val: int) -> None:
+-    v = ctypes.c_uint64(val)
+-    n = _libc.write(fd, ctypes.byref(v), ctypes.sizeof(v))
+-    if n != ctypes.sizeof(v):
+-        err = ctypes.get_errno()
+-        raise OSError(err, f"eventfd write failed: {os.strerror(err)}")
+-
+-
+-def eventfd_read(fd: int) -> int:
+-    v = ctypes.c_uint64()
+-    n = _libc.read(fd, ctypes.byref(v), ctypes.sizeof(v))
+-    if n != ctypes.sizeof(v):
+-        err = ctypes.get_errno()
+-        if err == errno.EAGAIN:
+-            return 0
+-        raise OSError(err, f"eventfd read failed: {os.strerror(err)}")
+-    return v.value
+-
+-
+-def send_fds(sock: socket.socket, fds: list, extra_data: bytes = b"x") -> None:
+-    """SCM_RIGHTS-send a list of file descriptors over a UDS socket."""
+-    fds_packed = struct.pack(f"{len(fds)}i", *fds)
+-    ancdata = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds_packed)]
+-    sock.sendmsg([extra_data], ancdata)
+-
+-
+-# ----------------------------------------------------------------------
+-# Layerwise transfer signaling (eventfd-backed)
+-# ----------------------------------------------------------------------
+-
+-
+-class FlexKVLayerLoadingEvent:
+-    """One per producer slot. Holds ``num_layers`` semaphore eventfds —
+-    the FlexKV layerwise worker writes 1 to each as the corresponding
+-    layer's H2D copy completes; the consumer (sglang's
+-    ``register_layer_transfer_counter`` hook) reads to wait for them."""
+-
+-    def __init__(self, num_layers: int):
+-        self._num_layers = num_layers
+-        # Semaphore mode so each read consumes exactly one signal. NONBLOCK
+-        # lets ``reset_for_new_transfer`` drain leftover counter values
+-        # without blocking; ``wait`` re-arms the fd to blocking before
+-        # reading so consumers still get the desired blocking semantics.
+-        self.load_event_fds: List[int] = [
+-            eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK) for _ in range(num_layers)
+-        ]
+-        self._finished = True
+-        self.wait_remaining: List[int] = [1] * num_layers
+-
+-    def reset_for_new_transfer(self) -> None:
+-        """Drain any leftover signals from prior transfers, then arm.
+-
+-        Without this drain, a previous transfer that wrote N eventfd
+-        signals but only had N-K reads (e.g. because the attention
+-        backend skipped a layer's ``get_key_buffer`` call) leaves K
+-        pending. The next transfer's first ``wait(layer)`` returns
+-        immediately reading one of those stale signals, even though
+-        the FlexKV worker hasn't actually finished that layer's H2D
+-        yet — and forward proceeds with wrong KV data.
+-        """
+-        import os
+-
+-        for fd in self.load_event_fds:
+-            # The fd is NONBLOCK: read until EAGAIN. Each read is 8 bytes.
+-            while True:
+-                try:
+-                    if not os.read(fd, 8):
+-                        break
+-                except BlockingIOError:
+-                    break
+-                except OSError:
+-                    break
+-        self._finished = False
+-        self.wait_remaining = [1] * self._num_layers
+-
+-    def wait(self, layer_index: int) -> None:
+-        """Block until the FlexKV worker signals layer ``layer_index``.
+-
+-        The fd was created with EFD_NONBLOCK so reset can drain it. We
+-        re-introduce the blocking semantics with ``select.select`` on a
+-        NONBLOCK fd: the read after select is guaranteed to consume one
+-        signal.
+-        """
+-        import os
+-        import select
+-
+-        assert 0 <= layer_index < self._num_layers
+-        fd = self.load_event_fds[layer_index]
+-        while True:
+-            select.select([fd], [], [])
+-            try:
+-                buf = os.read(fd, 8)
+-                if buf:
+-                    break
+-            except BlockingIOError:
+-                # Spurious wakeup; loop and re-select.
+-                continue
+-        if layer_index == self._num_layers - 1:
+-            self._finished = True
+-
+-    def close(self) -> None:
+-        for fd in self.load_event_fds:
+-            try:
+-                os.close(fd)
+-            except Exception:
+-                pass
+-        self.load_event_fds.clear()
+-
+-    def __del__(self) -> None:
+-        try:
+-            self.close()
+-        except Exception:
+-            pass
+-
+-
+-class FlexKVLayerDoneCounter:
+-    """Triple-buffered slot-based layerwise counter.
+-
+-    The KV pool calls ``wait_until(layer_id)`` once per layer during
+-    forward. We track which producer slot the current task is using and
+-    block on that slot's ``layer_id``-th eventfd. Producer rotation lets
+-    the next prefetch start before the current one finishes consuming.
+-    """
+-
+-    def __init__(self, num_layers: int, num_counters: int = 3):
+-        self.num_layers = num_layers
+-        self.num_counters = num_counters
+-        self.events: List[FlexKVLayerLoadingEvent] = [
+-            FlexKVLayerLoadingEvent(num_layers) for _ in range(num_counters)
+-        ]
+-        self.producer_index = -1
+-        self.consumer_index = -1
+-        self._task_to_producer: Dict[int, int] = {}
+-
+-    def register_task(self, task_id: int, producer_id: int) -> None:
+-        self._task_to_producer[task_id] = producer_id
+-
+-    def register_task_with_explicit_counter_id(
+-        self, task_id: int, counter_id: int
+-    ) -> None:
+-        if not 0 <= counter_id < self.num_counters:
+-            raise ValueError(
+-                f"Invalid counter_id={counter_id}, must be in [0, {self.num_counters})"
+-            )
+-        self._task_to_producer[task_id] = counter_id
+-        self.events[counter_id].reset_for_new_transfer()
+-
+-    def update_producer(self) -> int:
+-        self.producer_index = (self.producer_index + 1) % self.num_counters
+-        assert self.events[
+-            self.producer_index
+-        ]._finished, "Producer event should be finished before reuse"
+-        return self.producer_index
+-
+-    def set_consumer(self, task_id: int) -> None:
+-        if task_id < 0:
+-            self.consumer_index = -1
+-            return
+-        producer_id = self._task_to_producer.pop(task_id, None)
+-        self.consumer_index = producer_id if producer_id is not None else -1
+-
+-    def wait_until(self, threshold: int) -> None:
+-        if self.consumer_index < 0:
+-            return
+-        event = self.events[self.consumer_index]
+-        if event.wait_remaining[threshold] <= 0:
+-            return
+-        event.wait_remaining[threshold] -= 1
+-        event.wait(threshold)
+-
+-    def reset(self) -> None:
+-        self.producer_index = -1
+-        self.consumer_index = -1
+-        self._task_to_producer.clear()
+-
+-    def __del__(self) -> None:
+-        try:
+-            for event in self.events:
+-                event.close()
+-            self.events.clear()
+-        except Exception:
+-            pass
+diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+deleted file mode 100644
+index a1fb14462..000000000
+--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
++++ /dev/null
+@@ -1,925 +0,0 @@
+-"""Wrapper around FlexKV ``KVManager`` for sglang.
+-
+-The public surface is small (see "Public API" below). The class owns:
+-
+-* the FlexKV ``KVManager`` (server-client mode when ``dp_size > 1`` or
+-  multi-instance; in-process otherwise — handled by FlexKV itself);
+-* the per-rank ``KVTPClient`` that registers this rank's GPU KV cache
+-  with the FlexKV TransferManager;
+-* an optional ``FlexKVLayerDoneCounter`` plus the UDS-side handshake
+-  that wires its eventfds into the FlexKV layerwise transfer worker.
+-
+-Cross-rank sync uses :class:`FlexKVComm`. Only the **sync leader**
+-(rank 0 of every PP × CP × TP axis) talks to ``KVManager``; other
+-ranks block on broadcast / barrier.
+-
+-Modes:
+-  * **MP / synchronous** (default): ``retrieve_kv`` fires ``launch``
+-    and blocks on ``wait`` so the device slots are ready by the time
+-    sglang's prefill runs.
+-  * **Layerwise** (``FLEXKV_ENABLE_LAYERWISE_TRANSFER=1``): ``launch``
+-    is fired with ``layerwise_transfer=True`` and the per-layer hook
+-    registered via ``register_layer_transfer_counter`` blocks each
+-    forward layer on its own eventfd.
+-"""
+-
+-from __future__ import annotations
+-
+-import logging
+-import os
+-import socket
+-import struct
+-import time
+-from typing import Any, Dict, List, Optional, Tuple
+-
+-import numpy as np
+-import torch
+-
+-from sglang.srt.mem_cache.storage.flexkv.flexkv_comm import (
+-    CMD_LAYERWISE,
+-    CMD_PUT_META,
+-    CMD_STORE_COMPLETE,
+-    FlexKVComm,
+-    FlexKVLayerDoneCounter,
+-    send_fds,
+-)
+-
+-try:
+-    from flexkv.common.request import KVResponseStatus
+-    from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+-    from flexkv.integration.config import FlexKVConfig
+-    from flexkv.kvmanager import KVManager
+-    from flexkv.server.client import KVTPClient
+-    from flexkv.transfer.layerwise import build_layerwise_eventfd_socket_path
+-    from flexkv.transfer_manager import TransferManagerOnRemote
+-except ImportError as exc:  # pragma: no cover - runtime check
+-    raise RuntimeError(
+-        "FlexKV is not installed. Please install the FlexKV package to use "
+-        "--enable-flexkv."
+-    ) from exc
+-
+-logger = logging.getLogger(__name__)
+-
+-
+-class FlexKVConnector:
+-    """A FlexKV-side façade used by :class:`FlexKVRadixCache`.
+-
+-    This class manages connection lifecycle and provides a small,
+-    sgl-friendly contract over FlexKV's task-based API:
+-
+-      * ``lookup_kv`` — page-aligned hit count + a held task id.
+-      * ``retrieve_kv`` — synchronous load (launch + wait).
+-      * ``start_load_kv_layerwise`` — layerwise async load.
+-      * ``store_kv`` — page-aligned write back.
+-      * ``check_completed_stores`` — drain async store completions.
+-      * ``prefetch_async`` / ``check_prefetch_progress`` /
+-        ``cancel_prefetch`` — opportunistic CPU↔SSD/Remote staging.
+-      * ``release_pending`` — cancel a held task whose load won't run.
+-      * ``reset`` / ``shutdown``.
+-    """
+-
+-    def __init__(
+-        self,
+-        *,
+-        sgl_model_config: Any,
+-        server_args: Any,
+-        page_size: int,
+-        kvcache: Any,
+-        tp_rank: int,
+-        dp_rank: Optional[int],
+-        pp_rank: int,
+-        attn_cp_rank: int,
+-        pp_group: Any = None,
+-        attn_tp_group: Any = None,
+-        attn_cp_group: Any = None,
+-    ) -> None:
+-        self.page_size = int(page_size)
+-
+-        # 1. Resolve FlexKV config from env + sglang server args.
+-        self.flexkv_config = FlexKVConfig.from_env()
+-        self.rank_info = self.flexkv_config.post_init_from_sglang_config(
+-            sglang_config=sgl_model_config,
+-            server_args=server_args,
+-            page_size=self.page_size,
+-            tp_rank=tp_rank,
+-            pp_rank=pp_rank,
+-            dp_rank=dp_rank if dp_rank is not None else 0,
+-            attn_cp_rank=attn_cp_rank,
+-        )
+-        self.model_config = self.flexkv_config.model_config
+-        self.cache_config = self.flexkv_config.cache_config
+-        self._label = f"[model_config={self.model_config}, rank_info={self.rank_info}]"
+-
+-        # 2. Cross-rank sync context.
+-        world_rank = (
+-            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+-        )
+-        self._sync_ctx = FlexKVComm(
+-            rank_info=self.rank_info,
+-            world_rank=world_rank,
+-            pp_group=pp_group,
+-            attn_tp_group=attn_tp_group,
+-            attn_cp_group=attn_cp_group,
+-        )
+-
+-        # 3. Align block counts across all ranks (MIN reduce) so each
+-        # rank's KVManager registers compatible sizes.
+-        for attr in ("num_cpu_blocks", "num_ssd_blocks", "num_remote_blocks"):
+-            orig = getattr(self.cache_config, attr, None)
+-            if orig is None or orig <= 0:
+-                continue
+-            aligned = self._sync_ctx.all_reduce_min(int(orig))
+-            if aligned != orig:
+-                logger.info(
+-                    "[FlexKV] Block count MIN alignment '%s': %d -> %d",
+-                    attr,
+-                    orig,
+-                    aligned,
+-                )
+-            setattr(self.cache_config, attr, aligned)
+-
+-        # 4. Extract MLA/MHA KV buffers + optional indexer buffers.
+-        indexer_buffers = getattr(kvcache, "index_k_with_scale_buffer", None)
+-        if hasattr(kvcache, "kv_buffer"):
+-            # MLA: K and V share the same buffer (per-layer tensor).
+-            kv_caches = list(kvcache.kv_buffer)
+-        elif hasattr(kvcache, "k_buffer"):
+-            # MHA: K buffers concatenated with V buffers, layer-first.
+-            kv_caches = list(kvcache.k_buffer) + list(kvcache.v_buffer)
+-        else:
+-            raise AttributeError(
+-                f"Unsupported KV cache type {type(kvcache).__name__}: "
+-                f"expected kv_buffer (MLA/NSA) or k_buffer/v_buffer (MHA)."
+-            )
+-        self._kvcache = kvcache
+-
+-        # 5. On multi-node setups, every node beyond node 0 needs a
+-        # TransferManagerOnRemote process (FlexKV side) before any rank
+-        # on that node can register GPU buffers.
+-        self._remote_process = None
+-        if (
+-            self.model_config.nnodes > 1
+-            and self.rank_info.node_rank > 0
+-            and self.rank_info.local_rank == 0
+-        ):
+-            self._remote_process = TransferManagerOnRemote.create_process(
+-                master_host=self.model_config.master_host,
+-                master_ports=self.model_config.master_ports,
+-            )
+-            logger.info(
+-                "[FlexKV] Launched TransferManagerOnRemote on node_rank=%d %s",
+-                self.rank_info.node_rank,
+-                self._label,
+-            )
+-
+-        # 6. Bring up KVManager on the sync leader only.
+-        self.kv_manager: Optional[KVManager] = None
+-        if self._sync_ctx.is_sync_leader:
+-            self.kv_manager = KVManager(
+-                model_config=self.model_config,
+-                cache_config=self.cache_config,
+-                dp_client_id=self.rank_info.dp_client_id,
+-                server_recv_port=self.flexkv_config.server_recv_port,
+-                gpu_register_port=self.flexkv_config.gpu_register_port,
+-            )
+-            self.kv_manager.start()
+-
+-        # 7. Per-rank TP client registers this rank's GPU buffers.
+-        self.tp_client = KVTPClient(
+-            self.flexkv_config.gpu_register_port,
+-            dp_client_id=self.rank_info.dp_client_id,
+-            pp_rank=self.rank_info.pp_rank,
+-            device_id=self.rank_info.local_rank,
+-        )
+-        self._register_with_retry(kv_caches, indexer_buffers)
+-
+-        # 8. Layerwise transfer plumbing.
+-        self.enable_layerwise = bool(
+-            int(os.environ.get("FLEXKV_ENABLE_LAYERWISE_TRANSFER", "0"))
+-        )
+-        self._layerwise_socket = build_layerwise_eventfd_socket_path(
+-            dp_client_id=self.rank_info.dp_client_id,
+-            pp_rank=self.rank_info.pp_rank,
+-            model_config=self.model_config,
+-        )
+-        self._layerwise_eventfd_connect_max_retries = max(
+-            360,
+-            int(os.environ.get("FLEXKV_LAYERWISE_EVENTFD_CONNECT_MAX_RETRIES", "0")),
+-        )
+-        self.layer_done_counter: Optional[FlexKVLayerDoneCounter] = None
+-        if self.enable_layerwise:
+-            self.layer_done_counter = FlexKVLayerDoneCounter(
+-                self.rank_info.num_layers_per_pp_stage
+-            )
+-            self._send_eventfds_to_worker()
+-
+-        # 9. Wait for the KVManager (and its remote subprocess) to be ready.
+-        if self._sync_ctx.is_sync_leader:
+-            self._wait_kv_manager_ready()
+-
+-        # 10. Per-rank in-flight tracking.
+-        # Loads
+-        self._pending_lookups: Dict[str, int] = {}  # rid -> fkv_task_id
+-        self._inflight_loads: Dict[int, int] = {}  # producer_id -> rid hashlike
+-        self._completed_layerwise: List[int] = []
+-        self._launched_load_tids: List[int] = []  # leader-only, for periodic drain
+-        # Stores
+-        self._inflight_stores: Dict[str, int] = {}  # rid -> fkv_task_id
+-        # Prefetches
+-        self._ongoing_prefetches: Dict[str, int] = {}  # rid -> fkv_task_id
+-        self._prefetch_enabled = bool(
+-            self.cache_config.enable_ssd
+-            or self.cache_config.enable_remote
+-            or self.cache_config.enable_kv_sharing
+-        )
+-
+-        logger.info(
+-            "[FlexKV] Connector ready %s: layerwise=%s, prefetch=%s",
+-            self._label,
+-            self.enable_layerwise,
+-            self._prefetch_enabled,
+-        )
+-
+-    # ------------------------------------------------------------------
+-    # Public API — lookup / load
+-    # ------------------------------------------------------------------
+-
+-    def lookup_kv(
+-        self,
+-        token_ids: List[int],
+-        token_mask: torch.Tensor,
+-        rid: Optional[str] = None,
+-    ) -> Tuple[int, int]:
+-        """Page-aligned prefix lookup against FlexKV.
+-
+-        Args:
+-          token_ids: full token id sequence we'd like to check.
+-          token_mask: 1-D bool tensor or array, True for "this token is
+-            *not* already on GPU and is a candidate for load-back".
+-          rid: if set and hit > 0, the held FlexKV task id is stashed
+-            under this key so a later ``retrieve_kv(rid, slots)`` call
+-            can resolve it. If not set, the held task is cancelled when
+-            hit > 0 and the caller didn't ask to track it.
+-
+-        Returns:
+-          ``(fkv_task_id, hit_count)``. ``hit_count`` is page-aligned
+-          and may be smaller than the raw FlexKV match if the page
+-          floor truncated it.
+-        """
+-        fkv_task_id = -1
+-        hit_length = 0
+-
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            tids_np = np.asarray(token_ids, dtype=np.int64)
+-            mask_np = self._as_numpy_mask(token_mask)
+-            try:
+-                res = self.kv_manager.get_match(token_ids=tids_np, token_mask=mask_np)
+-            except Exception as exc:  # noqa: BLE001
+-                logger.warning("[FlexKV] get_match raised: %s", exc)
+-                res = None
+-            if res is None:
+-                fkv_task_id = -1
+-                hit_length = 0
+-            else:
+-                fkv_task_id, matched_mask = res
+-                hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
+-
+-        if self._sync_ctx.needs_sync:
+-            payload = self._sync_ctx.scatter(
+-                {"task_id": fkv_task_id, "hit": hit_length}
+-            )
+-            fkv_task_id = payload["task_id"]
+-            hit_length = payload["hit"]
+-
+-        # Page-align: FlexKV transfers whole pages.
+-        if hit_length > 0 and self.page_size > 1:
+-            aligned = (hit_length // self.page_size) * self.page_size
+-            if aligned < hit_length:
+-                logger.debug(
+-                    "[FlexKV] lookup_kv: page-aligning hit %d -> %d (page=%d)",
+-                    hit_length,
+-                    aligned,
+-                    self.page_size,
+-                )
+-            hit_length = aligned
+-
+-        # Decide what to do with the held task. Three cases:
+-        #   1. hit_length > 0 and rid given → stash for retrieve_kv later.
+-        #   2. hit_length > 0 and rid is None → cancel; caller can't use it.
+-        #   3. hit_length == 0 → no work to do; FlexKV already marked the
+-        #      empty graph COMPLETED inside get_match, cancel would warn.
+-        if hit_length > 0 and rid is not None and fkv_task_id >= 0:
+-            self._pending_lookups[rid] = fkv_task_id
+-        elif hit_length > 0 and fkv_task_id >= 0 and self._sync_ctx.is_sync_leader:
+-            assert self.kv_manager is not None
+-            self.kv_manager.cancel([fkv_task_id])
+-
+-        return fkv_task_id, hit_length
+-
+-    def release_pending(self, rid: str) -> None:
+-        """Cancel the task held by an earlier ``lookup_kv(rid=...)`` that
+-        won't be followed by a ``retrieve_kv`` (e.g. allocation failed)."""
+-        fkv_task_id = self._pending_lookups.pop(rid, -1)
+-        if fkv_task_id >= 0 and self._sync_ctx.is_sync_leader:
+-            assert self.kv_manager is not None
+-            self.kv_manager.cancel([fkv_task_id])
+-
+-    def retrieve_kv(
+-        self,
+-        rid: str,
+-        slot_mapping: torch.Tensor,
+-    ) -> int:
+-        """Synchronous load: ``launch`` + ``wait``.
+-
+-        Returns the number of slots actually loaded. The caller is
+-        responsible for having allocated ``slot_mapping`` of length
+-        equal to ``hit_length`` from a prior ``lookup_kv``.
+-        """
+-        fkv_task_id = self._pending_lookups.pop(rid, -1)
+-        if fkv_task_id < 0:
+-            return 0
+-
+-        slot_mapping_cpu = self._to_cpu_int64(slot_mapping)
+-
+-        # Cross-node PP receivers must send their slot mapping back to
+-        # the TransferManagerOnRemote so the remote side knows where to
+-        # land the H2D copies on its own GPUs.
+-        if self._sync_ctx.should_send_slot_mapping_to_remote:
+-            self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+-
+-        n = slot_mapping_cpu.numel()
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            self.kv_manager.launch(
+-                task_ids=[fkv_task_id],
+-                slot_mappings=[slot_mapping_cpu],
+-                as_batch=True,
+-                layerwise_transfer=False,
+-            )
+-            resp = self.kv_manager.wait([fkv_task_id], timeout=30.0)
+-            if not (
+-                fkv_task_id in resp
+-                and resp[fkv_task_id].status == KVResponseStatus.SUCCESS
+-            ):
+-                logger.warning(
+-                    "[FlexKV] retrieve_kv: task %d failed/timed out",
+-                    fkv_task_id,
+-                )
+-                n = 0
+-        if self._sync_ctx.needs_sync:
+-            self._sync_ctx.barrier()
+-        return n
+-
+-    def start_load_kv_layerwise(
+-        self,
+-        rid: str,
+-        slot_mapping: torch.Tensor,
+-    ) -> Tuple[int, int]:
+-        """Layerwise load. Fires ``launch(layerwise_transfer=True)`` and
+-        returns ``(n_slots, producer_id)``. The caller registers
+-        ``producer_id`` with the layer hook so the KV pool blocks on
+-        the right eventfds during forward."""
+-        assert self.enable_layerwise and self.layer_done_counter is not None, (
+-            "start_load_kv_layerwise called but layerwise transfer is "
+-            "disabled. Set FLEXKV_ENABLE_LAYERWISE_TRANSFER=1."
+-        )
+-        fkv_task_id = self._pending_lookups.pop(rid, -1)
+-        if fkv_task_id < 0:
+-            return 0, -1
+-
+-        slot_mapping_cpu = self._to_cpu_int64(slot_mapping)
+-        n = slot_mapping_cpu.numel()
+-
+-        if self._sync_ctx.should_send_slot_mapping_to_remote:
+-            self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+-
+-        # Allocate / receive producer slot.
+-        if self._sync_ctx.is_pp_receiver:
+-            payload = self._sync_ctx.scatter_pp(None)
+-            if payload.get("cmd") != CMD_LAYERWISE:
+-                raise RuntimeError(
+-                    f"Tag mismatch: expected CMD_LAYERWISE, got "
+-                    f"{payload.get('cmd')}"
+-                )
+-            producer_id = int(payload["counter_id"])
+-            self.layer_done_counter.register_task_with_explicit_counter_id(
+-                fkv_task_id, producer_id
+-            )
+-        else:
+-            producer_id = self.layer_done_counter.update_producer()
+-            self.layer_done_counter.events[producer_id].reset_for_new_transfer()
+-            self.layer_done_counter.register_task(fkv_task_id, producer_id)
+-
+-        if self._sync_ctx.is_pp_sender:
+-            self._sync_ctx.scatter_pp(
+-                {
+-                    "cmd": CMD_LAYERWISE,
+-                    "fkv_task_id": fkv_task_id,
+-                    "counter_id": producer_id,
+-                }
+-            )
+-
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            self.kv_manager.launch(
+-                task_ids=[fkv_task_id],
+-                slot_mappings=[slot_mapping_cpu],
+-                as_batch=True,
+-                layerwise_transfer=True,
+-                counter_id=producer_id,
+-            )
+-            self._launched_load_tids.append(fkv_task_id)
+-
+-        # Tell the layer hook which counter slot to wait on.
+-        self.layer_done_counter.set_consumer(fkv_task_id)
+-        return n, producer_id
+-
+-    def drain_launched_loads(self, threshold: int = 100) -> None:
+-        """Periodic non-blocking sweep on long-lived launched tasks so the
+-        FlexKV pipe doesn't accumulate. No-op on non-leader ranks."""
+-        if not self._sync_ctx.is_sync_leader or self.kv_manager is None:
+-            return
+-        if len(self._launched_load_tids) < threshold:
+-            return
+-        try:
+-            self.kv_manager.try_wait(task_ids=list(self._launched_load_tids))
+-        except Exception as exc:  # noqa: BLE001
+-            logger.debug("[FlexKV] drain_launched_loads try_wait: %s", exc)
+-        self._launched_load_tids.clear()
+-
+-    # ------------------------------------------------------------------
+-    # Public API — store
+-    # ------------------------------------------------------------------
+-
+-    def store_kv(
+-        self,
+-        rid: str,
+-        token_ids: List[int],
+-        kv_indices: torch.Tensor,
+-    ) -> int:
+-        """Schedule a write back from GPU into FlexKV.
+-
+-        On the sync leader this runs ``put_match`` to discover which
+-        tokens are NOT yet in FlexKV's CPU cache (= the "unmatched"
+-        slice), then ``launch`` on those. On non-leaders the unmatched
+-        mask is received over the PP fan-out so cross-node PP can
+-        forward its slot mappings.
+-
+-        Returns the FlexKV task id of the in-flight store, or -1 if
+-        nothing needed to be written.
+-        """
+-        token_ids_np = np.asarray(token_ids, dtype=np.int64)
+-        n = len(token_ids_np)
+-        if n != len(kv_indices):
+-            raise ValueError(
+-                f"store_kv: token_ids has {n} entries but kv_indices "
+-                f"has {len(kv_indices)} entries"
+-            )
+-
+-        # Page-align inputs *before* put_match so the FlexKV allocator
+-        # only reserves slots that line up with the slot_mapping we send.
+-        if self.page_size > 1:
+-            aligned_len = (n // self.page_size) * self.page_size
+-            if aligned_len == 0:
+-                self._send_pp_put_meta(-1, [])
+-                return -1
+-            if aligned_len < n:
+-                token_ids_np = token_ids_np[:aligned_len]
+-                kv_indices = kv_indices[:aligned_len]
+-
+-        fkv_task_id = -1
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            try:
+-                res = self.kv_manager.put_match(token_ids=token_ids_np, token_mask=None)
+-            except Exception as exc:  # noqa: BLE001
+-                logger.warning("[FlexKV] put_match raised: %s", exc)
+-                res = None
+-            if res is None:
+-                self._send_pp_put_meta(-1, [])
+-                return -1
+-            fkv_task_id, unmatched_mask = res
+-
+-            self._send_pp_put_meta(fkv_task_id, unmatched_mask)
+-
+-            if int(unmatched_mask.sum()) > 0:
+-                filtered = kv_indices[unmatched_mask]
+-                slot_mapping_cpu = self._to_cpu_int64(filtered)
+-                self.kv_manager.launch(
+-                    task_ids=[fkv_task_id],
+-                    slot_mappings=[slot_mapping_cpu],
+-                    as_batch=False,
+-                    layerwise_transfer=False,
+-                )
+-                self._inflight_stores[rid] = fkv_task_id
+-                return fkv_task_id
+-            return -1
+-
+-        # Non-leader path: receive the unmatched mask + maybe forward
+-        # slot_mapping to the remote-side TransferManager.
+-        if self._sync_ctx.is_pp_receiver:
+-            payload = self._sync_ctx.scatter_pp(None)
+-            if payload.get("cmd") != CMD_PUT_META:
+-                raise RuntimeError(
+-                    f"Tag mismatch: expected CMD_PUT_META, got " f"{payload.get('cmd')}"
+-                )
+-            fkv_task_id = int(payload["fkv_task_id"])
+-            mask_list = payload.get("unmatched_mask", [])
+-            unmatched_mask = torch.tensor(mask_list, dtype=torch.bool)
+-            if (
+-                int(unmatched_mask.sum()) > 0
+-                and fkv_task_id >= 0
+-                and self._sync_ctx.should_send_slot_mapping_to_remote
+-            ):
+-                filtered = kv_indices[unmatched_mask]
+-                slot_mapping_cpu = self._to_cpu_int64(filtered)
+-                self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
+-                self._inflight_stores[rid] = fkv_task_id
+-        return fkv_task_id
+-
+-    def check_completed_stores(self) -> List[str]:
+-        """Return rids whose stores have completed since the last call."""
+-        completed_rids: List[str] = []
+-        completed_dict: Dict[int, Any] = {}
+-
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            if self._inflight_stores:
+-                fk_to_rid = {v: k for k, v in self._inflight_stores.items()}
+-                try:
+-                    completed_dict = self.kv_manager.try_wait(
+-                        task_ids=list(fk_to_rid.keys())
+-                    )
+-                except Exception as exc:  # noqa: BLE001
+-                    logger.debug("[FlexKV] check_completed_stores: %s", exc)
+-                    completed_dict = {}
+-                for fk_tid in completed_dict:
+-                    rid = fk_to_rid[fk_tid]
+-                    completed_rids.append(rid)
+-                    self._inflight_stores.pop(rid, None)
+-
+-        if self._sync_ctx.is_pp_sender:
+-            self._sync_ctx.scatter_pp(
+-                {
+-                    "cmd": CMD_STORE_COMPLETE,
+-                    "completed_fk_ids": list(completed_dict),
+-                }
+-            )
+-        elif self._sync_ctx.is_pp_receiver:
+-            payload = self._sync_ctx.scatter_pp(None)
+-            if payload.get("cmd") != CMD_STORE_COMPLETE:
+-                raise RuntimeError(
+-                    f"Tag mismatch: expected CMD_STORE_COMPLETE, got "
+-                    f"{payload.get('cmd')}"
+-                )
+-            fk_ids = payload.get("completed_fk_ids", [])
+-            if fk_ids and self._inflight_stores:
+-                fk_to_rid = {v: k for k, v in self._inflight_stores.items()}
+-                for fk_tid in fk_ids:
+-                    if fk_tid in fk_to_rid:
+-                        rid = fk_to_rid[fk_tid]
+-                        completed_rids.append(rid)
+-                        self._inflight_stores.pop(rid, None)
+-
+-        if self._sync_ctx.needs_sync:
+-            completed_rids = self._sync_ctx.scatter(completed_rids)
+-        return completed_rids
+-
+-    def wait_store(self, rid: str, timeout: float = 30.0) -> bool:
+-        """Block until a single store task identified by ``rid`` finishes."""
+-        fkv_task_id = self._inflight_stores.pop(rid, -1)
+-        if fkv_task_id < 0:
+-            return True
+-        if not self._sync_ctx.is_sync_leader or self.kv_manager is None:
+-            return True
+-        try:
+-            resp = self.kv_manager.wait([fkv_task_id], timeout=timeout)
+-        except Exception as exc:  # noqa: BLE001
+-            logger.warning("[FlexKV] wait_store: %s", exc)
+-            return False
+-        return (
+-            fkv_task_id in resp and resp[fkv_task_id].status == KVResponseStatus.SUCCESS
+-        )
+-
+-    # ------------------------------------------------------------------
+-    # Public API — prefetch
+-    # ------------------------------------------------------------------
+-
+-    def prefetch_async(self, rid: str, token_ids: List[int]) -> int:
+-        if not self._prefetch_enabled or not rid:
+-            return -1
+-        task_id = -1
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            try:
+-                task_id = self.kv_manager.prefetch_async(
+-                    token_ids=np.asarray(token_ids, dtype=np.int64)
+-                )
+-            except Exception as exc:  # noqa: BLE001
+-                logger.debug("[FlexKV] prefetch_async: %s", exc)
+-                task_id = -1
+-        if self._sync_ctx.needs_sync:
+-            payload = self._sync_ctx.scatter({"task_id": task_id})
+-            task_id = payload["task_id"]
+-        if task_id >= 0:
+-            self._ongoing_prefetches[rid] = task_id
+-        return task_id
+-
+-    def check_prefetch_progress(self, rid: str) -> bool:
+-        if not self._prefetch_enabled:
+-            return True
+-        task_id = self._ongoing_prefetches.get(rid, -1)
+-        if task_id < 0:
+-            return True
+-        done = False
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            try:
+-                completed = self.kv_manager.try_wait(task_ids=[task_id])
+-            except Exception:  # noqa: BLE001
+-                completed = {}
+-            if task_id in completed:
+-                done = True
+-        if self._sync_ctx.needs_sync:
+-            payload = self._sync_ctx.scatter({"done": done})
+-            done = payload["done"]
+-        if done:
+-            self._ongoing_prefetches.pop(rid, None)
+-        return done
+-
+-    def cancel_prefetch(self, rid: str) -> None:
+-        self._pending_lookups.pop(rid, None)
+-        # FlexKV doesn't currently support prefetch cancellation, but
+-        # we still drop our tracking entry.
+-        self._ongoing_prefetches.pop(rid, None)
+-
+-    # ------------------------------------------------------------------
+-    # Layerwise transfer hooks
+-    # ------------------------------------------------------------------
+-
+-    def register_layer_transfer_counter(self, kvcache: Any) -> None:
+-        """Register the FlexKVLayerDoneCounter onto sglang's KV pool so
+-        each forward layer blocks on its eventfd. No-op when layerwise
+-        is disabled."""
+-        if (
+-            self.layer_done_counter is None
+-            or kvcache is None
+-            or not hasattr(kvcache, "register_layer_transfer_counter")
+-        ):
+-            return
+-        kvcache.register_layer_transfer_counter(self.layer_done_counter)
+-
+-    # ------------------------------------------------------------------
+-    # Lifecycle
+-    # ------------------------------------------------------------------
+-
+-    def reset(self) -> None:
+-        # Drop pending lookups (cancel their held tasks on the leader).
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            pending = [tid for tid in self._pending_lookups.values() if tid >= 0]
+-            if pending:
+-                try:
+-                    self.kv_manager.cancel(pending)
+-                except Exception as exc:  # noqa: BLE001
+-                    logger.debug("[FlexKV] reset cancel: %s", exc)
+-        self._pending_lookups.clear()
+-        self._ongoing_prefetches.clear()
+-        self._inflight_loads.clear()
+-        self._completed_layerwise.clear()
+-        self._launched_load_tids.clear()
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            for fk_tid in list(self._inflight_stores.values()):
+-                if fk_tid >= 0:
+-                    try:
+-                        self.kv_manager.wait([fk_tid], timeout=20.0)
+-                    except Exception:  # noqa: BLE001
+-                        pass
+-        self._inflight_stores.clear()
+-        if self.layer_done_counter is not None:
+-            self.layer_done_counter.reset()
+-
+-    def shutdown(self) -> None:
+-        if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
+-            try:
+-                self.kv_manager.shutdown()
+-            except Exception as exc:  # noqa: BLE001
+-                logger.warning("[FlexKV] kv_manager.shutdown: %s", exc)
+-        if self._remote_process is not None:
+-            try:
+-                self._remote_process.terminate()
+-                self._remote_process.join(timeout=5.0)
+-                if self._remote_process.is_alive():
+-                    self._remote_process.kill()
+-                    self._remote_process.join()
+-            except Exception as exc:  # noqa: BLE001
+-                logger.warning("[FlexKV] remote process shutdown: %s", exc)
+-            self._remote_process = None
+-
+-    # ------------------------------------------------------------------
+-    # Private helpers
+-    # ------------------------------------------------------------------
+-
+-    @staticmethod
+-    def _as_numpy_mask(mask) -> np.ndarray:
+-        if mask is None:
+-            return None
+-        if isinstance(mask, torch.Tensor):
+-            return mask.detach().cpu().numpy()
+-        return np.asarray(mask)
+-
+-    @staticmethod
+-    def _to_cpu_int64(tensor: torch.Tensor) -> torch.Tensor:
+-        if tensor.is_cuda:
+-            tensor = tensor.cpu()
+-        return tensor.to(torch.int64)
+-
+-    def _wait_kv_manager_ready(self, poll_interval: float = 10.0) -> None:
+-        assert self.kv_manager is not None
+-        wait_count = 0
+-        while not self.kv_manager.is_ready():
+-            time.sleep(poll_interval)
+-            wait_count += 1
+-            logger.info(
+-                "[FlexKV] Waiting for FlexKV ready %s (waited %.0fs)",
+-                self._label,
+-                wait_count * poll_interval,
+-            )
+-        logger.info("[FlexKV] FlexKV is ready %s", self._label)
+-
+-    def _register_with_retry(
+-        self,
+-        kv_caches: List[torch.Tensor],
+-        indexer_buffers: Optional[List[torch.Tensor]] = None,
+-        max_retries: int = 360,
+-    ) -> None:
+-        """Retry GPU registration. On node_rank>0, the
+-        TransferManagerOnRemote may not be ready immediately; retry up
+-        to ~6 minutes."""
+-        for attempt in range(max_retries):
+-            try:
+-                self._register_to_server(kv_caches, indexer_buffers)
+-                return
+-            except Exception as exc:  # noqa: BLE001
+-                if attempt == max_retries - 1:
+-                    raise
+-                if attempt % 30 == 0:
+-                    logger.info(
+-                        "[FlexKV] GPU register retry %s attempt=%d/%d " "error=%s",
+-                        self._label,
+-                        attempt + 1,
+-                        max_retries,
+-                        exc,
+-                    )
+-                time.sleep(1.0)
+-
+-    def _register_to_server(
+-        self,
+-        kv_caches: List[torch.Tensor],
+-        indexer_buffers: Optional[List[torch.Tensor]] = None,
+-    ) -> None:
+-        assert len(kv_caches) > 0
+-        assert (
+-            kv_caches[0].ndim == 3
+-        ), f"Expected 3D KV cache tensor, got shape={kv_caches[0].shape}"
+-
+-        is_mla = self.model_config.use_mla
+-        num_blocks, num_kv_heads, head_size = kv_caches[0].shape
+-
+-        gpu_layout = KVCacheLayout(
+-            type=KVCacheLayoutType.LAYERFIRST,
+-            num_layer=self.rank_info.num_layers_per_pp_stage,
+-            num_block=num_blocks // self.page_size,
+-            tokens_per_block=self.page_size,
+-            num_head=num_kv_heads,
+-            head_size=head_size,
+-            is_mla=is_mla,
+-        )
+-
+-        indexer_layout = None
+-        if indexer_buffers is not None and len(indexer_buffers) > 0:
+-            indexer_tensor = indexer_buffers[0]
+-            assert indexer_tensor.ndim == 2, (
+-                f"Expected 2D indexer tensor (num_pages, page_stride_size), "
+-                f"got shape={indexer_tensor.shape}"
+-            )
+-            indexer_layout = KVCacheLayout(
+-                type=KVCacheLayoutType.LAYERFIRST,
+-                num_layer=len(indexer_buffers),
+-                num_block=indexer_tensor.shape[0],
+-                tokens_per_block=1,
+-                num_head=1,
+-                head_size=indexer_tensor.shape[1],
+-                is_mla=True,
+-            )
+-
+-        self.tp_client.register_to_server(
+-            kv_caches=kv_caches,
+-            kv_layout=gpu_layout,
+-            indexer_buffers=indexer_buffers,
+-            indexer_layout=indexer_layout,
+-        )
+-        logger.info("[FlexKV] Registered KV caches to server %s", self._label)
+-
+-    def _send_pp_put_meta(self, fkv_task_id: int, unmatched_mask) -> None:
+-        if not self._sync_ctx.is_pp_active:
+-            return
+-        if hasattr(unmatched_mask, "tolist"):
+-            mask_list = unmatched_mask.tolist()
+-        else:
+-            mask_list = list(unmatched_mask)
+-        self._sync_ctx.scatter_pp(
+-            {
+-                "cmd": CMD_PUT_META,
+-                "fkv_task_id": fkv_task_id,
+-                "unmatched_mask": mask_list,
+-            }
+-        )
+-
+-    def _send_slot_mapping_to_remote(
+-        self, task_id: int, slot_mapping_cpu: torch.Tensor
+-    ) -> None:
+-        np_arr = slot_mapping_cpu.numpy()
+-        self.tp_client.set_slot_mapping(task_id, np_arr)
+-
+-    def _send_eventfds_to_worker(self, retry_interval: float = 1.0) -> None:
+-        """UDS handshake with the FlexKV layerwise transfer worker.
+-
+-        Sends per-counter eventfd FDs over a unix domain socket using
+-        ``SCM_RIGHTS``. Retries connect (worker may not yet be up) and
+-        retries the whole connect+send sequence on send error.
+-        """
+-        max_retries = self._layerwise_eventfd_connect_max_retries
+-        max_send_retries = 3
+-        last_error: Optional[BaseException] = None
+-
+-        assert self.layer_done_counter is not None
+-
+-        for send_attempt in range(max_send_retries):
+-            sock: Optional[socket.socket] = None
+-            try:
+-                # Phase 1: connect (worker may not yet be up).
+-                for attempt in range(max_retries):
+-                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+-                    try:
+-                        sock.connect(self._layerwise_socket)
+-                        logger.info(
+-                            "[FlexKV] Eventfd connected %s socket=%s attempts=%d",
+-                            self._label,
+-                            self._layerwise_socket,
+-                            attempt + 1,
+-                        )
+-                        break
+-                    except (FileNotFoundError, ConnectionRefusedError) as exc:
+-                        sock.close()
+-                        sock = None
+-                        if attempt == max_retries - 1:
+-                            raise RuntimeError(
+-                                f"[FlexKV] Failed to connect to eventfd socket "
+-                                f"{self._layerwise_socket} after {max_retries} attempts"
+-                            ) from exc
+-                        time.sleep(retry_interval)
+-                assert sock is not None
+-
+-                # Phase 2: send 16-byte metadata + per-counter FDs + read ACK.
+-                num_counters = self.layer_done_counter.num_counters
+-                metadata = struct.pack(
+-                    "iiii",
+-                    self.rank_info.tp_rank_per_node,
+-                    self.model_config.tp_size_per_node,
+-                    self.rank_info.num_layers_per_pp_stage,
+-                    num_counters,
+-                )
+-                sock.sendall(metadata)
+-                for counter_id in range(num_counters):
+-                    fds = self.layer_done_counter.events[counter_id].load_event_fds
+-                    send_fds(sock, fds, struct.pack("i", counter_id))
+-                sock.settimeout(30.0)
+-                try:
+-                    ack = sock.recv(1)
+-                except socket.timeout as exc:
+-                    raise RuntimeError(
+-                        "Timed out waiting for ACK from FlexKV layerwise worker"
+-                    ) from exc
+-                if not ack or ack[0] != 1:
+-                    raise RuntimeError(
+-                        f"FlexKV layerwise worker NACK'd eventfd transfer "
+-                        f"(ack={ack!r})"
+-                    )
+-                logger.info(
+-                    "[FlexKV] Eventfd handshake complete %s counters=%d layers=%d",
+-                    self._label,
+-                    num_counters,
+-                    self.rank_info.num_layers_per_pp_stage,
+-                )
+-                return
+-            except Exception as exc:  # noqa: BLE001
+-                last_error = exc
+-                logger.warning(
+-                    "[FlexKV] Eventfd handshake send_attempt=%d/%d failed: %s",
+-                    send_attempt + 1,
+-                    max_send_retries,
+-                    exc,
+-                )
+-            finally:
+-                if sock is not None:
+-                    sock.close()
+-                time.sleep(retry_interval)
+-
+-        raise RuntimeError(
+-            f"[FlexKV] Failed to send eventfds to {self._layerwise_socket} "
+-            f"after {max_send_retries} attempts: {last_error}"
+-        )
+diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_hybrid_radix_cache.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_hybrid_radix_cache.py
 new file mode 100644
-index 000000000..afbd654a7
+index 000000000..6450c6432
 --- /dev/null
-+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/.clang-format
-@@ -0,0 +1,15 @@
-+BasedOnStyle: Google
-+IndentWidth: 2
-+ColumnLimit: 120
-+AllowShortFunctionsOnASingleLine: Empty
-+DerivePointerAlignment: false
-+PointerAlignment: Left
-+NamespaceIndentation: None
-+SortIncludes: true
-+AllowShortLoopsOnASingleLine: false
-+BinPackParameters: false              # Prevents packing parameters in declarations
-+BinPackArguments: false               # Prevents packing arguments in function calls
-+AlignAfterOpenBracket: AlwaysBreak    # Forces a break after the opening parenthesis
-+AlignOperands: Align                  # Aligns arguments vertically
-+PenaltyBreakBeforeFirstCallParameter: 1  # Encourages breaking before the first argument
-+PenaltyReturnTypeOnItsOwnLine: 100    # Keeps return type with function name
-diff --git a/python/sglang/srt/mem_cache/extended_radix_cache.py b/python/sglang/srt/mem_cache/extended_radix_cache.py
-new file mode 100644
-index 000000000..57ed8e19d
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
-@@ -0,0 +1,355 @@
++++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_hybrid_radix_cache.py
+@@ -0,0 +1,617 @@
++"""FlexKV adapter for SGLang's component-based hybrid radix cache."""
++
 +from __future__ import annotations
 +
 +import logging
-+from typing import TYPE_CHECKING, Dict, List, Optional
++import threading
++from array import array
++from dataclasses import dataclass
++from typing import TYPE_CHECKING, Any, Optional, Sequence
 +
 +import torch
 +
-+from sglang.srt.mem_cache.base_prefix_cache import (
-+    BasePrefixCache,
-+    EvictParams,
-+    EvictResult,
-+    MatchPrefixParams,
-+    MatchResult,
++from sglang.srt.mem_cache.allocator.hisparse import (
++    DeepSeekV4HiSparseTokenToKVPoolAllocator,
 +)
-+from sglang.srt.mem_cache.kv_connector import BaseKVConnector, LoadOperation
-+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode, page_align_keys
-+from sglang.srt.mem_cache.base_prefix_cache import InitLoadBackParams
-+if TYPE_CHECKING:
-+    from sglang.srt.managers.schedule_batch import Req
-+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-+
-+logger = logging.getLogger(__name__)
-+
-+
-+class ExtendedRadixCache(BasePrefixCache):
-+    """RadixCache decorator with external KV storage connector."""
-+
-+    def __init__(
-+        self,
-+        params: CacheInitParams,
-+        connector: Optional[BaseKVConnector] = None,
-+    ):
-+        self._inner_radixtree = RadixCache(params)
-+        self._connector = connector
-+
-+        self._load_task_id_counter = 0
-+        self._load_queue: List[LoadOperation] = []
-+        self._ongoing_load_tasks: Dict[int, List[TreeNode]] = {}
-+        self._ongoing_store_tasks: Dict[int, TreeNode] = {}
-+
-+    # -- Forward PrefixCacheTrait properties to inner cache --
-+
-+    @property
-+    def req_to_token_pool(self):
-+        return self._inner_radixtree.req_to_token_pool
-+
-+    @req_to_token_pool.setter
-+    def req_to_token_pool(self, value):
-+        self._inner_radixtree.req_to_token_pool = value
-+
-+    @property
-+    def token_to_kv_pool_allocator(self):
-+        return self._inner_radixtree.token_to_kv_pool_allocator
-+
-+    @token_to_kv_pool_allocator.setter
-+    def token_to_kv_pool_allocator(self, value):
-+        self._inner_radixtree.token_to_kv_pool_allocator = value
-+
-+    @property
-+    def page_size(self):
-+        return self._inner_radixtree.page_size
-+
-+    @page_size.setter
-+    def page_size(self, value):
-+        self._inner_radixtree.page_size = value
-+
-+    @property
-+    def disable(self):
-+        return self._inner_radixtree.disable
-+
-+    @property
-+    def device(self):
-+        return self._inner_radixtree.device
-+
-+    @property
-+    def metrics_collector(self):
-+        return self._inner_radixtree.metrics_collector
-+
-+    @metrics_collector.setter
-+    def metrics_collector(self, value):
-+        self._inner_radixtree.metrics_collector = value
-+
-+    @property
-+    def layer_done_counter(self):
-+        if self._connector is None:
-+            return None
-+        return self._connector.layer_done_counter
-+
-+    # -- Core methods with connector logic --
-+
-+    def reset(self):
-+        self._ongoing_store_tasks.clear()
-+        self._ongoing_load_tasks.clear()
-+        self._load_queue.clear()
-+
-+        if self._connector is not None:
-+            self._connector.reset()
-+
-+        self._inner_radixtree.reset()
-+
-+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
-+        device_match_result = self._inner_radixtree.match_prefix(params)
-+        if self._connector is None:
-+            return device_match_result
-+
-+        key = params.key
-+        device_indices: torch.Tensor = device_match_result.device_indices
-+        last_device_node = device_match_result.last_device_node
-+
-+        uncached_len = len(key) - device_indices.numel()
-+        if uncached_len <= 0:
-+            if params.req is not None:
-+                params.req.cached_tokens_extended_device = 0
-+            return device_match_result
-+
-+        token_mask = torch.zeros(len(key), dtype=torch.bool)
-+        token_mask[device_indices.numel() :] = True
-+
-+        new_hit_length = self._connector.get_new_hit_length(
-+            token_ids=key.token_ids,
-+            token_mask=token_mask,
-+            update_state_for_load=params.update_connector_state,
-+            rid=params.req.rid if params.req is not None else None,
-+        )
-+
-+        if params.req is not None:
-+            params.req.cached_tokens_extended_device = new_hit_length
-+
-+        return MatchResult(
-+            device_indices=device_indices,
-+            last_device_node=last_device_node,
-+            last_host_node=last_device_node,
-+            host_hit_length=new_hit_length,
-+        )
-+
-+    def init_load_back(
-+        self,
-+        params: InitLoadBackParams
-+    ) -> None:
-+        req = params.req
-+        mem_quota = params.mem_quota
-+
-+        if self._connector is None:
-+            return
-+
-+        host_hit_length = req.host_hit_length
-+
-+        if host_hit_length <= 0 or (
-+            mem_quota is not None and host_hit_length > mem_quota
-+        ):
-+            self._connector.release_load_state(req.rid)
-+            return
-+
-+        device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
-+            host_hit_length
-+        )
-+        if device_indices is None:
-+            self.evict(EvictParams(num_tokens=host_hit_length))
-+            device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
-+                host_hit_length
-+            )
-+        if device_indices is None:
-+            logger.warning(
-+                "Failed to allocate %d GPU slots for external load",
-+                host_hit_length,
-+            )
-+            self._connector.release_load_state(req.rid)
-+            return
-+
-+        gpu_cached_len = len(req.prefix_indices)
-+        key = RadixKey(
-+            token_ids=req.fill_ids[gpu_cached_len : gpu_cached_len + host_hit_length],
-+            extra_key=req.extra_key,
-+        )
-+
-+        last_node = req.last_node
-+        new_node = TreeNode()
-+        new_node.key = key
-+        new_node.value = device_indices
-+        new_node.parent = last_node
-+        last_node.children[self._inner_radixtree.get_child_key_fn(new_node.key)] = (
-+            new_node
-+        )
-+        self._inner_radixtree.evictable_size_ += len(device_indices)
-+        self._inner_radixtree._record_store_event(new_node)
-+
-+        self._inner_radixtree.inc_lock_ref(new_node)
-+
-+        self._load_queue.append(
-+            LoadOperation(
-+                rid=req.rid,
-+                device_indices=device_indices,
-+                node=new_node,
-+            )
-+        )
-+
-+        req.prefix_indices = torch.cat([req.prefix_indices, device_indices])
-+        req.last_node = new_node
-+
-+    def ready_to_load_host_cache(self) -> int:
-+        if self._connector is None or not self._load_queue:
-+            return -1
-+
-+        task_id = self._load_task_id_counter
-+        self._load_task_id_counter += 1
-+
-+        self._connector.start_load_kv(task_id, self._load_queue)
-+
-+        nodes = [op.node for op in self._load_queue]
-+        self._ongoing_load_tasks[task_id] = nodes
-+
-+        self._load_queue.clear()
-+        return task_id
-+
-+    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
-+        # Save kv_committed_len before super() pops it (pop_committed_kv_cache
-+        # sets kv_committed_freed=True and cannot be called again).
-+        kv_committed_len = req.kv_committed_len
-+
-+        token_ids = None
-+        cache_to_connector = False
-+        if self._connector is not None and is_insert:
-+            req_id = req.req_pool_idx
-+            token_ids = (req.origin_input_ids + req.output_ids)[:kv_committed_len]
-+            # Reuse sglang's page_align_keys to truncate to page boundary
-+            token_ids = page_align_keys(token_ids, self.page_size)
-+            if len(token_ids) > 0 and req_id is not None:
-+                cache_to_connector = True
-+
-+        # Let the inner radix tree do insert + free duplicates + dec_lock_ref.
-+        self._inner_radixtree.cache_finished_req(req, is_insert=is_insert, **kwargs)
-+
-+        if not cache_to_connector:
-+            return
-+
-+        # Re-match the tree to get the actual leaf node and its kv_indices
-+        # AFTER insert.  These kv_indices are the tree node values (not the
-+        # req_to_token_pool snapshot), so they are protected by lock_ref and
-+        # won't be freed by the allocator while D2H transfer is in flight.
-+        radix_key = RadixKey(token_ids, req.extra_key)
-+        match_result = self._inner_radixtree.match_prefix(
-+            MatchPrefixParams(key=radix_key)
-+        )
-+        new_last_node = match_result.last_device_node
-+        if new_last_node is None or new_last_node is self._inner_radixtree.root_node:
-+            return
-+
-+        kv_indices = match_result.device_indices
-+        if kv_indices is None or kv_indices.numel() == 0:
-+            return
-+
-+        if len(token_ids) != kv_indices.numel():
-+            logger.warning(
-+                "[FlexKV] cache_finished_req: length mismatch! "
-+                "len(token_ids)=%d, kv_indices.numel()=%d, skipping store",
-+                len(token_ids), kv_indices.numel(),
-+            )
-+            return
-+
-+        # Lock the resolved tree node BEFORE starting async D2H transfer
-+        # so that evict cannot free these pages while transfer is in flight.
-+        self._inner_radixtree.inc_lock_ref(new_last_node)
-+
-+        task_id = self._load_task_id_counter
-+        self._load_task_id_counter += 1
-+        
-+        self._connector.start_store_kv(
-+            task_id=task_id,
-+            token_ids=token_ids,
-+            kv_indices=kv_indices,
-+        )
-+
-+        self._ongoing_store_tasks[task_id] = new_last_node
-+
-+    def evict(self, params: EvictParams) -> EvictResult:
-+        return self._inner_radixtree.evict(params)
-+
-+    def check_kv_events(self):
-+        if self._connector is None:
-+            return
-+        self._check_store_completion()
-+        self._check_load_completion()
-+
-+    def prefetch(self, req: Req) -> None:
-+        if self._connector is None:
-+            return
-+        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
-+        self._connector.prefetch(req.rid, token_ids)
-+
-+    def check_prefetch_progress(self, req_id: str) -> bool:
-+        if self._connector is None:
-+            return True
-+        return self._connector.check_prefetch_progress(req_id)
-+
-+    def pop_prefetch_loaded_tokens(self, req_id: str) -> int:
-+        if self._connector is None:
-+            return 0
-+        return self._connector.pop_prefetch_loaded_tokens(req_id)
-+
-+    def release_aborted_request(self, req_id: str) -> None:
-+        if self._connector is None:
-+            return
-+        self._connector.cancel_prefetch(req_id)
-+
-+    # -- Private helpers --
-+
-+    def _check_store_completion(self) -> None:
-+        completed_ids = self._connector.check_completed_store_tasks()
-+        for task_id in completed_ids:
-+            node = self._ongoing_store_tasks.pop(task_id, None)
-+            if node is not None:
-+                self._inner_radixtree.dec_lock_ref(node)
-+
-+    def _check_load_completion(self) -> None:
-+        completed_ids = self._connector.check_completed_load_tasks()
-+        for task_id in completed_ids:
-+            nodes = self._ongoing_load_tasks.pop(task_id, None)
-+            if nodes is not None:
-+                for node in nodes:
-+                    self._inner_radixtree.dec_lock_ref(node)
-+
-+    # -- Pass-through methods --
-+
-+    def insert(self, key, value=None, **kwargs):
-+        return self._inner_radixtree.insert(key, value=value, **kwargs)
-+
-+    def inc_lock_ref(self, node):
-+        return self._inner_radixtree.inc_lock_ref(node)
-+
-+    def dec_lock_ref(self, node):
-+        return self._inner_radixtree.dec_lock_ref(node)
-+
-+    def cache_unfinished_req(self, req: Req, **kwargs):
-+        return self._inner_radixtree.cache_unfinished_req(req, **kwargs)
-+
-+    def evictable_size(self):
-+        return self._inner_radixtree.evictable_size()
-+
-+    def protected_size(self):
-+        return self._inner_radixtree.protected_size()
-+
-+    def total_size(self):
-+        return self._inner_radixtree.total_size()
-+
-+    def pretty_print(self):
-+        return self._inner_radixtree.pretty_print()
-+
-+    def all_values_flatten(self):
-+        return self._inner_radixtree.all_values_flatten()
-+
-+    def take_events(self):
-+        return self._inner_radixtree.take_events()
-+
-+    def __getattr__(self, name):
-+        return getattr(self._inner_radixtree, name)
-diff --git a/python/sglang/srt/mem_cache/hiradix_cache.py b/python/sglang/srt/mem_cache/hiradix_cache.py
-index 853baef6b..28b0d7aa8 100644
---- a/python/sglang/srt/mem_cache/hiradix_cache.py
-+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
-@@ -541,7 +541,7 @@ class HiRadixCache(RadixCache):
-         """
-         return self.cache_controller.start_loading()
- 
--    def check_hicache_events(self):
-+    def check_kv_events(self):
-         self.writing_check()
-         self.loading_check()
-         if self.enable_storage:
-diff --git a/python/sglang/srt/mem_cache/kv_connector.py b/python/sglang/srt/mem_cache/kv_connector.py
-new file mode 100644
-index 000000000..cbc1f7c6d
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/kv_connector.py
-@@ -0,0 +1,177 @@
-+from __future__ import annotations
-+
-+from abc import ABC, abstractmethod
-+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
-+
-+import torch
-+
-+if TYPE_CHECKING:
-+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-+    from sglang.srt.server_args import ServerArgs
-+
-+
-+class LoadOperation(NamedTuple):
-+    rid: str
-+    device_indices: torch.Tensor
-+    node: Any
-+
-+
-+class BaseKVConnector(ABC):
-+    def __init__(
-+        self,
-+        params: "CacheInitParams",
-+        server_args: "ServerArgs",
-+        tp_rank: int = 0,
-+        dp_rank: Optional[int] = 0,
-+        attn_cp_rank: Optional[int] = 0,
-+        pp_group: Optional[torch.distributed.ProcessGroup] = None,
-+        attn_tp_group: Optional[torch.distributed.ProcessGroup] = None,
-+        attn_cp_group: Optional[torch.distributed.ProcessGroup] = None,
-+    ):
-+        self.params = params
-+        self.server_args = server_args
-+        self.tp_rank = tp_rank
-+        self.dp_rank = dp_rank
-+        self.attn_cp_rank = attn_cp_rank
-+        self.pp_group = pp_group
-+        self.attn_tp_group = attn_tp_group
-+        self.attn_cp_group = attn_cp_group
-+
-+    @abstractmethod
-+    def get_new_hit_length(
-+        self,
-+        token_ids: List[int],
-+        token_mask: torch.Tensor,
-+        update_state_for_load: bool = False,
-+        rid: Optional[str] = None,
-+    ) -> int:
-+        """Return number of externally cached tokens beyond the device hit.
-+
-+        Args:
-+            token_ids: Full token id sequence.
-+            token_mask: Boolean mask; True for positions to match.
-+            update_state_for_load: Lock internal state until the load is
-+                started or cancelled via *rid*.
-+            rid: Request id for tracking the subsequent load task.
-+        Returns:
-+            Number of new matched tokens.
-+        """
-+        ...
-+
-+    @abstractmethod
-+    def release_load_state(self, rid: str) -> None:
-+        """Release the load state acquired by get_new_hit_length.
-+
-+        Args:
-+            rid: Request id previously passed to get_new_hit_length.
-+        """
-+        ...
-+
-+    @abstractmethod
-+    def start_load_kv(
-+        self,
-+        task_id: int,
-+        load_ops: List[LoadOperation],
-+    ) -> None:
-+        """Start a batch of external-to-GPU load operations.
-+
-+        Args:
-+            task_id: Caller-assigned id for completion tracking.
-+            load_ops: Pending load operations to execute.
-+        """
-+        ...
-+
-+    @abstractmethod
-+    def check_completed_load_tasks(self) -> List[int]:
-+        """Return task_ids of completed load tasks.
-+
-+        Returns:
-+            List of completed load task_ids.
-+        """
-+        ...
-+
-+    @abstractmethod
-+    def start_store_kv(
-+        self,
-+        task_id: int,
-+        token_ids: List[int],
-+        kv_indices: torch.Tensor,
-+    ) -> None:
-+        """Asynchronously store KV cache to external storage.
-+
-+        Args:
-+            task_id: Caller-assigned id for completion tracking.
-+            token_ids: Token id sequence to store.
-+            kv_indices: Corresponding GPU KV pool indices.
-+        """
-+        ...
-+
-+    @abstractmethod
-+    def check_completed_store_tasks(self) -> List[int]:
-+        """Return task_ids of completed store tasks.
-+
-+        Returns:
-+            List of completed store task_ids.
-+        """
-+        ...
-+
-+    def prefetch(self, rid: str, token_ids: List[int]) -> None:
-+        """Start prefetching KV cache from external storage.
-+
-+        Args:
-+            rid: Request id.
-+            token_ids: Token id sequence to prefetch.
-+        """
-+        pass
-+
-+    def check_prefetch_progress(self, rid: str) -> bool:
-+        """Return True if the prefetch for *rid* has completed.
-+
-+        Args:
-+            rid: Request id previously passed to prefetch.
-+        Returns:
-+            True if complete or no prefetch was needed.
-+        """
-+        return True
-+
-+    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
-+        """
-+        Pop and return the number of tokens loaded from storage for a request.
-+        Returns 0 if no prefetch was done or was revoked.
-+        This should be called after check_prefetch_progress() returns True.
-+
-+        Args:
-+            rid: Request id previously passed to prefetch.
-+        Returns:
-+            Number of tokens loaded from storage.
-+        """
-+        return 0
-+
-+    def cancel_prefetch(self, rid: str) -> None:
-+        """Cancel an in-progress or pending prefetch for *rid*.
-+
-+        Args:
-+            rid: Request id previously passed to prefetch.
-+        """
-+        pass
-+
-+    @property
-+    def layer_done_counter(self) -> Any:
-+        """Return the layer-wise transfer counter, or None."""
-+        return None
-+
-+    def register_layer_transfer_counter(self, kvcache: Any) -> None:
-+        """Register the layer transfer counter with the KV cache pool.
-+
-+        Args:
-+            kvcache: KV cache pool instance.
-+        """
-+        pass
-+
-+    def reset(self) -> None:
-+        """Reset connector state (called on cache reset)."""
-+        pass
-+
-+    def shutdown(self) -> None:
-+        """Cleanup resources."""
-+        pass
-\ No newline at end of file
-diff --git a/python/sglang/srt/mem_cache/session_aware_cache.py b/python/sglang/srt/mem_cache/session_aware_cache.py
-new file mode 100644
-index 000000000..b44ed560a
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
-@@ -0,0 +1,368 @@
-+from __future__ import annotations
-+
-+from dataclasses import dataclass, field
-+from typing import TYPE_CHECKING, Any, Dict, Optional
-+
-+import torch
-+
 +from sglang.srt.mem_cache.base_prefix_cache import (
 +    BasePrefixCache,
 +    DecLockRefParams,
-+    DecLockRefResult,
 +    EvictParams,
 +    EvictResult,
 +    IncLockRefResult,
@@ -1175,2088 +2127,675 @@ index 000000000..b44ed560a
 +    MatchPrefixParams,
 +    MatchResult,
 +)
-+from sglang.srt.utils.common import ceil_align
++from sglang.srt.mem_cache.radix_cache import RadixKey
++from flexkv.integration.sglang.connector import (
++    FlexKVConnector,
++    FlexKVHostReleaseShim,
++)
 +
 +if TYPE_CHECKING:
++    from sglang.srt.configs.model_config import ModelConfig
 +    from sglang.srt.managers.schedule_batch import Req
++    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
++    from sglang.srt.server_args import ServerArgs
 +
-+
-+class _VirtualNode:
-+    """Sentinel node for streaming session requests.
-+
-+    Passed to inc_lock_ref / dec_lock_ref so the wrapper can distinguish
-+    streaming-session locks (no-op) from real radix-tree locks (forwarded).
-+    """
-+
-+    pass
++logger = logging.getLogger(__name__)
 +
 +
 +@dataclass
-+class SessionSlot:
-+    """Holds KV state between streaming session turns."""
++class _LoadMarker:
++    key: RadixKey
++    device_length: int
 +
-+    virtual_node: _VirtualNode = field(default_factory=_VirtualNode)
 +
-+    # KV pool state (None means no KV is currently held by this slot)
-+    req_pool_idx: Optional[int] = None
-+    kv_committed_len: int = 0
-+    kv_allocated_len: int = 0
++@dataclass
++class _RestoreLease:
++    generation: int
++    req: Req
++    device_indices: torch.Tensor
 +
-+    # First req's radix tree node (for dec_lock_ref on session close)
-+    last_node: Any = None
-+    cache_protected_len: int = 0
-+    swa_uuid_for_lock: Optional[str] = None
 +
-+    # SWA state
-+    swa_evicted_seqlen: int = 0
++class FlexKVHybridRadixCache(BasePrefixCache):
++    """Compose FlexKV I/O with an existing hybrid radix implementation.
 +
-+    # Mamba states
-+    mamba_pool_idx: Any = None
-+    mamba_ping_pong_track_buffer: Any = None
-+    mamba_next_track_idx: Any = None
-+    mamba_last_track_seqlen: Any = None
-+    mamba_branching_seqlen: Any = None
-+
-+    @property
-+    def is_holding_kv(self) -> bool:
-+        """Whether this slot currently holds KV pool resources."""
-+        return self.req_pool_idx is not None
-+
-+    def save_from_req(self, req: Req, is_first: bool):
-+        """Save KV state from a finishing request into this slot."""
-+        self.req_pool_idx = req.req_pool_idx
-+        self.kv_committed_len = req.kv_committed_len
-+        self.kv_allocated_len = req.kv_allocated_len
-+        self.swa_evicted_seqlen = req.swa_evicted_seqlen
-+
-+        if is_first:
-+            self.last_node = req.last_node
-+            self.cache_protected_len = req.cache_protected_len
-+            self.swa_uuid_for_lock = req.swa_uuid_for_lock
-+
-+        self.mamba_pool_idx = req.mamba_pool_idx
-+        self.mamba_ping_pong_track_buffer = req.mamba_ping_pong_track_buffer
-+        self.mamba_next_track_idx = req.mamba_next_track_idx
-+        self.mamba_last_track_seqlen = req.mamba_last_track_seqlen
-+        self.mamba_branching_seqlen = req.mamba_branching_seqlen
-+
-+        req.req_pool_idx = None
-+        req.mamba_pool_idx = None
-+
-+    def restore_to_req(self, req: Req):
-+        """Restore KV state from this slot into an incoming request."""
-+        req.req_pool_idx = self.req_pool_idx
-+        req.kv_committed_len = self.kv_committed_len
-+        req.kv_allocated_len = self.kv_allocated_len
-+        req.swa_evicted_seqlen = self.swa_evicted_seqlen
-+        req.swa_uuid_for_lock = self.swa_uuid_for_lock
-+
-+        req.mamba_pool_idx = self.mamba_pool_idx
-+        req.mamba_ping_pong_track_buffer = self.mamba_ping_pong_track_buffer
-+        req.mamba_next_track_idx = self.mamba_next_track_idx
-+        req.mamba_last_track_seqlen = self.mamba_last_track_seqlen
-+        req.mamba_branching_seqlen = self.mamba_branching_seqlen
-+
-+        # NOTE: req_pool_idx and mamba_pool_idx are intentionally NOT cleared
-+        # from the slot. During chunked prefill, a request may be rejected by
-+        # the scheduler (e.g. budget exhausted) and retried in the next cycle.
-+        # Each retry calls match_prefix -> restore_to_req again, so the slot
-+        # must remain intact for idempotent restoration.
-+
-+
-+def _is_streaming(req: Optional[Req]) -> bool:
-+    return req is not None and req.session is not None and req.session.streaming
-+
-+
-+class SessionAwareCache(BasePrefixCache):
-+    """Decorator around any BasePrefixCache that manages streaming session KV.
-+
-+    Non-streaming requests are pure pass-through. Streaming requests have their
-+    KV lifecycle managed by SessionSlot objects, avoiding any invasive changes
-+    to the scheduling pipeline.
-+    """
-+
-+    def __init__(self, inner: BasePrefixCache):
-+        self.inner = inner
-+        self.slots: Dict[str, SessionSlot] = {}
-+
-+    # -- Forward PrefixCacheTrait properties to inner cache --
-+
-+    @property
-+    def req_to_token_pool(self):
-+        return self.inner.req_to_token_pool
-+
-+    @req_to_token_pool.setter
-+    def req_to_token_pool(self, value):
-+        self.inner.req_to_token_pool = value
-+
-+    @property
-+    def token_to_kv_pool_allocator(self):
-+        return self.inner.token_to_kv_pool_allocator
-+
-+    @token_to_kv_pool_allocator.setter
-+    def token_to_kv_pool_allocator(self, value):
-+        self.inner.token_to_kv_pool_allocator = value
-+
-+    @property
-+    def page_size(self):
-+        return self.inner.page_size
-+
-+    @page_size.setter
-+    def page_size(self, value):
-+        self.inner.page_size = value
-+
-+    @property
-+    def disable(self):
-+        return self.inner.disable
-+
-+    @disable.setter
-+    def disable(self, value):
-+        self.inner.disable = value
-+
-+    @property
-+    def metrics_collector(self):
-+        return self.inner.metrics_collector
-+
-+    @metrics_collector.setter
-+    def metrics_collector(self, value):
-+        self.inner.metrics_collector = value
-+
-+    # -- BasePrefixCache abstract methods --
-+
-+    def reset(self):
-+        self.slots.clear()
-+        self.inner.reset()
-+
-+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
-+        req = params.req
-+        if not _is_streaming(req):
-+            return self.inner.match_prefix(params)
-+
-+        session_id = req.session.session_id
-+        slot = self.slots.get(session_id)
-+        if slot is None or slot.req_pool_idx is None:
-+            return self.inner.match_prefix(params)
-+
-+        slot.restore_to_req(req)
-+
-+        # logprob_start_len is already forced to -1 for streaming sessions
-+        # (in Req.init_next_round_input), so the prefix key is not truncated
-+        # and we can directly reuse the committed KV length.
-+        prefix_len = min(req.kv_committed_len, max(len(params.key.token_ids) - 1, 0))
-+        device_indices = self.req_to_token_pool.req_to_token[
-+            req.req_pool_idx, :prefix_len
-+        ].to(dtype=torch.int64)
-+
-+        return MatchResult(
-+            device_indices=device_indices,
-+            last_device_node=slot.virtual_node,
-+            last_host_node=slot.virtual_node,
-+            cache_protected_len=slot.cache_protected_len,
-+        )
-+
-+    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
-+        if not _is_streaming(req):
-+            return self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
-+
-+        session_id = req.session.session_id
-+        slot = self.slots.get(session_id)
-+        is_first = slot is None
-+        if is_first:
-+            slot = SessionSlot()
-+            self.slots[session_id] = slot
-+
-+        slot.save_from_req(req, is_first=is_first)
-+
-+    def cache_unfinished_req(self, req: Req, **kwargs):
-+        if _is_streaming(req):
-+            # in chunked_prefill for streaming, we skip the stash path which triggers radix.
-+            # only the last chunk in first turn trigger a full prompt radix insert.
-+            if kwargs.get("chunked", False):
-+                kv_indices = self.req_to_token_pool.req_to_token[
-+                    req.req_pool_idx, : len(req.fill_ids)
-+                ]
-+                req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
-+                return
-+            if req.session.session_id in self.slots:
-+                # Subsequent turns: slot exists, skip inner entirely.
-+                return
-+            # First turn (no slot): fall through to inner for lock management,
-+            # tree insertion, and cache_protected_len updates between chunks.
-+        self.inner.cache_unfinished_req(req, **kwargs)
-+
-+    def evict(self, params: EvictParams) -> EvictResult:
-+        return self.inner.evict(params)
-+
-+    def inc_lock_ref(self, node: Any) -> IncLockRefResult:
-+        if isinstance(node, _VirtualNode):
-+            return IncLockRefResult()
-+        return self.inner.inc_lock_ref(node)
-+
-+    def dec_lock_ref(
-+        self, node: Any, params: Optional[DecLockRefParams] = None
-+    ) -> DecLockRefResult:
-+        if isinstance(node, _VirtualNode):
-+            return DecLockRefResult()
-+        return self.inner.dec_lock_ref(node, params)
-+
-+    # -- Session lifecycle --
-+
-+    def release_session(self, session_id: str):
-+        """Release all KV resources held by a streaming session."""
-+        slot = self.slots.pop(session_id, None)
-+        if slot is None:
-+            return
-+
-+        if slot.last_node is not None:
-+            if slot.swa_uuid_for_lock is not None:
-+                self.inner.dec_lock_ref(
-+                    slot.last_node,
-+                    DecLockRefParams(swa_uuid_for_lock=slot.swa_uuid_for_lock),
-+                )
-+            else:
-+                self.inner.dec_lock_ref(slot.last_node)
-+
-+        if slot.is_holding_kv:
-+            start = slot.cache_protected_len
-+            end = slot.kv_allocated_len
-+            if start < end:
-+                kv_indices = self.req_to_token_pool.req_to_token[
-+                    slot.req_pool_idx, start:end
-+                ]
-+                self.token_to_kv_pool_allocator.free(kv_indices)
-+            self.req_to_token_pool.free_slots.append(slot.req_pool_idx)
-+
-+    def session_held_tokens(self) -> int:
-+        """Total KV tokens held by session slots, not tracked by the tree."""
-+        total = 0
-+        for slot in self.slots.values():
-+            if slot.is_holding_kv:
-+                allocated = ceil_align(slot.kv_allocated_len, self.page_size)
-+                total += allocated - slot.cache_protected_len
-+        return total
-+
-+    def session_held_full_tokens(self) -> int:
-+        """An alias to align the naming style of SWA"""
-+        return self.session_held_tokens()
-+
-+    def session_held_swa_tokens(self) -> int:
-+        """Total SWA tokens held by session slots, not tracked by the tree."""
-+        total = 0
-+        for slot in self.slots.values():
-+            if slot.is_holding_kv:
-+                allocated = ceil_align(slot.kv_allocated_len, self.page_size)
-+                total += allocated - max(
-+                    slot.cache_protected_len, slot.swa_evicted_seqlen
-+                )
-+        return total
-+
-+    def session_held_req_count(self) -> int:
-+        """Number of req pool slots held by session slots."""
-+        return sum(s.is_holding_kv for s in self.slots.values())
-+
-+    # -- Pass-through methods --
-+
-+    def evictable_size(self):
-+        return self.inner.evictable_size()
-+
-+    def full_evictable_size(self):
-+        return self.inner.full_evictable_size()
-+
-+    def swa_evictable_size(self):
-+        return self.inner.swa_evictable_size()
-+
-+    def protected_size(self):
-+        return self.inner.protected_size()
-+
-+    def full_protected_size(self):
-+        return self.inner.full_protected_size()
-+
-+    def swa_protected_size(self):
-+        return self.inner.swa_protected_size()
-+
-+    def total_size(self):
-+        return self.inner.total_size()
-+
-+    def pretty_print(self):
-+        return self.inner.pretty_print()
-+
-+    def init_load_back(self, params: InitLoadBackParams):
-+        return self.inner.init_load_back(params)
-+
-+    def ready_to_load_host_cache(self):
-+        return self.inner.ready_to_load_host_cache()
-+
-+    def flush_write_through_acks(self) -> None:
-+        return self.inner.flush_write_through_acks()
-+
-+    def check_kv_events(self):
-+        return self.inner.check_kv_events()
-+
-+    def take_events(self):
-+        return self.inner.take_events()
-+
-+    def supports_swa(self):
-+        return self.inner.supports_swa()
-+
-+    def supports_mamba(self):
-+        return self.inner.supports_mamba()
-+
-+    def is_chunk_cache(self):
-+        return self.inner.is_chunk_cache()
-+
-+    def is_tree_cache(self):
-+        return self.inner.is_tree_cache()
-+
-+    def available_and_evictable_str(self):
-+        return self.inner.available_and_evictable_str()
-+
-+    def init_metrics_collector(self):
-+        return self.inner.init_metrics_collector()
-+
-+    def sanity_check(self):
-+        # Skip inner sanity check when sessions hold tree locks, because
-+        # the check asserts all nodes are unlocked during idle.
-+        if any(s.is_holding_kv for s in self.slots.values()):
-+            return
-+        self.inner.sanity_check()
-+
-+    # Forward attribute access for cache-specific methods (e.g.
-+    # sliding_window_size, all_values_flatten, etc.)
-+    def __getattr__(self, name):
-+        return getattr(self.inner, name)
-diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py
-new file mode 100644
-index 000000000..76734bcf9
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_comm.py
-@@ -0,0 +1,642 @@
-+import ctypes
-+import errno
-+import logging
-+import os
-+import pickle
-+import socket
-+import struct
-+from datetime import timedelta
-+from typing import Any, Dict, List, Optional
-+
-+import torch
-+import torch.distributed as dist
-+
-+from sglang.srt.distributed.parallel_state import get_world_group
-+
-+logger = logging.getLogger(__name__)
-+
-+# ---- PP control command constants ----
-+CMD_PUT_META = 2
-+CMD_LAYERWISE = 3
-+CMD_STORE_COMPLETE = 5
-+
-+
-+class FlexKVComm:
-+    """FlexKV hierarchical communication on 3D topology (PP x CP x TP).
-+
-+    Public API: scatter, scatter_pp, barrier, all_reduce_min.
-+    Public read-only attributes: is_sync_leader, needs_sync, is_pp_active,
-+    is_pp_sender, is_pp_receiver.
-+
-+    Communication hierarchy (3 dimensions, fan-out / aggregate):
-+
-+        Scatter (async):   PP_leader --isend--> PP_stage_leaders
-+                                     --isend--> CP_ranks  (per PP stage)
-+                                     --isend--> TP_ranks  (per CP group)
-+
-+        AllReduce (sync):  TP group all_reduce
-+                           -> CP group all_reduce
-+                           -> PP P2P reduce (stage leaders)
-+                           -> bcast result back down
-+
-+        scatter_pp (async): PP0 stage leader --isend--> PP1+ stage leaders
-+        barrier (sync):     hierarchical barrier: TP -> CP -> PP
-+    """
-+
-+    # ---- Tags for P2P scatter on world_cpu_group ----
-+    _TAG_SCATTER = int.from_bytes(b"FxSc", byteorder="big")
-+    _TAG_PP      = int.from_bytes(b"FxPP", byteorder="big")
-+    _TAG_CP      = int.from_bytes(b"FxCP", byteorder="big")
-+    _TAG_TP      = int.from_bytes(b"FxTP", byteorder="big")
-+    # ---- Tags for PP P2P all-reduce / barrier on world_cpu_group ----
-+    _TAG_PP_AR_MIN = int.from_bytes(b"FxA2", byteorder="big")
-+    _TAG_PP_BARRIER = int.from_bytes(b"FxB2", byteorder="big")
-+    _TAG_PP_BARRIER_BCAST = int.from_bytes(b"FxB3", byteorder="big")
-+    _TAG_AR_BCAST = int.from_bytes(b"FxAR", byteorder="big")
-+
-+    # ---- Async-work reaper tunables ----
-+    # Background: gloo isend Work objects do not auto-advance their
-+    # "completed" state on poll, so a pure poll-based reaper leaks. We
-+    # actively wait() the oldest works with a tiny timeout. The watermark
-+    # adapts: it grows on stuck reaps (peer slow / asymmetric) and shrinks
-+    # back on clean reaps. Empty scatter payloads (~50B over loopback /
-+    # LAN) complete in <1ms, so PROBE=1ms is comfortable.
-+    _REAP_HIGH_BASE = 1024            # initial / minimum trigger watermark
-+    _REAP_HIGH_MAX  = 32768           # cap on the adaptive watermark
-+    _REAP_MAX_DRAIN = 512             # bound on works popped per reap call
-+    _REAP_PROBE     = timedelta(milliseconds=1)
-+    _REAP_LOG_EVERY = 64              # sample-log every N reap calls
-+
-+    def __init__(
-+        self,
-+        rank_info,
-+        world_rank: int,
-+        pp_group=None,
-+        attn_tp_group=None,
-+        attn_cp_group=None,
-+    ):
-+        model_config = rank_info.model_config
-+        self.world_rank = world_rank
-+        self._async_works: List = []
-+        # Adaptive watermark for async-work reaping. Grows on stuck reaps
-+        # (peer asymmetric / slow), shrinks back to base on clean reaps.
-+        self._reap_high: int = self._REAP_HIGH_BASE
-+        # Counters for sampled debug logging.
-+        self._reap_calls: int = 0
-+        self._reap_stuck_total: int = 0
-+        self._reap_drained_total: int = 0
-+
-+        # ---- Extract cpu_group from wrapper objects if present ----
-+        self.pp_cpu_group = (
-+            getattr(pp_group, "cpu_group", pp_group) if pp_group is not None else None
-+        )
-+        self.attn_tp_cpu_group = (
-+            getattr(attn_tp_group, "cpu_group", attn_tp_group)
-+            if attn_tp_group is not None
-+            else None
-+        )
-+        self.attn_cp_cpu_group = (
-+            getattr(attn_cp_group, "cpu_group", attn_cp_group)
-+            if attn_cp_group is not None
-+            else None
-+        )
-+
-+        # ---- Dimension sizes ----
-+        self.pp_size = model_config.pp_size
-+        self.attn_tp_size = model_config.attn_tp_size
-+        self.attn_cp_size = model_config.attn_cp_size
-+
-+        # ---- 3D coordinate ----
-+        self.pp_rank = rank_info.pp_rank
-+        self.attn_tp_rank = rank_info.attn_tp_rank
-+        self.attn_cp_rank = rank_info.attn_cp_rank
-+
-+        # ---- Role resolution ----
-+        self.is_pp_stage_leader = (self.attn_tp_rank == 0 and self.attn_cp_rank == 0)
-+        self.is_sync_leader = (
-+            self.pp_rank == 0 and self.is_pp_stage_leader
-+        )
-+        self.is_pp_leader = (self.pp_rank == 0 and self.is_pp_stage_leader)
-+        self.is_cp_leader = (self.attn_cp_rank == 0)
-+        self.is_tp_leader = (self.attn_tp_rank == 0)
-+
-+        # ---- Rank mapping for point-to-point scatter ----
-+        # PP stage leaders: one per PP stage (tp=0, cp=0)
-+        stride = self.attn_tp_size * self.attn_cp_size
-+        self._pp_stage_leader_ranks = [s * stride for s in range(self.pp_size)]
-+        # CP leaders: tp_rank=0 of each CP group within this PP stage
-+        pp_stage_offset = self.pp_rank * stride
-+        self._cp_leader_ranks = (
-+            [pp_stage_offset + cp * self.attn_tp_size for cp in range(self.attn_cp_size)]
-+            if self.attn_cp_size > 1 else []
-+        )
-+        # TP group ranks (pre-computed once)
-+        if self.attn_tp_size > 1:
-+            if self.attn_tp_cpu_group is None:
-+                raise RuntimeError(
-+                    f"[FlexKV] attn_tp_size={self.attn_tp_size} > 1 but "
-+                    f"attn_tp_cpu_group is None — TP group is required for "
-+                    f"scatter/collective operations"
-+                )
-+            self._tp_group_ranks = [
-+                dist.get_global_rank(self.attn_tp_cpu_group, i)
-+                for i in range(self.attn_tp_cpu_group.size())
-+            ]
-+        else:
-+            self._tp_group_ranks = []
-+        # PP group ranks for scatter_pp (pre-computed once)
-+        self._pp_group_global_ranks = (
-+            [dist.get_global_rank(self.pp_cpu_group, i)
-+             for i in range(self.pp_cpu_group.size())]
-+            if self.pp_size > 1 and self.pp_cpu_group is not None else []
-+        )
-+        # PP stage member ranks (all ranks in same PP stage)
-+        self._pp_stage_member_ranks = list(
-+            range(pp_stage_offset, pp_stage_offset + stride)
-+        )
-+
-+        # ---- Whether sync is needed (any dimension > 1) ----
-+        self.needs_sync = (self.pp_size > 1 or self.attn_tp_size > 1 or self.attn_cp_size > 1)
-+
-+        # ==================================================================
-+        # Communication group strategy
-+        # ----------------------------
-+        # P2P operations (send/recv/isend/irecv) on CPU tensors:
-+        #   -> use world_group.cpu_group (gloo-backed, full TCP mesh).
-+        #      Sub-group cpu_groups have unreliable TCP pairs for P2P.
-+        #
-+        # Collective operations (all_reduce/barrier):
-+        #   -> use sglang's sub-group _cpu_groups (fine for collectives).
-+        # ==================================================================
-+
-+        self._world_cpu_group = get_world_group().cpu_group
-+
-+        # ---- PP scatter role flags (used by flexkv_connector) ----
-+        self.pp_group = self.pp_cpu_group if (self.pp_size > 1 and self.is_pp_stage_leader) else None
-+        self.is_pp_active = self.pp_size > 1
-+        self.is_pp_sender = self.is_pp_leader
-+        self.is_pp_receiver = self.is_pp_stage_leader and not self.is_pp_leader
-+
-+        self.is_cross_node_pp = (self.pp_size > rank_info.pp_size_per_node)
-+        self.should_send_slot_mapping_to_remote = (
-+            self.is_pp_receiver and self.is_cross_node_pp
-+        )
-+
-+        logger.info(
-+            f"[FlexKV] Comm init: rank={world_rank}, "
-+            f"pp={self.pp_rank}/{self.pp_size}, "
-+            f"tp={self.attn_tp_rank}/{self.attn_tp_size}, "
-+            f"cp={self.attn_cp_rank}/{self.attn_cp_size}, "
-+            f"sync_leader={self.is_sync_leader}, "
-+            f"stage_leader={self.is_pp_stage_leader}, "
-+            f"is_cross_node_pp={self.is_cross_node_pp}, "
-+            f"should_send_slot_mapping_to_remote={self.should_send_slot_mapping_to_remote}"
-+        )
-+
-+    # ==================================================================
-+    # Public API
-+    # ==================================================================
-+
-+    def scatter(self, data: Any, blocking: bool = False) -> Any:
-+        """Hierarchical scatter: PP -> CP -> TP (async isend).
-+
-+        Fan-out in 3 stages, each uses isend/irecv on world_cpu_group:
-+          1. PP: sync_leader -> each PP stage's stage_leader
-+          2. CP: each stage's cp_leader -> other CP ranks in same stage
-+          3. TP: each CP group's tp_leader -> other TP ranks
-+        """
-+        # Stage 1: PP scatter (sync_leader -> stage leaders)
-+        if self.pp_size > 1 and self.is_pp_stage_leader:
-+            data = self._scatter_group(
-+                data, self._pp_stage_leader_ranks,
-+                self.is_pp_leader, self._TAG_PP, blocking,
-+            )
-+
-+        # Stage 2: CP scatter (cp_leader -> other CP leaders in same PP stage)
-+        if self._cp_leader_ranks:
-+            data = self._scatter_group(
-+                data, self._cp_leader_ranks,
-+                self.is_cp_leader, self._TAG_CP, blocking,
-+            )
-+
-+        # Stage 3: TP scatter (tp_leader -> other TP ranks)
-+        if self._tp_group_ranks:
-+            data = self._scatter_group(
-+                data, self._tp_group_ranks,
-+                self.is_tp_leader, self._TAG_TP, blocking,
-+            )
-+
-+        return data
-+
-+    def scatter_pp(self, data: Any) -> Any:
-+        """Fan-out across PP stages (PP0 stage leader -> PP1+ stage leaders).
-+
-+        Only PP stage leaders participate. Non-leaders are no-ops.
-+        """
-+        if not self._pp_group_global_ranks:
-+            return data
-+        is_leader = (self._pp_group_global_ranks[0] == self.world_rank)
-+        return self._scatter_group(
-+            data, self._pp_group_global_ranks,
-+            is_leader, self._TAG_SCATTER, blocking=False,
-+        )
-+
-+    def all_reduce_min(self, value: int) -> int:
-+        """Hierarchical all-reduce MIN across TP, CP, and PP dimensions.
-+
-+        Every rank participates in each collective layer it belongs to:
-+          Layer 1  TP all_reduce   all attn_tp group members
-+          Layer 2  CP all_reduce   all attn_cp group members
-+          Layer 3  PP P2P reduce   only PP stage leaders
-+          Layer 4  bcast result    stage leaders -> non-stage-leaders
-+        """
-+        logger.debug(
-+            f"[FlexKV] all_reduce_min rank={self.world_rank} value={value}"
-+        )
-+
-+        tensor = torch.tensor(value, dtype=torch.int64)
-+
-+        # Layer 1: TP all_reduce
-+        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
-+            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_tp_cpu_group)
-+
-+        # Layer 2: CP all_reduce
-+        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
-+            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self.attn_cp_cpu_group)
-+
-+        # Layer 3: PP all_reduce via P2P (stage leaders only)
-+        if self.pp_size > 1 and self.is_pp_stage_leader:
-+            self._pp_all_reduce_min_p2p(tensor)
-+
-+        # Layer 4: broadcast PP result to non-stage-leaders
-+        if self.pp_size > 1:
-+            self._bcast_to_stage_members(tensor, self._TAG_AR_BCAST)
-+
-+        result = tensor.item()
-+        logger.debug(
-+            f"[FlexKV] all_reduce_min rank={self.world_rank} "
-+            f"value={value} -> {result}"
-+        )
-+        return result
-+
-+    def barrier(self):
-+        """Hierarchical global barrier: TP -> CP -> PP -> bcast."""
-+        logger.debug(f"[FlexKV] barrier ENTER rank={self.world_rank}")
-+
-+        # Layer 1: TP barrier
-+        if self.attn_tp_size > 1 and self.attn_tp_cpu_group is not None:
-+            dist.barrier(group=self.attn_tp_cpu_group)
-+
-+        # Layer 2: CP barrier
-+        if self.attn_cp_size > 1 and self.attn_cp_cpu_group is not None:
-+            dist.barrier(group=self.attn_cp_cpu_group)
-+
-+        # Layer 3: PP barrier (stage leaders, P2P)
-+        if self.pp_size > 1 and self.is_pp_stage_leader:
-+            self._pp_barrier_p2p()
-+
-+        # Layer 4: broadcast PP barrier completion to non-stage-leaders
-+        if self.pp_size > 1:
-+            dummy = torch.tensor([0], dtype=torch.int64)
-+            self._bcast_to_stage_members(dummy, self._TAG_PP_BARRIER_BCAST)
-+
-+        logger.debug(f"[FlexKV] barrier EXIT  rank={self.world_rank}")
-+
-+    # ==================================================================
-+    # Unified scatter helper
-+    # ==================================================================
-+
-+    def _scatter_group(
-+        self,
-+        data: Any,
-+        group_ranks: List[int],
-+        is_leader: bool,
-+        tag: int,
-+        blocking: bool = False,
-+    ) -> Any:
-+        """Scatter within a group: leader sends to all others, followers recv.
-+
-+        If current rank is not in group_ranks, returns data unchanged.
-+        """
-+        if not group_ranks or self.world_rank not in group_ranks:
-+            return data
-+
-+        if is_leader:
-+            dsts = [r for r in group_ranks if r != self.world_rank]
-+            works = []
-+            for dst in dsts:
-+                works.extend(self._isend(dst, data, tag, self._world_cpu_group))
-+            if blocking:
-+                for w in works:
-+                    w.wait()
-+            else:
-+                # Reap completed works to bound list growth, but never
-+                # block on a peer that hasn't posted recv yet — the
-+                # reaper uses a tiny timeout and bails out on stuck.
-+                self._reap_completed_async_works()
-+                self._async_works.extend(works)
-+            return data
-+        else:
-+            return self._recv(group_ranks[0], tag, self._world_cpu_group)
-+
-+    # ==================================================================
-+    # Async work management
-+    # ==================================================================
-+
-+    def _reap_completed_async_works(self):
-+        """Drain oldest completed isends with bounded main-thread cost.
-+
-+        gloo's Work.is_completed() does not auto-advance on poll, so a
-+        pure-poll reaper leaks. Here we actively wait() the oldest works
-+        with a tiny timeout: on a symmetric channel the head of the
-+        queue has been in flight for many seconds and its matching recv
-+        is long posted, so wait() returns in microseconds. On timeout
-+        (peer slow / asymmetric) we break immediately so the main thread
-+        is never blocked, and widen the trigger watermark via exponential
-+        backoff. On a clean reap we shrink the watermark back toward the
-+        base. When the peer recovers we converge back to steady-state.
-+        """
-+        n = len(self._async_works)
-+        if n <= self._reap_high:
-+            return
-+
-+        drained = 0
-+        stuck = False
-+        for _ in range(self._REAP_MAX_DRAIN):
-+            if not self._async_works:
-+                break
-+            w = self._async_works[0]
-+            try:
-+                w.wait(self._REAP_PROBE)
-+            except RuntimeError:
-+                # Oldest work still pending → newer ones are even less
-+                # likely to be ready. Bail out; next reap will retry.
-+                stuck = True
-+                break
-+            self._async_works.pop(0)
-+            drained += 1
-+
-+        # Update counters (used for sampled summary log below).
-+        self._reap_calls += 1
-+        self._reap_drained_total += drained
-+        if stuck:
-+            self._reap_stuck_total += 1
-+
-+        # Adapt watermark. Log on every actual transition — these are
-+        # rare and informative on their own.
-+        prev_high = self._reap_high
-+        if stuck:
-+            self._reap_high = min(self._REAP_HIGH_MAX, self._reap_high * 2)
-+        else:
-+            self._reap_high = max(self._REAP_HIGH_BASE, self._reap_high // 2)
-+        if self._reap_high != prev_high:
-+            logger.debug(
-+                f"[FlexKV] reap watermark rank={self.world_rank} "
-+                f"{prev_high}->{self._reap_high} "
-+                f"(stuck={stuck} drained={drained} backlog={n})"
-+            )
-+
-+        # Sampled summary every N calls so steady-state behavior is
-+        # observable without flooding the log.
-+        if self._reap_calls % self._REAP_LOG_EVERY == 0:
-+            logger.debug(
-+                f"[FlexKV] reap stats rank={self.world_rank} "
-+                f"calls={self._reap_calls} "
-+                f"drained_total={self._reap_drained_total} "
-+                f"stuck_total={self._reap_stuck_total} "
-+                f"backlog={len(self._async_works)} "
-+                f"high={self._reap_high}"
-+            )
-+
-+    # ==================================================================
-+    # Low-level send / recv
-+    # ==================================================================
-+
-+    def _isend(self, dst: int, data: Any, tag: int = 0, group=None) -> list:
-+        """Non-blocking send via gloo-backed cpu_group (CPU tensor P2P)."""
-+        serialized = bytearray(pickle.dumps(data))
-+        t_size = torch.tensor([len(serialized)], dtype=torch.long)
-+        t_data = torch.frombuffer(serialized, dtype=torch.uint8)
-+        return [
-+            dist.isend(t_size, dst=dst, tag=tag, group=group),
-+            dist.isend(t_data, dst=dst, tag=tag, group=group),
-+        ]
-+
-+    def _recv(self, src: int, tag: int = 0, group=None) -> Any:
-+        """Blocking recv via gloo-backed cpu_group (CPU tensor P2P)."""
-+        t_size = torch.tensor([0], dtype=torch.long)
-+        dist.irecv(t_size, src=src, tag=tag, group=group).wait()
-+        size = t_size.item()
-+        if size == 0:
-+            return []
-+        t_data = torch.empty(size, dtype=torch.uint8)
-+        dist.irecv(t_data, src=src, tag=tag, group=group).wait()
-+        return pickle.loads(t_data.numpy().tobytes())
-+
-+    def _send_tensor(self, tensor: torch.Tensor, dst: int, tag: int = 0, group=None):
-+        dist.send(tensor, dst=dst, tag=tag, group=group)
-+
-+    def _recv_tensor(self, tensor: torch.Tensor, src: int, tag: int = 0, group=None):
-+        dist.recv(tensor, src=src, tag=tag, group=group)
-+
-+    # ==================================================================
-+    # Intra-stage broadcast (stage leader -> non-leaders in same PP stage)
-+    # ==================================================================
-+
-+    def _bcast_to_stage_members(self, tensor: torch.Tensor, tag: int):
-+        if not self.is_pp_stage_leader:
-+            self._recv_tensor(
-+                tensor, src=self._pp_stage_leader_ranks[self.pp_rank],
-+                tag=tag, group=self._world_cpu_group,
-+            )
-+        else:
-+            for rank in self._pp_stage_member_ranks:
-+                if rank != self.world_rank:
-+                    self._send_tensor(
-+                        tensor, dst=rank, tag=tag, group=self._world_cpu_group,
-+                    )
-+
-+    # ==================================================================
-+    # PP-level P2P collectives (cross-node safe on world_cpu_group)
-+    # ==================================================================
-+
-+    def _pp_all_reduce_min_p2p(self, tensor: torch.Tensor):
-+        """PP all_reduce MIN via star-pattern P2P on world_cpu_group."""
-+        leader_rank = self._pp_stage_leader_ranks[0]
-+        other_leaders = self._pp_stage_leader_ranks[1:]
-+        tag = self._TAG_PP_AR_MIN
-+
-+        if self.world_rank == leader_rank:
-+            result = tensor.item()
-+            for src in other_leaders:
-+                other = torch.tensor(0, dtype=torch.int64)
-+                self._recv_tensor(other, src=src, tag=tag, group=self._world_cpu_group)
-+                result = min(result, other.item())
-+            tensor.fill_(result)
-+            for dst in other_leaders:
-+                self._send_tensor(tensor, dst=dst, tag=tag, group=self._world_cpu_group)
-+        else:
-+            self._send_tensor(tensor, dst=leader_rank, tag=tag, group=self._world_cpu_group)
-+            self._recv_tensor(tensor, src=leader_rank, tag=tag, group=self._world_cpu_group)
-+
-+    def _pp_barrier_p2p(self):
-+        """PP barrier via star-pattern P2P on world_cpu_group."""
-+        leader_rank = self._pp_stage_leader_ranks[0]
-+        other_leaders = self._pp_stage_leader_ranks[1:]
-+        tag = self._TAG_PP_BARRIER
-+        dummy = torch.tensor([1], dtype=torch.int64)
-+
-+        if self.world_rank == leader_rank:
-+            for src in other_leaders:
-+                self._recv_tensor(dummy, src=src, tag=tag, group=self._world_cpu_group)
-+            for dst in other_leaders:
-+                self._send_tensor(dummy, dst=dst, tag=tag, group=self._world_cpu_group)
-+        else:
-+            self._send_tensor(dummy, dst=leader_rank, tag=tag, group=self._world_cpu_group)
-+            self._recv_tensor(dummy, src=leader_rank, tag=tag, group=self._world_cpu_group)
-+
-+
-+# ===================================================================
-+# libc / eventfd helpers (module-private)
-+# ===================================================================
-+
-+_libc = ctypes.CDLL("libc.so.6", use_errno=True)
-+_libc.eventfd.argtypes = [ctypes.c_uint, ctypes.c_int]
-+_libc.eventfd.restype = ctypes.c_int
-+_libc.read.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
-+_libc.read.restype = ctypes.c_ssize_t
-+_libc.write.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
-+_libc.write.restype = ctypes.c_ssize_t
-+
-+EFD_SEMAPHORE = 0x1
-+EFD_NONBLOCK = 0x800
-+
-+
-+def eventfd(initval=0, flags=0):
-+    fd = _libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
-+    if fd == -1:
-+        err = ctypes.get_errno()
-+        raise OSError(err, os.strerror(err))
-+    return fd
-+
-+
-+def eventfd_write(fd, val):
-+    v = ctypes.c_uint64(val)
-+    n = _libc.write(fd, ctypes.byref(v), ctypes.sizeof(v))
-+    if n != ctypes.sizeof(v):
-+        err = ctypes.get_errno()
-+        raise OSError(err, f"eventfd write failed: {os.strerror(err)}")
-+
-+
-+def eventfd_read(fd):
-+    v = ctypes.c_uint64()
-+    n = _libc.read(fd, ctypes.byref(v), ctypes.sizeof(v))
-+    if n != ctypes.sizeof(v):
-+        err = ctypes.get_errno()
-+        if err == errno.EAGAIN:
-+            return 0
-+        raise OSError(err, f"eventfd read failed: {os.strerror(err)}")
-+    return v.value
-+
-+
-+def send_fds(sock: socket.socket, fds: list, extra_data: bytes = b"x"):
-+    fds_packed = struct.pack(f"{len(fds)}i", *fds)
-+    ancdata = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds_packed)]
-+    sock.sendmsg([extra_data], ancdata)
-+
-+
-+# ===================================================================
-+# Layer-wise transfer components
-+# ===================================================================
-+
-+
-+class FlexKVLayerLoadingEvent:
-+    def __init__(self, num_layers: int):
-+        self._num_layers = num_layers
-+        self.load_event_fds: List[int] = [
-+            eventfd(0, EFD_SEMAPHORE) for _ in range(num_layers)
-+        ]
-+        self._finished = True
-+        self.wait_remaining: List[int] = [1] * num_layers
-+
-+    def reset_for_new_transfer(self):
-+        self._finished = False
-+        self.wait_remaining = [1] * self._num_layers
-+
-+    def wait(self, layer_index: int):
-+        assert 0 <= layer_index < self._num_layers
-+        eventfd_read(self.load_event_fds[layer_index])
-+        if layer_index == self._num_layers - 1:
-+            self._finished = True
-+
-+    def close(self):
-+        for fd in self.load_event_fds:
-+            try:
-+                os.close(fd)
-+            except Exception:
-+                pass
-+        self.load_event_fds.clear()
-+
-+    def __del__(self):
-+        self.close()
-+
-+
-+class FlexKVLayerDoneCounter:
-+    """Triple-buffered layer-wise transfer counter using eventfds."""
-+
-+    def __init__(self, num_layers: int):
-+        self.num_layers = num_layers
-+        self.num_counters = 3
-+        self.events: List[FlexKVLayerLoadingEvent] = [
-+            FlexKVLayerLoadingEvent(num_layers) for _ in range(self.num_counters)
-+        ]
-+        self.producer_index = -1
-+        self.consumer_index = -1
-+        self._task_to_producer: Dict[int, int] = {}
-+
-+    def register_task(self, task_id: int, producer_id: int):
-+        self._task_to_producer[task_id] = producer_id
-+
-+    def register_task_with_explicit_counter_id(self, task_id: int, counter_id: int):
-+        if counter_id < 0 or counter_id >= self.num_counters:
-+            raise ValueError(
-+                f"Invalid counter_id={counter_id}, must be in [0, {self.num_counters})"
-+            )
-+        self._task_to_producer[task_id] = counter_id
-+        self.events[counter_id].reset_for_new_transfer()
-+
-+    def update_producer(self) -> int:
-+        self.producer_index = (self.producer_index + 1) % self.num_counters
-+        assert self.events[
-+            self.producer_index
-+        ]._finished, "Producer event should be finished before reuse"
-+        return self.producer_index
-+
-+    def set_consumer(self, task_id: int):
-+        if task_id < 0:
-+            self.consumer_index = -1
-+            return
-+        producer_id = self._task_to_producer.pop(task_id, None)
-+        if producer_id is not None:
-+            self.consumer_index = producer_id
-+        else:
-+            self.consumer_index = -1
-+
-+    def wait_until(self, threshold: int):
-+        if self.consumer_index < 0:
-+            return
-+        event = self.events[self.consumer_index]
-+        if event.wait_remaining[threshold] <= 0:
-+            return
-+        event.wait_remaining[threshold] -= 1
-+        event.wait(threshold)
-+
-+    def reset(self):
-+        self.producer_index = -1
-+        self.consumer_index = -1
-+        self._task_to_producer.clear()
-+
-+    def __del__(self):
-+        for event in self.events:
-+            event.close()
-+        self.events.clear()
-diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
-new file mode 100644
-index 000000000..3c6ceb9b4
---- /dev/null
-+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
-@@ -0,0 +1,1023 @@
-+import ctypes
-+import logging
-+import os
-+import socket
-+import struct
-+import time
-+from typing import Any, Dict, List, Optional
-+
-+import numpy as np
-+import torch
-+
-+from sglang.srt.configs.model_config import ModelConfig
-+from sglang.srt.mem_cache.kv_connector import BaseKVConnector, LoadOperation
-+from sglang.srt.mem_cache.storage.flexkv.flexkv_comm import (
-+    CMD_PUT_META,
-+    CMD_LAYERWISE,
-+    CMD_STORE_COMPLETE,
-+    FlexKVLayerLoadingEvent,
-+    FlexKVLayerDoneCounter,
-+    FlexKVComm,
-+    send_fds,
-+)
-+
-+try:
-+    from flexkv.common.request import KVResponseStatus
-+    from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
-+    from flexkv.integration.config import FlexKVConfig
-+    from flexkv.kvmanager import KVManager
-+    from flexkv.server.client import KVTPClient
-+    from flexkv.transfer.layerwise import build_layerwise_eventfd_socket_path
-+    from flexkv.transfer_manager import TransferManagerOnRemote
-+except ImportError as e:
-+    raise RuntimeError("FlexKV is not installed. Please install it.") from e
-+
-+logger = logging.getLogger(__name__)
-+
-+# ---- CUDA Runtime (via ctypes) ----
-+def load_cudart():
-+    candidates = [
-+        "libcudart.so",
-+        "libcudart.so.12",
-+        "libcudart.so.11.0",
-+        "/usr/local/cuda/lib64/libcudart.so",
-+    ]
-+    for lib in candidates:
-+        try:
-+            return ctypes.CDLL(lib)
-+        except OSError:
-+            continue
-+    return None
-+
-+
-+cudart = load_cudart()
-+
-+if cudart:
-+    cudart.cudaLaunchHostFunc.argtypes = [
-+        ctypes.c_void_p,
-+        ctypes.CFUNCTYPE(None, ctypes.c_void_p),
-+        ctypes.c_void_p,
-+    ]
-+    cudart.cudaLaunchHostFunc.restype = ctypes.c_int
-+
-+
-+# ---- FlexKV Connector ----
-+
-+
-+class FlexKVConnector(BaseKVConnector):
-+    """KV cache connector backed by FlexKV's distributed cache system.
-+
-+    Implements ``BaseKVConnector`` so it can be used with
-+    ``ExtendedRadixCache`` via ``--kv-connector-cls``.
++    The inner cache remains the sole owner of radix/SWA bookkeeping. FlexKV
++    only restores request-owned slots; the normal cache_finished_req path then
++    inserts those slots with the same component semantics as fresh prefill.
 +    """
 +
 +    def __init__(
 +        self,
-+        params: Any,
-+        server_args: Any,
-+        tp_rank: int = 0,
-+        dp_rank: Optional[int] = 0,
-+        attn_cp_rank: Optional[int] = 0,
++        *,
++        params: CacheInitParams,
++        inner_cache: BasePrefixCache,
++        model_config: Optional[ModelConfig],
++        server_args: ServerArgs,
++        tp_rank: int,
++        dp_rank: Optional[int],
++        pp_rank: int,
++        attn_cp_rank: int,
++        tp_group: Any = None,
 +        pp_group: Any = None,
 +        attn_tp_group: Any = None,
 +        attn_cp_group: Any = None,
-+    ):
-+        super().__init__(
-+            params=params,
-+            server_args=server_args,
-+            tp_rank=tp_rank,
-+            dp_rank=dp_rank,
-+            attn_cp_rank=attn_cp_rank,
-+            pp_group=pp_group,
-+            attn_tp_group=attn_tp_group,
-+            attn_cp_group=attn_cp_group,
-+        )
++    ) -> None:
++        self._inner_cache = inner_cache
++        self.req_to_token_pool = inner_cache.req_to_token_pool
++        self.token_to_kv_pool_allocator = inner_cache.token_to_kv_pool_allocator
++        self.page_size = inner_cache.page_size
++        self.disable = inner_cache.disable
++        self.device = inner_cache.device
 +
-+        # ---- Primitive variables (from params / constructor) ----
-+        self.page_size = params.page_size
-+        kvcache = params.token_to_kv_pool_allocator.get_kvcache()
-+
-+        sglang_model_config = ModelConfig.from_server_args(server_args)
-+
-+        # ---- Initialize FlexKV config ----
-+        self.flexkv_config = FlexKVConfig.from_env()
-+        rank_info = self.flexkv_config.post_init_from_sglang_config(
-+            sglang_config=sglang_model_config,
++        kvcache = self.token_to_kv_pool_allocator.get_kvcache()
++        if isinstance(
++            self.token_to_kv_pool_allocator,
++            DeepSeekV4HiSparseTokenToKVPoolAllocator,
++        ):
++            raise NotImplementedError(
++                "FlexKV does not support the independent DSv4 HiSparse "
++                "device-page mapping yet"
++            )
++        self.flexkv_connector = FlexKVConnector(
++            sgl_model_config=model_config,
 +            server_args=server_args,
 +            page_size=self.page_size,
++            kvcache=kvcache,
 +            tp_rank=tp_rank,
-+            pp_rank=params.pp_rank,
 +            dp_rank=dp_rank,
++            pp_rank=pp_rank,
 +            attn_cp_rank=attn_cp_rank,
-+        )
-+
-+        model_config = self.flexkv_config.model_config
-+        cache_config = self.flexkv_config.cache_config
-+        self.rank_info = rank_info
-+
-+        # Structured logging label
-+        self._rank_label = f" [model_config={model_config}, rank_info={rank_info}]"
-+
-+        # ---- Communication / sync context ----
-+        self._sync_ctx = FlexKVComm(
-+            rank_info=rank_info,
-+            world_rank=(
-+                torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-+            ),
 +            pp_group=pp_group,
-+            attn_tp_group=attn_tp_group,
++            attn_tp_group=attn_tp_group if attn_tp_group is not None else tp_group,
 +            attn_cp_group=attn_cp_group,
 +        )
-+        logger.debug(
-+            f"[FlexKV] sync_context{self._rank_label}: "
-+            f"is_sync_leader={self._sync_ctx.is_sync_leader}, "
-+            f"needs_sync={self._sync_ctx.needs_sync}, "
-+            f"is_pp_active={self._sync_ctx.is_pp_active}"
-+        )
++        if self.flexkv_connector.enable_layerwise:
++            self.flexkv_connector.register_layer_transfer_counter(kvcache)
 +
++        # Same hook HiCache uses: scheduler.release_host_resources → destroy().
++        self.token_to_kv_pool_host = FlexKVHostReleaseShim(self.flexkv_connector)
 +
-+        # ---- Align block counts on unified group (single all_reduce MIN) ----
-+        for _attr in ("num_cpu_blocks", "num_ssd_blocks", "num_remote_blocks"):
-+            _orig = getattr(self.flexkv_config.cache_config, _attr)
-+            if _orig is None or _orig <= 0:
-+                continue
-+            _aligned = self._sync_ctx.all_reduce_min(_orig)
-+            logger.debug(
-+                f"[FlexKV] Block count alignment{self._rank_label}: "
-+                f"attr={_attr}, {_orig} -> {_aligned}"
-+            )
-+            if _aligned != _orig:
-+                logger.info(
-+                    f"[FlexKV] Block count MIN alignment '{_attr}': "
-+                    f"{_orig} -> {_aligned}"
-+                )
-+            setattr(self.flexkv_config.cache_config, _attr, _aligned)
-+
-+        if model_config.nnodes > 1:
-+            logger.info(
-+                f"[FlexKV] Multi-node detected{self._rank_label}: "
-+                f"model_config={model_config}, rank_info={rank_info}"
-+            )
-+
-+        # Build unified kv_caches list (MLA vs MHA)
-+        indexer_buffers = getattr(kvcache, "index_k_with_scale_buffer", None)
-+        if indexer_buffers is not None and len(indexer_buffers) > 0:
-+            logger.info(
-+                f"[FlexKV] Detected sparse attention indexer cache with "
-+                f"{len(indexer_buffers)} indexer layers, "
-+                f"shape={indexer_buffers[0].shape}"
-+            )
-+
-+        if hasattr(kvcache, "kv_buffer"):
-+            # MLA: K and V share the same buffer, register once per layer
-+            kv_caches = kvcache.kv_buffer
-+        elif hasattr(kvcache, "k_buffer"):
-+            # MHA: separate K and V buffers, concat as [k_layers..., v_layers...]
-+            kv_caches = kvcache.k_buffer + kvcache.v_buffer
-+        else:
-+            raise AttributeError(
-+                f"Unsupported KV cache type {type(kvcache).__name__}: "
-+                f"expected 'kv_buffer' (MLA/NSA) or 'k_buffer'/'v_buffer' (MHA)."
-+            )
-+
-+        # ---- Node B: Launch TransferManagerOnRemote ----
-+        self._remote_process = None
-+        if model_config.nnodes > 1 and rank_info.node_rank > 0 and rank_info.local_rank == 0:
-+            logger.debug(
-+                f"[FlexKV] Launching TransferManagerOnRemote{self._rank_label}: "
-+                f"master_host={self.flexkv_config.model_config.master_host}, "
-+                f"master_ports={self.flexkv_config.model_config.master_ports}")
-+            self._remote_process = TransferManagerOnRemote.create_process(
-+                master_host=self.flexkv_config.model_config.master_host,
-+                master_ports=self.flexkv_config.model_config.master_ports,
-+            )
-+            logger.info(
-+                f"[FlexKV] Launched TransferManagerOnRemote on node_rank={rank_info.node_rank}"
-+                f"{self._rank_label}"
-+            )
-+
-+        if self._sync_ctx.is_sync_leader:
-+            self.kv_manager = KVManager(
-+                model_config=model_config,
-+                cache_config=cache_config,
-+                dp_client_id=rank_info.dp_client_id,
-+                server_recv_port=self.flexkv_config.server_recv_port,
-+                gpu_register_port=self.flexkv_config.gpu_register_port,
-+            )
-+            self.kv_manager.start()
-+            logger.info(
-+                f"[FlexKV] Creating KVManager{self._rank_label}: "
-+                f"server_recv_port={self.flexkv_config.server_recv_port}, "
-+                f"gpu_register_port={self.flexkv_config.gpu_register_port}")
-+
-+        # ---- GPU Registration Routing ----
-+        self.dp_client_id = rank_info.dp_client_id
-+        self.pp_rank = rank_info.pp_rank
-+        self.tp_client = KVTPClient(
-+            self.flexkv_config.gpu_register_port,
-+            dp_client_id=self.dp_client_id,
-+            pp_rank=self.pp_rank,
-+            device_id=rank_info.local_rank,
-+        )
-+
-+        # ---- GPU Registration (with retry) ----
-+        self._register_with_retry(kv_caches, indexer_buffers)
-+        logger.info(
-+            f"[FlexKV] KVTPClient registered to server{self._rank_label}: "
-+            f"gpu_register_port={self.flexkv_config.gpu_register_port}")
-+
-+        self.enable_layerwise_transfer = bool(
-+            int(os.getenv("FLEXKV_ENABLE_LAYERWISE_TRANSFER", "0"))
-+        )
-+
-+        self.layerwise_eventfd_socket = build_layerwise_eventfd_socket_path(
-+            dp_client_id=self.dp_client_id,
-+            pp_rank=self.pp_rank,
-+            model_config=model_config,
-+        )
-+        logger.info(
-+            f"[FlexKV] Eventfd socket path configured{self._rank_label}: "
-+            f"socket={self.layerwise_eventfd_socket}, "
-+            f"layerwise_transfer={self.enable_layerwise_transfer}")
-+        self.layerwise_eventfd_connect_max_retries = max(
-+            360,
-+            int(os.getenv("FLEXKV_LAYERWISE_EVENTFD_CONNECT_MAX_RETRIES", "0")),
-+        )
-+        self._layer_done_counter: Optional[FlexKVLayerDoneCounter] = None
-+        self._worker_connected = False
-+
-+        self._init_layer_transfer_components()
-+
-+        if self._layer_done_counter is not None and kvcache is not None:
-+            kvcache.register_layer_transfer_counter(self._layer_done_counter)
-+
-+        # rid -> flexkv_task_id (pending loads awaiting start_load_kv)
-+        self._pending_loads: Dict[str, int] = {}
-+        # ext_task_id -> producer_id (layerwise loads in flight)
-+        self._ongoing_loads: Dict[int, int] = {}
-+        # ext_task_ids whose load has completed
-+        self._completed_loads: List[int] = []
-+        # ext_task_id -> flexkv_task_id (stores in flight)
-+        self._ongoing_stores: Dict[int, int] = {}
-+        # ext_task_ids whose store has completed or was skipped
-+        self._completed_stores: List[int] = []
-+        # flexkv task ids for periodic drain to prevent pipe deadlock
-+        self._load_fkv_tids: List[int] = []
-+        # rid -> flexkv_task_id (prefetch in flight)
-+        self._ongoing_prefetches: Dict[str, int] = {}
-+        self._prefetch_enabled = bool(
-+            cache_config.enable_ssd
-+            or cache_config.enable_remote
-+            or cache_config.enable_kv_sharing
-+        )
-+
-+        if self._sync_ctx.is_sync_leader:
-+            wait_count = 0
-+            while not self.kv_manager.is_ready():
-+                time.sleep(10)
-+                wait_count += 1
-+                # Collect diagnostic info for debugging
-+                diag_parts = []
-+                # Check IPC socket file existence
-+                gpu_port = self.flexkv_config.gpu_register_port
-+                if gpu_port.startswith("ipc://"):
-+                    ipc_path = gpu_port[len("ipc://"):]
-+                    ipc_exists = os.path.exists(ipc_path)
-+                    diag_parts.append(f"ipc_socket={ipc_path} exists={ipc_exists}")
-+                # Check TransferManager subprocess status
-+                task_engine = getattr(self.kv_manager, 'kv_task_engine', None)
-+                if task_engine is not None:
-+                    for i, th in enumerate(getattr(task_engine, 'transfer_handles', [])):
-+                        handle = getattr(th, '_handle', None)
-+                        if handle is not None:
-+                            parts = []
-+                            start_evt = getattr(handle, 'start_event', None)
-+                            ready_evt = getattr(handle, 'ready_event', None)
-+                            proc = getattr(handle, 'process', None)
-+                            if start_evt is not None:
-+                                parts.append(f"started={start_evt.is_set()}")
-+                            if ready_evt is not None:
-+                                parts.append(f"ready={ready_evt.is_set()}")
-+                            if proc is not None:
-+                                parts.append(f"alive={proc.is_alive()}")
-+                            if parts:
-+                                diag_parts.append(f"transfer_handle[{i}]: {', '.join(parts)}")
-+                diag_str = "; ".join(diag_parts) if diag_parts else "no diagnostics available"
-+                logger.info(
-+                    f"[FlexKV] Waiting for FlexKV to be ready{self._rank_label}... "
-+                    f"(waited {wait_count * 10}s, {diag_str})"
-+                )
-+            logger.info(f"[FlexKV] FlexKV is ready{self._rank_label}")
-+        elif model_config.nnodes > 1 and rank_info.node_rank > 0:
-+            # Node B: no KVManager to wait for, GPU registration retry handles readiness
-+            logger.info(f"[FlexKV] Node B skipping is_ready wait{self._rank_label}")
-+
-+        logger.info(
-+            f"[FlexKV] Connector initialized{self._rank_label}: "
-+            f"layerwise_transfer={self.enable_layerwise_transfer}, "
-+            f"prefetch_enabled={self._prefetch_enabled}, "
-+            f"model_config={model_config}, rank_info={rank_info}"
-+        )
-+
-+    # ---- BaseKVConnector abstract methods ----
-+
-+    def get_new_hit_length(
-+        self,
-+        token_ids: List[int],
-+        token_mask: torch.Tensor,
-+        update_state_for_load: bool = False,
-+        rid: Optional[str] = None,
-+    ) -> int:
-+        hit_length = 0
-+        flexkv_task_id = -1
-+
-+        # INFO: TP/CP group is strictly synchronous, so TP/CP ranks are symmetric. This means they
-+        #       have identical dst GPU blocks. Hence, let TP/CP rank 0 do prefix matching on the
-+        #       TP/CP group's behalf and broadcast the result to the rest of the group.
-+        if self._sync_ctx.is_sync_leader:
-+            token_ids_np = np.array(token_ids, dtype=np.int64)
-+            result = self.kv_manager.get_match(
-+                token_ids=token_ids_np,
-+                token_mask=token_mask,
-+            )
-+            # get_match returns None when the FlexKV server encounters an
-+            # error (e.g. in server_client_mode).  Guard against unpacking a
-+            # None result to avoid crashing the scheduler.
-+            if result is None:
-+                logger.warning("[FlexKV] get_match returned None, treating as no hit")
-+                flexkv_task_id = -1
-+                hit_length = 0
-+            else:
-+                flexkv_task_id, matched_mask = result
-+                hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
-+            if not update_state_for_load and flexkv_task_id >= 0:
-+                # Only cancel if the task actually has pending work.  When
-+                # hit_length == 0 the transfer graph is empty and the task was
-+                # already marked COMPLETED synchronously inside get_match →
-+                # _process_empty_graph, so cancelling would be a no-op that
-+                # triggers a spurious "already completed" warning.
-+                if hit_length > 0:
-+                    self.kv_manager.cancel([flexkv_task_id])
-+            else:
-+                ## GPU hit length is the zero length of token masks
-+                gpu_hit_length = torch.logical_not(token_mask).sum()
-+                logger.debug(f"[FlexKV Connector] gpu hit length: {gpu_hit_length}, Flexkv hit length: {hit_length}")
-+
-+        if self._sync_ctx.needs_sync:
-+            data = self._sync_ctx.scatter(
-+                {"hit_length": hit_length, "task_id": flexkv_task_id},
-+            )
-+            hit_length = data["hit_length"]
-+            flexkv_task_id = data["task_id"]
-+
-+        # Page-align host_hit_length: ensure GET loads complete pages
-+        if hit_length > 0 and self.page_size > 1:
-+            aligned_hit = (hit_length // self.page_size) * self.page_size
-+            if aligned_hit < hit_length:
-+                logger.debug(
-+                    "[FlexKV] get_new_hit_length: host_hit_length page_align %d -> %d (page_size=%d)",
-+                    hit_length, aligned_hit, self.page_size,
-+                )
-+                hit_length = aligned_hit
-+
-+        if update_state_for_load and rid is not None and hit_length > 0:
-+            self._pending_loads[rid] = flexkv_task_id
-+        elif update_state_for_load and flexkv_task_id >= 0 and self._sync_ctx.is_sync_leader:
-+            # Task was not cancelled earlier, but won't be used — cancel it now
-+            # to avoid resource leak (e.g. hit_length page-aligned to 0, or rid is None).
-+            # Skip cancel when hit_length == 0: the task's transfer graph was
-+            # empty and _process_empty_graph already marked it COMPLETED.
-+            if hit_length > 0:
-+                self.kv_manager.cancel([flexkv_task_id])
-+        return hit_length
-+
-+    def release_load_state(self, rid: str) -> None:
-+        fkv_tid = self._pending_loads.pop(rid, -1)
-+        if fkv_tid >= 0 and self._sync_ctx.is_sync_leader:
-+            self.kv_manager.cancel([fkv_tid])
-+
-+    def start_load_kv(
-+        self,
-+        task_id: int,
-+        load_ops: List[LoadOperation],
-+    ) -> None:
-+        flexkv_task_ids: List[int] = []
-+        slot_mappings: List[torch.Tensor] = []
-+
-+        for op in load_ops:
-+            fkv_tid = self._pending_loads.pop(op.rid, -1)
-+            if fkv_tid < 0:
-+                continue
-+            flexkv_task_ids.append(fkv_tid)
-+            indices = op.device_indices
-+            slot_mapping_cpu = indices.cpu() if indices.is_cuda else indices
-+            slot_mapping_cpu = slot_mapping_cpu.to(torch.int64)
-+            slot_mappings.append(slot_mapping_cpu)
-+
-+        logger.debug(f"[FlexKV] start_load_kv: resolved {len(flexkv_task_ids)} flexkv tasks")
-+        if not flexkv_task_ids:
-+            self._completed_loads.append(task_id)
-+            return
-+
-+        if self._sync_ctx.should_send_slot_mapping_to_remote:
-+            logger.debug(f"[FlexKV] start_load_kv: sending slot_mapping for cross-node pp_receiver")
-+            for fkv_tid, slot_map in zip(flexkv_task_ids, slot_mappings):
-+                self.send_slot_mapping_to_remote(fkv_tid, slot_map)
-+
-+        if self.enable_layerwise_transfer and self._layer_done_counter is not None:
-+            # PP1+: receive counter_id from PP0 first
-+            if self._sync_ctx.is_pp_receiver:
-+                payload = self._sync_ctx.scatter_pp(None)
-+                if payload.get("cmd") != CMD_LAYERWISE:
-+                    raise RuntimeError(f"Tag mismatch: expected {CMD_LAYERWISE}, got {payload.get('cmd')}")
-+                producer_id = payload["counter_id"]
-+                self._layer_done_counter.register_task_with_explicit_counter_id(task_id, producer_id)
-+            else:
-+                # Original logic: every rank independently updates producer
-+                producer_id = self._layer_done_counter.update_producer()
-+                self._layer_done_counter.events[producer_id].reset_for_new_transfer()
-+                self._layer_done_counter.register_task(task_id, producer_id)
-+
-+            # PP0 sync leader: send counter_id to PP1+
-+            if self._sync_ctx.is_pp_sender:
-+                self._sync_ctx.scatter_pp(
-+                    {"cmd": CMD_LAYERWISE, "fkv_task_id": flexkv_task_ids[0], "counter_id": producer_id},
-+                )
-+
-+            if self._sync_ctx.is_sync_leader:
-+                self.kv_manager.launch(
-+                    task_ids=flexkv_task_ids,
-+                    slot_mappings=slot_mappings,
-+                    as_batch=True,
-+                    layerwise_transfer=True,
-+                    counter_id=producer_id,
-+                )
-+                self._load_fkv_tids.extend(flexkv_task_ids)
-+            self._ongoing_loads[task_id] = producer_id
-+        else:
-+            if self._sync_ctx.is_sync_leader:
-+                self.kv_manager.launch(
-+                    task_ids=flexkv_task_ids,
-+                    slot_mappings=slot_mappings,
-+                    as_batch=True,
-+                    layerwise_transfer=False,
-+                )
-+                response = self.kv_manager.wait(flexkv_task_ids, timeout=30.0)
-+                if not all(
-+                    tid in response and response[tid].status == KVResponseStatus.SUCCESS
-+                    for tid in flexkv_task_ids
-+                ):
-+                    logger.warning(
-+                        "[FlexKV] Some tasks failed in non-layerwise transfer"
-+                    )
-+
-+            if self._sync_ctx.needs_sync:
-+                self._sync_ctx.barrier()
-+
-+            self._completed_loads.append(task_id)
-+
-+    def check_completed_load_tasks(self) -> List[int]:
-+        if self._sync_ctx.is_sync_leader and len(self._load_fkv_tids) >= 100:
-+            self.kv_manager.try_wait(task_ids=self._load_fkv_tids)
-+            self._load_fkv_tids.clear()
-+
-+        if self._layer_done_counter is not None:
-+            for ext_tid, producer_id in list(self._ongoing_loads.items()):
-+                if self._layer_done_counter.events[producer_id]._finished:
-+                    self._completed_loads.append(ext_tid)
-+                    del self._ongoing_loads[ext_tid]
-+
-+        result = list(self._completed_loads)
-+        self._completed_loads.clear()
-+        return result
-+
-+    def start_store_kv(
-+        self,
-+        task_id: int,
-+        token_ids: List[int],
-+        kv_indices: torch.Tensor,
-+    ) -> None:
-+
-+        def _send_pp_put_meta(fkv_task_id: int, unmatched_mask):
-+            if not self._sync_ctx.is_pp_active:
-+                return
-+            mask_list = (
-+                unmatched_mask.cpu().tolist()
-+                if hasattr(unmatched_mask, "is_cuda") and unmatched_mask.is_cuda
-+                else (unmatched_mask.tolist() if hasattr(unmatched_mask, "tolist") else [])
-+            )
-+            self._sync_ctx.scatter_pp(
-+                {"cmd": CMD_PUT_META, "fkv_task_id": fkv_task_id, "unmatched_mask": mask_list},
-+            )
-+
-+        if not self._sync_ctx.is_sync_leader:
-+            if self._sync_ctx.is_pp_receiver:
-+                logger.debug(
-+                    f"[FlexKV-Connector] start_store_kv: PP1+ scatter recv PUT_META"
-+                )
-+                payload = self._sync_ctx.scatter_pp(None)
-+                if payload.get("cmd") != CMD_PUT_META:
-+                    raise RuntimeError(f"Tag mismatch: expected {CMD_PUT_META}, got {payload.get('cmd')}")
-+                fkv_task_id = payload["fkv_task_id"]
-+                unmatched_mask = torch.tensor(payload["unmatched_mask"])
-+                if unmatched_mask.sum() > 0 and fkv_task_id >= 0:
-+                    if self._sync_ctx.should_send_slot_mapping_to_remote:
-+                        filtered = kv_indices[unmatched_mask]
-+                        slot_mapping = filtered.cpu() if filtered.is_cuda else filtered
-+                        slot_mapping = slot_mapping.to(torch.int64)
-+                        self.send_slot_mapping_to_remote(fkv_task_id, slot_mapping)
-+                    self._ongoing_stores[task_id] = fkv_task_id
-+                else:
-+                    self._completed_stores.append(task_id)
-+            return
-+
-+        try:
-+            token_ids_np = np.array(token_ids, dtype=np.int64)
-+            assert len(token_ids) == len(kv_indices), (
-+                f"len(token_ids)={len(token_ids)} != len(kv_indices)={len(kv_indices)}, "
-+                f"task_id={task_id}, page_size={self.page_size}, "
-+                f"kv_indices_shape={kv_indices.shape if hasattr(kv_indices, 'shape') else 'N/A'}"
-+            )
-+
-+            # Page-align token_ids and kv_indices BEFORE put_match so that
-+            # put_match allocates dst_block_ids consistent with the slot_mapping
-+            # we will later pass to launch().
-+            original_len = len(token_ids_np)
-+            if self.page_size > 1:
-+                aligned_len = (original_len // self.page_size) * self.page_size
-+                if aligned_len == 0:
-+                    _send_pp_put_meta(fkv_task_id=-1, unmatched_mask=[])
-+                    self._completed_stores.append(task_id)
-+                    return
-+                if aligned_len < original_len:
-+                    token_ids_np = token_ids_np[:aligned_len]
-+                    kv_indices = kv_indices[:aligned_len]
-+            result = self.kv_manager.put_match(
-+                token_ids=token_ids_np,
-+                token_mask=None,
-+            )
-+            # put_match returns None when the FlexKV server encounters an
-+            # error (e.g. in server_client_mode).  Treat as a failed store.
-+            if result is None:
-+                logger.warning("[FlexKV] put_match returned None, skipping store for task %d", task_id)
-+                _send_pp_put_meta(fkv_task_id=-1, unmatched_mask=[])
-+                self._completed_stores.append(task_id)
-+                return
-+            fkv_task_id, unmatched_mask = result
-+
-+            logger.debug(
-+                f"[FlexKV] start_store_kv: tokens={len(token_ids)}, "
-+                f"kv_indices={len(kv_indices)}, fkv_task_id={fkv_task_id}, "
-+                f"unmatched={unmatched_mask.sum().item() if hasattr(unmatched_mask, 'sum') else len(unmatched_mask)}"
-+            )
-+
-+            _send_pp_put_meta(fkv_task_id, unmatched_mask)
-+
-+            if unmatched_mask.sum() > 0:
-+                filtered = kv_indices[unmatched_mask]
-+                slot_mapping = filtered.cpu() if filtered.is_cuda else filtered
-+                slot_mapping = slot_mapping.to(torch.int64)
-+
-+                self.kv_manager.launch(
-+                    task_ids=[fkv_task_id], slot_mappings=[slot_mapping]
-+                )
-+                self._ongoing_stores[task_id] = fkv_task_id
-+            else:
-+                self._completed_stores.append(task_id)
-+        except Exception as e:
-+            logger.error("[FlexKV] start_store_kv failed: %s", e, exc_info=True)
-+            _send_pp_put_meta(fkv_task_id=-1, unmatched_mask=[])
-+            self._completed_stores.append(task_id)
-+
-+    def check_completed_store_tasks(self) -> List[int]:
-+        completed_ext_ids = list(self._completed_stores)
-+        self._completed_stores.clear()
-+
-+        completed_dict = {}
-+        if self._sync_ctx.is_sync_leader and self._ongoing_stores:
-+            fk_to_ext = {v: k for k, v in self._ongoing_stores.items()}
-+            completed_dict = self.kv_manager.try_wait(task_ids=list(fk_to_ext.keys()))
-+            for fk_tid in completed_dict:
-+                ext_tid = fk_to_ext[fk_tid]
-+                completed_ext_ids.append(ext_tid)
-+                del self._ongoing_stores[ext_tid]
-+
-+        if self._sync_ctx.is_pp_sender:
-+            self._sync_ctx.scatter_pp(
-+                {"cmd": CMD_STORE_COMPLETE, "completed_fk_ids": list(completed_dict)},
-+            )
-+        elif self._sync_ctx.is_pp_receiver:
-+            payload = self._sync_ctx.scatter_pp(None)
-+            if payload.get("cmd") != CMD_STORE_COMPLETE:
-+                raise RuntimeError(f"Tag mismatch: expected {CMD_STORE_COMPLETE}, got {payload.get('cmd')}")
-+            fk_ids = payload["completed_fk_ids"]
-+            if fk_ids and self._ongoing_stores:
-+                fk_to_ext = {v: k for k, v in self._ongoing_stores.items()}
-+                for fk_tid in fk_ids:
-+                    if fk_tid in fk_to_ext:
-+                        ext_tid = fk_to_ext[fk_tid]
-+                        completed_ext_ids.append(ext_tid)
-+                        del self._ongoing_stores[ext_tid]
-+
-+        if self._sync_ctx.needs_sync:
-+            completed_ext_ids = self._sync_ctx.scatter(completed_ext_ids)
-+
-+        return completed_ext_ids
-+
-+    # ---- Optional overrides ----
-+
-+    def prefetch(self, rid: str, token_ids: List[int]) -> None:
-+        if not self._prefetch_enabled:
-+            return
-+        if not rid:
-+            return
-+
-+        prefetch_task_id = -1
-+        if self._sync_ctx.is_sync_leader:
-+            token_ids_np = np.array(token_ids, dtype=np.int64)
-+            prefetch_task_id = self.kv_manager.prefetch_async(
-+                token_ids=token_ids_np,
-+            )
-+            logger.debug(f"[FlexKV] prefetch: launched task_id={prefetch_task_id}")
-+
-+        if self._sync_ctx.needs_sync:
-+            data = self._sync_ctx.scatter(
-+                {"task_id": prefetch_task_id},
-+            )
-+            prefetch_task_id = data["task_id"]
-+
-+        if prefetch_task_id >= 0:
-+            self._ongoing_prefetches[rid] = prefetch_task_id
-+
-+    def check_prefetch_progress(self, rid: str) -> bool:
-+        if not self._prefetch_enabled:
-+            return True
-+
-+        prefetch_task_id = self._ongoing_prefetches.get(rid, -1)
-+        if prefetch_task_id < 0:
-+            return True
-+
-+        is_completed = False
-+        if self._sync_ctx.is_sync_leader:
-+            completed = self.kv_manager.try_wait(task_ids=[prefetch_task_id])
-+            if prefetch_task_id in completed:
-+                status = completed[prefetch_task_id].status
-+                if status != KVResponseStatus.SUCCESS:
-+                    logger.warning(
-+                        "[FlexKV] prefetch task %d for rid=%s finished with status=%s",
-+                        prefetch_task_id,
-+                        rid,
-+                        status,
-+                    )
-+                is_completed = True
-+
-+        if self._sync_ctx.needs_sync:
-+            data = self._sync_ctx.scatter(
-+                {"is_completed": is_completed, "loaded_tokens": 0},
-+            )
-+            is_completed = data["is_completed"]
-+
-+        if is_completed:
-+            self._ongoing_prefetches.pop(rid, None)
-+        return is_completed
-+
-+    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
-+        # TODO: Implement this
-+        return 0
-+
-+    def cancel_prefetch(self, rid: str) -> None:
-+        self._pending_loads.pop(rid, None)
-+        prefetch_task_id = self._ongoing_prefetches.pop(rid, -1)
-+        if self._sync_ctx.is_sync_leader and prefetch_task_id >= 0:
-+            # Flexkv not support cancel prefetch task yet
-+            pass
-+
-+    @property
-+    def layer_done_counter(self) -> Any:
-+        return self._layer_done_counter
-+
-+    def register_layer_transfer_counter(self, kvcache: Any) -> None:
-+        if self._layer_done_counter is not None:
-+            kvcache.register_layer_transfer_counter(self._layer_done_counter)
++        self._load_markers: dict[str, _LoadMarker] = {}
++        self._restore_leases: dict[str, _RestoreLease] = {}
++        self._restore_generation = 0
++        self._inflight_store_nodes: dict[str, tuple[Any, DecLockRefParams]] = {}
++        self._store_generation = 0
++        self._node_lock = threading.Lock()
 +
 +    def reset(self) -> None:
-+        if self._sync_ctx.is_sync_leader and self._pending_loads:
-+            pending_tids = [tid for tid in self._pending_loads.values() if tid >= 0]
-+            if pending_tids:
-+                self.kv_manager.cancel(pending_tids)
-+        self._pending_loads.clear()
-+        self._ongoing_prefetches.clear()
-+        self._ongoing_loads.clear()
-+        self._completed_loads.clear()
-+        self._load_fkv_tids.clear()
-+
-+        if self._sync_ctx.is_sync_leader:
-+            for fk_tid in list(self._ongoing_stores.values()):
-+                if fk_tid >= 0:
-+                    self._wait_flexkv_task(fk_tid)
-+        self._ongoing_stores.clear()
-+        self._completed_stores.clear()
-+
-+        if self._layer_done_counter is not None:
-+            self._layer_done_counter.reset()
++        # FlexKV still owns references to GPU source/destination slots while an
++        # asynchronous store or layerwise load is in flight. Drain those tasks
++        # before the inner cache releases the slots.
++        self.flexkv_connector.reset()
++        self._free_uncommitted_restores()
++        self._inner_cache.reset()
++        self._load_markers.clear()
++        with self._node_lock:
++            self._inflight_store_nodes.clear()
 +
 +    def shutdown(self) -> None:
-+        if self._sync_ctx.is_sync_leader:
-+            self.kv_manager.shutdown()
++        # Prefer token_to_kv_pool_host.destroy() (HiCache path); keep this alias.
++        self.token_to_kv_pool_host.destroy()
 +
-+        # Shutdown TransferManagerOnRemote process on Node B
-+        if self._remote_process is not None:
-+            try:
-+                self._remote_process.terminate()
-+                self._remote_process.join(timeout=5.0)
-+                if self._remote_process.is_alive():
-+                    logger.warning(
-+                        f"[FlexKV] TransferManagerOnRemote did not terminate gracefully, "
-+                        f"killing{self._rank_label}")
-+                    self._remote_process.kill()
-+                    self._remote_process.join()
-+            except Exception as e:
-+                logger.warning(
-+                    f"[FlexKV] Error shutting down TransferManagerOnRemote{self._rank_label}: {e}")
-+            self._remote_process = None
++    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
++        result = self._inner_cache.match_prefix(params)
++        if self.disable or params.req is None:
++            return result
 +
-+    # ---- Private helpers ----
-+
-+    def _wait_flexkv_task(self, fk_task_id: int, timeout: float = 20.0) -> bool:
-+        if fk_task_id < 0 or not self._sync_ctx.is_sync_leader:
-+            return True
-+        try:
-+            response = self.kv_manager.wait([fk_task_id], timeout=timeout)
-+            return (
-+                fk_task_id in response
-+                and response[fk_task_id].status == KVResponseStatus.SUCCESS
++        # An active lease owns GPU slots that have not reached the inner radix
++        # cache yet. The scheduler normally defers this request until commit;
++        # keep this guard here as a second line of defense for direct callers.
++        # Starting another lookup would overwrite the rid-keyed pending task and
++        # allocate another restore generation for the same request.
++        if params.req.rid in self._restore_leases:
++            logger.warning(
++                "Skipping duplicate FlexKV lookup for uncommitted restore rid=%s",
++                params.req.rid,
 +            )
-+        except Exception as e:
-+            logger.error("[FlexKV] wait task failed: %s", e, exc_info=True)
-+            return False
++            return result
 +
-+    def _register_with_retry(
-+        self,
-+        kv_caches: List[torch.Tensor],
-+        indexer_buffers: Optional[List[torch.Tensor]] = None,
-+        max_retries: int = 360,
-+    ) -> None:
-+        """Register GPU with retry for Node B (wait for TransferManagerOnRemote).
++        key = params.key.page_aligned(self.page_size)
++        token_ids = key.raw_token_ids()
++        device_length = int(result.device_indices.numel())
++        if not token_ids or device_length >= len(token_ids):
++            return result
 +
-+        Node B's non-leader ranks may attempt to register before
-+        TransferManagerOnRemote has finished initializing. This method
-+        retries the registration up to ``max_retries`` times (default 360,
-+        i.e. 6 minutes at 1 s intervals).
-+        """
-+        for attempt in range(max_retries):
-+            try:
-+                self._register_to_server(kv_caches, indexer_buffers)
-+                return
-+            except Exception as e:
-+                if attempt == max_retries - 1:
-+                    raise
-+                if attempt % 30 == 0:
-+                    logger.info(
-+                        f"[FlexKV] GPU register retry{self._rank_label}: "
-+                        f"attempt={attempt+1}/{max_retries}, error={e}"
-+                    )
-+                time.sleep(1.0)
++        token_mask = torch.zeros(len(token_ids), dtype=torch.bool)
++        token_mask[device_length:] = True
++        _, hit_length = self.flexkv_connector.lookup_kv(
++            token_ids,
++            token_mask,
++            rid=params.req.rid,
++            sglang_req_id=params.req.rid,
++        )
++        if hit_length <= 0:
++            return result
 +
-+    def _register_to_server(
-+        self,
-+        kv_caches: List[torch.Tensor],
-+        indexer_buffers: Optional[List[torch.Tensor]] = None,
-+    ) -> None:
-+        """Register GPU KV cache buffers to FlexKV server.
-+
-+        Args:
-+            kv_caches: Unified KV cache tensor list.
-+                - MLA: num_layer tensors (K and V share the same buffer).
-+                - MHA: 2 * num_layer tensors (K buffers followed by V buffers).
-+            indexer_buffers: Optional sparse attention indexer buffers.
-+        """
-+        assert len(kv_caches) > 0
-+        assert kv_caches[0].ndim == 3, f"Expected 3D tensor, got shape={kv_caches[0].shape}"
-+
-+        is_mla = self.flexkv_config.model_config.use_mla
-+        num_blocks, num_kv_heads, head_size = kv_caches[0].shape
-+
-+        # GPU layout uses page_size as tokens_per_block so that the transfer
-+        # engine's block_stride covers an entire page of tokens.  The physical
-+        # GPU tensor shape is [num_blocks, num_kv_heads, head_size] where each
-+        # slot stores 1 token, but we present it to FlexKV as
-+        # [num_blocks/page_size, page_size, num_kv_heads, head_size] so that
-+        # block_id * block_stride correctly addresses the start of a page.
-+
-+        gpu_layout = KVCacheLayout(
-+            type=KVCacheLayoutType.LAYERFIRST,
-+            num_layer=self.rank_info.num_layers_per_pp_stage,
-+            num_block=num_blocks // self.page_size,
-+            tokens_per_block=self.page_size,
-+            num_head=num_kv_heads,
-+            head_size=head_size,
-+            is_mla=is_mla,
++        snapshot = token_ids[:] if token_ids is key.token_ids else token_ids
++        self._load_markers[params.req.rid] = _LoadMarker(
++            key=RadixKey(snapshot, key.extra_key, key.is_bigram),
++            device_length=device_length,
++        )
++        return result._replace(
++            last_host_node=result.last_device_node,
++            best_match_node=result.last_device_node,
++            host_hit_length=hit_length,
++            cache_protected_len=device_length,
 +        )
 +
-+        # Build indexer layout if indexer buffers are present
-+        indexer_layout = None
-+        if indexer_buffers is not None and len(indexer_buffers) > 0:
-+            indexer_tensor = indexer_buffers[0]
-+            assert indexer_tensor.ndim == 2, (
-+                f"Expected 2D indexer tensor (num_pages, page_stride_size), "
-+                f"got shape={indexer_tensor.shape}"
++    def init_load_back(self, params: InitLoadBackParams) -> tuple[torch.Tensor, Any]:
++        req = params.req
++        if req.rid in self._restore_leases:
++            self._load_markers.pop(req.rid, None)
++            self.flexkv_connector.release_pending(req.rid)
++            logger.warning(
++                "Skipping duplicate FlexKV load-back for uncommitted restore rid=%s",
++                req.rid,
 +            )
-+            # sglang's NSA indexer buffer is 2D: (num_pages, page_stride_size),
-+            # where page_stride_size = page_size * (index_head_dim + scale_bytes).
-+            # All tokens within a page are flattened into a single contiguous
-+            # vector, so from FlexKV's perspective each page is one indivisible
-+            # block with tokens_per_block=1.  The resulting block_stride
-+            # (= 1 * 1 * page_stride_size) correctly addresses each page.
-+            indexer_layout = KVCacheLayout(
-+                type=KVCacheLayoutType.LAYERFIRST,
-+                num_layer=len(indexer_buffers),
-+                num_block=indexer_tensor.shape[0],
-+                tokens_per_block=1,
-+                num_head=1,
-+                head_size=indexer_tensor.shape[1],
-+                is_mla=True,
-+            )
-+            logger.debug(
-+                "[FlexKV] Indexer layout: num_layer=%d, num_block=%d, "
-+                "tokens_per_block=%d, head_size=%d",
-+                len(indexer_buffers), indexer_tensor.shape[0],
-+                1, indexer_tensor.shape[1],
-+            )
-+            # Consistency check: indexer num_block should equal main KV num_block
-+            # (1:1 mapping since tokens_per_block = page_size)
-+            indexer_config = self.flexkv_config.cache_config.indexer
-+            if indexer_config is not None:
-+                expected_indexer_blocks = num_blocks // self.page_size
-+                assert indexer_tensor.shape[0] == expected_indexer_blocks, (
-+                    f"[FlexKV] Indexer num_block mismatch: indexer has {indexer_tensor.shape[0]} pages, "
-+                    f"but main KV has {num_blocks} slots / page_size {self.page_size} "
-+                    f"= {expected_indexer_blocks} expected blocks"
-+                )
++            return self._empty_indices(), req.last_node
 +
-+        # Register KV caches (and optional indexer buffers) to FlexKV server
-+        self.tp_client.register_to_server(
-+            kv_caches=kv_caches,
-+            kv_layout=gpu_layout,
-+            indexer_buffers=indexer_buffers,
-+            indexer_layout=indexer_layout,
++        marker = self._load_markers.pop(req.rid, None)
++        if marker is None or params.host_hit_length <= 0:
++            self.flexkv_connector.release_pending(req.rid)
++            return self._empty_indices(), req.last_node
++
++        device_indices = self._alloc_restore_slots(req, params.host_hit_length)
++        if device_indices is None:
++            self.flexkv_connector.release_pending(req.rid)
++            return self._empty_indices(), req.last_node
++
++        # Register ownership before launching the connector. If launch raises,
++        # its write status may be unknown; reset must drain the connector before
++        # these slots can be freed safely.
++        generation = self._restore_generation
++        self._restore_generation += 1
++        lease = _RestoreLease(
++            generation=generation,
++            req=req,
++            device_indices=device_indices,
 +        )
-+        logger.info("[FlexKV] Registered KV caches to server")
++        self._restore_leases[req.rid] = lease
++        req.pending_restore_generation = generation
++        req.pending_restore_slots = device_indices
 +
-+    def _init_layer_transfer_components(self):
-+        if not self.enable_layerwise_transfer:
-+            self._layer_done_counter = None
-+            self._worker_connected = False
-+            logger.debug(f"[FlexKV] Layerwise transfer disabled{self._rank_label}")
++        if self.flexkv_connector.enable_layerwise:
++            loaded, _ = self.flexkv_connector.start_load_kv_layerwise(
++                req.rid, device_indices
++            )
++        else:
++            loaded = self.flexkv_connector.retrieve_kv(req.rid, device_indices)
++
++        # Admission planning uses the lookup hit length. Keep load-back
++        # all-or-nothing so a successful restore cannot invalidate the checks
++        # that deliberately ran before this allocation. Both connector paths
++        # normally return either the entire mapping or zero.
++        if loaded != device_indices.numel():
++            self._free_restore_lease(lease)
++            return self._empty_indices(), req.last_node
++
++        if (
++            self.supports_swa()
++            and self.page_size > 1
++            and hasattr(self.token_to_kv_pool_allocator, "alloc_extend_swa_tail")
++            and device_indices.numel() > 0
++        ):
++            restored_end = int(req.prefix_indices.numel() + device_indices.numel())
++            swa_tail_length = min(self.page_size, int(device_indices.numel()))
++            req._flexkv_swa_evicted_seqlen = restored_end - swa_tail_length
++
++        # The restored tail is request-owned until the normal cache completion
++        # path inserts it. Preserve the pre-restore protection boundary so the
++        # inner cache can deduplicate or free every restored slot correctly.
++        req.cache_protected_len = marker.device_length
++        req._flexkv_uncached_restore = True
++        return device_indices, req.last_node
++
++    def has_uncommitted_restore(self, req: Req) -> bool:
++        # Treat rid as the single-flight key even if a malformed caller creates
++        # a second Req object with the same rid. Letting that object start a new
++        # lookup would overwrite connector state owned by the first request.
++        return req.rid in self._restore_leases
++
++    def _commit_restore(self, req: Req) -> None:
++        lease = self._restore_leases.get(req.rid)
++        if lease is None:
++            req._flexkv_uncached_restore = False
 +            return
 +
-+        self._layer_done_counter = FlexKVLayerDoneCounter(self.rank_info.num_layers_per_pp_stage)
-+        self._send_eventfds_to_worker()
-+        logger.info(f"[FlexKV] Initialized layerwise transfer{self._rank_label}")
++        generation = getattr(req, "pending_restore_generation", None)
++        slots = getattr(req, "pending_restore_slots", None)
++        if (
++            lease.req is not req
++            or generation != lease.generation
++            or slots is not lease.device_indices
++        ):
++            logger.error(
++                "FlexKV restore lease mismatch on commit rid=%s lease_gen=%s req_gen=%s",
++                req.rid,
++                lease.generation,
++                generation,
++            )
++            return
 +
-+    def send_slot_mapping_to_remote(self, task_id: int, slot_mapping: torch.Tensor) -> None:
-+        """Send slot_mapping to TransferManagerOnRemote via existing ZMQ channel (PP1 side only).
++        self._restore_leases.pop(req.rid, None)
++        req._flexkv_uncached_restore = False
++        req.pending_restore_generation = None
++        req.pending_restore_slots = None
 +
-+        In cross-node PP mode, PP1's FlexKVConnector sends slot_mapping
-+        via KVTPClient.send_to_server -> TransferManagerOnRemote.command_socket,
-+        so that the remote side can call set_gpu_blocks() with its own local GPU block_ids.
-+        """
-+        slot_mapping_np = slot_mapping.cpu().to(torch.int64).numpy() if slot_mapping.is_cuda else slot_mapping.numpy()
-+        self.tp_client.set_slot_mapping(task_id, slot_mapping_np)
-+        logger.debug(
-+            f"[FlexKV] send_slot_mapping_to_remote: "
-+            f"sent task_id={task_id} to TransferManagerOnRemote"
++    def _free_restore_lease(self, lease: _RestoreLease) -> None:
++        tracked = self._restore_leases.get(lease.req.rid)
++        if tracked is not lease:
++            raise RuntimeError(
++                "FlexKV restore lease changed before free: "
++                f"rid={lease.req.rid} generation={lease.generation}"
++            )
++        self.token_to_kv_pool_allocator.free(lease.device_indices)
++        self._restore_leases.pop(lease.req.rid)
++        lease.req.pending_restore_generation = None
++        lease.req.pending_restore_slots = None
++        lease.req._flexkv_uncached_restore = False
++
++    def _free_uncommitted_restores(self) -> None:
++        for lease in list(self._restore_leases.values()):
++            self._free_restore_lease(lease)
++
++    def _alloc_restore_slots(
++        self, req: Req, host_hit_length: int
++    ) -> Optional[torch.Tensor]:
++        allocator = self.token_to_kv_pool_allocator
++        if self.page_size == 1:
++            slots = allocator.alloc(host_hit_length)
++        else:
++            prefix_length = int(req.prefix_indices.numel())
++            sequence_length = prefix_length + host_hit_length
++            prefix_lengths = torch.tensor(
++                [prefix_length], dtype=torch.int64, device=self.device
++            )
++            prefix_lengths_cpu = torch.tensor([prefix_length], dtype=torch.int64)
++            sequence_lengths = torch.tensor(
++                [sequence_length], dtype=torch.int64, device=self.device
++            )
++            sequence_lengths_cpu = torch.tensor([sequence_length], dtype=torch.int64)
++            last_location = (
++                req.prefix_indices[-1:].to(device=self.device, dtype=torch.int64)
++                if prefix_length > 0
++                else torch.tensor([-1], dtype=torch.int64, device=self.device)
++            )
++            if hasattr(allocator, "alloc_extend_swa_tail") and self.supports_swa():
++                # FlexKV stores one page of SWA/state sidecars for a full-prefix hit.
++                swa_tail_length = min(self.page_size, host_hit_length)
++                slots = allocator.alloc_extend_swa_tail(
++                    prefix_lengths,
++                    prefix_lengths_cpu,
++                    sequence_lengths,
++                    sequence_lengths_cpu,
++                    last_location,
++                    host_hit_length,
++                    swa_tail_length,
++                )
++            else:
++                slots = allocator.alloc_extend(
++                    prefix_lengths,
++                    prefix_lengths_cpu,
++                    sequence_lengths,
++                    sequence_lengths_cpu,
++                    last_location,
++                    host_hit_length,
++                )
++
++        if slots is not None:
++            return slots
++
++        from sglang.srt.mem_cache.common import evict_from_tree_cache
++
++        swa_need = None
++        if self.supports_swa():
++            swa_need = (
++                host_hit_length
++                if self.page_size == 1
++                else min(self.page_size, host_hit_length)
++            )
++        evict_from_tree_cache(self, host_hit_length, swa_num_tokens=swa_need)
++        if self.page_size == 1:
++            return allocator.alloc(host_hit_length)
++        return self._alloc_restore_slots_once(req, host_hit_length)
++
++    def _alloc_restore_slots_once(
++        self, req: Req, host_hit_length: int
++    ) -> Optional[torch.Tensor]:
++        """Retry the paged allocation once after eviction."""
++        allocator = self.token_to_kv_pool_allocator
++        prefix_length = int(req.prefix_indices.numel())
++        sequence_length = prefix_length + host_hit_length
++        prefix_lengths = torch.tensor(
++            [prefix_length], dtype=torch.int64, device=self.device
++        )
++        prefix_lengths_cpu = torch.tensor([prefix_length], dtype=torch.int64)
++        sequence_lengths = torch.tensor(
++            [sequence_length], dtype=torch.int64, device=self.device
++        )
++        sequence_lengths_cpu = torch.tensor([sequence_length], dtype=torch.int64)
++        last_location = (
++            req.prefix_indices[-1:].to(device=self.device, dtype=torch.int64)
++            if prefix_length > 0
++            else torch.tensor([-1], dtype=torch.int64, device=self.device)
++        )
++        if hasattr(allocator, "alloc_extend_swa_tail") and self.supports_swa():
++            return allocator.alloc_extend_swa_tail(
++                prefix_lengths,
++                prefix_lengths_cpu,
++                sequence_lengths,
++                sequence_lengths_cpu,
++                last_location,
++                host_hit_length,
++                min(self.page_size, host_hit_length),
++            )
++        return allocator.alloc_extend(
++            prefix_lengths,
++            prefix_lengths_cpu,
++            sequence_lengths,
++            sequence_lengths_cpu,
++            last_location,
++            host_hit_length,
 +        )
 +
-+    def _send_eventfds_to_worker(
-+        self, retry_interval: float = 1.0
-+    ):
-+        max_retries = self.layerwise_eventfd_connect_max_retries
-+        # Allow up to 3 full connect+send attempts before giving up.
-+        max_send_retries = 3
-+        logger.info(
-+            f"[FlexKV] Attempting eventfd connection{self._rank_label}: "
-+            f"socket={self.layerwise_eventfd_socket}, max_retries={max_retries}")
++    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs) -> None:
++        self._apply_restore_swa_boundary(req)
++        kv_length = int(kwargs.get("kv_len_to_handle", req.kv_committed_len))
++        token_ids = (req.origin_input_ids + req.output_ids)[:kv_length]
++        self._inner_cache.cache_finished_req(req, is_insert=is_insert, **kwargs)
++        self._commit_restore(req)
++        if not is_insert:
++            return
 +
-+        last_error = None
-+        for send_attempt in range(max_send_retries):
-+            sock = None
-+            try:
-+                # Phase 1: Connect to the worker socket (retry until ready).
-+                for attempt in range(max_retries):
-+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-+                    try:
-+                        sock.connect(self.layerwise_eventfd_socket)
-+                        logger.info(
-+                            f"[FlexKV] Eventfd connected{self._rank_label}: "
-+                            f"socket={self.layerwise_eventfd_socket}, "
-+                            f"attempts={attempt + 1}"
-+                            f"{f', send_retry={send_attempt}' if send_attempt > 0 else ''}"
-+                        )
-+                        break
-+                    except (FileNotFoundError, ConnectionRefusedError) as e:
-+                        sock.close()
-+                        sock = None
-+                        if attempt == max_retries - 1:
-+                            logger.error(
-+                                f"[FlexKV] Eventfd connection failed{self._rank_label}: "
-+                                f"socket={self.layerwise_eventfd_socket}, "
-+                                f"attempts={max_retries}, error={type(e).__name__}"
-+                            )
-+                            raise RuntimeError(
-+                                f"[FlexKV] Failed to connect to eventfd socket "
-+                                f"{self.layerwise_eventfd_socket} after {max_retries} attempts"
-+                            )
-+                        if attempt % 10 == 0:
-+                            socket_exists = os.path.exists(self.layerwise_eventfd_socket)
-+                            logger.debug(
-+                                f"[FlexKV] Eventfd connect retry{self._rank_label}: "
-+                                f"socket={self.layerwise_eventfd_socket}, "
-+                                f"attempt={attempt + 1}/{max_retries}, "
-+                                f"error={type(e).__name__}, socket_exists={socket_exists}"
-+                            )
-+                        time.sleep(retry_interval)
++        self._store_prefix(req, token_ids)
 +
-+                if sock is None:
-+                    raise RuntimeError(
-+                        f"[FlexKV] Eventfd socket unavailable after {max_retries} attempts: "
-+                        f"{self.layerwise_eventfd_socket}"
-+                    )
++    def cache_unfinished_req(self, req: Req, **kwargs) -> None:
++        self._apply_restore_swa_boundary(req)
++        self._inner_cache.cache_unfinished_req(req, **kwargs)
++        self._commit_restore(req)
 +
-+                # Phase 2: Send metadata + eventfds over the connected socket.
-+                # UDS is node-local, so use _per_node TP rank/size so that
-+                # LayerwiseWorker builds the correct eventfd tensor shape.
-+                num_counters = self._layer_done_counter.num_counters
-+                model_config = self.flexkv_config.model_config
-+                rank_info = self.rank_info
-+                # Send 16-byte metadata: tp_rank_per_node, tp_size_per_node, num_layers, num_counters
-+                metadata = struct.pack(
-+                    "iiii",
-+                    rank_info.tp_rank_per_node,
-+                    model_config.tp_size_per_node,
-+                    rank_info.num_layers_per_pp_stage,
-+                    num_counters,
-+                )
-+                sock.sendall(metadata)
-+                logger.debug(
-+                    f"[FlexKV] Eventfd metadata sent{self._rank_label}: "
-+                    f"tp_rank_per_node={rank_info.tp_rank_per_node}, "
-+                    f"tp_size_per_node={model_config.tp_size_per_node}, "
-+                    f"num_layers={rank_info.num_layers_per_pp_stage}, num_counters={num_counters}"
-+                )
++        # A chunk boundary is not a reusable request boundary and its state may
++        # still be changing. The non-chunked call marks prefill completion, when
++        # DSv4's SWA/compress state exactly describes the prompt prefix.
++        if kwargs.get("chunked", False):
++            return
++        self._store_prefix(req, list(req.get_fill_ids()))
 +
-+                for counter_id in range(num_counters):
-+                    fds = self._layer_done_counter.events[counter_id].load_event_fds
-+                    send_fds(sock, fds, struct.pack("i", counter_id))
-+                    logger.debug(
-+                        f"[FlexKV] Eventfd fds sent{self._rank_label}: "
-+                        f"counter_id={counter_id}, num_fds={len(fds)}"
-+                    )
++    def _store_prefix(self, req: Req, token_ids: Sequence[int]) -> None:
++        """Store a page-aligned prefix and its exact SWA/state snapshot."""
 +
-+                # Wait for ACK from server to confirm fds were received.
-+                sock.settimeout(30.0)
-+                try:
-+                    ack = sock.recv(1)
-+                except socket.timeout:
-+                    raise RuntimeError("Timed out waiting for ACK from FlexKV worker")
-+                if not ack or ack[0] != 1:
-+                    raise RuntimeError(
-+                        f"FlexKV worker NACK'd eventfd transfer (ack={ack!r})"
-+                    )
-+
-+                self._worker_connected = True
-+                logger.info(
-+                    f"[FlexKV] Eventfd setup complete{self._rank_label}: "
-+                    f"socket={self.layerwise_eventfd_socket}, "
-+                    f"counters={num_counters}, layers={rank_info.num_layers_per_pp_stage}"
-+                )
-+                return
-+            except Exception as e:
-+                last_error = e
-+                logger.warning(
-+                    f"[FlexKV] Failed to send eventfds{self._rank_label} "
-+                    f"(send_attempt {send_attempt + 1}/{max_send_retries}): "
-+                    f"socket={self.layerwise_eventfd_socket}, error={e}. "
-+                    f"Will reconnect and retry..."
-+                )
-+            finally:
-+                if sock is not None:
-+                    sock.close()
-+                # Brief pause before reconnecting.
-+                time.sleep(retry_interval)
-+
-+        # All send retries exhausted.
-+        logger.error(
-+            f"[FlexKV] Failed to send eventfds{self._rank_label} after "
-+            f"{max_send_retries} attempts: "
-+            f"socket={self.layerwise_eventfd_socket}, last_error={last_error}",
-+            exc_info=True,
++        aligned_length = len(token_ids) // self.page_size * self.page_size
++        if aligned_length <= 0:
++            return
++        token_ids = list(token_ids[:aligned_length])
++        key = RadixKey(
++            array("q", token_ids),
++            req.extra_key,
++            is_bigram=bool(getattr(self._inner_cache, "is_eagle", False)),
 +        )
-+        raise RuntimeError(
-+            f"[FlexKV] Failed to send eventfds to {self.layerwise_eventfd_socket} "
-+            f"after {max_send_retries} attempts: {last_error}"
-+        )
-diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index d48dab875..54542e446 100644
---- a/python/sglang/srt/server_args.py
-+++ b/python/sglang/srt/server_args.py
-@@ -527,6 +527,10 @@ class ServerArgs:
-     # LMCache
-     enable_lmcache: bool = False
++        match = self._inner_cache.match_prefix(MatchPrefixParams(key=key))
++        node = match.last_device_node
++        indices = match.device_indices
++        if node is self._inner_cache.root_node or indices.numel() == 0:
++            return
++        if indices.numel() < len(token_ids):
++            token_ids = token_ids[: indices.numel()]
++        if not token_ids or len(token_ids) != indices.numel():
++            return
++
++        lock_result = self._inner_cache.inc_lock_ref(node)
++        with self._node_lock:
++            store_key = f"{req.rid}:flexkv-store:{self._store_generation}"
++            self._store_generation += 1
++        try:
++            task_id = self.flexkv_connector.store_kv(
++                store_key,
++                token_ids,
++                indices,
++                sglang_req_id=req.rid,
++            )
++        except Exception:
++            self._inner_cache.dec_lock_ref(node, lock_result.to_dec_params())
++            raise
++        if task_id < 0:
++            self._inner_cache.dec_lock_ref(node, lock_result.to_dec_params())
++            return
++        with self._node_lock:
++            self._inflight_store_nodes[store_key] = (
++                node,
++                lock_result.to_dec_params(),
++            )
++
++    @staticmethod
++    def _apply_restore_swa_boundary(req: Req) -> None:
++        boundary = getattr(req, "_flexkv_swa_evicted_seqlen", None)
++        if boundary is None or req.kv is None:
++            return
++        req.kv.swa_evicted_seqlen = max(req.kv.swa_evicted_seqlen, boundary)
++        del req._flexkv_swa_evicted_seqlen
++
++    def evict(self, params: EvictParams) -> EvictResult:
++        self._drain_completed_stores()
++        return self._inner_cache.evict(params)
++
++    def check_hicache_events(self) -> None:
++        self._drain_completed_stores()
++        self.flexkv_connector.drain_launched_loads()
++
++    def _drain_completed_stores(self) -> None:
++        completed = self.flexkv_connector.check_completed_stores()
++        if not completed:
++            return
++        with self._node_lock:
++            for rid in completed:
++                tracked = self._inflight_store_nodes.pop(rid, None)
++                if tracked is not None:
++                    node, dec_params = tracked
++                    self._inner_cache.dec_lock_ref(node, dec_params)
++
++    def release_aborted_request(self, rid: str) -> None:
++        self._load_markers.pop(rid, None)
++        self.flexkv_connector.release_pending(rid)
++        self.flexkv_connector.cancel_prefetch(rid)
++        # Do not free an active restore here. Scheduled aborts immediately flow
++        # through cache_finished_req(is_insert=False), which transfers/frees the
++        # request slots before committing the lease. A direct free here could
++        # race the layerwise H2D writer. Waiting requests cannot own a lease
++        # because every admission rejection runs before init_load_back.
++
++    def prefetch_from_storage(self, rid: str, last_host_node: Any, token_ids) -> None:
++        del last_host_node
++        self.flexkv_connector.prefetch_async(rid, list(token_ids), sglang_req_id=rid)
++
++    def check_prefetch_progress(self, rid: str) -> bool:
++        return self.flexkv_connector.check_prefetch_progress(rid)
++
++    def terminate_prefetch(self, rid: str) -> None:
++        self.flexkv_connector.cancel_prefetch(rid)
++
++    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
++        del rid
++        return 0
++
++    def inc_lock_ref(self, node: Any) -> IncLockRefResult:
++        return self._inner_cache.inc_lock_ref(node)
++
++    def dec_lock_ref(self, node: Any, params: Optional[DecLockRefParams] = None) -> Any:
++        return self._inner_cache.dec_lock_ref(node, params)
++
++    def supports_swa(self) -> bool:
++        return self._inner_cache.supports_swa()
++
++    def supports_mamba(self) -> bool:
++        return self._inner_cache.supports_mamba()
++
++    def supports_fast_match_prefix(self) -> bool:
++        return self._inner_cache.supports_fast_match_prefix()
++
++    # BasePrefixCache provides default implementations for these methods, so
++    # __getattr__ cannot forward them. Delegate them explicitly; otherwise the
++    # scheduler sees zero evictable/protected tokens and reports the inner
++    # UnifiedRadixCache's live pages as a pool leak.
++    def evictable_size(self) -> int:
++        return self._inner_cache.evictable_size()
++
++    def full_evictable_size(self) -> int:
++        return self._inner_cache.full_evictable_size()
++
++    def swa_evictable_size(self) -> int:
++        return self._inner_cache.swa_evictable_size()
++
++    def protected_size(self) -> int:
++        return self._inner_cache.protected_size()
++
++    def full_protected_size(self) -> int:
++        return self._inner_cache.full_protected_size()
++
++    def swa_protected_size(self) -> int:
++        return self._inner_cache.swa_protected_size()
++
++    def total_size(self) -> int:
++        return self._inner_cache.total_size()
++
++    def pretty_print(self) -> None:
++        return self._inner_cache.pretty_print()
++
++    def ready_to_load_host_cache(self) -> Any:
++        return self._inner_cache.ready_to_load_host_cache()
++
++    def flush_write_through_acks(self) -> None:
++        self._drain_completed_stores()
++        self._inner_cache.flush_write_through_acks()
++
++    def take_events(self) -> list[Any]:
++        return self._inner_cache.take_events()
++
++    def swa_reprefill_tail_tokens(self) -> int:
++        return self._inner_cache.swa_reprefill_tail_tokens()
++
++    def supports_streaming_session(self) -> bool:
++        return self._inner_cache.supports_streaming_session()
++
++    def release_session(self, session_id: str) -> None:
++        self._inner_cache.release_session(session_id)
++
++    def release_radix_session(self, session_id: str) -> None:
++        self._inner_cache.release_radix_session(session_id)
++
++    def session_held_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
++        return self._inner_cache.session_held_tokens(active_pool_idxs)
++
++    def session_held_full_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
++        return self._inner_cache.session_held_full_tokens(active_pool_idxs)
++
++    def session_held_swa_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
++        return self._inner_cache.session_held_swa_tokens(active_pool_idxs)
++
++    def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
++        return self._inner_cache.session_held_req_count(active_pool_idxs)
++
++    def session_held_mamba_slots(self, active_pool_idxs: Optional[set] = None) -> int:
++        return self._inner_cache.session_held_mamba_slots(active_pool_idxs)
++
++    def is_chunk_cache(self) -> bool:
++        return self._inner_cache.is_chunk_cache()
++
++    def is_tree_cache(self) -> bool:
++        return self._inner_cache.is_tree_cache()
++
++    def available_and_evictable_str(self) -> str:
++        return self._inner_cache.available_and_evictable_str()
++
++    def init_metrics_collector(self) -> None:
++        self._inner_cache.init_metrics_collector()
++
++    def _empty_indices(self) -> torch.Tensor:
++        return torch.empty((0,), dtype=torch.int64, device=self.device)
++
++    def __getattr__(self, name: str) -> Any:
++        if name.startswith("__"):
++            raise AttributeError(name)
++        inner = self.__dict__.get("_inner_cache")
++        if inner is None:
++            raise AttributeError(name)
++        return getattr(inner, name)
+diff --git a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
+index 3c3f8e562..b2fb57118 100644
+--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
++++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
+@@ -41,7 +41,10 @@ from sglang.srt.mem_cache.base_prefix_cache import (
+     MatchResult,
+ )
+ from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+-from sglang.srt.mem_cache.storage.flexkv.flexkv_connector import FlexKVConnector
++from flexkv.integration.sglang.connector import (
++    FlexKVConnector,
++    FlexKVHostReleaseShim,
++)
  
-+    # External KV connector (KV-cache offloading)
-+    kv_connector_cls: Optional[str] = None
-+    kv_connector_extra_config: Optional[str] = None
-+
-     # Ktransformers/AMX expert parallelism
-     kt_weight_path: Optional[str] = None
-     kt_method: Optional[str] = None
-@@ -2540,6 +2544,18 @@ class ServerArgs:
-                 "and cannot be used at the same time. Please use only one of them."
-             )
+ if TYPE_CHECKING:
+     from sglang.srt.configs.model_config import ModelConfig
+@@ -116,6 +119,9 @@ class FlexKVRadixCache(RadixCache):
+             # forward layer blocks on its own eventfd.
+             self.flexkv_connector.register_layer_transfer_counter(kvcache)
  
-+        if self.kv_connector_cls is not None:
-+            if self.disable_radix_cache:
-+                raise ValueError(
-+                    "The arguments kv-connector-cls and disable-radix-cache are mutually exclusive "
-+                    "because ExtendedRadixCache requires radix cache enabled."
-+                )
-+            if self.enable_hierarchical_cache:
-+                raise ValueError(
-+                    "The arguments kv-connector-cls and enable-hierarchical-cache are mutually exclusive. "
-+                    "Please use only one of them."
-+                )
++        # Same hook HiCache uses: scheduler.release_host_resources → destroy().
++        self.token_to_kv_pool_host = FlexKVHostReleaseShim(self.flexkv_connector)
 +
-         if self.disaggregation_decode_enable_offload_kvcache:
-             if self.disaggregation_mode != "decode":
-                 raise ValueError(
-@@ -4149,6 +4165,23 @@ class ServerArgs:
-             help="Using LMCache as an alternative hierarchical cache solution",
+         # CUDA streams (mirroring LMCRadixCache).
+         self.load_stream = torch.cuda.Stream()
+         self.store_stream = torch.cuda.Stream()
+@@ -144,7 +150,9 @@ class FlexKVRadixCache(RadixCache):
+             self.flexkv_connector.reset()
+ 
+     def shutdown(self) -> None:
+-        if hasattr(self, "flexkv_connector"):
++        if hasattr(self, "token_to_kv_pool_host"):
++            self.token_to_kv_pool_host.destroy()
++        elif hasattr(self, "flexkv_connector"):
+             self.flexkv_connector.shutdown()
+ 
+     # ------------------------------------------------------------------
+@@ -204,7 +212,10 @@ class FlexKVRadixCache(RadixCache):
+         token_mask[device_len:] = True
+ 
+         fkv_task_id, hit = self.flexkv_connector.lookup_kv(
+-            token_ids=token_ids, token_mask=token_mask, rid=req.rid
++            token_ids=token_ids,
++            token_mask=token_mask,
++            rid=req.rid,
++            sglang_req_id=req.rid,
          )
+         if hit <= 0:
+             return base_res
+@@ -246,7 +257,10 @@ class FlexKVRadixCache(RadixCache):
+         # No rid here — IP mode self-pops; pass a synthetic stable key.
+         synthetic_rid = f"_ip_{id(key)}"
+         _, hit = self.flexkv_connector.lookup_kv(
+-            token_ids=token_ids, token_mask=token_mask, rid=synthetic_rid
++            token_ids=token_ids,
++            token_mask=token_mask,
++            rid=synthetic_rid,
++            sglang_req_id=None,
+         )
+         if hit <= 0:
+             return base_res
+@@ -425,6 +439,7 @@ class FlexKVRadixCache(RadixCache):
+                     rid=req.rid,
+                     token_ids=list(token_ids),
+                     kv_indices=kv_indices,
++                    sglang_req_id=req.rid,
+                 )
+         except Exception:  # noqa: BLE001
+             self.dec_lock_ref(new_last_node)
+@@ -492,7 +507,9 @@ class FlexKVRadixCache(RadixCache):
+     ) -> None:
+         """Kick off an opportunistic prefetch (SSD/Remote → CPU)."""
+         try:
+-            self.flexkv_connector.prefetch_async(rid, list(token_ids))
++            self.flexkv_connector.prefetch_async(
++                rid, list(token_ids), sglang_req_id=rid
++            )
+         except Exception as exc:  # noqa: BLE001
+             logger.debug("[FlexKV] prefetch_from_storage: %s", exc)
  
-+        # KVConnector
-+        parser.add_argument(
-+            "--kv-connector-cls",
-+            type=str,
-+            default=ServerArgs.kv_connector_cls,
-+            help="The full Python class path for the external KV connector "
-+            "(e.g., 'my_module.MyConnector'). The class must inherit from "
-+            "sglang.srt.mem_cache.kv_connector.BaseKVConnector.",
-+        )
-+        parser.add_argument(
-+            "--kv-connector-extra-config",
-+            type=str,
-+            default=ServerArgs.kv_connector_extra_config,
-+            help="A dictionary in JSON string format containing extra configuration "
-+            "for the external KV connector.",
-+        )
-+
-         # Ktransformer server args
-         parser.add_argument(
-             "--kt-weight-path",


### PR DESCRIPTION
## Summary

Move `FlexKVComm` and `FlexKVConnector` from sglang's `storage/flexkv/` into `flexkv/integration/sglang/`, so future FlexKV logic changes only touch this repo.

## Changes

**New files**:
- `flexkv/integration/sglang/comm.py` (981 lines) — 3-axis (PP × CP × TP) communication layer, `get_world_group` deferred import
- `flexkv/integration/sglang/connector.py` (2209 lines) — `FlexKVConnector` wrapping `KVManager` for sglang

**Config improvements**:
- `effective_tp_rank`: removed MLA special-case, unified to `cp_rank * tp_size + tp_rank` for all models
- `FLEXKV_ENABLE_COLLECTIVE_SYNC` env var (default `1`): set to `0` to disable cross-rank scatter/barrier/all_reduce — useful for non-PP deployments to reduce sync overhead

**Updated**:
- `flexkv/integration/sglang/sglang_flexkv_connector.patch` — regenerated (2801 lines, 12 files, code-only) based on sglang main merge-base `075bd9795`
- `flexkv/integration/sglang/README.md` — updated file layout and usage
- `docs/flexkv_config_reference/README_zh.md` + `README_en.md` — added `FLEXKV_ENABLE_COLLECTIVE_SYNC` under SGLang Integration section

## Companion PR

sglang repo: https://github.com/XingLiu1/sglang/pull/2