### PR TITLE
[bugfix] Fix FlexKV for RL scenerio

### DIFF
--- a/benchmarks/benchmark_dist_kvcache.py
+++ b/benchmarks/benchmark_dist_kvcache.py
@@ -186,7 +186,8 @@ class BenchmarkConfig:
 def run_tp_client(dp_client_id, tp_rank, gpu_register_port, model_config, cache_config, num_gpu_blocks):
     """Run tp_client process to register GPU blocks"""
     device_id = tp_rank + dp_client_id * model_config.tp_size
-    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id)
+    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id,
+                           intra_client_id=tp_rank)
 
     gpu_kv_layout = KVCacheLayout(
         type=KVCacheLayoutType.LAYERFIRST,

--- a/benchmarks/benchmark_single_batch.py
+++ b/benchmarks/benchmark_single_batch.py
@@ -28,7 +28,8 @@ class BenchmarkConfig:
 def run_tp_client(dp_client_id, tp_rank, gpu_register_port, model_config, cache_config):
     """Run tp_client process"""
     device_id = tp_rank + dp_client_id * model_config.tp_size
-    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id)
+    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id,
+                           intra_client_id=tp_rank)
 
     num_gpu_blocks = cache_config.num_gpu_blocks
 

--- a/benchmarks/dist_benchmark/benchmark_dist_direct.py
+++ b/benchmarks/dist_benchmark/benchmark_dist_direct.py
@@ -203,7 +203,8 @@ def run_tp_client(dp_client_id, tp_rank, gpu_register_port, model_config, cache_
     in the main process (not in a KVServer subprocess).
     """
     device_id = tp_rank + dp_client_id * model_config.tp_size
-    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id)
+    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id,
+                           intra_client_id=tp_rank)
 
     gpu_kv_layout = KVCacheLayout(
         type=KVCacheLayoutType.LAYERFIRST,

--- a/benchmarks/dist_benchmark/benchmark_dist_kvcache.py
+++ b/benchmarks/dist_benchmark/benchmark_dist_kvcache.py
@@ -185,7 +185,8 @@ class BenchmarkConfig:
 def run_tp_client(dp_client_id, tp_rank, gpu_register_port, model_config, cache_config, num_gpu_blocks):
     """Run tp_client process to register GPU blocks"""
     device_id = tp_rank + dp_client_id * model_config.tp_size
-    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id)
+    tp_client = KVTPClient(gpu_register_port, dp_client_id, device_id,
+                           intra_client_id=tp_rank)
 
     gpu_kv_layout = KVCacheLayout(
         type=KVCacheLayoutType.LAYERFIRST,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -1221,7 +1221,38 @@ PYBIND11_MODULE(c_ext, m) {
             std::deque<int64_t> dq(hashes.begin(), hashes.end());
             return ch.delete_blockmeta_batch(node_id, &dq, batch_size);
           },
-          py::arg("node_id"), py::arg("hashes"), py::arg("batch_size") = 200);
+          py::arg("node_id"), py::arg("hashes"), py::arg("batch_size") = 200)
+      .def("delete_node_blocks", &flexkv::RedisMetaChannel::delete_node_blocks,
+           py::arg("node_id"), py::arg("batch_size") = 200)
+      .def("has_any_block_keys", [](flexkv::RedisMetaChannel &ch) {
+        bool has_keys = false;
+        if (!ch.has_any_block_keys(has_keys)) {
+          throw std::runtime_error("Failed to scan Redis block metadata");
+        }
+        return has_keys;
+      })
+      .def("begin_reset_barrier", [](flexkv::RedisMetaChannel &ch,
+                                      uint64_t ttl_ms) {
+        uint64_t epoch = 0;
+        if (!ch.begin_reset_barrier(ttl_ms, epoch)) {
+          throw std::runtime_error("Failed to begin Redis reset barrier");
+        }
+        return epoch;
+      }, py::arg("ttl_ms"))
+      .def("mark_reset_barrier_arrival",
+           &flexkv::RedisMetaChannel::mark_reset_barrier_arrival,
+           py::arg("epoch"), py::arg("ttl_ms"))
+      .def("is_reset_barrier_ready", [](flexkv::RedisMetaChannel &ch,
+                                         uint64_t epoch) {
+        bool ready = false;
+        if (!ch.is_reset_barrier_ready(epoch, ready)) {
+          throw std::runtime_error("Failed to inspect Redis reset barrier");
+        }
+        return ready;
+      }, py::arg("epoch"))
+      .def("finish_reset_barrier",
+           &flexkv::RedisMetaChannel::finish_reset_barrier,
+           py::arg("epoch"));
 
   py::class_<flexkv::LocalRadixTree, flexkv::CRadixTreeIndex>(m,
                                                               "LocalRadixTree")
@@ -1267,7 +1298,8 @@ PYBIND11_MODULE(c_ext, m) {
       .def("total_ready_blocks", &flexkv::LocalRadixTree::total_ready_blocks)
       .def("total_cached_blocks", &flexkv::LocalRadixTree::total_cached_blocks)
       .def("total_node_num", &flexkv::LocalRadixTree::total_node_num)
-      .def("reset", &flexkv::LocalRadixTree::reset)
+      .def("reset", &flexkv::LocalRadixTree::reset,
+           py::call_guard<py::gil_scoped_release>())
       .def("is_root", &flexkv::LocalRadixTree::is_root, py::arg("node"))
       .def("remove_node", &flexkv::LocalRadixTree::remove_node, py::arg("node"))
       .def("remove_leaf", &flexkv::LocalRadixTree::remove_leaf, py::arg("node"))
@@ -1278,6 +1310,9 @@ PYBIND11_MODULE(c_ext, m) {
       .def("is_empty", &flexkv::LocalRadixTree::is_empty)
       .def("inc_node_count", &flexkv::LocalRadixTree::inc_node_count)
       .def("dec_node_count", &flexkv::LocalRadixTree::dec_node_count)
+      .def("lease_pool_capacity", &flexkv::LocalRadixTree::lease_pool_capacity)
+      .def("lease_pool_free_size", &flexkv::LocalRadixTree::lease_pool_free_size)
+      .def("pending_queue_size", &flexkv::LocalRadixTree::pending_queue_size)
       .def("set_ready", &flexkv::LocalRadixTree::set_ready, py::arg("node"),
            py::arg("ready"), py::arg("ready_length") = -1);
   m.attr("LocalRadixTree")
@@ -1294,6 +1329,8 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("lease_renew_ms") = 5000, py::arg("hit_reward_seconds") = 0)
       .def("start", &flexkv::DistributedRadixTree::start, py::arg("channel"))
       .def("stop", &flexkv::DistributedRadixTree::stop)
+      .def("reset", &flexkv::DistributedRadixTree::reset,
+           py::call_guard<py::gil_scoped_release>())
       .def("remote_tree_refresh",
            &flexkv::DistributedRadixTree::remote_tree_refresh,
            py::return_value_policy::reference)

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -815,6 +815,9 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("is_mla") = false,
            py::arg("ce_gather_threads") = 4,
            py::arg("ce_gather_nt") = true)
+      .def("update_gpu_block_ptrs",
+           &flexkv::TPTransferThreadGroup::update_gpu_block_ptrs,
+           py::arg("gpu_block_ptrs_flat"))
       .def("tp_group_transfer",
            &flexkv::TPTransferThreadGroup::tp_group_transfer,
            py::arg("gpu_block_id_tensor"), py::arg("cpu_block_id_tensor"),

--- a/csrc/dist/distributed_radix_tree.cpp
+++ b/csrc/dist/distributed_radix_tree.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <iostream>
+#include <stdexcept>
 
 namespace flexkv {
 DistributedRadixTree::DistributedRadixTree(int tokens_per_block, unsigned int max_num_blocks,
@@ -33,10 +34,37 @@ DistributedRadixTree::DistributedRadixTree(int tokens_per_block, unsigned int ma
 
 DistributedRadixTree::~DistributedRadixTree() {
   stop();
-  // Drain renew_lease_queue; nodes are owned by RefRadixTree, do not delete here
+  reset();
+}
+
+void DistributedRadixTree::reset() {
+  if (refresh_started) {
+    throw std::runtime_error(
+        "DistributedRadixTree::reset requires the refresh worker to be stopped");
+  }
+
   QueuedNode queued_node;
   while (renew_lease_queue.pop(queued_node)) {
-    // discard
+  }
+
+  RefRadixTree *current = nullptr;
+  RefRadixTree *previous = nullptr;
+  {
+    std::unique_lock<std::shared_mutex> lock(index_mutex);
+    current = c_index.exchange(nullptr, std::memory_order_acq_rel);
+    previous = old_index.exchange(nullptr, std::memory_order_acq_rel);
+    c_index_generation.store(0, std::memory_order_release);
+    old_index_generation.store(0, std::memory_order_release);
+  }
+
+  while (renew_lease_queue.pop(queued_node)) {
+  }
+
+  if (current != nullptr) {
+    current->dec_ref_cnt();
+  }
+  if (previous != nullptr && previous != current) {
+    previous->dec_ref_cnt();
   }
 }
 
@@ -70,7 +98,7 @@ void* DistributedRadixTree::refresh_worker_trampoline(void* arg) {
 bool DistributedRadixTree::start(RedisMetaChannel *ch) {
   if (refresh_started) return true;
   channel = ch;
-  refresh_should_stop = false;
+  refresh_should_stop.store(false, std::memory_order_release);
   refresh_started = true;
   int result = pthread_create(&refresh_tid, nullptr, &DistributedRadixTree::refresh_worker_trampoline, this);
   if (result != 0) {
@@ -83,7 +111,7 @@ bool DistributedRadixTree::start(RedisMetaChannel *ch) {
 
 void DistributedRadixTree::stop() {
   if (!refresh_started) return;
-  refresh_should_stop = true;
+  refresh_should_stop.store(true, std::memory_order_release);
   pthread_join(refresh_tid, nullptr);
   refresh_started = false;
 }
@@ -95,7 +123,7 @@ void DistributedRadixTree::refresh_worker() {
   struct timeval tv_start; gettimeofday(&tv_start, nullptr);
   uint64_t last_rebuild_ms = (uint64_t)tv_start.tv_sec * 1000 + (uint64_t)(tv_start.tv_usec / 1000);
   
-  while (!refresh_should_stop) {
+  while (!refresh_should_stop.load(std::memory_order_acquire)) {
     std::vector<CRadixNode*> batch;
     batch.reserve(batch_size);
     QueuedNode queued_node;
@@ -1040,5 +1068,4 @@ void attach_and_merge_root_child(CRadixTreeIndex* temp_tree, CRadixNode* root_ch
 }
 
 } // namespace flexkv
-
 

--- a/csrc/dist/distributed_radix_tree.h
+++ b/csrc/dist/distributed_radix_tree.h
@@ -109,7 +109,7 @@ private:
   uint32_t hit_reward_seconds_ = 0;
   LockFreeQueue<QueuedNode> renew_lease_queue;
   bool refresh_started = false;
-  volatile bool refresh_should_stop = false;
+  std::atomic<bool> refresh_should_stop{false};
   pthread_t refresh_tid{};
   std::atomic<RefRadixTree *> c_index;
   std::atomic<RefRadixTree *> old_index;
@@ -140,6 +140,7 @@ public:
 
   bool start(RedisMetaChannel *channel);
   void stop();
+  void reset();
   RefRadixTree* remote_tree_refresh();
   std::shared_ptr<CMatchResult> match_prefix(torch::Tensor &block_hashes,
     int num_blocks, bool update_cache_info = true);
@@ -151,5 +152,4 @@ public:
 };
 
 } // namespace flexkv
-
 

--- a/csrc/dist/lease_meta_mempool.cpp
+++ b/csrc/dist/lease_meta_mempool.cpp
@@ -105,6 +105,27 @@ void LeaseMetaMemPool::free(LeaseMeta *ptr) {
   free_count.fetch_add(1, std::memory_order_relaxed);
 }
 
+void LeaseMetaMemPool::reset() {
+  std::lock_guard<std::mutex> lk(allocated_mu);
+  free_queue.clear();
+  allocated_set.clear();
+
+  size_t rebuilt_free_count = 0;
+  for (const auto &block : allocated_blocks) {
+    const size_t count = block.bytes / sizeof(LeaseMeta);
+    char *raw = reinterpret_cast<char *>(block.raw);
+    for (size_t i = 0; i < count; ++i) {
+      LeaseMeta *ptr = reinterpret_cast<LeaseMeta *>(raw + i * sizeof(LeaseMeta));
+      ptr->state = NODE_STATE_EVICTED;
+      ptr->lease_time = 0;
+      ptr->published = false;
+      free_queue.push_back(ptr);
+      rebuilt_free_count++;
+    }
+  }
+  free_count.store(rebuilt_free_count, std::memory_order_relaxed);
+}
+
 
 size_t LeaseMetaMemPool::capacity() const {
   return total_capacity.load(std::memory_order_relaxed);
@@ -115,5 +136,4 @@ size_t LeaseMetaMemPool::free_size() const {
 }
 
 } // namespace flexkv
-
 

--- a/csrc/dist/lease_meta_mempool.h
+++ b/csrc/dist/lease_meta_mempool.h
@@ -57,6 +57,8 @@ public:
   // Returns a LeaseMeta to the pool. The object is reset for reuse.
   void free(LeaseMeta *ptr);
 
+  void reset();
+
 
   // Iterate over currently allocated items and invoke callback for each.
   // The iteration is done on a snapshot to avoid holding the mutex while executing user code.
@@ -80,5 +82,3 @@ public:
 };
 
 } // namespace flexkv
-
-

--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <queue>
+#include <stdexcept>
 #include <sys/time.h>
 
 namespace flexkv {
@@ -43,6 +44,11 @@ bool OrderedHashList::contains(int64_t hash) {
   return map.find(hash) != map.end();
 }
 
+void OrderedHashList::clear() {
+  list.clear();
+  map.clear();
+}
+
 LocalRadixTree::LocalRadixTree(int tokens_per_block, unsigned int max_num_blocks,
   uint32_t ttl_ms, uint32_t renew_ms,
   uint32_t batch_sz, uint32_t idle_sleep_ms,
@@ -75,27 +81,7 @@ LocalRadixTree::LocalRadixTree(int tokens_per_block, unsigned int max_num_blocks
 LocalRadixTree::~LocalRadixTree() {
   // Ensure background worker is stopped before nodes/lease pool destruction
   stop();
-  // Drain and delete any pending block lists in the eviction queues
-  {
-    std::unique_ptr<std::deque<int64_t>> ptr;
-    while (evicted_blocks_queue.pop(ptr)) {
-      // unique_ptr auto-frees
-      ptr.reset();
-    }
-  }
-  {
-    std::unique_ptr<std::deque<int64_t>> ptr;
-    while (about_to_evict_blocks_queue.pop(ptr)) {
-      // unique_ptr auto-frees
-      ptr.reset();
-    }
-  }
-  {
-    NewBlockMeta* ptr = nullptr;
-    while (new_block_queue.pop(ptr)) {
-      if (ptr) delete ptr;
-    }
-  }
+  discard_pending_queues();
 }
 
 CRadixNode *LocalRadixTree::insert(torch::Tensor &physical_block_ids,
@@ -362,7 +348,7 @@ void LocalRadixTree::refresh_worker() {
   struct timeval tv0; gettimeofday(&tv0, nullptr);
   uint64_t now_ms0 = (uint64_t)tv0.tv_sec * 1000 + (uint64_t)(tv0.tv_usec / 1000);
   uint64_t next_renew_ms = now_ms0 + renew_lease_ms;
-  while (!refresh_should_stop) {
+  while (!refresh_should_stop.load(std::memory_order_acquire)) {
     size_t n = local_block_report(batch);
     struct timeval tv; gettimeofday(&tv, nullptr);
     uint64_t now_ms = (uint64_t)tv.tv_sec * 1000 + (uint64_t)(tv.tv_usec / 1000);
@@ -381,7 +367,7 @@ bool LocalRadixTree::start(RedisMetaChannel *ch) {
   // Initialize channel and node_id from ch
   set_meta_channel(ch);
   if (channel == nullptr) return false;
-  refresh_should_stop = false;
+  refresh_should_stop.store(false, std::memory_order_release);
   refresh_started = true;
   int result = pthread_create(&refresh_tid, nullptr, &LocalRadixTree::refresh_worker_trampoline, this);
   if (result != 0) {
@@ -415,7 +401,7 @@ void LocalRadixTree::renew_relese_time() {
 
 void LocalRadixTree::stop() {
   if (!refresh_started) return;
-  refresh_should_stop = true;
+  refresh_should_stop.store(true, std::memory_order_release);
   pthread_join(refresh_tid, nullptr);
   refresh_started = false;
 }
@@ -681,7 +667,23 @@ int LocalRadixTree::total_unready_blocks() { return CRadixTreeIndex::total_unrea
 int LocalRadixTree::total_ready_blocks() { return CRadixTreeIndex::total_ready_blocks(); }
 int LocalRadixTree::total_cached_blocks() { return CRadixTreeIndex::total_cached_blocks(); }
 int LocalRadixTree::total_node_num() { return CRadixTreeIndex::total_node_num(); }
-void LocalRadixTree::reset() { CRadixTreeIndex::reset(); }
+void LocalRadixTree::reset() {
+  if (refresh_started) {
+    throw std::runtime_error("LocalRadixTree::reset requires the refresh worker to be stopped");
+  }
+
+  discard_pending_queues();
+
+  if (channel != nullptr && !channel->delete_node_blocks(node_id, refresh_batch_size)) {
+    throw std::runtime_error(
+        "LocalRadixTree::reset failed to delete this node's Redis block metadata");
+  }
+
+  normal_block_hashes.clear();
+  CRadixTreeIndex::reset();
+  lease_pool.reset();
+  current_block_count = 0;
+}
 bool LocalRadixTree::is_root(CRadixNode *node) { return CRadixTreeIndex::is_root(node); }
 void LocalRadixTree::remove_node(CRadixNode *node) {
   auto lm = node->get_lease_meta();
@@ -700,6 +702,41 @@ void LocalRadixTree::inc_node_count() { CRadixTreeIndex::inc_node_count(); }
 void LocalRadixTree::dec_node_count() { CRadixTreeIndex::dec_node_count(); }
 void LocalRadixTree::set_ready(CRadixNode *node, bool ready, int ready_length) {
   CRadixTreeIndex::set_ready(node, ready, ready_length);
+}
+
+size_t LocalRadixTree::lease_pool_capacity() const { return lease_pool.capacity(); }
+size_t LocalRadixTree::lease_pool_free_size() const { return lease_pool.free_size(); }
+size_t LocalRadixTree::pending_queue_size() const {
+  return new_block_queue.size() + evicted_blocks_queue.size() +
+         about_to_evict_blocks_queue.size();
+}
+
+size_t LocalRadixTree::discard_pending_queues() {
+  size_t discarded = 0;
+  {
+    std::unique_ptr<std::deque<int64_t>> ptr;
+    while (evicted_blocks_queue.pop(ptr)) {
+      if (ptr) discarded += ptr->size();
+      ptr.reset();
+    }
+  }
+  {
+    std::unique_ptr<std::deque<int64_t>> ptr;
+    while (about_to_evict_blocks_queue.pop(ptr)) {
+      if (ptr) discarded += ptr->size();
+      ptr.reset();
+    }
+  }
+  {
+    NewBlockMeta *ptr = nullptr;
+    while (new_block_queue.pop(ptr)) {
+      if (ptr) {
+        discarded += ptr->block_hashes.size();
+        delete ptr;
+      }
+    }
+  }
+  return discarded;
 }
 
 size_t LocalRadixTree::drain_pending_queues() {

--- a/csrc/dist/local_radix_tree.h
+++ b/csrc/dist/local_radix_tree.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <atomic>
 #include <vector>
 #include <map>
 #include <list>
@@ -35,6 +36,7 @@ public:
   void insert(int64_t hash);
   void remove(int64_t hash);
   bool contains(int64_t hash);
+  void clear();
   std::list<int64_t>& get_list() { return list; }
 };
 
@@ -59,7 +61,7 @@ private:
   // It's not thread safe, so we need to ensure only refresh thread can access it
   OrderedHashList normal_block_hashes;
   bool refresh_started = false;
-  volatile bool refresh_should_stop = false;
+  std::atomic<bool> refresh_should_stop{false};
   pthread_t refresh_tid{};
   // Lease meta memory pool for nodes created by this LocalRadixTree
   LeaseMetaMemPool lease_pool;
@@ -74,6 +76,7 @@ private:
   bool publish_single_node(CRadixNode *src);
   // Renew in-memory LeaseMeta times and refresh Redis lt for this node
   void renew_relese_time();
+  size_t discard_pending_queues();
 
 public:
   LocalRadixTree(int tokens_per_block,
@@ -129,6 +132,10 @@ public:
   void inc_node_count();
   void dec_node_count();
   void set_ready(CRadixNode *node, bool ready = true, int ready_length = -1);
+
+  size_t lease_pool_capacity() const;
+  size_t lease_pool_free_size() const;
+  size_t pending_queue_size() const;
 
   // Drain and free all pending items from eviction queues; returns total hashes dropped
   size_t drain_pending_queues();

--- a/csrc/dist/redis_meta_channel.cpp
+++ b/csrc/dist/redis_meta_channel.cpp
@@ -595,4 +595,173 @@ bool RedisMetaChannel::delete_blockmeta_batch(uint32_t node_id,
   return true;
 }
 
+bool RedisMetaChannel::delete_node_blocks(uint32_t node_id, size_t batch_size) {
+  std::vector<std::string> keys;
+  if (!list_block_keys(node_id, keys)) return false;
+  if (keys.empty()) return true;
+  if (batch_size == 0) batch_size = 200;
+
+  size_t idx = 0;
+  while (idx < keys.size()) {
+    const size_t end = std::min(idx + batch_size, keys.size());
+    std::vector<std::vector<std::string>> batch;
+    batch.reserve(end - idx);
+    for (size_t i = idx; i < end; ++i) {
+      batch.push_back({"DEL", keys[i]});
+    }
+    std::vector<std::vector<std::string>> replies;
+    if (!client.pipeline(batch, replies)) return false;
+    idx = end;
+  }
+  return true;
+}
+
+bool RedisMetaChannel::has_any_block_keys(bool &has_keys) {
+  has_keys = false;
+  const std::string pattern = blocks_key + ":block:*";
+  std::string cursor = "0";
+  size_t iter_safety = 0;
+  const size_t max_scan_iterations = 100000;
+
+  do {
+    redisContext *context = client.get_context();
+    if (context == nullptr) return false;
+
+    const std::vector<std::string> scan_cmd = {
+        "SCAN", cursor, "MATCH", pattern, "COUNT", "100"};
+    std::vector<const char *> argv;
+    std::vector<size_t> arglen;
+    argv.reserve(scan_cmd.size());
+    arglen.reserve(scan_cmd.size());
+    for (const auto &arg : scan_cmd) {
+      argv.push_back(arg.c_str());
+      arglen.push_back(arg.length());
+    }
+
+    redisReply *reply = nullptr;
+    if (redisAppendCommandArgv(context, argv.size(), argv.data(),
+                              arglen.data()) != REDIS_OK) {
+      return false;
+    }
+    if (redisGetReply(context, reinterpret_cast<void **>(&reply)) != REDIS_OK ||
+        reply == nullptr) {
+      if (reply != nullptr) freeReplyObject(reply);
+      return false;
+    }
+
+    bool valid_reply = reply->type == REDIS_REPLY_ARRAY && reply->elements >= 2;
+    if (valid_reply) {
+      redisReply *cursor_reply = reply->element[0];
+      if (cursor_reply->type == REDIS_REPLY_STRING) {
+        cursor.assign(cursor_reply->str, cursor_reply->len);
+      } else if (cursor_reply->type == REDIS_REPLY_INTEGER) {
+        cursor = std::to_string(cursor_reply->integer);
+      } else {
+        valid_reply = false;
+      }
+    }
+
+    if (valid_reply) {
+      redisReply *keys_reply = reply->element[1];
+      if (keys_reply->type != REDIS_REPLY_ARRAY) {
+        valid_reply = false;
+      } else {
+        for (size_t i = 0; i < keys_reply->elements; ++i) {
+          if (keys_reply->element[i]->type == REDIS_REPLY_STRING) {
+            has_keys = true;
+            break;
+          }
+        }
+      }
+    }
+
+    freeReplyObject(reply);
+    if (!valid_reply) return false;
+    if (has_keys) return true;
+    if (++iter_safety > max_scan_iterations) return false;
+  } while (cursor != "0");
+
+  return true;
+}
+
+bool RedisMetaChannel::begin_reset_barrier(uint64_t ttl_ms, uint64_t &epoch) {
+  const std::string active_key = blocks_key + ":reset:active";
+  const std::string epoch_key = blocks_key + ":reset:epoch";
+  const std::string script =
+      "local current = redis.call('GET', KEYS[1]); "
+      "if current then "
+      "redis.call('PEXPIRE', KEYS[1], ARGV[1]); "
+      "return tonumber(current); "
+      "end; "
+      "local next_epoch = redis.call('INCR', KEYS[2]); "
+      "redis.call('PSETEX', KEYS[1], ARGV[1], tostring(next_epoch)); "
+      "return next_epoch;";
+  std::vector<std::string> reply;
+  if (!client.command({"EVAL", script, "2", active_key, epoch_key,
+                       std::to_string(ttl_ms)},
+                      reply) ||
+      reply.empty()) {
+    return false;
+  }
+  try {
+    epoch = std::stoull(reply[0]);
+  } catch (const std::exception &) {
+    return false;
+  }
+  return epoch != 0;
+}
+
+bool RedisMetaChannel::mark_reset_barrier_arrival(uint64_t epoch,
+                                                  uint64_t ttl_ms) {
+  const std::string arrivals_key = blocks_key + ":reset:arrivals";
+  std::vector<std::vector<std::string>> commands = {
+      {"HSET", arrivals_key, std::to_string(node_id), std::to_string(epoch)},
+      {"PEXPIRE", arrivals_key, std::to_string(ttl_ms)}};
+  std::vector<std::vector<std::string>> replies;
+  return client.pipeline(commands, replies);
+}
+
+bool RedisMetaChannel::is_reset_barrier_ready(uint64_t epoch, bool &ready) {
+  ready = false;
+  std::vector<std::string> node_keys;
+  if (!list_node_keys(node_keys) || node_keys.empty()) return false;
+
+  const std::string arrivals_key = blocks_key + ":reset:arrivals";
+  std::vector<std::vector<std::string>> commands;
+  commands.reserve(node_keys.size());
+  for (const auto &key : node_keys) {
+    if (key.size() <= 5 || key.rfind("node:", 0) != 0) continue;
+    commands.push_back({"HGET", arrivals_key, key.substr(5)});
+  }
+  if (commands.empty()) return false;
+
+  std::vector<std::vector<std::string>> replies;
+  if (!client.pipeline(commands, replies) || replies.size() != commands.size()) {
+    return false;
+  }
+  const std::string expected_epoch = std::to_string(epoch);
+  for (const auto &reply : replies) {
+    if (reply.empty() || reply[0] != expected_epoch) return true;
+  }
+  ready = true;
+  return true;
+}
+
+bool RedisMetaChannel::finish_reset_barrier(uint64_t epoch) {
+  const std::string active_key = blocks_key + ":reset:active";
+  const std::string script =
+      "local current = redis.call('GET', KEYS[1]); "
+      "if not current then return 1; end; "
+      "if current == ARGV[1] then redis.call('DEL', KEYS[1]); return 1; end; "
+      "return 0;";
+  std::vector<std::string> reply;
+  if (!client.command({"EVAL", script, "1", active_key,
+                       std::to_string(epoch)},
+                      reply) ||
+      reply.empty()) {
+    return false;
+  }
+  return reply[0] == "1";
+}
+
 } // namespace flexkv

--- a/csrc/dist/redis_meta_channel.h
+++ b/csrc/dist/redis_meta_channel.h
@@ -100,6 +100,14 @@ public:
                               std::deque<int64_t> *hashes,
                               size_t batch_size = 200);
 
+  bool delete_node_blocks(uint32_t node_id, size_t batch_size = 200);
+
+  bool has_any_block_keys(bool &has_keys);
+  bool begin_reset_barrier(uint64_t ttl_ms, uint64_t &epoch);
+  bool mark_reset_barrier_arrival(uint64_t epoch, uint64_t ttl_ms);
+  bool is_reset_barrier_ready(uint64_t epoch, bool &ready);
+  bool finish_reset_barrier(uint64_t epoch);
+
   // Generic helpers for metadata queries
   bool list_keys(const std::string &pattern, std::vector<std::string> &keys);
 
@@ -125,5 +133,3 @@ public:
 };
 
 } // namespace flexkv
-
-

--- a/csrc/tp_transfer_thread_group.cpp
+++ b/csrc/tp_transfer_thread_group.cpp
@@ -137,6 +137,30 @@ TPTransferThreadGroup::TPTransferThreadGroup(
 
 }
 
+void TPTransferThreadGroup::update_gpu_block_ptrs(
+    const std::vector<int64_t> &gpu_block_ptrs_flat) {
+  const size_t expected =
+      static_cast<size_t>(num_gpus_) * num_tensors_per_gpu_;
+  if (gpu_block_ptrs_flat.size() != expected) {
+    throw std::invalid_argument("GPU pointer count does not match transfer group");
+  }
+  for (int i = 0; i < num_gpus_; ++i) {
+    cudaError_t err = cudaSetDevice(gpu_device_ids_[i]);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(std::string("cudaSetDevice failed: ") +
+                               cudaGetErrorString(err));
+    }
+    err = cudaStreamSynchronize(streams_[i]);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(std::string("cudaStreamSynchronize failed: ") +
+                               cudaGetErrorString(err));
+    }
+  }
+  for (size_t i = 0; i < expected; ++i) {
+    gpu_blocks_[i] = reinterpret_cast<void *>(gpu_block_ptrs_flat[i]);
+  }
+}
+
 TPTransferThreadGroup::~TPTransferThreadGroup() {
   const c10::cuda::CUDAGuard restore_device_on_exit(c10::cuda::current_device());
 

--- a/csrc/tp_transfer_thread_group.h
+++ b/csrc/tp_transfer_thread_group.h
@@ -56,6 +56,9 @@ public:
 
   ~TPTransferThreadGroup();
 
+  void update_gpu_block_ptrs(
+      const std::vector<int64_t> &gpu_block_ptrs_flat);
+
   void tp_group_transfer(const torch::Tensor &gpu_block_id_tensor,
                          const torch::Tensor &cpu_block_id_tensor,
                          const int64_t cpu_kv_stride_in_bytes,

--- a/docs/flexkv_config_reference/README_en.md
+++ b/docs/flexkv_config_reference/README_en.md
@@ -84,6 +84,7 @@ Some configurations can only be set through environment variables.
 | Environment Variable | Type | Default | Description |
 |---------------------|------|---------|-------------|
 | `FLEXKV_SERVER_CLIENT_MODE` | bool | 0 | `server_client_mode`: Whether to force enable server-client mode |
+| `FLEXKV_SERVER_LAUNCH_MODE` | str | "embedded" | Shared-server ownership: `embedded` lets client 0 launch it; `external` makes every instance client-only |
 | `FLEXKV_SERVER_RECV_PORT` | str | "ipc:///tmp/flexkv_server" | `server_recv_port`: Server receive port configuration. Different instances in multi-instance mode should use the same port |
 | `FLEXKV_INSTANCE_NUM` | int | 1 | Number of inference engine instances |
 | `FLEXKV_INSTANCE_ID` | int | 0 | Inference engine instance ID |

--- a/docs/flexkv_config_reference/README_zh.md
+++ b/docs/flexkv_config_reference/README_zh.md
@@ -85,6 +85,7 @@ swa_multi_group: false
 | 环境变量 | 类型 | 默认值 | 说明 |
 |--------|------|--------|------|
 | `FLEXKV_SERVER_CLIENT_MODE` | bool | 0 | `server_client_mode`: 是否强制启用服务器-客户端模式 |
+| `FLEXKV_SERVER_LAUNCH_MODE` | str | "embedded" | 共享 Server 的所有权：`embedded` 由 client 0 启动；`external` 下所有实例仅作为 client |
 | `FLEXKV_SERVER_RECV_PORT` | str | "ipc:///tmp/flexkv_server" | `server_recv_port`: 服务器接收端口配置，多实例模式下不同实例应当使用相同的端口 |
 | `FLEXKV_INSTANCE_NUM` | int | 1 | 推理引擎实例的数量 |
 | `FLEXKV_INSTANCE_ID` | int | 0 | 推理引擎实例ID |

--- a/flexkv/cache/hie_cache_engine.py
+++ b/flexkv/cache/hie_cache_engine.py
@@ -39,7 +39,9 @@ class HierarchyLRCacheEngine:
                  evict_start_threshold: float = 1.0,
                  hit_reward_seconds: int = 0,
                  eviction_policy: str = "lru",
-                 meta: Optional[RedisMeta] = None) -> None:
+                 meta: Optional[RedisMeta] = None,
+                 reset_barrier_timeout_ms: int = 60000,
+                 reset_barrier_poll_ms: int = 50) -> None:
         if num_total_blocks <= 0:
             raise ValueError(f"Invalid num_total_blocks: {num_total_blocks}")
         if tokens_per_block <= 0 or (tokens_per_block & (tokens_per_block - 1)) != 0:
@@ -92,6 +94,12 @@ class HierarchyLRCacheEngine:
         self.num_total_blocks = num_total_blocks
         self.evict_ratio = evict_ratio
         self.evict_start_threshold = evict_start_threshold
+        self.reset_barrier_timeout_ms = int(reset_barrier_timeout_ms)
+        self.reset_barrier_poll_ms = int(reset_barrier_poll_ms)
+        if self.reset_barrier_timeout_ms <= 0:
+            raise ValueError("reset_barrier_timeout_ms must be positive")
+        if self.reset_barrier_poll_ms <= 0:
+            raise ValueError("reset_barrier_poll_ms must be positive")
 
         # cumulative statistics: for analyzing distributed KV reuse benefits
         self._stats_total_queried_tokens = 0       # total tokens queried
@@ -167,8 +175,52 @@ class HierarchyLRCacheEngine:
         self.remote_index.stop()
 
     def reset(self) -> None:
+        restart_local_index = self.local_index.started
+        restart_remote_index = self.remote_index.started
+        barrier_ttl_ms = max(self.reset_barrier_timeout_ms * 2, 1000)
+        self.local_index.stop()
+        self.remote_index.stop()
+        reset_epoch = self.local_ch.begin_reset_barrier(barrier_ttl_ms)
+
         self.local_index.reset()
+        self.remote_index.reset()
+        if not self.local_ch.mark_reset_barrier_arrival(
+            reset_epoch, barrier_ttl_ms
+        ):
+            raise RuntimeError(
+                f"Failed to mark reset barrier arrival for device type: {self.device_type}"
+            )
+        self._wait_for_global_block_cleanup(reset_epoch)
+        if not self.local_ch.finish_reset_barrier(reset_epoch):
+            raise RuntimeError(
+                f"Failed to finish reset barrier for device type: {self.device_type}"
+            )
         self.mempool.reset()
+
+        if restart_remote_index and not self.remote_index.start(self.remote_ch):
+            raise RuntimeError(
+                f"Failed to restart distributed radix tree for device type: {self.device_type}"
+            )
+        if restart_local_index and not self.local_index.start(self.local_ch):
+            if restart_remote_index:
+                self.remote_index.stop()
+            raise RuntimeError(
+                f"Failed to restart local radix tree for device type: {self.device_type}"
+            )
+
+    def _wait_for_global_block_cleanup(self, reset_epoch: int) -> None:
+        deadline = time.monotonic() + self.reset_barrier_timeout_ms / 1000.0
+        while True:
+            barrier_ready = self.local_ch.is_reset_barrier_ready(reset_epoch)
+            has_block_keys = self.local_ch.has_any_block_keys()
+            if barrier_ready and not has_block_keys:
+                return
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "Timed out waiting for all nodes to enter reset and remove Redis block metadata "
+                    f"for device type: {self.device_type}; physical blocks were not reset"
+                )
+            time.sleep(self.reset_barrier_poll_ms / 1000.0)
 
     def match(self, sequence_meta: SequenceMeta) -> MatchResultAccel:
         """Match a sequence against the cache index.
@@ -584,6 +636,8 @@ class HierarchyLRCacheEngine:
             remote_idle_sleep_ms=int(GLOBAL_CONFIG_FROM_ENV.idle_sleep_ms),
             local_safety_ttl_ms=int(GLOBAL_CONFIG_FROM_ENV.safety_ttl_ms),
             eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
+            reset_barrier_timeout_ms=int(GLOBAL_CONFIG_FROM_ENV.reset_barrier_timeout_ms),
+            reset_barrier_poll_ms=int(GLOBAL_CONFIG_FROM_ENV.reset_barrier_poll_ms),
             meta=meta,
         )
 
@@ -625,6 +679,8 @@ class HierarchyLRCacheEngine:
                 evict_start_threshold=float(GLOBAL_CONFIG_FROM_ENV.evict_start_threshold),
                 hit_reward_seconds=int(GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds),
                 eviction_policy=GLOBAL_CONFIG_FROM_ENV.eviction_policy,
+                reset_barrier_timeout_ms=int(GLOBAL_CONFIG_FROM_ENV.reset_barrier_timeout_ms),
+                reset_barrier_poll_ms=int(GLOBAL_CONFIG_FROM_ENV.reset_barrier_poll_ms),
                 meta=meta,
             )
             raise ValueError("Invalid device type: {cache_config.device_type}")

--- a/flexkv/cache/radix_remote.py
+++ b/flexkv/cache/radix_remote.py
@@ -68,6 +68,13 @@ class DistributedRadixTree:
         self._c.stop()
         self._started = False
 
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    def reset(self) -> None:
+        self._c.reset()
+
     def remote_tree_refresh(self) -> Optional["RefRadixTree"]:
         """Refresh the remote tree by loading block metadata from Redis.
         
@@ -167,6 +174,10 @@ class LocalRadixTree:
         self._c.stop()
         self._started = False
 
+    @property
+    def started(self) -> bool:
+        return self._started
+
     # Mirror base class methods on LocalRadixTree
     def match_prefix(self, block_hashes: torch.Tensor, num_blocks: int, update_cache_info: bool = True):
         return self._c.match_prefix(block_hashes, int(num_blocks), bool(update_cache_info))
@@ -185,6 +196,15 @@ class LocalRadixTree:
 
     def reset(self) -> None:
         self._c.reset()
+
+    def lease_pool_capacity(self) -> int:
+        return int(self._c.lease_pool_capacity())
+
+    def lease_pool_free_size(self) -> int:
+        return int(self._c.lease_pool_free_size())
+
+    def pending_queue_size(self) -> int:
+        return int(self._c.pending_queue_size())
 
     def is_root(self, node: "CRadixNode") -> bool:
         # Note: CRadixNode pointer type is opaque in Python; in practice this is used internally
@@ -263,5 +283,3 @@ class LocalRadixTree:
 
     def drain_pending_queues(self) -> int:
         return int(self._c.drain_pending_queues())
-
-

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -141,6 +141,7 @@ class RedisNodeInfo:
     # Default TTL for node:<id> key in seconds. Active nodes renew before expiry.
     # If a process crashes (kill -9), the key auto-expires after this period.
     DEFAULT_NODE_TTL_SECONDS: int = 30
+    META_TTL_MULTIPLIER: int = 5
     
     def __init__(self, host: str, port: int, local_ip: str, password: str = "", node_ttl_seconds: int = 0) -> None:
         if _redis is None:
@@ -162,6 +163,8 @@ class RedisNodeInfo:
         self._client: Optional["_redis.Redis"] = None
         self._sub_client: Optional["_redis.Redis"] = None
         self._cleanup_done = False
+        self._meta_keys: set[str] = set()
+        self._meta_keys_lock = threading.Lock()
         
         # register cleanup function on exit
         atexit.register(self._cleanup_on_exit)
@@ -341,6 +344,15 @@ class RedisNodeInfo:
     def is_node_active(self, node_id: int) -> bool:
         """Check if a node_id is active - lock-free RCU check"""
         return node_id in self.current_node_id_set
+
+    def track_meta_key(self, key: str) -> None:
+        """Track node metadata that must be renewed with this node lease."""
+        with self._meta_keys_lock:
+            self._meta_keys.add(str(key))
+
+    def untrack_meta_key(self, key: str) -> None:
+        with self._meta_keys_lock:
+            self._meta_keys.discard(str(key))
     
     def _heartbeat_worker(self) -> None:
         """Background thread that periodically renews the TTL of node:<id> key.
@@ -365,6 +377,11 @@ class RedisNodeInfo:
                     ttl_renewed = heartbeat_client.expire(node_key, self.node_ttl_seconds)
                     if ttl_renewed:
                         heartbeat_client.hset(node_key, "timestamp", str(int(time.time())))
+                        meta_ttl = self.node_ttl_seconds * self.META_TTL_MULTIPLIER
+                        with self._meta_keys_lock:
+                            meta_keys = tuple(self._meta_keys)
+                        for meta_key in meta_keys:
+                            heartbeat_client.expire(meta_key, meta_ttl)
                     else:
                         print(f"[RedisNodeInfo] WARNING: node key {node_key} expired/missing, "
                               f"skipping hset to avoid resurrection")
@@ -754,7 +771,7 @@ class RedisMeta:
 
     # TTL for meta:<node_id> keys — set to 5x the node TTL so that meta
     # survives normal heartbeat jitter but auto-expires after a crash.
-    META_TTL_MULTIPLIER: int = 5
+    META_TTL_MULTIPLIER: int = RedisNodeInfo.META_TTL_MULTIPLIER
 
     def regist_node_meta(self, node_id: int, addr: str, zmq_addr: str, cpu_buffer_ptr: int, ssd_buffer_ptr: int, pp_rank: int = 0, pp_size: int = 1) -> None:
         """Register node meta information as a Redis hash.
@@ -782,6 +799,7 @@ class RedisMeta:
         meta_ttl = self.nodeinfo.node_ttl_seconds * self.META_TTL_MULTIPLIER
         if meta_ttl > 0:
             r.expire(key, meta_ttl)
+            self.nodeinfo.track_meta_key(key)
 
     def get_node_meta(self, node_id: int) -> dict:
         """Get node meta information from Redis.
@@ -816,7 +834,9 @@ class RedisMeta:
             key = f"meta:{int(node_id)}:pp{pp_rank}"
         else:
             key = f"meta:{int(node_id)}"
-        return bool(r.delete(key))
+        deleted = bool(r.delete(key))
+        self.nodeinfo.untrack_meta_key(key)
+        return deleted
 
 
     def set_node_id(self, node_id: int):

--- a/flexkv/cache/redis_meta.py
+++ b/flexkv/cache/redis_meta.py
@@ -135,6 +135,26 @@ class RedisMetaChannel:
         """batch delete block metadata for specified node"""
         return self._c.delete_blockmeta_batch(int(node_id), list(int(h) for h in hashes), int(batch_size))
 
+    def delete_node_blocks(self, node_id: int, batch_size: int = 200) -> bool:
+        """Delete all block metadata for this storage layer and node."""
+        return bool(self._c.delete_node_blocks(int(node_id), int(batch_size)))
+
+    def has_any_block_keys(self) -> bool:
+        """Return whether this storage layer still has any block advertisements."""
+        return bool(self._c.has_any_block_keys())
+
+    def begin_reset_barrier(self, ttl_ms: int) -> int:
+        return int(self._c.begin_reset_barrier(int(ttl_ms)))
+
+    def mark_reset_barrier_arrival(self, epoch: int, ttl_ms: int) -> bool:
+        return bool(self._c.mark_reset_barrier_arrival(int(epoch), int(ttl_ms)))
+
+    def is_reset_barrier_ready(self, epoch: int) -> bool:
+        return bool(self._c.is_reset_barrier_ready(int(epoch)))
+
+    def finish_reset_barrier(self, epoch: int) -> bool:
+        return bool(self._c.finish_reset_barrier(int(epoch)))
+
 class RedisNodeInfo:
     """Redis node information management class implemented in Python"""
 

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -506,6 +506,14 @@ class RankInfo:
         return self.cp_rank * max(1, self.model_config.tp_size) + self.tp_rank
 
     @property
+    def intra_client_id(self) -> int:
+        """Unique data-plane worker ID within one DP client."""
+        return (
+            self.pp_rank * self.model_config.effective_tp_size
+            + self.effective_tp_rank
+        )
+
+    @property
     def pp_size_per_node(self) -> int:
         """Number of PP stages co-located on a single node."""
         model_config = self.model_config

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -806,6 +806,8 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     lease_ttl_ms=int(os.getenv('FLEXKV_LEASE_TTL_MS', 30000)),
     safety_ttl_ms=int(os.getenv('FLEXKV_SAFETY_TTL_MS', 100)),
     renew_lease_ms=int(os.getenv('FLEXKV_RENEW_LEASE_MS', 4000)),
+    reset_barrier_timeout_ms=int(os.getenv('FLEXKV_RESET_BARRIER_TIMEOUT_MS', 60000)),
+    reset_barrier_poll_ms=int(os.getenv('FLEXKV_RESET_BARRIER_POLL_MS', 50)),
 
     nvcomp_batch_size=int(os.getenv('FLEXKV_NVCOMP_BATCH_SIZE', '0')),  # 0 = auto
 

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -752,6 +752,7 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
 
     # Server-client mode configuration
     server_client_mode=bool(int(os.getenv('FLEXKV_SERVER_CLIENT_MODE', 0))),
+    server_launch_mode=os.getenv('FLEXKV_SERVER_LAUNCH_MODE', 'embedded').lower(),
     server_recv_port=os.getenv('FLEXKV_SERVER_RECV_PORT', 'ipc:///tmp/flexkv_server'),
 
     index_accel=bool(int(os.getenv('FLEXKV_INDEX_ACCEL', 1))),

--- a/flexkv/common/debug.py
+++ b/flexkv/common/debug.py
@@ -107,6 +107,17 @@ class FlexkvLogger:
         if self.is_enabled_for(logging.ERROR):
             self._log(logging.ERROR, msg, args, kwargs)
 
+    def exception(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        """Log at ERROR with the active traceback, mirroring stdlib logging.
+
+        Call sites already exist (worker control ack, GPU control drain) and
+        expect the stdlib name; without it the ``except`` block that calls
+        this raises AttributeError and masks the original failure.
+        """
+        kwargs.setdefault("exc_info", True)
+        if self.is_enabled_for(logging.ERROR):
+            self._log(logging.ERROR, msg, args, kwargs)
+
     def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.is_enabled_for(logging.CRITICAL):
             self._log(logging.CRITICAL, msg, args, kwargs)

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -16,6 +16,16 @@ class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * 64)]
 
 
+# CUmemFabricHandle mirrors the driver API layout: an opaque 64-byte struct.
+# vLLM's CuMemAllocator (enable_sleep_mode) allocates KV cache via cuMemCreate
+# + cuMemMap, which cannot be shared through the legacy cudaIpcGetMemHandle
+# path. Fabric handles are byte-serializable so they travel over the same ZMQ
+# transport we already use for cudaIpc handles — no auxiliary UDS channel is
+# required on GPUs that support CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC.
+class CUmemFabricHandle_t(ctypes.Structure):
+    _fields_ = [("data", ctypes.c_ubyte * 64)]
+
+
 # Load CUDA runtime library
 try:
     cudart = ctypes.CDLL("libcudart.so")
@@ -25,12 +35,396 @@ except:
     except:
         cudart = ctypes.CDLL("libcudart.so.11")
 
+# Load CUDA driver library. CuMemAllocator's cuMemCreate + cuMemMap live in
+# libcuda, not libcudart, so we need both. Setting to None on ImportError
+# keeps the legacy code path working on systems without the driver stub.
+try:
+    libcuda = ctypes.CDLL("libcuda.so")
+except OSError:
+    try:
+        libcuda = ctypes.CDLL("libcuda.so.1")
+    except OSError:
+        libcuda = None
+
+
 # CUDA IPC handle size (64 bytes on Linux)
 CUDA_IPC_HANDLE_SIZE = 64
+CU_MEM_FABRIC_HANDLE_SIZE = 64
 
-# CUDA error codes
+# CUDA runtime error codes
 cudaSuccess = 0
 cudaErrorInvalidValue = 11
+
+# CUDA driver error codes / enums used by the VMM path.
+CUDA_SUCCESS = 0
+
+# cuPointerGetAttribute selectors we consume. Values match cuda.h; the
+# CUDA API guarantees stability so hardcoding is safe. IS_LEGACY_CUDA_IPC_CAPABLE
+# is the most authoritative "can I call cudaIpcGetMemHandle on this pointer?"
+# probe — it returns 1 for cudaMalloc allocations and 0 for VMM ranges.
+CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10
+CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+
+# CUmemAllocationHandleType bitmask values.
+CU_MEM_HANDLE_TYPE_NONE = 0
+CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 0x1
+CU_MEM_HANDLE_TYPE_WIN32 = 0x2
+CU_MEM_HANDLE_TYPE_WIN32_KMT = 0x4
+CU_MEM_HANDLE_TYPE_FABRIC = 0x8
+
+# CUmemLocationType.
+CU_MEM_LOCATION_TYPE_DEVICE = 1
+
+# CUmemAccess_flags.
+CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3
+
+# CUmemAllocationType.
+CU_MEM_ALLOCATION_TYPE_PINNED = 1
+
+# CUmemAllocationGranularity_flags.
+CU_MEM_ALLOC_GRANULARITY_MINIMUM = 0
+CU_MEM_ALLOC_GRANULARITY_RECOMMENDED = 1
+
+
+class CUmemLocation(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_int), ("id", ctypes.c_int)]
+
+
+class CUmemAllocationProp_st_allocFlags(ctypes.Structure):
+    _fields_ = [
+        ("compressionType", ctypes.c_ubyte),
+        ("gpuDirectRDMACapable", ctypes.c_ubyte),
+        ("usage", ctypes.c_ushort),
+        ("reserved", ctypes.c_ubyte * 4),
+    ]
+
+
+class CUmemAllocationProp(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("requestedHandleTypes", ctypes.c_int),
+        ("location", CUmemLocation),
+        ("win32HandleMetaData", ctypes.c_void_p),
+        ("allocFlags", CUmemAllocationProp_st_allocFlags),
+    ]
+
+
+class CUmemAccessDesc(ctypes.Structure):
+    _fields_ = [("location", CUmemLocation), ("flags", ctypes.c_int)]
+
+
+# Configure argtypes/restype so ctypes marshals pointers correctly on 64-bit
+# systems (the default int-return-type would truncate CUresult values above
+# INT_MAX in principle; the CUDA driver stays under that but explicit types
+# make the intent clear).
+if libcuda is not None:
+    _CUresult = ctypes.c_int
+    _CUdeviceptr = ctypes.c_ulonglong  # 64-bit device address
+
+    libcuda.cuPointerGetAttribute.restype = _CUresult
+    libcuda.cuPointerGetAttribute.argtypes = [
+        ctypes.c_void_p, ctypes.c_int, _CUdeviceptr
+    ]
+    libcuda.cuMemRetainAllocationHandle.restype = _CUresult
+    libcuda.cuMemRetainAllocationHandle.argtypes = [
+        ctypes.c_void_p, ctypes.c_void_p
+    ]
+    libcuda.cuMemGetAllocationPropertiesFromHandle.restype = _CUresult
+    libcuda.cuMemGetAllocationPropertiesFromHandle.argtypes = [
+        ctypes.POINTER(CUmemAllocationProp), ctypes.c_void_p
+    ]
+    libcuda.cuMemExportToShareableHandle.restype = _CUresult
+    libcuda.cuMemExportToShareableHandle.argtypes = [
+        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, ctypes.c_ulonglong
+    ]
+    libcuda.cuMemImportFromShareableHandle.restype = _CUresult
+    libcuda.cuMemImportFromShareableHandle.argtypes = [
+        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int
+    ]
+    libcuda.cuMemAddressReserve.restype = _CUresult
+    libcuda.cuMemAddressReserve.argtypes = [
+        ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t,
+        _CUdeviceptr, ctypes.c_ulonglong,
+    ]
+    libcuda.cuMemAddressFree.restype = _CUresult
+    libcuda.cuMemAddressFree.argtypes = [_CUdeviceptr, ctypes.c_size_t]
+    libcuda.cuMemMap.restype = _CUresult
+    libcuda.cuMemMap.argtypes = [
+        _CUdeviceptr, ctypes.c_size_t, ctypes.c_ulonglong,
+        ctypes.c_void_p, ctypes.c_ulonglong,
+    ]
+    libcuda.cuMemUnmap.restype = _CUresult
+    libcuda.cuMemUnmap.argtypes = [_CUdeviceptr, ctypes.c_size_t]
+    libcuda.cuMemSetAccess.restype = _CUresult
+    libcuda.cuMemSetAccess.argtypes = [
+        _CUdeviceptr, ctypes.c_size_t,
+        ctypes.POINTER(CUmemAccessDesc), ctypes.c_size_t,
+    ]
+    libcuda.cuMemGetAllocationGranularity.restype = _CUresult
+    libcuda.cuMemGetAllocationGranularity.argtypes = [
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(CUmemAllocationProp),
+        ctypes.c_int,
+    ]
+    libcuda.cuMemRelease.restype = _CUresult
+    libcuda.cuMemRelease.argtypes = [ctypes.c_void_p]
+
+
+# FDs returned by cuMemExportToShareableHandle stay valid only while the
+# exporting process holds them open. We stash them in a module-level list so
+# importers that arrive later (or restart) can still pidfd_getfd them.
+# List is intentionally simple (no eviction) — FlexKV registers a bounded
+# number of KV cache tensors at startup and never re-exports.
+_EXPORTED_VMM_FDS: list[int] = []
+
+# Linux 5.6+ syscalls used for cross-process FD passing without SCM_RIGHTS.
+# Numbers are architecture-specific; these are for x86_64 (the FlexKV
+# supported target). ppc64/aarch64 add-ons can extend this dict later.
+_SYS_pidfd_open = 434
+_SYS_pidfd_getfd = 438
+
+try:
+    _libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    _libc.syscall.restype = ctypes.c_long
+    _libc.syscall.argtypes = None  # varargs; caller supplies proper types
+except OSError:
+    _libc = None
+
+
+def _pidfd_open(pid: int) -> int:
+    if _libc is None:
+        raise RuntimeError("libc not available for pidfd_open syscall")
+    ret = _libc.syscall(
+        ctypes.c_long(_SYS_pidfd_open), ctypes.c_int(pid), ctypes.c_uint(0)
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"pidfd_open({pid}) failed: errno={err}")
+    return int(ret)
+
+
+def _pidfd_getfd(pidfd: int, target_fd: int) -> int:
+    if _libc is None:
+        raise RuntimeError("libc not available for pidfd_getfd syscall")
+    ret = _libc.syscall(
+        ctypes.c_long(_SYS_pidfd_getfd),
+        ctypes.c_int(pidfd),
+        ctypes.c_int(target_fd),
+        ctypes.c_uint(0),
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(
+            err,
+            f"pidfd_getfd(pidfd={pidfd}, target_fd={target_fd}) failed: "
+            f"errno={err}",
+        )
+    return int(ret)
+
+
+# --- SCM_RIGHTS FD-serving side channel -------------------------------------
+#
+# CUDA POSIX-FD shareable handles reference a driver-specific kernel object
+# accessed via ``/dev/nvidiactl``. They cannot be duplicated by opening
+# ``/proc/<pid>/fd/<n>`` (which gives you a fresh ``/dev/nvidiactl`` handle,
+# not a copy of the underlying CUDA resource) and cannot be duplicated via
+# ``pidfd_getfd`` unless the caller has ``CAP_SYS_PTRACE`` — which Docker
+# drops from its default profile. The only portable way to move them across
+# process boundaries is SCM_RIGHTS on an ``AF_UNIX`` socket.
+#
+# To keep the fix confined to ``memory_handle.py`` (no changes needed to the
+# KVManager / KVTPClient wire format), each exporter process spins up a
+# background thread that accepts connections on a well-known UDS path
+# derived from its PID. Importers include the exporter PID and an
+# opaque FD key in the 64-byte VMM handle payload; on ``get_tensor`` they
+# connect to the UDS and receive the FD via SCM_RIGHTS. FDs stay registered
+# for the lifetime of the exporter process (KV cache tensors are permanent
+# from FlexKV's perspective) so there is no unregistration API to design.
+
+import socket
+import threading
+import array
+
+_VMM_FD_SERVER_STATE: dict = {
+    "lock": threading.Lock(),
+    "sock": None,      # socket.socket
+    "path": None,      # str
+    "thread": None,    # threading.Thread
+    "fd_by_key": {},   # int -> int (key -> fd we exported)
+    "next_key": 0,
+}
+
+
+def _vmm_fd_server_path(pid: Optional[int] = None) -> str:
+    if pid is None:
+        pid = os.getpid()
+    # ``FLEXKV_VMM_FD_SOCK_DIR`` lets deployments override the location for
+    # sandboxed environments where /tmp is restricted. Default /tmp keeps
+    # the naming consistent with FlexKV's other ipc:// paths.
+    root = os.environ.get("FLEXKV_VMM_FD_SOCK_DIR", "/tmp")
+    return os.path.join(root, f"flexkv_vmm_fd_{pid}.sock")
+
+
+def _vmm_fd_server_ensure_started() -> None:
+    """Idempotently start the SCM_RIGHTS FD-serving thread for this process."""
+    state = _VMM_FD_SERVER_STATE
+    with state["lock"]:
+        if state["sock"] is not None:
+            return
+        path = _vmm_fd_server_path()
+        # Best-effort cleanup of a stale socket left by a crashed prior run
+        # under the same PID (unlikely but possible after PID recycling).
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(path)
+        # Restrict access: only the owning UID should be able to obtain FDs.
+        # ``chmod 0600`` blocks other users on the host from stealing KV cache
+        # buffers even if they know the socket path.
+        os.chmod(path, 0o600)
+        srv.listen(16)
+        state["sock"] = srv
+        state["path"] = path
+
+        thread = threading.Thread(
+            target=_vmm_fd_server_loop,
+            name="flexkv-vmm-fd-server",
+            daemon=True,
+        )
+        state["thread"] = thread
+        thread.start()
+        flexkv_logger.info(
+            f"[VMM] FD-serving thread started at {path} (SCM_RIGHTS)."
+        )
+
+
+def _vmm_fd_server_loop() -> None:
+    """Accept-and-serve loop: read a 4-byte key, reply with the matching FD."""
+    state = _VMM_FD_SERVER_STATE
+    srv = state["sock"]
+    while True:
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            return
+        try:
+            raw = conn.recv(4)
+            if len(raw) != 4:
+                conn.close()
+                continue
+            key = int.from_bytes(raw, "little", signed=False)
+            fd = state["fd_by_key"].get(key)
+            if fd is None:
+                # Signal "unknown key" by sending a single zero byte with
+                # no ancillary FD.
+                conn.sendmsg([b"\x00"])
+            else:
+                conn.sendmsg(
+                    [b"\x01"],
+                    [(socket.SOL_SOCKET, socket.SCM_RIGHTS,
+                      array.array("i", [fd]))],
+                )
+        except Exception as exc:
+            flexkv_logger.warning(f"[VMM] FD-serving loop error: {exc}")
+        finally:
+            conn.close()
+
+
+def _vmm_fd_server_register(fd: int) -> int:
+    """Register ``fd`` for later retrieval and return its opaque key."""
+    _vmm_fd_server_ensure_started()
+    state = _VMM_FD_SERVER_STATE
+    with state["lock"]:
+        key = state["next_key"]
+        state["next_key"] = (key + 1) & 0xFFFFFFFF
+        state["fd_by_key"][key] = fd
+        return key
+
+
+def _fetch_remote_fd(pid: int, key: int) -> int:
+    """Connect to the exporter's SCM_RIGHTS server and dup the target FD."""
+    path = _vmm_fd_server_path(pid)
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"VMM FD server socket not found for pid {pid} at {path}. "
+            f"The exporter process may have crashed or been misconfigured."
+        )
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(path)
+        sock.sendall(int(key).to_bytes(4, "little", signed=False))
+        msg, ancdata, flags, _ = sock.recvmsg(
+            1, socket.CMSG_LEN(4 * array.array("i").itemsize)
+        )
+        if not msg:
+            raise RuntimeError("empty response from VMM FD server")
+        if msg[0] == 0:
+            raise KeyError(
+                f"exporter (pid {pid}) has no FD registered under key {key}"
+            )
+        if len(ancdata) != 1:
+            raise RuntimeError(
+                f"expected exactly one SCM_RIGHTS cmsg, got {len(ancdata)}"
+            )
+        _, _, data = ancdata[0]
+        fds = array.array("i")
+        fds.frombytes(data[:fds.itemsize])
+        return int(fds[0])
+    finally:
+        sock.close()
+
+
+def _pack_vmm_fd(pid: int, key: int) -> bytes:
+    """Encode ``(exporter_pid, fd_key)`` in the 64-byte handle envelope.
+
+    ``fd_key`` is the opaque token issued by _vmm_fd_server_register, not
+    the raw FD — the importer swaps it for a real FD by talking to the
+    exporter's SCM_RIGHTS server.
+    """
+    buf = bytearray(64)
+    buf[0:4] = int(pid).to_bytes(4, "little", signed=False)
+    buf[4:8] = int(key).to_bytes(4, "little", signed=False)
+    return bytes(buf)
+
+
+def _unpack_vmm_fd(handle_bytes: bytes) -> Tuple[int, int]:
+    pid = int.from_bytes(handle_bytes[0:4], "little", signed=False)
+    key = int.from_bytes(handle_bytes[4:8], "little", signed=False)
+    return pid, key
+
+
+def _check_cu(where: str, result: int) -> None:
+    """Raise on non-CUDA_SUCCESS return codes from the driver API."""
+    if result != CUDA_SUCCESS:
+        raise RuntimeError(f"{where} failed with CUresult={result}")
+
+
+def _is_vmm_pointer(data_ptr: int) -> bool:
+    """Return True when ``data_ptr`` points into a cuMemCreate/cuMemMap range.
+
+    We query ``CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE`` which is
+    documented as "1 if this pointer maps to an allocation suitable for
+    cudaIpcGetMemHandle, 0 otherwise". cudaMalloc returns 1; VMM ranges
+    return 0. Inverting the answer gives us the VMM discriminator we want.
+    If the attribute query itself fails we conservatively answer False so
+    the caller falls back to the existing cudaIpc path (which then errors
+    out cleanly on a truly non-shareable allocation).
+    """
+    if libcuda is None:
+        return False
+    legacy_ok = ctypes.c_uint(0)
+    result = libcuda.cuPointerGetAttribute(
+        ctypes.byref(legacy_ok),
+        CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE,
+        ctypes.c_ulonglong(data_ptr),
+    )
+    if result != CUDA_SUCCESS:
+        return False
+    return legacy_ok.value == 0
 
 
 @dataclass
@@ -46,6 +440,19 @@ class TensorSharedHandle:
     tensor_numel: Optional[int] = None
     offset: int = 0
 
+    # VMM (cuMemCreate/cuMemMap) sharing metadata. Populated only when the
+    # source tensor lives in a virtual-memory allocation such as vLLM's
+    # CuMemAllocator (enable_sleep_mode). ``handle_type`` disambiguates which
+    # importer path to run on ``get_tensor``:
+    #   'torch_reduce'  – legacy PyTorch reduce_tensor  (use_direct_ipc=False)
+    #   'cuda_ipc'      – legacy cudaIpcGetMemHandle    (use_direct_ipc=True)
+    #   'vmm_fabric'    – cuMemExport(FABRIC) bytes, no auxiliary channel
+    #   'vmm_posix_fd'  – FD-based sharing; requires an out-of-band UDS
+    #                     (not yet implemented — see _init_from_tensor)
+    handle_type: str = "torch_reduce"
+    vmm_allocation_size: int = 0
+    vmm_granularity: int = 0
+
     def __init__(
         self,
         data: Union[torch.Tensor, bytes],
@@ -57,12 +464,20 @@ class TensorSharedHandle:
             Union[torch.dtype, str]
         ] = None,  # only used when data is bytes
         offset: int = 0,  # offset in bytes from base pointer (for memory pool allocations)
+        handle_type: Optional[str] = None,  # only used when data is bytes
+        vmm_allocation_size: int = 0,       # only used when data is bytes + VMM
+        vmm_granularity: int = 0,           # only used when data is bytes + VMM
     ):
         """
         Now we support three ways to construct TensorSharedHandle:
         If data is a tensor that is managed by torch, we will use the reduce_tensor method to export the TensorSharedHandle.
         If data is a tensor that is allocated by cudamalloc, we will use the cudaIpcGetMemHandle method to export the TensorSharedHandle.
-        If data is bytes-like, it means the memory has already been shared by CUDA IPC, we will skip the export process to construct the TensorSharedHandle.
+        If data is a tensor that is allocated by CUDA VMM (cuMemCreate/cuMemMap — used by vLLM's CuMemAllocator when
+        enable_sleep_mode is on), we will use cuMemExportToShareableHandle with a fabric handle so the resulting bytes
+        can still be sent over ZMQ. When fabric is unavailable we fall back to POSIX FDs, which require an out-of-band
+        channel — this path is currently not wired up and raises a clear error instead of silently corrupting state.
+        If data is bytes-like, it means the memory has already been shared by CUDA IPC / VMM, we will skip the export
+        process to construct the TensorSharedHandle.
         """
 
         self.use_direct_ipc = False
@@ -70,6 +485,9 @@ class TensorSharedHandle:
         self.tensor_shape = None
         self.tensor_dtype = None
         self.tensor_numel = None
+        self.handle_type = "torch_reduce"
+        self.vmm_allocation_size = 0
+        self.vmm_granularity = 0
 
         if isinstance(data, torch.Tensor):
             self._init_from_tensor(data, device_id, force_direct_ipc)
@@ -77,7 +495,11 @@ class TensorSharedHandle:
 
         elif isinstance(data, bytes):
             self._init_from_ipc_handle(
-                bytes(data), device_id, tensor_shape, tensor_dtype, offset=offset
+                bytes(data), device_id, tensor_shape, tensor_dtype,
+                offset=offset,
+                handle_type=handle_type,
+                vmm_allocation_size=vmm_allocation_size,
+                vmm_granularity=vmm_granularity,
             )
             return
         else:
@@ -94,6 +516,16 @@ class TensorSharedHandle:
         if not tensor.is_cuda:
             raise ValueError("Only support CUDA tensor sharing")
 
+        # VMM allocations (vLLM CuMemAllocator etc.) cannot be exported via
+        # cudaIpcGetMemHandle at all — the legacy IPC API rejects them. We
+        # must detect this up front and route to the driver-API export path,
+        # otherwise both existing legacy attempts below would fail and we'd
+        # surface a confusing "Both PyTorch and direct CUDA IPC export failed"
+        # error message that gives no hint that sleep_mode is the culprit.
+        if libcuda is not None and _is_vmm_pointer(tensor.data_ptr()):
+            self._export_vmm(tensor, device_id)
+            return
+
         if not force_direct_ipc:
             ## Try PyTorch's built-in method first
             try:
@@ -109,9 +541,7 @@ class TensorSharedHandle:
                     tmp_list = list(self.rebuild_args)
                     tmp_list[6] = device_id
                     self.rebuild_args = tuple(tmp_list)
-                # flexkv_logger.debug(
-                #     f"Tensor exported via PyTorch CUDA IPC for device {self.device}"
-                # )
+                self.handle_type = "torch_reduce"
                 return
             except RuntimeError as e:
                 flexkv_logger.warning(f"PyTorch CUDA IPC export failed: {e}")
@@ -121,6 +551,7 @@ class TensorSharedHandle:
             ## Try direct CUDA IPC export
             self.ipc_handle = self._export_cuda_ipc_handle(tensor)
             self.use_direct_ipc = True
+            self.handle_type = "cuda_ipc"
             self.tensor_shape = tuple(tensor.shape)
             self.tensor_dtype = tensor.dtype
             self.tensor_numel = tensor.numel()
@@ -136,6 +567,124 @@ class TensorSharedHandle:
         except Exception as e:
             raise RuntimeError(f"Both PyTorch and direct CUDA IPC export failed: {e}")
 
+    def _export_vmm(self, tensor: torch.Tensor, device_id: int) -> None:
+        """Export a VMM-backed tensor via cuMemExportToShareableHandle.
+
+        Prefers CU_MEM_HANDLE_TYPE_FABRIC because the resulting 64-byte
+        handle is byte-serializable and can travel over the existing ZMQ
+        transport unchanged. Only falls back to POSIX FD when the
+        allocation explicitly does not permit fabric, and even then only
+        emits a clear NotImplementedError since FD passing requires an
+        auxiliary UDS channel that the FlexKV control plane does not
+        currently expose.
+        """
+        assert libcuda is not None
+        data_ptr = tensor.data_ptr()
+
+        base_ptr = ctypes.c_ulonglong()
+        alloc_size = ctypes.c_size_t()
+        res = libcuda.cuPointerGetAttribute(
+            ctypes.byref(base_ptr),
+            CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+            ctypes.c_ulonglong(data_ptr),
+        )
+        _check_cu("cuPointerGetAttribute(RANGE_START_ADDR)", res)
+        res = libcuda.cuPointerGetAttribute(
+            ctypes.byref(alloc_size),
+            CU_POINTER_ATTRIBUTE_RANGE_SIZE,
+            ctypes.c_ulonglong(data_ptr),
+        )
+        _check_cu("cuPointerGetAttribute(RANGE_SIZE)", res)
+
+        mem_handle = ctypes.c_void_p()
+        res = libcuda.cuMemRetainAllocationHandle(
+            ctypes.byref(mem_handle), ctypes.c_void_p(base_ptr.value)
+        )
+        _check_cu("cuMemRetainAllocationHandle", res)
+
+        try:
+            prop = CUmemAllocationProp()
+            res = libcuda.cuMemGetAllocationPropertiesFromHandle(
+                ctypes.byref(prop), mem_handle
+            )
+            _check_cu("cuMemGetAllocationPropertiesFromHandle", res)
+
+            allowed = int(prop.requestedHandleTypes)
+            if allowed & CU_MEM_HANDLE_TYPE_FABRIC:
+                fabric = CUmemFabricHandle_t()
+                res = libcuda.cuMemExportToShareableHandle(
+                    ctypes.byref(fabric),
+                    mem_handle,
+                    ctypes.c_int(CU_MEM_HANDLE_TYPE_FABRIC),
+                    ctypes.c_ulonglong(0),
+                )
+                _check_cu("cuMemExportToShareableHandle(FABRIC)", res)
+                self.ipc_handle = ctypes.string_at(
+                    ctypes.byref(fabric), CU_MEM_FABRIC_HANDLE_SIZE
+                )
+                self.handle_type = "vmm_fabric"
+            elif allowed & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR:
+                # POSIX FD path — the driver hands us an integer FD in the
+                # exporting process. CUDA POSIX FDs reference an internal
+                # kernel object (backed by /dev/nvidiactl) and cannot be
+                # cloned by re-opening ``/proc/<pid>/fd/<n>`` or by
+                # ``pidfd_getfd`` without CAP_SYS_PTRACE. To move them
+                # cross-process we register the FD with a small
+                # SCM_RIGHTS-serving thread (see _vmm_fd_server_*) and
+                # ship (pid, key) as bytes; the importer connects to the
+                # UDS, sends the key, and receives the FD back. The
+                # exporter keeps its FD open for the lifetime of the
+                # process (see _EXPORTED_VMM_FDS below) so importers may
+                # arrive arbitrarily later.
+                fd_out = ctypes.c_int(-1)
+                res = libcuda.cuMemExportToShareableHandle(
+                    ctypes.byref(fd_out),
+                    mem_handle,
+                    ctypes.c_int(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+                    ctypes.c_ulonglong(0),
+                )
+                _check_cu("cuMemExportToShareableHandle(POSIX_FD)", res)
+                _EXPORTED_VMM_FDS.append(int(fd_out.value))
+                key = _vmm_fd_server_register(int(fd_out.value))
+                self.ipc_handle = _pack_vmm_fd(os.getpid(), key)
+                self.handle_type = "vmm_posix_fd"
+            else:
+                raise RuntimeError(
+                    "VMM allocation has no shareable handle type set "
+                    f"(requestedHandleTypes=0x{allowed:x})."
+                )
+
+            granularity = ctypes.c_size_t()
+            res = libcuda.cuMemGetAllocationGranularity(
+                ctypes.byref(granularity),
+                ctypes.byref(prop),
+                ctypes.c_int(CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+            )
+            _check_cu("cuMemGetAllocationGranularity", res)
+
+            self.use_direct_ipc = True  # importer must go through get_tensor
+            self.tensor_shape = tuple(tensor.shape)
+            self.tensor_dtype = tensor.dtype
+            self.tensor_numel = tensor.numel()
+            self.device = (
+                tensor.device
+                if device_id == -1
+                else torch.device(f"cuda:{device_id}")
+            )
+            self.rebuild_func = None
+            self.rebuild_args = None
+            self.offset = int(data_ptr - base_ptr.value)
+            self.vmm_allocation_size = int(alloc_size.value)
+            self.vmm_granularity = int(granularity.value)
+            flexkv_logger.info(
+                f"Tensor exported via CUDA VMM ({self.handle_type}): "
+                f"device={self.device}, base=0x{base_ptr.value:x}, "
+                f"offset={self.offset}, size={self.vmm_allocation_size}, "
+                f"granularity={self.vmm_granularity}"
+            )
+        finally:
+            libcuda.cuMemRelease(mem_handle)
+
     def _init_from_ipc_handle(
         self,
         ipc_handle: Optional[bytes],
@@ -143,6 +692,9 @@ class TensorSharedHandle:
         tensor_shape: Optional[Tuple[int, ...]],
         tensor_dtype: Optional[Union[torch.dtype, str]],
         offset: int = 0,
+        handle_type: Optional[str] = None,
+        vmm_allocation_size: int = 0,
+        vmm_granularity: int = 0,
     ) -> None:
         if ipc_handle is None:
             raise ValueError("ipc_handle is required when constructing from external handle")
@@ -168,6 +720,18 @@ class TensorSharedHandle:
         self.rebuild_func = None
         self.rebuild_args = None
         self.offset = offset
+        # Default to cuda_ipc so pre-existing callers that construct from raw
+        # bytes without specifying handle_type keep the legacy behavior.
+        self.handle_type = handle_type or "cuda_ipc"
+        self.vmm_allocation_size = int(vmm_allocation_size)
+        self.vmm_granularity = int(vmm_granularity)
+        if self.handle_type in ("vmm_fabric", "vmm_posix_fd") and (
+            self.vmm_allocation_size <= 0 or self.vmm_granularity <= 0
+        ):
+            raise ValueError(
+                "VMM handle_type requires vmm_allocation_size and "
+                "vmm_granularity to be set (both must be positive)."
+            )
         
   
         # flexkv_logger.info(
@@ -205,14 +769,181 @@ class TensorSharedHandle:
         raise ValueError(f"Unsupported tensor dtype: {dtype}")
 
     def get_tensor(self) -> torch.Tensor:
+        if self.handle_type == "vmm_fabric":
+            return self._import_vmm_handle(
+                self.ipc_handle,
+                self.tensor_shape,
+                self.tensor_dtype,
+                self.device,
+                offset=self.offset,
+                allocation_size=self.vmm_allocation_size,
+                granularity=self.vmm_granularity,
+                handle_type=CU_MEM_HANDLE_TYPE_FABRIC,
+            )
+        if self.handle_type == "vmm_posix_fd":
+            return self._import_vmm_handle(
+                self.ipc_handle,
+                self.tensor_shape,
+                self.tensor_dtype,
+                self.device,
+                offset=self.offset,
+                allocation_size=self.vmm_allocation_size,
+                granularity=self.vmm_granularity,
+                handle_type=CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+            )
         if self.use_direct_ipc:
             return self._import_cuda_ipc_handle(
-                self.ipc_handle, self.tensor_shape, self.tensor_dtype, self.device, offset=self.offset
+                self.ipc_handle, self.tensor_shape, self.tensor_dtype,
+                self.device, offset=self.offset,
             )
+        return self._import_tensor_handle(
+            self.rebuild_func, self.rebuild_args, self.device
+        )
+
+    ## Import CUDA VMM allocation
+    @staticmethod
+    def _import_vmm_handle(
+        shareable_bytes: bytes,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+        offset: int,
+        allocation_size: int,
+        granularity: int,
+        handle_type: int,
+    ) -> torch.Tensor:
+        """Rehydrate a VMM allocation exported via cuMemExportToShareableHandle.
+
+        The exporter side sent us just the 64-byte fabric handle. Here we
+        cuMemImportFromShareableHandle -> cuMemAddressReserve ->
+        cuMemMap -> cuMemSetAccess, then wrap the virtual address in a
+        zero-copy torch tensor. The imported allocation stays mapped for
+        the lifetime of the process; freeing it would invalidate every
+        tensor we handed out, and FlexKV's KVManager already owns the
+        registration lifetime.
+        """
+        if libcuda is None:
+            raise RuntimeError(
+                "libcuda not available; cannot import a VMM shareable handle."
+            )
+
+        if not torch.cuda.is_initialized():
+            torch.cuda.init()
+        device_id = device.index if device.index is not None else 0
+        torch.cuda.set_device(device_id)
+        _ = torch.zeros(1, device=device)  # force context
+
+        # Both fabric and POSIX-FD paths reuse the same import primitive; the
+        # only difference is what we point osHandle at.
+        mem_handle = ctypes.c_void_p()
+        if handle_type == CU_MEM_HANDLE_TYPE_FABRIC:
+            fabric = CUmemFabricHandle_t()
+            ctypes.memmove(
+                ctypes.byref(fabric), shareable_bytes,
+                CU_MEM_FABRIC_HANDLE_SIZE,
+            )
+            res = libcuda.cuMemImportFromShareableHandle(
+                ctypes.byref(mem_handle),
+                ctypes.byref(fabric),
+                ctypes.c_int(handle_type),
+            )
+            _check_cu("cuMemImportFromShareableHandle(FABRIC)", res)
+        elif handle_type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR:
+            pid, key = _unpack_vmm_fd(shareable_bytes)
+            # If we're being replayed inside the same process (unlikely
+            # since CUDA rejects same-process import, but we handle it
+            # anyway for defense in depth) look up the FD directly.
+            if pid == os.getpid():
+                local_fd = _VMM_FD_SERVER_STATE["fd_by_key"].get(key)
+                if local_fd is None:
+                    raise KeyError(
+                        f"no VMM FD registered locally under key {key}"
+                    )
+                close_local_fd = False
+            else:
+                local_fd = _fetch_remote_fd(pid, key)
+                close_local_fd = True
+            try:
+                link_target = os.readlink(f"/proc/self/fd/{local_fd}")
+            except OSError:
+                link_target = "?"
+            flexkv_logger.info(
+                f"[VMM import] pid={pid} key={key} -> local_fd={local_fd} "
+                f"({link_target})"
+            )
+            try:
+                # NCCL and CUDA sample code (vectorAddMMAP, cudaVMM_p2p)
+                # pass the FD directly as ``osHandle`` (cast to ``void*``),
+                # NOT a pointer to an int. This is the value-shaped
+                # convention documented by CUDA for the POSIX FD handle
+                # type: for FABRIC osHandle points to a 64-byte struct,
+                # for POSIX FD osHandle IS the FD.
+                res = libcuda.cuMemImportFromShareableHandle(
+                    ctypes.byref(mem_handle),
+                    ctypes.c_void_p(local_fd),
+                    ctypes.c_int(handle_type),
+                )
+                _check_cu(
+                    "cuMemImportFromShareableHandle(POSIX_FD)", res
+                )
+            finally:
+                # cuMemImportFromShareableHandle dups the FD internally, so
+                # we can close our local copy once the driver has consumed
+                # it. Skip if the FD was already owned by this process.
+                if close_local_fd:
+                    os.close(local_fd)
         else:
-            return self._import_tensor_handle(
-                self.rebuild_func, self.rebuild_args, self.device
+            raise ValueError(f"unsupported vmm handle_type {handle_type}")
+
+        try:
+            # Reserve a VA range of exactly the allocation size, aligned to
+            # the exporter's granularity so cuMemMap will accept it.
+            va = ctypes.c_ulonglong(0)
+            res = libcuda.cuMemAddressReserve(
+                ctypes.byref(va),
+                ctypes.c_size_t(allocation_size),
+                ctypes.c_size_t(granularity),
+                ctypes.c_ulonglong(0),
+                ctypes.c_ulonglong(0),
             )
+            _check_cu("cuMemAddressReserve", res)
+
+            res = libcuda.cuMemMap(
+                ctypes.c_ulonglong(va.value),
+                ctypes.c_size_t(allocation_size),
+                ctypes.c_ulonglong(0),
+                mem_handle,
+                ctypes.c_ulonglong(0),
+            )
+            _check_cu("cuMemMap", res)
+
+            # Grant this device read/write access to the mapped range.
+            access = CUmemAccessDesc()
+            access.location.type = CU_MEM_LOCATION_TYPE_DEVICE
+            access.location.id = device_id
+            access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+            res = libcuda.cuMemSetAccess(
+                ctypes.c_ulonglong(va.value),
+                ctypes.c_size_t(allocation_size),
+                ctypes.byref(access),
+                ctypes.c_size_t(1),
+            )
+            _check_cu("cuMemSetAccess", res)
+        except Exception:
+            libcuda.cuMemRelease(mem_handle)
+            raise
+        # NOTE: the mem_handle refcount is retained by cuMemMap for as long
+        # as the mapping lives, so we can safely release our own ref now.
+        libcuda.cuMemRelease(mem_handle)
+
+        data_ptr = va.value + int(offset)
+        flexkv_logger.info(
+            f"Imported VMM tensor: device={device}, base=0x{va.value:x}, "
+            f"offset={offset}, size={allocation_size}"
+        )
+        return TensorSharedHandle._create_tensor_from_cuda_ptr(
+            data_ptr, shape, dtype, device
+        )
 
     ## Export tensor handle
     @staticmethod

--- a/flexkv/common/memory_handle.py
+++ b/flexkv/common/memory_handle.py
@@ -171,12 +171,17 @@ if libcuda is not None:
     libcuda.cuMemRelease.restype = _CUresult
     libcuda.cuMemRelease.argtypes = [ctypes.c_void_p]
 
+# Imported VMM mappings are process-local. Keep the reserved base address and
+# size so a long-lived transfer worker can release the imported allocation
+# before vLLM tears down the exporting CuMemAllocator allocation for sleep.
+_IMPORTED_VMM_MAPPINGS: dict[int, tuple[int, int]] = {}
+
 
 # FDs returned by cuMemExportToShareableHandle stay valid only while the
 # exporting process holds them open. We stash them in a module-level list so
 # importers that arrive later (or restart) can still pidfd_getfd them.
-# List is intentionally simple (no eviction) — FlexKV registers a bounded
-# number of KV cache tensors at startup and never re-exports.
+# Entries are removed after FlexKV importers unmap for vLLM sleep; wake-up
+# exports fresh handles for the allocator's new physical allocation.
 _EXPORTED_VMM_FDS: list[int] = []
 
 # Linux 5.6+ syscalls used for cross-process FD passing without SCM_RIGHTS.
@@ -240,8 +245,7 @@ def _pidfd_getfd(pidfd: int, target_fd: int) -> int:
 # derived from its PID. Importers include the exporter PID and an
 # opaque FD key in the 64-byte VMM handle payload; on ``get_tensor`` they
 # connect to the UDS and receive the FD via SCM_RIGHTS. FDs stay registered
-# for the lifetime of the exporter process (KV cache tensors are permanent
-# from FlexKV's perspective) so there is no unregistration API to design.
+# until the connector confirms every FlexKV importer has unmapped before sleep.
 
 import socket
 import threading
@@ -401,6 +405,37 @@ def _check_cu(where: str, result: int) -> None:
     """Raise on non-CUDA_SUCCESS return codes from the driver API."""
     if result != CUDA_SUCCESS:
         raise RuntimeError(f"{where} failed with CUresult={result}")
+
+
+def release_vmm_tensor(tensor: torch.Tensor) -> bool:
+    """Release a VMM mapping created by ``TensorSharedHandle.get_tensor``.
+
+    The caller must drain transfers and synchronize all streams first. The
+    tensor becomes invalid immediately and must not be accessed again.
+    """
+    if libcuda is None:
+        return False
+
+    data_ptr = tensor.data_ptr()
+    mapping = _IMPORTED_VMM_MAPPINGS.get(data_ptr)
+    if mapping is None:
+        return False
+
+    base, allocation_size = mapping
+    res = libcuda.cuMemUnmap(
+        ctypes.c_ulonglong(base), ctypes.c_size_t(allocation_size)
+    )
+    _check_cu("cuMemUnmap", res)
+    res = libcuda.cuMemAddressFree(
+        ctypes.c_ulonglong(base), ctypes.c_size_t(allocation_size)
+    )
+    _check_cu("cuMemAddressFree", res)
+    del _IMPORTED_VMM_MAPPINGS[data_ptr]
+    flexkv_logger.debug(
+        f"Released imported VMM tensor: base=0x{base:x}, "
+        f"size={allocation_size}"
+    )
+    return True
 
 
 def _is_vmm_pointer(data_ptr: int) -> bool:
@@ -632,10 +667,9 @@ class TensorSharedHandle:
                 # cross-process we register the FD with a small
                 # SCM_RIGHTS-serving thread (see _vmm_fd_server_*) and
                 # ship (pid, key) as bytes; the importer connects to the
-                # UDS, sends the key, and receives the FD back. The
-                # exporter keeps its FD open for the lifetime of the
-                # process (see _EXPORTED_VMM_FDS below) so importers may
-                # arrive arbitrarily later.
+                # UDS, sends the key, and receives the FD back. The connector
+                # closes it only after the node manager confirms that every
+                # transfer-worker importer has unmapped it.
                 fd_out = ctypes.c_int(-1)
                 res = libcuda.cuMemExportToShareableHandle(
                     ctypes.byref(fd_out),
@@ -644,8 +678,11 @@ class TensorSharedHandle:
                     ctypes.c_ulonglong(0),
                 )
                 _check_cu("cuMemExportToShareableHandle(POSIX_FD)", res)
-                _EXPORTED_VMM_FDS.append(int(fd_out.value))
-                key = _vmm_fd_server_register(int(fd_out.value))
+                exported_fd = int(fd_out.value)
+                _EXPORTED_VMM_FDS.append(exported_fd)
+                key = _vmm_fd_server_register(exported_fd)
+                self._exported_vmm_fd = exported_fd
+                self._exported_vmm_fd_key = key
                 self.ipc_handle = _pack_vmm_fd(os.getpid(), key)
                 self.handle_type = "vmm_posix_fd"
             else:
@@ -800,6 +837,25 @@ class TensorSharedHandle:
             self.rebuild_func, self.rebuild_args, self.device
         )
 
+    def release_exported_vmm_handle(self) -> bool:
+        """Close this exporter-side POSIX FD after all importers unmap."""
+        fd = getattr(self, "_exported_vmm_fd", None)
+        key = getattr(self, "_exported_vmm_fd_key", None)
+        if fd is None:
+            return False
+        state = _VMM_FD_SERVER_STATE
+        with state["lock"]:
+            if key is not None and state["fd_by_key"].get(key) == fd:
+                del state["fd_by_key"][key]
+        try:
+            os.close(fd)
+        finally:
+            if fd in _EXPORTED_VMM_FDS:
+                _EXPORTED_VMM_FDS.remove(fd)
+            self._exported_vmm_fd = None
+            self._exported_vmm_fd_key = None
+        return True
+
     ## Import CUDA VMM allocation
     @staticmethod
     def _import_vmm_handle(
@@ -814,13 +870,8 @@ class TensorSharedHandle:
     ) -> torch.Tensor:
         """Rehydrate a VMM allocation exported via cuMemExportToShareableHandle.
 
-        The exporter side sent us just the 64-byte fabric handle. Here we
-        cuMemImportFromShareableHandle -> cuMemAddressReserve ->
-        cuMemMap -> cuMemSetAccess, then wrap the virtual address in a
-        zero-copy torch tensor. The imported allocation stays mapped for
-        the lifetime of the process; freeing it would invalidate every
-        tensor we handed out, and FlexKV's KVManager already owns the
-        registration lifetime.
+        The returned tensor owns no storage. Its process-local VMM mapping is
+        tracked until ``release_vmm_tensor`` is called before exporter sleep.
         """
         if libcuda is None:
             raise RuntimeError(
@@ -937,13 +988,38 @@ class TensorSharedHandle:
         libcuda.cuMemRelease(mem_handle)
 
         data_ptr = va.value + int(offset)
+        if data_ptr in _IMPORTED_VMM_MAPPINGS:
+            raise RuntimeError(
+                f"duplicate imported VMM tensor pointer 0x{data_ptr:x}"
+            )
+        _IMPORTED_VMM_MAPPINGS[data_ptr] = (
+            int(va.value), int(allocation_size)
+        )
         flexkv_logger.info(
             f"Imported VMM tensor: device={device}, base=0x{va.value:x}, "
             f"offset={offset}, size={allocation_size}"
         )
-        return TensorSharedHandle._create_tensor_from_cuda_ptr(
-            data_ptr, shape, dtype, device
-        )
+        try:
+            return TensorSharedHandle._create_tensor_from_cuda_ptr(
+                data_ptr, shape, dtype, device
+            )
+        except Exception:
+            _IMPORTED_VMM_MAPPINGS.pop(data_ptr, None)
+            _check_cu(
+                "cuMemUnmap",
+                libcuda.cuMemUnmap(
+                    ctypes.c_ulonglong(va.value),
+                    ctypes.c_size_t(allocation_size),
+                ),
+            )
+            _check_cu(
+                "cuMemAddressFree",
+                libcuda.cuMemAddressFree(
+                    ctypes.c_ulonglong(va.value),
+                    ctypes.c_size_t(allocation_size),
+                ),
+            )
+            raise
 
     ## Export tensor handle
     @staticmethod

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -256,6 +256,7 @@ class FlexKVConnector:
             self.flexkv_config.gpu_register_port,
             dp_client_id=self.rank_info.dp_client_id,
             pp_rank=self.rank_info.pp_rank,
+            intra_client_id=self.rank_info.intra_client_id,
             device_id=self.rank_info.local_rank,
         )
         self._register_with_retry(kv_caches, indexer_buffers)

--- a/flexkv/integration/tensorrt_llm/trtllm_adapter.py
+++ b/flexkv/integration/tensorrt_llm/trtllm_adapter.py
@@ -527,6 +527,7 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
             flexkv_config.gpu_register_port,
             dp_client_id=rank_info.dp_client_id,
             pp_rank=rank_info.pp_rank,
+            intra_client_id=rank_info.intra_client_id,
             device_id=rank_info.local_rank,
         )
         flexkv_logger.info("Finish init FlexKVWorkerConnector")
@@ -644,4 +645,3 @@ class FlexKVWorkerConnector(KvCacheConnectorWorker):
         """Cleanup on deletion."""
         if hasattr(self, 'remote_process') and self.remote_process is not None:
             self.shutdown()
-

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -507,15 +507,17 @@ class FlexKVSchedulerConnector:
         request: "Request",
         block_ids: list[int],
     ) -> bool:
-        """
+        """Handle a vLLM request before its KV cache blocks are freed.
+
         Args:
-            request: Request to put.
-            blocks: All block_ids of the request.
+            request: The vLLM scheduler request being finalized.
+            block_ids: IDs of all GPU KV cache blocks owned by the request.
 
         Returns:
-            bool: whether thire is unfinished task for this request.
+            True if a FlexKV transfer still needs the request's blocks and
+            vLLM must defer freeing them; False if the blocks can be freed.
         """
-        # Task not finished, can't free blocks
+        # An existing FlexKV task still owns these blocks, so keep them alive.
         if request.request_id in self.req_id_to_task_dict:
             return True
 
@@ -525,9 +527,8 @@ class FlexKVSchedulerConnector:
             finish_reason == FinishReason.ABORT
             and bool(getattr(request, "offload_kv_on_finish", False))
         )
-        if not request.is_finished() or not (
-            normal_finish or requested_abort_offload
-        ):
+        should_put = request.is_finished() and (normal_finish or requested_abort_offload)
+        if not should_put:
             return False
 
         if self.maybe_skip_put and os.path.exists('/tmp/flexkv_skip_put'):

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -284,6 +284,23 @@ class FlexKVSchedulerConnector:
         if self.collector is not None:
             self.collector.close()
 
+    def reset_cache(self) -> bool:
+        """Fully invalidate the FlexKV cache (all tiers).
+
+        Invoked from vLLM's scheduler via reset_prefix_cache(reset_connector=True)
+        after a weight update, so KV computed against stale weights is dropped.
+        Also clears local scheduler-side task bookkeeping.
+        """
+        self.flexkv_manager.reset()
+        # Drop stale local bookkeeping so no dangling task refs survive the reset.
+        self.req_id_to_task_dict.clear()
+        self.get_tasks.clear()
+        self.put_tasks.clear()
+        self.tasks_to_launch.clear()
+        self.tasks_to_cancel.clear()
+        self.failed_block_ids.clear()
+        return True
+
     ####################
     #### Get Method ####
     ####################
@@ -962,6 +979,14 @@ class FlexKVConnectorV1Impl:
     def shutdown(self):
         if self.role == KVConnectorRole.SCHEDULER:
             self.connector.shutdown()
+
+    def reset_cache(self) -> Optional[bool]:
+        """Reset the FlexKV cache. Only meaningful on the scheduler side
+        (vLLM invokes connector.reset_cache() from the scheduler process).
+        """
+        if self.role == KVConnectorRole.SCHEDULER:
+            return self.connector.reset_cache()
+        return None
 
     # ==============================
     # Worker-side methods

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -812,6 +812,7 @@ class FlexKVWorkerConnector:
             flexkv_config.gpu_register_port,
             dp_client_id=rank_info.dp_client_id,
             pp_rank=rank_info.pp_rank,
+            intra_client_id=rank_info.intra_client_id,
             device_id=rank_info.local_rank,
         )
         logger.info("Finish init FlexKVWorkerConnector")

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -817,7 +817,9 @@ class FlexKVWorkerConnector:
         )
         logger.info("Finish init FlexKVWorkerConnector")
 
-    def register_to_server(self, kv_caches: dict[str, torch.Tensor]):
+    def register_to_server(
+        self, kv_caches: dict[str, torch.Tensor], *, resume: bool = False
+    ):
         logger.info("Start register kv_caches")
 
         # Separate main KV caches from indexer caches by layer name.
@@ -895,6 +897,7 @@ class FlexKVWorkerConnector:
             self.tp_client.register_to_server(
                 kv_caches=gpu_blocks,
                 kv_layout=gpu_layout,
+                resume=resume,
             )
         else:
             indexer_buffers = list(indexer_kv_caches.values())
@@ -938,9 +941,19 @@ class FlexKVWorkerConnector:
                 layer_groups=layer_groups,
                 gpu_layouts=[gpu_layout, indexer_layout],
                 handles_per_group=[gpu_blocks, indexer_buffers],
+                resume=resume,
             )
 
         logger.info("Finish register kv_caches")
+        self._registered_kv_caches = dict(kv_caches)
+
+    def before_device_sleep(self) -> int:
+        return self.tp_client.suspend_gpu_mappings()
+
+    def after_device_wake(self) -> None:
+        if not hasattr(self, "_registered_kv_caches"):
+            raise RuntimeError("KV caches were not registered before wake")
+        self.register_to_server(self._registered_kv_caches, resume=True)
 
     def __del__(self):
         if hasattr(self, "remote_transfer_manager_process") and \
@@ -1088,6 +1101,14 @@ class FlexKVConnectorV1Impl:
             dictionary of layer names, kv cache
         """
         self.connector.register_to_server(kv_caches)
+
+    def before_device_sleep(self) -> None:
+        if self.role == KVConnectorRole.WORKER:
+            self.connector.before_device_sleep()
+
+    def after_device_wake(self) -> None:
+        if self.role == KVConnectorRole.WORKER:
+            self.connector.after_device_wake()
 
     # ==============================
     # Scheduler-side methods

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -285,14 +285,20 @@ class FlexKVSchedulerConnector:
             self.collector.close()
 
     def reset_cache(self) -> bool:
-        """Fully invalidate the FlexKV cache (all tiers).
+        """Invalidate the FlexKV cache: drop the radix tree + mempool on every
+        tier, so KV computed against stale weights can no longer be matched.
 
         Invoked from vLLM's scheduler via reset_prefix_cache(reset_connector=True)
-        after a weight update, so KV computed against stale weights is dropped.
-        Also clears local scheduler-side task bookkeeping.
+        after a weight update. Safety relies only on the radix tree being
+        cleared (get_match can no longer hit stale KV); in-flight transfers need
+        not be drained.
+
+        We also clear this connector's own per-request bookkeeping. These dicts
+        map vLLM request_id -> flexkv task_id for requests currently in flight;
+        after a reset those task_ids reference dropped cache, so we clear them to
+        avoid dangling references (they are normally empty at a reset boundary).
         """
         self.flexkv_manager.reset()
-        # Drop stale local bookkeeping so no dangling task refs survive the reset.
         self.req_id_to_task_dict.clear()
         self.get_tasks.clear()
         self.put_tasks.clear()

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -667,7 +667,7 @@ class FlexKVSchedulerConnector:
         if get_task_ids:
             launched_get_task_ids = self.flexkv_manager.launch(task_ids=get_task_ids,
                                        slot_mappings=get_slot_mappings,
-                                       as_batch=self.enable_batch)
+                                       as_batch=self.enable_batch and len(get_task_ids) > 1)
             if len(launched_get_task_ids) == 1 and len(get_tasks_to_launch) > 1:
                 self.get_tasks[launched_get_task_ids[0]] = get_tasks_to_launch
             elif len(launched_get_task_ids) == len(get_tasks_to_launch):
@@ -678,7 +678,7 @@ class FlexKVSchedulerConnector:
         if put_task_ids:
             launched_put_task_ids = self.flexkv_manager.launch(task_ids=put_task_ids,
                                        slot_mappings=put_slot_mappings,
-                                       as_batch=self.enable_batch)
+                                       as_batch=self.enable_batch and len(put_task_ids) > 1)
             if len(launched_put_task_ids) == 1 and len(put_tasks_to_launch) > 1:
                 self.put_tasks[launched_put_task_ids[0]] = put_tasks_to_launch
             elif len(launched_put_task_ids) == len(put_tasks_to_launch):

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -22,6 +22,7 @@ from flexkv.transfer_manager import TransferManagerOnRemote
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata, KVConnectorRole)
 from vllm.distributed.parallel_state import get_tp_group
+from vllm.v1.engine import FinishReason
 
 # KVConnectorStats: available since v0.11.0
 try:
@@ -518,8 +519,15 @@ class FlexKVSchedulerConnector:
         if request.request_id in self.req_id_to_task_dict:
             return True
 
-        # Abnormal finished, don't put
-        if not (request.is_finished() and request.get_finished_reason() < 2):
+        finish_reason = request.get_finished_reason()
+        normal_finish = finish_reason in (FinishReason.STOP, FinishReason.LENGTH)
+        requested_abort_offload = (
+            finish_reason == FinishReason.ABORT
+            and bool(getattr(request, "offload_kv_on_finish", False))
+        )
+        if not request.is_finished() or not (
+            normal_finish or requested_abort_offload
+        ):
             return False
 
         if self.maybe_skip_put and os.path.exists('/tmp/flexkv_skip_put'):

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -335,7 +335,7 @@ class KVManager:
         if isinstance(task_ids, int):
             task_ids = [task_ids]
         if self.server_client_mode:
-            self.dp_client.cancel_task(task_ids)
+            self.dp_client.cancel_tasks(task_ids)
         else:
             self.kv_task_engine.cancel_tasks(task_ids)
 

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -69,17 +69,29 @@ class KVManager:
         self.server_client_mode = (model_config.dp_size > 1 or
                                    model_config.instance_num > 1 or
                                    GLOBAL_CONFIG_FROM_ENV.server_client_mode)
+        self.server_launch_mode = GLOBAL_CONFIG_FROM_ENV.server_launch_mode
+        if self.server_launch_mode not in ("embedded", "external"):
+            raise ValueError(
+                "FLEXKV_SERVER_LAUNCH_MODE must be embedded or external, "
+                f"got {self.server_launch_mode!r}"
+            )
+        if self.server_launch_mode == "external" and not self.server_client_mode:
+            raise ValueError(
+                "FLEXKV_SERVER_LAUNCH_MODE=external requires server-client mode"
+            )
 
         flexkv_logger.info(
             f"[KVManager] instance_num={model_config.instance_num}, dp_size={model_config.dp_size}, "
-            f"server_client_mode={self.server_client_mode}"
+            f"server_client_mode={self.server_client_mode}, "
+            f"server_launch_mode={self.server_launch_mode}"
         )
 
         self.redis_meta_client = None
         self.enable_mps = GLOBAL_CONFIG_FROM_ENV.enable_mps
+        self.owns_mps = self.enable_mps and self.server_launch_mode != "external"
 
         if self.server_client_mode:
-            if dp_client_id == 0:
+            if self.server_launch_mode == "embedded" and dp_client_id == 0:
                 self.server_handle = KVServer.create_server(model_config=model_config,
                                                             cache_config=cache_config,
                                                             gpu_register_port=self.gpu_register_port,
@@ -119,7 +131,7 @@ class KVManager:
             )
 
     def start(self) -> None:
-        if self.enable_mps:
+        if self.owns_mps:
             # try to start MPS
             subprocess.run(['nvidia-cuda-mps-control', '-d'], check=False)
             flexkv_logger.debug("MPS started")
@@ -140,15 +152,18 @@ class KVManager:
         flexkv_logger.info("[FLEXKV] KVManager.shutdown begin.")
         eviction_log_aggregator.flush()
         if self.server_client_mode:
-            self.dp_client.shutdown()
-            # Wait for the server process to exit after sending shutdown request
-            if self.server_handle is not None:
-                self.server_handle.shutdown()
-                self.server_handle = None
+            if self.server_launch_mode == "external":
+                self.dp_client.unregister()
+            else:
+                self.dp_client.shutdown()
+                # Wait for the server process to exit after sending shutdown request
+                if self.server_handle is not None:
+                    self.server_handle.shutdown()
+                    self.server_handle = None
         else:
             self.kv_task_engine.shutdown()
 
-        if self.enable_mps:
+        if self.owns_mps:
             flexkv_logger.info(
                 "MPS is enabled. To stop MPS daemon manually, run: "
                 "'echo quit | nvidia-cuda-mps-control'"

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -351,14 +351,15 @@ class KVManager:
         else:
             self.kv_task_engine._clear_cpu_cache()
 
-    def reset(self, timeout: float = 20.0) -> None:
-        """Fully invalidate the cache across all tiers (CPU + SSD + remote).
+    def reset(self) -> None:
+        """Invalidate the cache across all tiers (CPU + SSD + remote): drop the
+        radix tree and free the mempool.
 
         Call after a weight update so KV computed against stale weights is not
-        reused. Works in both in-process and server-client mode. Idempotent and
-        cheap when the cache is already empty / has no in-flight tasks.
+        reused. Works in both in-process and server-client mode. Cheap and
+        idempotent (resetting an already-empty tree/mempool is a no-op).
         """
         if self.server_client_mode:
-            self.dp_client.reset(timeout=timeout)
+            self.dp_client.reset()
         else:
-            self.kv_task_engine.reset_cache(drain="wait", timeout=timeout)
+            self.kv_task_engine.reset_cache()

--- a/flexkv/kvmanager.py
+++ b/flexkv/kvmanager.py
@@ -350,3 +350,15 @@ class KVManager:
             return
         else:
             self.kv_task_engine._clear_cpu_cache()
+
+    def reset(self, timeout: float = 20.0) -> None:
+        """Fully invalidate the cache across all tiers (CPU + SSD + remote).
+
+        Call after a weight update so KV computed against stale weights is not
+        reused. Works in both in-process and server-client mode. Idempotent and
+        cheap when the cache is already empty / has no in-flight tasks.
+        """
+        if self.server_client_mode:
+            self.dp_client.reset(timeout=timeout)
+        else:
+            self.kv_task_engine.reset_cache(drain="wait", timeout=timeout)

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -431,6 +431,12 @@ class KVTaskManager:
                     completed_op.num_bytes,
                     operation,
                 )
+            if task.status == TaskStatus.CANCELLED and task.callback is None:
+                # Cache was reset while this task was in flight: reset_cache() cleared its callbacks and freed the radix nodes / mempool blocks
+                flexkv_logger.warning(
+                    f"task {task_id}: transfer op {completed_op.op_id} completed after reset_cache(), callback no longer exists and will be skipped."
+                )
+                continue
             if completed_op.is_graph_completed():
                 self._mark_completed(task_id)
             elif completed_op.op_id == task.task_end_op_id:
@@ -1111,6 +1117,22 @@ class KVTaskEngine(KVTaskManager):
                 f"resetting anyway. In-flight transfers may target blocks that are "
                 f"being freed — ensure reset is issued at a quiesced boundary."
             )
+
+        # Invalidate in-flight tasks' callbacks BEFORE dropping the cache. The
+        # callback / op_callback_dict partials close over the exact radix nodes
+        # and mempool blocks we are about to free; if a late transfer fired them
+        # after reset they would unlock/set_ready a deleted node, or recycle a
+        # block into the freshly-emptied mempool (which raises "already free").
+        # Clear them here so the dispatch in _update_tasks has nothing to fire.
+        # Note: reset_cache() runs on the same thread as the callback dispatch
+        # (_update_tasks), so no lock is needed. We keep the graph_to_task
+        # mapping so a late-completing op still resolves to its task and warns.
+        for task_id, task in list(self.tasks.items()):
+            if task.is_completed():
+                continue  # already-fired callbacks are harmless
+            task.callback = None
+            task.op_callback_dict = {}
+            task.status = TaskStatus.CANCELLED
 
         # Drop index (radix tree) + mempool on every tier. CRadixTreeIndex (C++)
         # and the pure-Python RadixTreeIndex both expose reset(); GlobalCacheEngine

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -1088,3 +1088,68 @@ class KVTaskEngine(KVTaskManager):
 
     def _clear_cpu_cache(self) -> None:
         self.cache_engine.cpu_cache_engine.reset()
+
+    def reset_cache(self, drain: str = "wait", timeout: float = 20.0) -> None:
+        """Fully invalidate the cache across ALL tiers (CPU + SSD + remote):
+        drop the whole prefix tree and return every block to the mempool.
+
+        Used after a weight update (e.g. verl RL rollout) so that KV computed
+        against stale weights is never reused.
+
+        Because ``GlobalCacheEngine.reset()`` and the underlying
+        ``index.reset()`` / ``mempool.reset()`` take NO lock, and the real data
+        transfers run asynchronously in the TransferManager processes, we must
+        quiesce in-flight tasks BEFORE resetting; otherwise a late transfer
+        would read/write a block that has already been freed/rebuilt.
+
+        Args:
+            drain: "wait" waits for in-flight tasks to land (default, keeps
+                already-put data consistent); "cancel" aborts them (faster,
+                loses in-flight puts).
+            timeout: wait timeout (seconds) when ``drain == "wait"``.
+        """
+        # ---- part 4: quiesce in-flight tasks ----
+        # Snapshot incomplete task_ids (self.tasks is an ExpiringDict; copy the
+        # items to avoid mutation during iteration). When ② clear_kv_cache has
+        # already drained everything, ③'s snapshot is empty and this is a no-op,
+        # so the §2.5 triple-call collapses to one real drain.
+        pending = [tid for tid, t in list(self.tasks.items()) if not t.is_completed()]
+        if pending:
+            if drain == "cancel":
+                self.cancel_tasks(pending)
+            else:
+                # wait() drives _update_tasks() internally; completely=True
+                # blocks until the transfers have fully landed.
+                try:
+                    self.wait(pending, timeout=timeout, completely=True)
+                except Exception as e:  # noqa: BLE001
+                    flexkv_logger.warning(
+                        f"reset_cache: waiting for in-flight tasks failed ({e}); "
+                        f"forcing cancel before reset."
+                    )
+            # Defensive second pass: force-cancel any task that survived wait
+            # (e.g. timeout) so no TransferManager process still holds a block.
+            still = [tid for tid, t in list(self.tasks.items()) if not t.is_completed()]
+            if still:
+                self.cancel_tasks(still)
+
+        # ---- parts 1+2+3: drop index + mempool on every tier ----
+        self.cache_engine.reset()  # GlobalCacheEngine.reset()
+
+        # ---- part 5: clear task bookkeeping ----
+        # These dicts are NOT inside the cache engine; they track "who is moving
+        # what". drain() only removes entries from self.tasks (via _release_task),
+        # and cancelled tasks may leave stale counters in the *_ops/*_graphs maps
+        # and stale prefetch keys pointing at now-invalid cache. Clear them so no
+        # bookkeeping survives that references the just-reset cache.
+        # self.tasks / self.prefetch_tasks are ExpiringDict (third-party); guard
+        # in case .clear() is not proxied, falling back to per-key deletion.
+        for d in (self.tasks, self.prefetch_tasks):
+            try:
+                d.clear()
+            except AttributeError:
+                for k in list(d.keys()):
+                    d.pop(k, None)
+        self.graph_to_task.clear()
+        self.uncompleted_ops.clear()
+        self.uncompleted_graphs.clear()

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -1089,67 +1089,30 @@ class KVTaskEngine(KVTaskManager):
     def _clear_cpu_cache(self) -> None:
         self.cache_engine.cpu_cache_engine.reset()
 
-    def reset_cache(self, drain: str = "wait", timeout: float = 20.0) -> None:
-        """Fully invalidate the cache across ALL tiers (CPU + SSD + remote):
-        drop the whole prefix tree and return every block to the mempool.
+    def reset_cache(self) -> None:
+        """Invalidate the cache across ALL tiers (CPU + SSD + remote): drop the
+        whole prefix tree and return every block to the mempool.
 
         Used after a weight update (e.g. verl RL rollout) so that KV computed
         against stale weights is never reused.
 
-        Because ``GlobalCacheEngine.reset()`` and the underlying
-        ``index.reset()`` / ``mempool.reset()`` take NO lock, and the real data
-        transfers run asynchronously in the TransferManager processes, we must
-        quiesce in-flight tasks BEFORE resetting; otherwise a late transfer
-        would read/write a block that has already been freed/rebuilt.
-
-        Args:
-            drain: "wait" waits for in-flight tasks to land (default, keeps
-                already-put data consistent); "cancel" aborts them (faster,
-                loses in-flight puts).
-            timeout: wait timeout (seconds) when ``drain == "wait"``.
+        We do NOT drain or cancel in-flight transfers here. verl issues the
+        reset at a rollout/weight-update boundary where no new generation
+        requests are being served, so in practice no task is ongoing. If any
+        task IS still in flight we only warn: resetting the radix tree +
+        mempool is cheap and the stale-weight invalidation must not be blocked
+        on transfer completion. This mirrors vLLM's own reset_encoder_cache /
+        reset_mm_cache, which likewise only warn on has_unfinished_requests().
         """
-        # ---- part 4: quiesce in-flight tasks ----
-        # Snapshot incomplete task_ids (self.tasks is an ExpiringDict; copy the
-        # items to avoid mutation during iteration). When ② clear_kv_cache has
-        # already drained everything, ③'s snapshot is empty and this is a no-op,
-        # so the §2.5 triple-call collapses to one real drain.
-        pending = [tid for tid, t in list(self.tasks.items()) if not t.is_completed()]
-        if pending:
-            if drain == "cancel":
-                self.cancel_tasks(pending)
-            else:
-                # wait() drives _update_tasks() internally; completely=True
-                # blocks until the transfers have fully landed.
-                try:
-                    self.wait(pending, timeout=timeout, completely=True)
-                except Exception as e:  # noqa: BLE001
-                    flexkv_logger.warning(
-                        f"reset_cache: waiting for in-flight tasks failed ({e}); "
-                        f"forcing cancel before reset."
-                    )
-            # Defensive second pass: force-cancel any task that survived wait
-            # (e.g. timeout) so no TransferManager process still holds a block.
-            still = [tid for tid, t in list(self.tasks.items()) if not t.is_completed()]
-            if still:
-                self.cancel_tasks(still)
+        ongoing = sum(1 for t in list(self.tasks.values()) if not t.is_completed())
+        if ongoing:
+            flexkv_logger.warning(
+                f"reset_cache called while {ongoing} task(s) are still in flight; "
+                f"resetting anyway. In-flight transfers may target blocks that are "
+                f"being freed — ensure reset is issued at a quiesced boundary."
+            )
 
-        # ---- parts 1+2+3: drop index + mempool on every tier ----
+        # Drop index (radix tree) + mempool on every tier. CRadixTreeIndex (C++)
+        # and the pure-Python RadixTreeIndex both expose reset(); GlobalCacheEngine
+        # fans out to whichever tier engines are enabled.
         self.cache_engine.reset()  # GlobalCacheEngine.reset()
-
-        # ---- part 5: clear task bookkeeping ----
-        # These dicts are NOT inside the cache engine; they track "who is moving
-        # what". drain() only removes entries from self.tasks (via _release_task),
-        # and cancelled tasks may leave stale counters in the *_ops/*_graphs maps
-        # and stale prefetch keys pointing at now-invalid cache. Clear them so no
-        # bookkeeping survives that references the just-reset cache.
-        # self.tasks / self.prefetch_tasks are ExpiringDict (third-party); guard
-        # in case .clear() is not proxied, falling back to per-key deletion.
-        for d in (self.tasks, self.prefetch_tasks):
-            try:
-                d.clear()
-            except AttributeError:
-                for k in list(d.keys()):
-                    d.pop(k, None)
-        self.graph_to_task.clear()
-        self.uncompleted_ops.clear()
-        self.uncompleted_graphs.clear()

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -94,12 +94,13 @@ class KVDPClient:
         response: Response = self.recv_from_server.recv_pyobj()
         return response.is_ready
 
-    def reset(self, timeout: float = 20.0) -> None:
-        """Fully invalidate the shared FlexKV cache on the server.
+    def reset(self) -> None:
+        """Invalidate the shared FlexKV cache on the server (drop radix tree +
+        mempool on every tier).
 
         Synchronous round-trip (mirrors is_ready): blocks until the server has
-        finished draining in-flight tasks and resetting every tier. Only ONE
-        client needs to call this — the cache is global to the server process.
+        finished resetting. Only ONE client needs to call this — the cache is
+        global to the server process.
         """
         req = ResetRequest(self.dp_client_id)
         self.send_to_server.send_pyobj(req)

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -30,6 +30,7 @@ from flexkv.server.request import (
     CheckRunningRequest,
     StartRequest,
     ShutdownRequest,
+    ResetRequest,
     PrefetchRequest,
     Response
 )
@@ -92,6 +93,19 @@ class KVDPClient:
         self.send_to_server.send_pyobj(req)
         response: Response = self.recv_from_server.recv_pyobj()
         return response.is_ready
+
+    def reset(self, timeout: float = 20.0) -> None:
+        """Fully invalidate the shared FlexKV cache on the server.
+
+        Synchronous round-trip (mirrors is_ready): blocks until the server has
+        finished draining in-flight tasks and resetting every tier. Only ONE
+        client needs to call this — the cache is global to the server process.
+        """
+        req = ResetRequest(self.dp_client_id)
+        self.send_to_server.send_pyobj(req)
+        response: Response = self.recv_from_server.recv_pyobj()
+        if response.error_msg:
+            raise RuntimeError(f"flexkv reset failed on server: {response.error_msg}")
 
     def put_async(
         self,

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -58,6 +58,7 @@ class KVDPClient:
         self._task_id_range = (self.dp_client_id * 10000000, (self.dp_client_id + 1) * 10000000)
         self._task_id_counter = self._task_id_range[0]
         self._task_id_lock = Lock()
+        self._rpc_lock = Lock()
         flexkv_logger.info(f"KVDPClient Initialized! [DP Client ID]: {self.dp_client_id}")
 
     def _get_task_id(self) -> int:
@@ -214,21 +215,22 @@ class KVDPClient:
         counter_id: int = 0,
         swa_slot_mappings: Optional[List[Optional[np.ndarray]]] = None,
     ) -> List[int]:
-        batch_id = -1
-        if as_batch:
-            batch_id = self._get_task_id()
-        req = LaunchTaskRequest(
-            dp_client_id=self.dp_client_id,
-            task_ids=task_ids,
-            slot_mappings=slot_mappings,
-            swa_slot_mappings=swa_slot_mappings,
-            as_batch=as_batch,
-            batch_id=batch_id,
-            layerwise_transfer=layerwise_transfer,
-            counter_id=counter_id,
-        )
-        self.send_to_server.send_pyobj(req)
-        return [batch_id] if as_batch else task_ids
+        with self._rpc_lock:
+            batch_id = -1
+            if as_batch:
+                batch_id = self._get_task_id()
+            req = LaunchTaskRequest(
+                dp_client_id=self.dp_client_id,
+                task_ids=task_ids,
+                slot_mappings=slot_mappings,
+                swa_slot_mappings=swa_slot_mappings,
+                as_batch=as_batch,
+                batch_id=batch_id,
+                layerwise_transfer=layerwise_transfer,
+                counter_id=counter_id,
+            )
+            self.send_to_server.send_pyobj(req)
+            return [batch_id] if as_batch else task_ids
 
     def cancel_tasks(
         self,
@@ -261,8 +263,9 @@ class KVDPClient:
     ) -> Optional[Dict[int, KVResponse]]:
         req = TryWaitRequest(self.dp_client_id, try_wait_task_ids)
 
-        self.send_to_server.send_pyobj(req)
-        response: Response = self.recv_from_server.recv_pyobj()
+        with self._rpc_lock:
+            self.send_to_server.send_pyobj(req)
+            response: Response = self.recv_from_server.recv_pyobj()
         if response.status is not None:
             for k, v in response.status.items():
                 if v.status != KVResponseStatus.SUCCESS:

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -230,7 +230,7 @@ class KVDPClient:
         self.send_to_server.send_pyobj(req)
         return [batch_id] if as_batch else task_ids
 
-    def cancel_task(
+    def cancel_tasks(
         self,
         task_ids: List[int],
     ) -> None:

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -30,6 +30,7 @@ from flexkv.server.request import (
     CheckRunningRequest,
     StartRequest,
     ShutdownRequest,
+    UnregisterDPClientRequest,
     ResetRequest,
     PrefetchRequest,
     Response
@@ -274,6 +275,12 @@ class KVDPClient:
     def shutdown(self) -> None:
         req = ShutdownRequest(self.dp_client_id)
         self.send_to_server.send_pyobj(req)
+
+    def unregister(self) -> None:
+        """Detach this client without stopping the shared KVServer."""
+        req = UnregisterDPClientRequest(self.dp_client_id)
+        self.send_to_server.send_pyobj(req)
+
 
 class KVTPClient:
     def __init__(

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -282,6 +282,7 @@ class KVTPClient:
         dp_client_id: int,
         device_id: int,
         pp_rank: int = 0,
+        intra_client_id: int = 0,
     ):
         """A TP-level GPU registration client."""
         # Init inter-process communication
@@ -292,12 +293,14 @@ class KVTPClient:
 
         self.dp_client_id = dp_client_id
         self.pp_rank = pp_rank
+        self.intra_client_id = intra_client_id
         self.device_id = device_id
 
         flexkv_logger.info(
             f"KVTPClient {device_id} Initialized! "
             f"(gpu_register_port={gpu_register_port}, "
-            f"dp_client_id={dp_client_id}, pp_rank={pp_rank})")
+            f"dp_client_id={dp_client_id}, pp_rank={pp_rank}, "
+            f"intra_client_id={intra_client_id})")
 
     def set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
         """Send set_slot_mapping message to TransferManagerOnRemote via existing ZMQ channel.
@@ -402,6 +405,7 @@ class KVTPClient:
         register_req = RegisterTPClientRequest(
             dp_client_id=self.dp_client_id,
             pp_rank=self.pp_rank,
+            intra_client_id=self.intra_client_id,
             device_id=device_id,
             handles=handles,
             gpu_layout=kv_layout,
@@ -420,6 +424,7 @@ class KVTPClient:
             flexkv_logger.info(
                 f"KVTPClient {device_id}: registration message sent "
                 f"(dp_client_id={self.dp_client_id}, pp_rank={self.pp_rank}, "
+                f"intra_client_id={self.intra_client_id}, "
                 f"num_kv_caches={len(kv_caches)})")
         except zmq.Again:
             flexkv_logger.error(

--- a/flexkv/server/client.py
+++ b/flexkv/server/client.py
@@ -297,6 +297,13 @@ class KVTPClient:
         self.send_to_server = get_zmq_socket(
             context, zmq.SocketType.PUSH, gpu_register_port, False
         )
+        self.gpu_control_socket = get_zmq_socket(
+            context, zmq.SocketType.REQ,
+            f"{gpu_register_port}_control", False,
+        )
+        self.gpu_control_socket.setsockopt(zmq.RCVTIMEO, 120000)
+        self.gpu_control_socket.setsockopt(zmq.SNDTIMEO, 120000)
+        self._exported_handles: List[TensorSharedHandle] = []
 
         self.dp_client_id = dp_client_id
         self.pp_rank = pp_rank
@@ -336,6 +343,21 @@ class KVTPClient:
                 f"for task_id={task_id}"
             )
 
+    def suspend_gpu_mappings(self) -> int:
+        self.gpu_control_socket.send_pyobj({
+            "type": "suspend_gpu",
+            "registration_key": (self.dp_client_id, self.intra_client_id),
+        })
+        response = self.gpu_control_socket.recv_pyobj()
+        if not response.get("ok"):
+            raise RuntimeError(
+                f"FlexKV GPU unmap failed: {response.get('error')}"
+            )
+        for handle in self._exported_handles:
+            handle.release_exported_vmm_handle()
+        self._exported_handles = []
+        return int(response.get("released_mappings", 0))
+
     def register_to_server(
         self,
         kv_caches: List[torch.Tensor],
@@ -349,6 +371,7 @@ class KVTPClient:
         swa_layer_groups: Optional[List[LayerGroupSpec]] = None,
         swa_gpu_layouts: Optional[List[KVCacheLayout]] = None,
         swa_handles_per_group: Optional[List[List[torch.Tensor]]] = None,
+        resume: bool = False,
     ) -> None:
         if not kv_caches or not kv_caches[0].is_cuda:
             raise ValueError("GPU blocks must be CUDA tensors")
@@ -426,8 +449,34 @@ class KVTPClient:
             swa_handles_per_group=swa_handles_per_group_shared,
         )
 
+        exported_handles = list(handles)
+        for group in handles_per_group_shared or []:
+            exported_handles.extend(group)
+        exported_handles.extend(swa_handles_shared or [])
+        for group in swa_handles_per_group_shared or []:
+            exported_handles.extend(group)
+
+        if resume:
+            self.gpu_control_socket.send_pyobj({
+                "type": "resume_gpu",
+                "registration": register_req,
+            })
+            response = self.gpu_control_socket.recv_pyobj()
+            if not response.get("ok"):
+                raise RuntimeError(
+                    f"FlexKV GPU remap failed: {response.get('error')}"
+                )
+            self._exported_handles = exported_handles
+            flexkv_logger.info(
+                f"KVTPClient {device_id}: post-wake registration accepted "
+                f"(ready={response.get('ready')}, "
+                f"registered={response.get('registered')})"
+            )
+            return
+
         try:
             self.send_to_server.send_pyobj(register_req, flags=zmq.NOBLOCK)
+            self._exported_handles = exported_handles
             flexkv_logger.info(
                 f"KVTPClient {device_id}: registration message sent "
                 f"(dp_client_id={self.dp_client_id}, pp_rank={self.pp_rank}, "
@@ -438,6 +487,7 @@ class KVTPClient:
                 f"KVTPClient {device_id}: zmq.Again when sending registration "
                 f"(send buffer full or no connection). Retrying with blocking send...")
             self.send_to_server.send_pyobj(register_req)
+            self._exported_handles = exported_handles
             flexkv_logger.info(f"KVTPClient {device_id}: registration message sent (blocking retry)")
 
 

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -155,5 +155,10 @@ class ShutdownRequest:
 
 
 @dataclass
+class ResetRequest:
+    dp_client_id: int
+
+
+@dataclass
 class CheckRunningRequest:
     dp_client_id: int

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -163,6 +163,11 @@ class ShutdownRequest:
 
 
 @dataclass
+class UnregisterDPClientRequest:
+    dp_client_id: int
+
+
+@dataclass
 class ResetRequest:
     dp_client_id: int
 

--- a/flexkv/server/request.py
+++ b/flexkv/server/request.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -7,6 +7,9 @@ from flexkv.common.config import ModelConfig, LayerGroupSpec
 from flexkv.common.memory_handle import TensorSharedHandle
 from flexkv.common.storage import KVCacheLayout
 from flexkv.common.request import KVResponseStatus
+
+
+RegistrationKey = Tuple[int, int]
 
 
 @dataclass
@@ -20,6 +23,7 @@ class RegisterDPClientRequest:
 class RegisterTPClientRequest:
     dp_client_id: int
     pp_rank: int
+    intra_client_id: int
     device_id: int
     handles: List[TensorSharedHandle]
     gpu_layout: KVCacheLayout
@@ -38,6 +42,10 @@ class RegisterTPClientRequest:
     swa_layer_groups: Optional[List[LayerGroupSpec]] = None
     swa_gpu_layouts: Optional[List[KVCacheLayout]] = None
     swa_handles_per_group: Optional[List[List[TensorSharedHandle]]] = None
+
+    @property
+    def registration_key(self) -> RegistrationKey:
+        return (self.dp_client_id, self.intra_client_id)
 
 
 @dataclass

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -36,6 +36,7 @@ from flexkv.server.request import (
     Response,
     StartRequest,
     ShutdownRequest,
+    ResetRequest,
     CheckRunningRequest,
     PrefetchRequest,
 )
@@ -201,6 +202,7 @@ class KVServer:
             CancelTaskRequest: self._handle_cancel_task_request,
             TryWaitRequest: self._handle_try_wait_request,
             ShutdownRequest: self._handle_shutdown_request,
+            ResetRequest: self._handle_reset_request,
         }
 
     def is_ready(self) -> bool:
@@ -477,6 +479,24 @@ class KVServer:
         flexkv_logger.info(f"Received shutdown request from DP client "
                            f"(dp_client_id={req.dp_client_id})")
         self._running = False
+
+    def _handle_reset_request(self, req: ResetRequest) -> None:
+        """Handle cache-reset request: drain in-flight tasks and drop all tiers.
+
+        Synchronous (mirrors _handle_is_ready_request): replies only after the
+        reset has completed, so the client's reset() blocks until done.
+        """
+        flexkv_logger.info(f"Received reset request from DP client "
+                           f"(dp_client_id={req.dp_client_id})")
+        error_msg = None
+        try:
+            self.kv_task_engine.reset_cache(drain="wait")
+        except Exception as e:  # noqa: BLE001
+            error_msg = str(e)
+            flexkv_logger.error(f"reset_cache failed on server: {error_msg}")
+        response = Response(dp_client_id=req.dp_client_id, error_msg=error_msg)
+        result_zmq = self.client_manager.get_zmq(req.dp_client_id)
+        result_zmq.send_pyobj(response)
 
     def __del__(self) -> None:
         self.kv_task_engine.shutdown()

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -36,6 +36,7 @@ from flexkv.server.request import (
     Response,
     StartRequest,
     ShutdownRequest,
+    UnregisterDPClientRequest,
     ResetRequest,
     CheckRunningRequest,
     PrefetchRequest,
@@ -202,6 +203,7 @@ class KVServer:
             CancelTaskRequest: self._handle_cancel_task_request,
             TryWaitRequest: self._handle_try_wait_request,
             ShutdownRequest: self._handle_shutdown_request,
+            UnregisterDPClientRequest: self._handle_unregister_dp_client_request,
             ResetRequest: self._handle_reset_request,
         }
 
@@ -479,6 +481,12 @@ class KVServer:
         flexkv_logger.info(f"Received shutdown request from DP client "
                            f"(dp_client_id={req.dp_client_id})")
         self._running = False
+
+    def _handle_unregister_dp_client_request(self, req: UnregisterDPClientRequest) -> None:
+        """Detach one client while leaving the shared server running."""
+        flexkv_logger.info(f"Received unregister request from DP client "
+                           f"(dp_client_id={req.dp_client_id})")
+        self.client_manager.delete_dp_client(req.dp_client_id)
 
     def _handle_reset_request(self, req: ResetRequest) -> None:
         """Handle cache-reset request: drop radix tree + mempool on all tiers.

--- a/flexkv/server/server.py
+++ b/flexkv/server/server.py
@@ -481,7 +481,7 @@ class KVServer:
         self._running = False
 
     def _handle_reset_request(self, req: ResetRequest) -> None:
-        """Handle cache-reset request: drain in-flight tasks and drop all tiers.
+        """Handle cache-reset request: drop radix tree + mempool on all tiers.
 
         Synchronous (mirrors _handle_is_ready_request): replies only after the
         reset has completed, so the client's reset() blocks until done.
@@ -490,7 +490,7 @@ class KVServer:
                            f"(dp_client_id={req.dp_client_id})")
         error_msg = None
         try:
-            self.kv_task_engine.reset_cache(drain="wait")
+            self.kv_task_engine.reset_cache()
         except Exception as e:  # noqa: BLE001
             error_msg = str(e)
             flexkv_logger.error(f"reset_cache failed on server: {error_msg}")

--- a/flexkv/server/utils.py
+++ b/flexkv/server/utils.py
@@ -27,7 +27,7 @@ def get_zmq_socket(
         set_send_opt()
     elif socket_type == zmq.PULL:
         set_recv_opt()
-    elif socket_type == zmq.DEALER:
+    elif socket_type in (zmq.DEALER, zmq.REQ, zmq.REP):
         set_send_opt()
         set_recv_opt()
     else:

--- a/flexkv/transfer/transfer_engine.py
+++ b/flexkv/transfer/transfer_engine.py
@@ -220,6 +220,7 @@ class TransferEngine:
 
         self.num_gpu_groups = len(self.gpu_handle_groups)
         self._running = False
+        self._gpu_mappings_suspended = False
 
         self._child_id_to_child: Dict[int, TransferOp] = {}
         self._child_to_parent_op_id: Dict[int, int] = {}
@@ -1617,6 +1618,62 @@ class TransferEngine:
                 break
 
         return completed_ops
+
+    def suspend_gpu_mappings(self) -> int:
+        """Drain worker pipes and release imported vLLM VMM mappings."""
+        if self._gpu_mappings_suspended:
+            return 0
+        if GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer:
+            raise NotImplementedError(
+                "GPU hot remap does not support layerwise transfer"
+            )
+        if self.model_config.layer_groups is not None:
+            raise NotImplementedError(
+                "GPU hot remap does not support multi-group KV layouts"
+            )
+        if self._has_swa:
+            raise NotImplementedError(
+                "GPU hot remap does not support SWA KV pools"
+            )
+        if self.op_id_to_op or not self.task_queue.empty():
+            raise RuntimeError(
+                "Cannot suspend GPU mappings with transfers in flight"
+            )
+        released = 0
+        for workers in (self.h2d_workers, self.d2h_workers):
+            for worker in workers.values():
+                released += int(worker.control("suspend_gpu"))
+        self._gpu_mappings_suspended = True
+        return released
+
+    def resume_gpu_mappings(
+        self, gpu_handle_groups: Dict[WorkerKey, List[StorageHandle]]
+    ) -> int:
+        """Import fresh post-wake VMM handles into existing workers."""
+        if not self._gpu_mappings_suspended:
+            raise RuntimeError("GPU mappings are not suspended")
+        if set(gpu_handle_groups) != set(self.gpu_handle_groups):
+            raise ValueError(
+                "GPU worker groups changed across sleep: "
+                f"old={set(self.gpu_handle_groups)}, "
+                f"new={set(gpu_handle_groups)}"
+            )
+        imported = 0
+        for worker_key, handles in gpu_handle_groups.items():
+            payload = (
+                handles[0].get_tensor_handle_list()
+                if self.model_config.effective_tp_size_per_node == 1
+                else [handle.get_tensor_handle_list() for handle in handles]
+            )
+            imported += int(
+                self.h2d_workers[worker_key].control("resume_gpu", payload)
+            )
+            imported += int(
+                self.d2h_workers[worker_key].control("resume_gpu", payload)
+            )
+        self.gpu_handle_groups = gpu_handle_groups
+        self._gpu_mappings_suspended = False
+        return imported
 
     def shutdown(self) -> None:
         """Shutdown the transfer engine"""

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1733,7 +1733,9 @@ class CPURemoteTransferWorker(TransferWorkerBase):
             raise ValueError(f"num_remote_blocks_per_file {self.num_remote_blocks_per_file} "
                              f"is not divisible by round_robin {self.round_robin}")
 
-        self.has_multi_group = cpu_kv_layout.layer_groups is not None
+        self.has_multi_group = (
+            getattr(cpu_kv_layout, "layer_groups", None) is not None
+        )
         if self.has_multi_group:
             if (
                 cpu_kv_layout.type != KVCacheLayoutType.BLOCKFIRST
@@ -2927,7 +2929,7 @@ class PEER2CPUTransferWorker(TransferWorkerBase):
         self.num_cpu_blocks = cpu_kv_layout.num_block
         # For multi-group layouts, get_chunk_size() is invalid;
         # use get_block_stride() which works for both single and multi-group BLOCKFIRST.
-        if cpu_kv_layout.layer_groups is not None:
+        if getattr(cpu_kv_layout, "layer_groups", None) is not None:
             self.block_size = cpu_kv_layout.get_block_stride()
         else:
             self.block_size = cpu_kv_layout.get_chunk_size()

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -32,7 +32,7 @@ except ImportError:
     TPGDSTransferThreadGroup = None
 
 from flexkv.common.debug import flexkv_logger
-from flexkv.common.memory_handle import TensorSharedHandle
+from flexkv.common.memory_handle import TensorSharedHandle, release_vmm_tensor
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.transfer import TransferOp, TransferType, PartitionBlockType
 from flexkv.common.transfer import get_nvtx_range_color, LayerwiseTransferOp
@@ -477,6 +477,35 @@ class TransferWorkerBase(ABC):
     def launch_transfer(self, transfer_op: WorkerTransferOp) -> bool:
         pass
 
+    def _handle_control(self, command: str, payload: Any) -> Any:
+        handler = getattr(self, f"_control_{command}", None)
+        if handler is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support control {command}"
+            )
+        return handler(payload)
+
+    def _reply_control(self, op: Dict[str, Any]) -> None:
+        request_id = op["request_id"]
+        try:
+            reply = {
+                "type": "control_ack",
+                "request_id": request_id,
+                "result": self._handle_control(
+                    op["command"], op.get("payload")
+                ),
+            }
+        except Exception as exc:
+            flexkv_logger.exception(
+                f"Worker control {op.get('command')} failed"
+            )
+            reply = {
+                "type": "control_ack",
+                "request_id": request_id,
+                "error": str(exc),
+            }
+        self.transfer_conn.send(reply)
+
     def run(self) -> None:
         """Main loop for the worker process.
 
@@ -492,7 +521,8 @@ class TransferWorkerBase(ABC):
                 op = self.transfer_conn.recv()
                 if op is None:
                     return
-                op._received_ns = time.perf_counter_ns()
+                if not isinstance(op, dict):
+                    op._received_ns = time.perf_counter_ns()
 
                 batch_ops = [op]
                 shutdown_after_batch = False
@@ -501,9 +531,13 @@ class TransferWorkerBase(ABC):
                     if op is None:
                         shutdown_after_batch = True
                         break
-                    op._received_ns = time.perf_counter_ns()
+                    if not isinstance(op, dict):
+                        op._received_ns = time.perf_counter_ns()
                     batch_ops.append(op)
                 for op in batch_ops:
+                    if isinstance(op, dict) and op.get("type") == "control":
+                        self._reply_control(op)
+                        continue
                     transfer_status = False
                     transfer_start_ns = time.perf_counter_ns()
                     nvtx_pushed = False
@@ -598,6 +632,29 @@ class WorkerHandle:
             trace.inc_inflight()
         self.transfer_conn.send(worker_op)
 
+    def control(
+        self, command: str, payload: Any = None, timeout: float = 120.0
+    ) -> Any:
+        request_id = f"{self.worker_id}:{time.monotonic_ns()}"
+        self.transfer_conn.send({
+            "type": "control",
+            "command": command,
+            "payload": payload,
+            "request_id": request_id,
+        })
+        if not self.transfer_conn.poll(timeout):
+            raise TimeoutError(
+                f"Worker {self.worker_id} timed out handling {command}"
+            )
+        reply = self.transfer_conn.recv()
+        if reply.get("request_id") != request_id:
+            raise RuntimeError(f"Unexpected worker control reply: {reply}")
+        if "error" in reply:
+            raise RuntimeError(
+                f"Worker {self.worker_id} {command} failed: {reply['error']}"
+            )
+        return reply.get("result")
+
     def shutdown(self) -> None:
         try:
             self.transfer_conn.send(None)
@@ -661,6 +718,8 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
         flexkv_logger.info(f"Pinning CPU Memory: {cpu_blocks.numel() * cpu_blocks.element_size() / (1024 ** 3):.2f} GB")
         self._register_host_tensor(cpu_blocks, "cpu_kv_pool")
 
+        self.gpu_device_id = gpu_device_id
+        self._gpu_block_count = len(gpu_blocks)
         self.gpu_blocks = import_tensor_handles(gpu_blocks)
         # Get pointers first
         self.gpu_blocks_ptrs = self._get_layer_ptrs(self.gpu_blocks)
@@ -847,6 +906,41 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             f"total_block_bytes={total_block_bytes}"
         )
 
+    def _control_suspend_gpu(self, payload: Any) -> int:
+        if self.group_transfer_params is not None:
+            raise NotImplementedError(
+                "GPU hot remap does not support multi-group KV layouts"
+            )
+        if not self.gpu_blocks:
+            return 0
+        with torch.cuda.device(self.gpu_device_id):
+            torch.cuda.synchronize()
+        old_blocks = self.gpu_blocks
+        self.gpu_blocks = []
+        self.gpu_blocks_ptrs.zero_()
+        self.gpu_tensor_ptrs = self.gpu_blocks_ptrs
+        released = sum(release_vmm_tensor(tensor) for tensor in old_blocks)
+        if released != len(old_blocks):
+            raise RuntimeError(
+                f"Expected {len(old_blocks)} VMM mappings, released {released}"
+            )
+        return released
+
+    def _control_resume_gpu(
+        self, gpu_blocks: List[TensorSharedHandle]
+    ) -> int:
+        if self.gpu_blocks:
+            raise RuntimeError("GPU blocks are already registered")
+        if len(gpu_blocks) != self._gpu_block_count:
+            raise ValueError(
+                f"Expected {self._gpu_block_count} GPU blocks, "
+                f"got {len(gpu_blocks)}"
+            )
+        self.gpu_blocks = import_tensor_handles(gpu_blocks)
+        self.gpu_blocks_ptrs = self._get_layer_ptrs(self.gpu_blocks)
+        self.gpu_tensor_ptrs = self.gpu_blocks_ptrs
+        return len(self.gpu_blocks)
+
     def _transfer_impl(
         self,
         src_block_ids: torch.Tensor,
@@ -1015,6 +1109,7 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
         imported_gpu_blocks = []
         for handles_in_one_gpu in gpu_blocks:
             imported_gpu_blocks.append(import_tensor_handles(handles_in_one_gpu))
+        self._gpu_block_counts = [len(handles) for handles in gpu_blocks]
         self.gpu_blocks = imported_gpu_blocks
         self.dtype = dtype # note this should be quantized data type
         self.is_mla = gpu_kv_layouts[0].is_mla
@@ -1269,6 +1364,53 @@ class tpGPUCPUTransferWorker(TransferWorkerBase):
             f"total_block_bytes={total_block_bytes}"
         )
 
+
+    def _control_suspend_gpu(self, payload: Any) -> int:
+        if self.tp_group_transfer_groups is not None:
+            raise NotImplementedError(
+                "GPU hot remap does not support multi-group KV layouts"
+            )
+        if not self.gpu_blocks:
+            return 0
+        zero_ptrs = [0] * sum(self._gpu_block_counts)
+        self.tp_transfer_thread_group.update_gpu_block_ptrs(zero_ptrs)
+        old_blocks = self.gpu_blocks
+        self.gpu_blocks = []
+        released = sum(
+            release_vmm_tensor(tensor)
+            for blocks_in_one_gpu in old_blocks
+            for tensor in blocks_in_one_gpu
+        )
+        expected = sum(self._gpu_block_counts)
+        if released != expected:
+            raise RuntimeError(
+                f"Expected {expected} VMM mappings, released {released}"
+            )
+        return released
+
+    def _control_resume_gpu(
+        self, gpu_blocks: List[List[TensorSharedHandle]]
+    ) -> int:
+        if self.gpu_blocks:
+            raise RuntimeError("GPU blocks are already registered")
+        counts = [len(handles) for handles in gpu_blocks]
+        if counts != self._gpu_block_counts:
+            raise ValueError(
+                f"Expected GPU block counts {self._gpu_block_counts}, got {counts}"
+            )
+        imported_gpu_blocks = [
+            import_tensor_handles(handles) for handles in gpu_blocks
+        ]
+        gpu_block_ptrs_flat = [
+            tensor.data_ptr()
+            for blocks_in_one_gpu in imported_gpu_blocks
+            for tensor in blocks_in_one_gpu
+        ]
+        self.tp_transfer_thread_group.update_gpu_block_ptrs(
+            gpu_block_ptrs_flat
+        )
+        self.gpu_blocks = imported_gpu_blocks
+        return len(gpu_block_ptrs_flat)
 
     def _transfer_impl(self,
                        src_block_ids: torch.Tensor,

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -85,6 +85,13 @@ class TransferManager:
         self._pending_resume_registrations: Dict[
             RegistrationKey, RegisterTPClientRequest
         ] = {}
+        # The REP socket above is bound unconditionally, so *every* deployment
+        # mode has to service it -- an unserved REP endpoint turns a
+        # suspend/resume call into a silent 120s RCVTIMEO stall on the client.
+        # The subprocess mode drives it from its selector loop; the other two
+        # modes use the listener thread below.
+        self._gpu_control_shutdown = threading.Event()
+        self._gpu_control_thread: Optional[threading.Thread] = None
 
         self.transfer_engine: Optional[TransferEngine] = None
         self.storage_engine: Optional[StorageEngine] = None
@@ -95,8 +102,20 @@ class TransferManager:
         registration_key = req.registration_key
 
         if registration_key in self.all_gpu_blocks:
+            # A duplicate (dp_client_id, intra_client_id) means the framework
+            # adapter handed us the same logical identity for two different
+            # workers -- typically because it never passes intra_client_id and
+            # every TP rank collapses onto ...0. Registration can then never
+            # reach expected_gpus, so _register_gpu_blocks_via_socket spins
+            # forever printing "Still waiting for GPU registrations: k/N".
+            # Say so explicitly instead of leaving an unexplained hang.
             flexkv_logger.error(
-                f"GPU worker {registration_key} has already registered.")
+                f"GPU worker {registration_key} has already registered. "
+                f"A duplicate registration key from a different worker means "
+                f"registration can never complete and init will hang. Check "
+                f"that the framework adapter passes a per-worker-unique "
+                f"intra_client_id (registered so far: "
+                f"{sorted(self.all_gpu_blocks)}).")
         else:
             try:
                 self.all_gpu_blocks[registration_key] = req.handles
@@ -241,6 +260,59 @@ class TransferManager:
             self.gpu_control_socket.send_pyobj(response)
             processed += 1
         return processed
+
+    def start_gpu_control_listener(self) -> None:
+        """Serve the GPU control REP socket from a dedicated thread.
+
+        For the subprocess mode the selector loop in
+        ``TransferManagerInterProcessHandle._process_worker`` already drains
+        this socket, so it must not call this.  Thread mode and remote mode
+        have no such loop: without this thread the bound REP endpoint accepts
+        connections and then never answers, so a vLLM sleep/wake call blocks
+        for the client's full 120s RCVTIMEO and then fails.
+        """
+        if self._gpu_control_thread is not None:
+            return
+        self._gpu_control_shutdown.clear()
+        self._gpu_control_thread = threading.Thread(
+            target=self._gpu_control_listener,
+            name="flexkv-gpu-control",
+            daemon=True,
+        )
+        self._gpu_control_thread.start()
+
+    def _gpu_control_listener(self) -> None:
+        poller = zmq.Poller()
+        poller.register(self.gpu_control_socket, zmq.POLLIN)
+        try:
+            while not self._gpu_control_shutdown.is_set():
+                try:
+                    # Milliseconds -- zmq.Poller, unlike socket RCVTIMEO, does
+                    # not take seconds.
+                    if not poller.poll(timeout=100):
+                        continue
+                    self.drain_gpu_control_requests()
+                except zmq.ZMQError:
+                    # Context terminated during shutdown.
+                    break
+                except Exception:
+                    if not self._gpu_control_shutdown.is_set():
+                        flexkv_logger.exception(
+                            "GPU control listener failed; retrying"
+                        )
+                        time.sleep(0.01)
+        finally:
+            try:
+                poller.unregister(self.gpu_control_socket)
+            except Exception:
+                pass
+
+    def stop_gpu_control_listener(self) -> None:
+        self._gpu_control_shutdown.set()
+        thread = self._gpu_control_thread
+        self._gpu_control_thread = None
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=1.0)
 
     def _register_gpu_blocks_via_socket(self) -> None:
         try:
@@ -536,6 +608,9 @@ class TransferManagerOnRemote(TransferManager):
         poller = zmq.Poller()
         poller.register(self.command_socket, zmq.POLLIN)
         poller.register(self.query_socket, zmq.POLLIN)
+        # Inherited from TransferManager.__init__, which binds it
+        # unconditionally. Nothing else in this process serves it.
+        poller.register(self.gpu_control_socket, zmq.POLLIN)
 
         while not self._shutdown_flag:
             try:
@@ -572,6 +647,9 @@ class TransferManagerOnRemote(TransferManager):
                             flexkv_logger.warning(f"Unexpected command message type: {type(message)}")
                     except zmq.Again:
                         pass
+
+                if self.gpu_control_socket in socks:
+                    self.drain_gpu_control_requests()
 
                 if self.query_socket in socks:
                     try:
@@ -614,6 +692,7 @@ class TransferManagerOnRemote(TransferManager):
 
         poller.unregister(self.command_socket)
         poller.unregister(self.query_socket)
+        poller.unregister(self.gpu_control_socket)
 
     def _handle_set_slot_mapping(self, task_id: int, slot_mapping: np.ndarray) -> None:
         """Handle set_slot_mapping message from FlexKVConnector.
@@ -863,6 +942,9 @@ class TransferManagerIntraProcessHandle(TransferManagerHandleBase):
     def start(self) -> None:
         self.transfer_manager.initialize_transfer_engine()
         self.transfer_manager.start()
+        # No selector loop here (that is the subprocess mode), so the bound GPU
+        # control REP socket needs its own listener.
+        self.transfer_manager.start_gpu_control_listener()
         self._is_ready = True
 
     def is_ready(self) -> bool:
@@ -878,6 +960,7 @@ class TransferManagerIntraProcessHandle(TransferManagerHandleBase):
         return self.transfer_manager.wait(timeout)
 
     def shutdown(self) -> None:
+        self.transfer_manager.stop_gpu_control_listener()
         self.transfer_manager.shutdown()
 
 

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -32,7 +32,7 @@ from flexkv.common.storage import KVCacheLayout
 from flexkv.storage.storage_engine import StorageEngine
 from flexkv.transfer.transfer_engine import TransferEngine
 from flexkv.server.utils import get_zmq_socket
-from flexkv.server.request import RegisterTPClientRequest, Response
+from flexkv.server.request import RegistrationKey, RegisterTPClientRequest, Response
 
 
 class TransferManager:
@@ -47,25 +47,30 @@ class TransferManager:
         # Calculate total expected GPUs on this node across all instances
         self.expected_gpus = self.instance_num * self.model_config.gpus_per_node
 
-        self.all_gpu_layouts: Dict[int, KVCacheLayout] = {}
-        self.all_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}  # device_id -> gpu_blocks
-        self.gpu_worker_key_mapping: Dict[int, WorkerKey] = {}
+        self.all_gpu_layouts: Dict[RegistrationKey, KVCacheLayout] = {}
+        self.all_gpu_blocks: Dict[RegistrationKey, List[TensorSharedHandle]] = {}
+        self.gpu_worker_key_mapping: Dict[RegistrationKey, WorkerKey] = {}
+        self.gpu_device_id_mapping: Dict[RegistrationKey, int] = {}
 
         # Multi-group storage for heterogeneous KV shapes, including DSA/NSA
         # indexer-as-group. None for uniform single-shape registrations.
-        self.all_gpu_layouts_per_group: Dict[int, Optional[List[KVCacheLayout]]] = {}
-        self.all_gpu_blocks_per_group: Dict[int, Optional[List[List[TensorSharedHandle]]]] = {}
+        self.all_gpu_layouts_per_group: Dict[
+            RegistrationKey, Optional[List[KVCacheLayout]]
+        ] = {}
+        self.all_gpu_blocks_per_group: Dict[
+            RegistrationKey, Optional[List[List[TensorSharedHandle]]]
+        ] = {}
 
         # SWA dedicated GPU pool (channel B): independent of the main-KV pool.
-        # device_id -> SWA handles / layout. Populated only when the registering
-        # client provides swa_handles (DSv4 sliding-window-attention pool).
-        self.all_swa_gpu_blocks: Dict[int, List[TensorSharedHandle]] = {}
-        self.all_swa_gpu_layouts: Dict[int, KVCacheLayout] = {}
+        # Logical registration key -> SWA handles / layout. Populated only when
+        # the client provides swa_handles (DSv4 sliding-window-attention pool).
+        self.all_swa_gpu_blocks: Dict[RegistrationKey, List[TensorSharedHandle]] = {}
+        self.all_swa_gpu_layouts: Dict[RegistrationKey, KVCacheLayout] = {}
         self.all_swa_gpu_layouts_per_group: Dict[
-            int, Optional[List[KVCacheLayout]]
+            RegistrationKey, Optional[List[KVCacheLayout]]
         ] = {}
         self.all_swa_gpu_blocks_per_group: Dict[
-            int, Optional[List[List[TensorSharedHandle]]]
+            RegistrationKey, Optional[List[List[TensorSharedHandle]]]
         ] = {}
         self.swa_layer_groups: Optional[List[LayerGroupSpec]] = None
 
@@ -79,40 +84,32 @@ class TransferManager:
                            f"instance_num={self.instance_num}, expected_gpus={self.expected_gpus}")
 
     def _handle_gpu_blocks_registration(self, req: RegisterTPClientRequest) -> None:
-        device_id = req.device_id
+        registration_key = req.registration_key
 
-        if device_id in self.all_gpu_blocks:
-            # A duplicate device_id means the framework adapter handed us the
-            # same id for two different workers.  Registration can then never
-            # reach expected_gpus, so _register_gpu_blocks_via_socket spins
-            # forever printing "Still waiting for GPU registrations: k/N".
-            # Say so explicitly instead of leaving an unexplained hang.
+        if registration_key in self.all_gpu_blocks:
             flexkv_logger.error(
-                f"GPU {device_id} has already registered. Duplicate device_id "
-                f"from a different worker: registration cannot reach "
-                f"{self.expected_gpus}/{self.expected_gpus} and init will hang. "
-                f"Check that the framework adapter passes a per-worker-unique "
-                f"device_id (registered so far: {sorted(self.all_gpu_blocks)}).")
+                f"GPU worker {registration_key} has already registered.")
         else:
             try:
-                self.all_gpu_blocks[device_id] = req.handles
-                self.all_gpu_layouts[device_id] = req.gpu_layout
-                self.gpu_worker_key_mapping[device_id] = WorkerKey(
+                self.all_gpu_blocks[registration_key] = req.handles
+                self.all_gpu_layouts[registration_key] = req.gpu_layout
+                self.gpu_device_id_mapping[registration_key] = req.device_id
+                self.gpu_worker_key_mapping[registration_key] = WorkerKey(
                     dp_client_id=req.dp_client_id,
                     pp_rank=req.pp_rank,
                 )
                 # Store multi-group info (None when uniform single-shape registration).
                 # This covers heterogeneous shapes and DSA/NSA indexer-as-group.
-                self.all_gpu_layouts_per_group[device_id] = req.gpu_layouts
-                self.all_gpu_blocks_per_group[device_id] = req.handles_per_group
-                # Store SWA GPU data if present
+                self.all_gpu_layouts_per_group[registration_key] = req.gpu_layouts
+                self.all_gpu_blocks_per_group[registration_key] = req.handles_per_group
+                # Store SWA GPU data if present.
                 if getattr(req, "swa_handles", None) is not None and req.swa_layout is not None:
-                    self.all_swa_gpu_blocks[device_id] = req.swa_handles
-                    self.all_swa_gpu_layouts[device_id] = req.swa_layout
-                    self.all_swa_gpu_layouts_per_group[device_id] = (
+                    self.all_swa_gpu_blocks[registration_key] = req.swa_handles
+                    self.all_swa_gpu_layouts[registration_key] = req.swa_layout
+                    self.all_swa_gpu_layouts_per_group[registration_key] = (
                         req.swa_gpu_layouts
                     )
-                    self.all_swa_gpu_blocks_per_group[device_id] = (
+                    self.all_swa_gpu_blocks_per_group[registration_key] = (
                         req.swa_handles_per_group
                     )
                     if req.swa_layer_groups is not None:
@@ -123,7 +120,7 @@ class TransferManager:
                                 "SWA layer groups differ across GPU registrations"
                             )
                     flexkv_logger.info(
-                        f"GPU {device_id}: registered SWA handles "
+                        f"GPU worker {registration_key}: registered SWA handles "
                         f"({len(req.swa_handles)} tensors, "
                         f"groups={len(req.swa_layer_groups or [])})"
                     )
@@ -132,11 +129,13 @@ class TransferManager:
                 if req.layer_groups is not None and self.model_config.layer_groups is None:
                     self.model_config.layer_groups = req.layer_groups
                     flexkv_logger.info(
-                        f"Set model_config.layer_groups from GPU {device_id}: "
+                        f"Set model_config.layer_groups from GPU worker "
+                        f"{registration_key}: "
                         f"{[(g.num_layers, g.num_kv_heads, g.head_size) for g in req.layer_groups]}"
                     )
             except Exception as e:
-                flexkv_logger.error(f"Failed to register GPU {device_id}: {e}")
+                flexkv_logger.error(
+                    f"Failed to register GPU worker {registration_key}: {e}")
 
     def _register_gpu_blocks_via_socket(self) -> None:
         try:
@@ -153,11 +152,11 @@ class TransferManager:
                     # Periodically log waiting status for debugging
                     now = time.time()
                     if now - last_log_time >= 5.0:
-                        registered_ids = sorted(self.all_gpu_blocks.keys())
+                        registered_keys = sorted(self.all_gpu_blocks.keys())
                         flexkv_logger.info(
                             f"Still waiting for GPU registrations: "
                             f"{len(self.all_gpu_blocks)}/{self.expected_gpus} registered "
-                            f"(registered_device_ids={registered_ids}, "
+                            f"(registered_keys={registered_keys}, "
                             f"port={self.gpu_register_port})")
                         last_log_time = now
                     time.sleep(0.001)
@@ -165,10 +164,11 @@ class TransferManager:
 
                 if isinstance(req, RegisterTPClientRequest):
                     flexkv_logger.info(f"Received GPU blocks registration request: {type(req)}, "
+                                       f"registration_key={req.registration_key}, "
                                        f"device_id={req.device_id}, "
                                        f"dp_client_id={req.dp_client_id}, pp_rank={req.pp_rank}")
                     self._handle_gpu_blocks_registration(req)
-                    flexkv_logger.info(f"GPU {req.device_id} registered successfully, "
+                    flexkv_logger.info(f"GPU worker {req.registration_key} registered successfully, "
                                        f"waiting for {self.expected_gpus - len(self.all_gpu_blocks)} GPUs to register")
                 else:
                     flexkv_logger.error(f"Unrecognized RequestType in SchedulerServer: {type(req)}")
@@ -207,20 +207,22 @@ class TransferManager:
             swa_layer_groups=self.swa_layer_groups,
         )
 
-        # Register GPU blocks with their global device IDs
-        for device_id, gpu_blocks_wrapper in self.all_gpu_blocks.items():
+        # Logical registration identity is separate from the CUDA device ID.
+        for registration_key, gpu_blocks_wrapper in self.all_gpu_blocks.items():
+            device_id = self.gpu_device_id_mapping[registration_key]
             self.storage_engine.register_gpu_blocks(
                 gpu_blocks_wrapper,
-                self.all_gpu_layouts[device_id],
+                self.all_gpu_layouts[registration_key],
                 device_id,
                 dtype=self.model_config.dtype,
             )
 
         # Register SWA dedicated GPU pool.
-        for device_id, swa_blocks in self.all_swa_gpu_blocks.items():
+        for registration_key, swa_blocks in self.all_swa_gpu_blocks.items():
+            device_id = self.gpu_device_id_mapping[registration_key]
             self.storage_engine.register_swa_gpu_blocks(
                 swa_blocks,
-                self.all_swa_gpu_layouts[device_id],
+                self.all_swa_gpu_layouts[registration_key],
                 device_id,
                 dtype=torch.uint8,
             )
@@ -239,8 +241,9 @@ class TransferManager:
             grouped_gpu_blocks_per_group = {}
             grouped_gpu_layouts_per_group = {}
 
-        for device_id in sorted(self.all_gpu_blocks.keys()):
-            worker_key = self.gpu_worker_key_mapping[device_id]
+        for registration_key in sorted(self.all_gpu_blocks.keys()):
+            worker_key = self.gpu_worker_key_mapping[registration_key]
+            device_id = self.gpu_device_id_mapping[registration_key]
             if worker_key not in grouped_gpu_handles:
                 grouped_gpu_handles[worker_key] = []
             grouped_gpu_handles[worker_key].append(
@@ -251,9 +254,9 @@ class TransferManager:
                     grouped_gpu_blocks_per_group[worker_key] = []
                     grouped_gpu_layouts_per_group[worker_key] = []
                 grouped_gpu_blocks_per_group[worker_key].append(
-                    self.all_gpu_blocks_per_group[device_id])
+                    self.all_gpu_blocks_per_group[registration_key])
                 grouped_gpu_layouts_per_group[worker_key].append(
-                    self.all_gpu_layouts_per_group[device_id])
+                    self.all_gpu_layouts_per_group[registration_key])
 
         cpu_handle = self.storage_engine.get_storage_handle(DeviceType.CPU) \
             if self.cache_config.enable_cpu else None
@@ -275,9 +278,10 @@ class TransferManager:
             swa_grouped_gpu_layouts_per_group = {}
         if self.storage_engine.has_storage_handle(DeviceType.CPU, is_swa=True):
             swa_gpu_handles = {}
-            for device_id in sorted(self.all_swa_gpu_blocks.keys()):
+            for registration_key in sorted(self.all_swa_gpu_blocks.keys()):
+                device_id = self.gpu_device_id_mapping[registration_key]
                 if self.storage_engine.get_storage_handle(DeviceType.GPU, device_id, is_swa=True):
-                    worker_key = self.gpu_worker_key_mapping[device_id]
+                    worker_key = self.gpu_worker_key_mapping[registration_key]
                     if worker_key not in swa_gpu_handles:
                         swa_gpu_handles[worker_key] = []
                     swa_gpu_handles[worker_key].append(
@@ -285,10 +289,10 @@ class TransferManager:
                     if self.swa_layer_groups is not None:
                         swa_grouped_gpu_blocks_per_group.setdefault(
                             worker_key, []
-                        ).append(self.all_swa_gpu_blocks_per_group[device_id])
+                        ).append(self.all_swa_gpu_blocks_per_group[registration_key])
                         swa_grouped_gpu_layouts_per_group.setdefault(
                             worker_key, []
-                        ).append(self.all_swa_gpu_layouts_per_group[device_id])
+                        ).append(self.all_swa_gpu_layouts_per_group[registration_key])
 
         swa_cpu_handle =(
          self.storage_engine.get_storage_handle(DeviceType.CPU, is_swa=True)

--- a/flexkv/transfer_manager.py
+++ b/flexkv/transfer_manager.py
@@ -77,6 +77,14 @@ class TransferManager:
         self.context = zmq.Context(2)
         self.recv_from_client = get_zmq_socket(
             self.context, zmq.SocketType.PULL, gpu_register_port, True)
+        self.gpu_control_port = f"{gpu_register_port}_control"
+        self.gpu_control_socket = get_zmq_socket(
+            self.context, zmq.SocketType.REP, self.gpu_control_port, True
+        )
+        self._gpu_suspended = False
+        self._pending_resume_registrations: Dict[
+            RegistrationKey, RegisterTPClientRequest
+        ] = {}
 
         self.transfer_engine: Optional[TransferEngine] = None
         self.storage_engine: Optional[StorageEngine] = None
@@ -136,6 +144,103 @@ class TransferManager:
             except Exception as e:
                 flexkv_logger.error(
                     f"Failed to register GPU worker {registration_key}: {e}")
+
+    def handle_gpu_control(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle synchronous sleep/wake mapping lifecycle requests."""
+        if self.transfer_engine is None or self.storage_engine is None:
+            raise RuntimeError("Transfer engine is not initialized")
+
+        request_type = request.get("type")
+        if request_type == "suspend_gpu":
+            if not self._gpu_suspended:
+                released = self.transfer_engine.suspend_gpu_mappings()
+                self._gpu_suspended = True
+                self._pending_resume_registrations.clear()
+                flexkv_logger.info(
+                    f"Suspended FlexKV GPU mappings: released={released}"
+                )
+            else:
+                released = 0
+            return {"ok": True, "released_mappings": released}
+
+        if request_type != "resume_gpu":
+            raise ValueError(f"Unknown GPU control request: {request_type}")
+        if not self._gpu_suspended:
+            raise RuntimeError("GPU mappings are not suspended")
+
+        registration = request.get("registration")
+        if not isinstance(registration, RegisterTPClientRequest):
+            raise TypeError("resume_gpu requires RegisterTPClientRequest")
+        if registration.registration_key not in self.all_gpu_blocks:
+            raise KeyError(
+                f"Unknown registration key {registration.registration_key}"
+            )
+        if (
+            registration.layer_groups is not None
+            or registration.handles_per_group is not None
+            or registration.swa_handles is not None
+        ):
+            raise NotImplementedError(
+                "GPU hot remap currently supports uniform main KV only"
+            )
+        self._pending_resume_registrations[
+            registration.registration_key
+        ] = registration
+
+        ready = (
+            len(self._pending_resume_registrations) == self.expected_gpus
+        )
+        imported = 0
+        if ready:
+            grouped_gpu_handles = {}
+            for registration_key in sorted(
+                self._pending_resume_registrations
+            ):
+                fresh = self._pending_resume_registrations[registration_key]
+                self.all_gpu_blocks[registration_key] = fresh.handles
+                self.all_gpu_layouts[registration_key] = fresh.gpu_layout
+                handle = self.storage_engine.get_storage_handle(
+                    DeviceType.GPU, fresh.device_id
+                )
+                handle.data = fresh.handles
+                handle.kv_layout = fresh.gpu_layout
+                worker_key = self.gpu_worker_key_mapping[registration_key]
+                grouped_gpu_handles.setdefault(worker_key, []).append(handle)
+            imported = self.transfer_engine.resume_gpu_mappings(
+                grouped_gpu_handles
+            )
+            self._pending_resume_registrations.clear()
+            self._gpu_suspended = False
+            flexkv_logger.info(
+                f"Resumed FlexKV GPU mappings: imported={imported}"
+            )
+
+        return {
+            "ok": True,
+            "ready": ready,
+            "registered": (
+                self.expected_gpus if ready
+                else len(self._pending_resume_registrations)
+            ),
+            "imported_mappings": imported,
+        }
+
+    def drain_gpu_control_requests(self) -> int:
+        """Drain all requests after a ZeroMQ FD edge notification."""
+        processed = 0
+        while True:
+            try:
+                request = self.gpu_control_socket.recv_pyobj(zmq.NOBLOCK)
+            except zmq.Again:
+                break
+            try:
+                response = self.handle_gpu_control(request)
+            except Exception as e:
+                flexkv_logger.exception("GPU mapping lifecycle request failed")
+                response = {"ok": False, "error": str(e)}
+            self.gpu_control_socket.send_pyobj(response)
+            processed += 1
+        return processed
 
     def _register_gpu_blocks_via_socket(self) -> None:
         try:
@@ -874,6 +979,8 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
             # Also monitor completed_queue for finished ops (now it's mp.Queue with _reader)
             sel.register(transfer_manager.transfer_engine.completed_queue._reader,
                         selectors.EVENT_READ, data="finished_ops")
+            sel.register(transfer_manager.gpu_control_socket,
+                         selectors.EVENT_READ, data="gpu_control")
 
             flexkv_logger.info(
                 "TransferManager daemon process started with selector-based "
@@ -925,6 +1032,11 @@ class TransferManagerInterProcessHandle(TransferManagerHandleBase):
                         elif key.data == "finished_ops":
                             # Selector reports finished_ops queue has data
                             has_finished_ops = True
+
+                        elif key.data == "gpu_control":
+                            # ZeroMQ exposes an edge-triggered FD, so one event
+                            # must consume every request that is already queued.
+                            transfer_manager.drain_gpu_control_requests()
 
                     # Only collect finished_ops if selector reported data available
                     if has_finished_ops and not should_exit:

--- a/install.sh
+++ b/install.sh
@@ -413,6 +413,7 @@ if [ "$ENABLE_P2P" -eq 1 ]; then
         -DUSE_ETCD=OFF \
         -DUSE_CUDA=ON \
         -DWITH_STORE=OFF \
+        -DWITH_STORE_RUST=OFF \
         -DWITH_P2P_STORE=OFF \
         -DWITH_EP=OFF \
         -DWITH_METRICS=OFF \

--- a/tests/README_reset_cache.md
+++ b/tests/README_reset_cache.md
@@ -1,0 +1,83 @@
+# KV-cache reset feature — test guide
+
+This covers the `reset_cache` path that lets vLLM's
+`reset_prefix_cache(reset_connector=True)` (what verl calls after every weight
+update) propagate into FlexKV so stale-weight KV is dropped.
+
+Code changes under test:
+- `flexkv/kvtask.py` — `KVTaskEngine.reset_cache()` (drain in-flight → all-tier reset)
+- `flexkv/kvmanager.py` — `KVManager.reset()` (in-proc + server-client)
+- `flexkv/server/{request,client,server}.py` — `ResetRequest` IPC round-trip
+- `flexkv/integration/vllm/vllm_v1_adapter.py` — connector `reset_cache()`
+- (vLLM repo) `.../v1/flexkv_connector.py` — wrapper forwards `reset_cache()`
+
+## Two levels
+
+| Level | File | Needs | Proves |
+|---|---|---|---|
+| A | `test_reset_cache.py` | 1 GPU (pure-noop case: none) | FlexKV drops tree + frees mempool; IPC round-trip works |
+| B | `test_reset_cache_vllm_e2e.py` | 1 GPU + vLLM≥0.13 + small model | verl's real call reaches FlexKV and invalidates it |
+
+## Run
+
+```bash
+# Level A (fastest; test_reset_empty_is_noop needs no GPU)
+pytest -s tests/test_reset_cache.py
+
+# Level B (end-to-end through vLLM)
+export FLEXKV_TEST_MODEL=Qwen/Qwen2.5-0.5B-Instruct   # or any small model you have
+pytest -s tests/test_reset_cache_vllm_e2e.py
+```
+
+## Recommended robust assertion for Level B: a FlexKV-side spy
+
+vLLM's connector-stats API moves between versions, so the behavioral test in
+Level B falls back to `pytest.skip` if it can't read external-hit metrics. The
+**most reliable** way to prove "reset actually reached FlexKV" is to spy on the
+adapter method directly. Add this to a conftest or the test:
+
+```python
+import flexkv.integration.vllm.vllm_v1_adapter as adapter
+
+def test_reset_calls_flexkv(monkeypatch, llm):
+    calls = {"n": 0}
+    orig = adapter.FlexKVSchedulerConnector.reset_cache
+    def spy(self):
+        calls["n"] += 1
+        return orig(self)
+    monkeypatch.setattr(adapter.FlexKVSchedulerConnector, "reset_cache", spy)
+
+    llm.reset_prefix_cache(reset_connector=True)
+    assert calls["n"] >= 1   # proves the wire reached FlexKV, not the base no-op
+```
+
+Note: the connector runs in the scheduler process. With the offline `LLM` in
+enforce-eager, single-process mode the monkeypatch applies; if you move to a
+multi-process engine the spy must be installed in the scheduler process (or
+assert via a counter FlexKV writes to a file / shared value).
+
+## What each assertion buys you
+
+1. `test_reset_empty_is_noop` — idempotency & cheap short-circuit (§2.5: verl
+   calls reset up to 3× per weight update).
+2. `test_reset_after_put_clears_match` — the core correctness claim: a prefix
+   that hit before reset misses after, and the mempool is fully freed.
+3. `test_reset_cache_server_client` — the IPC path works (no more
+   "clear_cache is not supported in server client mode" no-op).
+4. Level B smoke — verl's exact call returns without error (wire is connected).
+5. Level B behavioral / spy — reset genuinely reaches FlexKV (not §3 silent
+   false-success).
+
+## Manual sanity check (no pytest)
+
+```python
+from flexkv.kvmanager import KVManager
+from flexkv.common.config import ModelConfig, CacheConfig
+import torch
+m = ModelConfig(num_layers=4, num_kv_heads=8, head_size=128,
+                dtype=torch.float16, use_mla=False, tp_size=1, dp_size=1)
+c = CacheConfig(tokens_per_block=16, enable_cpu=True, enable_ssd=False, num_cpu_blocks=1024)
+kv = KVManager(model_config=m, cache_config=c, dp_client_id=0); kv.start()
+kv.reset()          # must not raise, must be near-instant on empty cache
+kv.shutdown()
+```

--- a/tests/replay_from_tracer.py
+++ b/tests/replay_from_tracer.py
@@ -235,6 +235,8 @@ class FlexKVReplayEngine:
             # Create registration request
             register_req = RegisterTPClientRequest(
                 dp_client_id=gpu_id // self.model_config.tp_size,  # DP client ID
+                pp_rank=0,
+                intra_client_id=gpu_id % self.model_config.tp_size,
                 device_id=gpu_id,
                 handles=handles,
                 gpu_layout=self.gpu_layout

--- a/tests/test_external_server_mode.py
+++ b/tests/test_external_server_mode.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flexkv.common.config import CacheConfig, GLOBAL_CONFIG_FROM_ENV, ModelConfig
+from flexkv.kvmanager import KVManager
+from flexkv.server.client import KVDPClient
+from flexkv.server.request import UnregisterDPClientRequest
+from flexkv.server.server import KVServer
+
+
+@pytest.fixture
+def server_client_config(monkeypatch):
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_client_mode", True)
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_launch_mode", "embedded")
+    return ModelConfig(), CacheConfig()
+
+
+def test_embedded_mode_preserves_server_owner_behavior(server_client_config):
+    model_config, cache_config = server_client_config
+    server_handle = MagicMock()
+    dp_client = MagicMock()
+
+    with patch("flexkv.kvmanager.KVServer.create_server", return_value=server_handle) as create_server, \
+         patch("flexkv.kvmanager.KVDPClient", return_value=dp_client):
+        manager = KVManager(model_config, cache_config, dp_client_id=0)
+        manager.start()
+        manager.shutdown()
+
+    create_server.assert_called_once()
+    dp_client.start_server_and_register.assert_called_once()
+    dp_client.shutdown.assert_called_once()
+    dp_client.unregister.assert_not_called()
+    server_handle.shutdown.assert_called_once()
+
+
+def test_external_mode_never_starts_or_stops_shared_server(
+    monkeypatch, server_client_config
+):
+    model_config, cache_config = server_client_config
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_launch_mode", "external")
+    dp_client = MagicMock()
+
+    with patch("flexkv.kvmanager.KVServer.create_server") as create_server, \
+         patch("flexkv.kvmanager.KVDPClient", return_value=dp_client):
+        manager = KVManager(model_config, cache_config, dp_client_id=0)
+        manager.start()
+        manager.shutdown()
+
+    assert manager.server_handle is None
+    assert not manager.owns_mps
+    create_server.assert_not_called()
+    dp_client.start_server_and_register.assert_called_once()
+    dp_client.unregister.assert_called_once()
+    dp_client.shutdown.assert_not_called()
+
+
+def test_external_mode_requires_server_client_mode(monkeypatch):
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_client_mode", False)
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_launch_mode", "external")
+
+    with pytest.raises(ValueError, match="requires server-client mode"):
+        KVManager(ModelConfig(), CacheConfig(), dp_client_id=0)
+
+
+def test_unregister_request_does_not_use_global_shutdown():
+    client = object.__new__(KVDPClient)
+    client.dp_client_id = 7
+    client.send_to_server = MagicMock()
+
+    client.unregister()
+
+    request = client.send_to_server.send_pyobj.call_args.args[0]
+    assert isinstance(request, UnregisterDPClientRequest)
+    assert request.dp_client_id == 7
+
+
+def test_server_unregisters_only_the_requesting_client():
+    server = object.__new__(KVServer)
+    server.client_manager = MagicMock()
+    server.kv_task_engine = MagicMock()
+    server._running = True
+
+    server._handle_unregister_dp_client_request(UnregisterDPClientRequest(3))
+
+    server.client_manager.delete_dp_client.assert_called_once_with(3)
+    assert server._running

--- a/tests/test_gpu_control_listener.py
+++ b/tests/test_gpu_control_listener.py
@@ -1,0 +1,114 @@
+"""The GPU control REP socket must be served in every deployment mode.
+
+``TransferManager.__init__`` binds ``<gpu_register_port>_control``
+unconditionally, but only the subprocess mode's selector loop used to drain
+it.  In thread mode and remote mode the endpoint therefore accepted the
+client's REQ and then never answered, turning a vLLM sleep/wake call into a
+silent stall for the client's full 120s RCVTIMEO.
+"""
+import tempfile
+import threading
+
+import pytest
+import zmq
+
+from flexkv.transfer_manager import TransferManager
+
+
+@pytest.fixture
+def control_endpoint():
+    with tempfile.NamedTemporaryFile(suffix="_control") as handle:
+        yield f"ipc://{handle.name}"
+
+
+def _listening_manager(endpoint):
+    """A TransferManager with only the control-plane bits wired up."""
+    manager = TransferManager.__new__(TransferManager)
+    manager.context = zmq.Context(1)
+    manager.gpu_control_port = endpoint
+    manager.gpu_control_socket = manager.context.socket(zmq.REP)
+    manager.gpu_control_socket.bind(endpoint)
+    manager._gpu_control_shutdown = threading.Event()
+    manager._gpu_control_thread = None
+    return manager
+
+
+def _request(endpoint, payload, timeout_ms=5000):
+    context = zmq.Context(1)
+    socket = context.socket(zmq.REQ)
+    socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
+    socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.connect(endpoint)
+    try:
+        socket.send_pyobj(payload)
+        return socket.recv_pyobj()
+    finally:
+        socket.close()
+        context.term()
+
+
+def test_listener_answers_control_requests(control_endpoint):
+    manager = _listening_manager(control_endpoint)
+    seen = []
+    manager.handle_gpu_control = lambda request: (
+        seen.append(request) or {"ok": True, "echo": request["value"]}
+    )
+
+    manager.start_gpu_control_listener()
+    try:
+        # Without a listener this recv blocks until RCVTIMEO and raises.
+        assert _request(control_endpoint, {"value": 1}) == {"ok": True, "echo": 1}
+        # REQ/REP is strictly alternating: a second round-trip proves the
+        # listener loops rather than serving exactly one request.
+        assert _request(control_endpoint, {"value": 2}) == {"ok": True, "echo": 2}
+    finally:
+        manager.stop_gpu_control_listener()
+        manager.gpu_control_socket.close()
+        manager.context.term()
+
+    assert seen == [{"value": 1}, {"value": 2}]
+
+
+def test_listener_reports_handler_failure_instead_of_hanging(control_endpoint):
+    """A raising handler must still send a reply.
+
+    REQ/REP is a lockstep socket: skipping the reply would wedge the client
+    for its whole RCVTIMEO and leave the REP socket unable to accept the next
+    request.
+    """
+    manager = _listening_manager(control_endpoint)
+
+    def _boom(request):
+        raise RuntimeError("suspend failed")
+
+    manager.handle_gpu_control = _boom
+
+    manager.start_gpu_control_listener()
+    try:
+        response = _request(control_endpoint, {"type": "suspend_gpu"})
+    finally:
+        manager.stop_gpu_control_listener()
+        manager.gpu_control_socket.close()
+        manager.context.term()
+
+    assert response["ok"] is False
+    assert "suspend failed" in response["error"]
+
+
+def test_stop_is_idempotent_and_start_does_not_double_spawn(control_endpoint):
+    manager = _listening_manager(control_endpoint)
+    manager.handle_gpu_control = lambda request: {"ok": True}
+
+    manager.start_gpu_control_listener()
+    thread = manager._gpu_control_thread
+    manager.start_gpu_control_listener()
+    assert manager._gpu_control_thread is thread
+
+    try:
+        manager.stop_gpu_control_listener()
+        assert not thread.is_alive()
+        manager.stop_gpu_control_listener()
+    finally:
+        manager.gpu_control_socket.close()
+        manager.context.term()

--- a/tests/test_hierarchy_reset.py
+++ b/tests/test_hierarchy_reset.py
@@ -1,0 +1,286 @@
+import pytest
+import torch
+
+from flexkv.cache.hie_cache_engine import HierarchyLRCacheEngine
+from flexkv.cache.radix_remote import DistributedRadixTree, LocalRadixTree
+from flexkv.cache.redis_meta import RedisMetaChannel, dist_available
+
+
+class _FakeIndex:
+    def __init__(self, events, name, reset_error=None, start_result=True):
+        self.events = events
+        self.name = name
+        self.reset_error = reset_error
+        self.start_result = start_result
+        self.started = True
+
+    def stop(self):
+        self.events.append(f"{self.name}_stop")
+        self.started = False
+
+    def reset(self):
+        self.events.append(f"{self.name}_reset")
+        if self.reset_error is not None:
+            raise self.reset_error
+
+    def start(self, channel):
+        self.events.append((f"{self.name}_start", channel))
+        self.started = self.start_result
+        return self.start_result
+
+
+class _FakeMempool:
+    def __init__(self, events):
+        self.events = events
+
+    def reset(self):
+        self.events.append("mempool_reset")
+
+
+class _FakeChannel:
+    def __init__(self, events, barrier_ready=None, has_blocks=None, error=None):
+        self.events = events
+        self.barrier_ready = list(barrier_ready or [True])
+        self.has_blocks = list(has_blocks or [False])
+        self.error = error
+
+    def begin_reset_barrier(self, ttl_ms):
+        self.events.append(("begin_reset_barrier", ttl_ms))
+        if self.error is not None:
+            raise self.error
+        return 7
+
+    def mark_reset_barrier_arrival(self, epoch, ttl_ms):
+        self.events.append(("mark_reset_barrier_arrival", epoch, ttl_ms))
+        return True
+
+    def is_reset_barrier_ready(self, epoch):
+        self.events.append(("is_reset_barrier_ready", epoch))
+        if len(self.barrier_ready) > 1:
+            return self.barrier_ready.pop(0)
+        return self.barrier_ready[0]
+
+    def has_any_block_keys(self):
+        self.events.append("scan_global_blocks")
+        if self.error is not None:
+            raise self.error
+        if len(self.has_blocks) > 1:
+            return self.has_blocks.pop(0)
+        return self.has_blocks[0]
+
+    def finish_reset_barrier(self, epoch):
+        self.events.append(("finish_reset_barrier", epoch))
+        return True
+
+
+def _fake_hierarchy_engine(local_index, remote_index, mempool, local_channel, remote_channel):
+    engine = object.__new__(HierarchyLRCacheEngine)
+    engine.local_index = local_index
+    engine.remote_index = remote_index
+    engine.mempool = mempool
+    engine.local_ch = local_channel
+    engine.remote_ch = remote_channel
+    engine.device_type = "test"
+    engine.reset_barrier_timeout_ms = 100
+    engine.reset_barrier_poll_ms = 1
+    return engine
+
+
+def test_hierarchy_reset_orders_local_cleanup_before_mempool_reuse():
+    events = []
+    local_channel = _FakeChannel(events)
+    remote_channel = object()
+    local_index = _FakeIndex(events, "local")
+    remote_index = _FakeIndex(events, "remote")
+    engine = _fake_hierarchy_engine(
+        local_index,
+        remote_index,
+        _FakeMempool(events),
+        local_channel,
+        remote_channel,
+    )
+
+    engine.reset()
+
+    assert events == [
+        "local_stop",
+        "remote_stop",
+        ("begin_reset_barrier", 1000),
+        "local_reset",
+        "remote_reset",
+        ("mark_reset_barrier_arrival", 7, 1000),
+        ("is_reset_barrier_ready", 7),
+        "scan_global_blocks",
+        ("finish_reset_barrier", 7),
+        "mempool_reset",
+        ("remote_start", remote_channel),
+        ("local_start", local_channel),
+    ]
+    assert local_index.started
+    assert remote_index.started
+
+
+def test_hierarchy_reset_does_not_reuse_mempool_after_redis_failure():
+    events = []
+    reset_error = RuntimeError("redis cleanup failed")
+    local_index = _FakeIndex(events, "local", reset_error=reset_error)
+    remote_index = _FakeIndex(events, "remote")
+    engine = _fake_hierarchy_engine(
+        local_index,
+        remote_index,
+        _FakeMempool(events),
+        _FakeChannel(events),
+        object(),
+    )
+
+    with pytest.raises(RuntimeError, match="redis cleanup failed"):
+        engine.reset()
+
+    assert events == [
+        "local_stop",
+        "remote_stop",
+        ("begin_reset_barrier", 1000),
+        "local_reset",
+    ]
+    assert not local_index.started
+    assert not remote_index.started
+
+
+def test_hierarchy_reset_waits_for_all_nodes_before_reusing_blocks():
+    events = []
+    local_channel = _FakeChannel(
+        events,
+        barrier_ready=[False, True, True],
+        has_blocks=[True, True, False],
+    )
+    engine = _fake_hierarchy_engine(
+        _FakeIndex(events, "local"),
+        _FakeIndex(events, "remote"),
+        _FakeMempool(events),
+        local_channel,
+        object(),
+    )
+
+    engine.reset()
+
+    assert events.count("scan_global_blocks") == 3
+    assert events.index("mempool_reset") > max(
+        index for index, event in enumerate(events) if event == "scan_global_blocks"
+    )
+
+
+def test_hierarchy_reset_does_not_reuse_blocks_when_global_cleanup_times_out():
+    events = []
+    local_index = _FakeIndex(events, "local")
+    remote_index = _FakeIndex(events, "remote")
+    engine = _fake_hierarchy_engine(
+        local_index,
+        remote_index,
+        _FakeMempool(events),
+        _FakeChannel(events, barrier_ready=[True], has_blocks=[True]),
+        object(),
+    )
+    engine.reset_barrier_timeout_ms = 1
+
+    with pytest.raises(RuntimeError, match="physical blocks were not reset"):
+        engine.reset()
+
+    assert "mempool_reset" not in events
+    assert not any(
+        isinstance(event, tuple) and event[0].endswith("_start") for event in events
+    )
+    assert not local_index.started
+    assert not remote_index.started
+
+
+def test_hierarchy_reset_stops_remote_if_local_restart_fails():
+    events = []
+    local_index = _FakeIndex(events, "local", start_result=False)
+    remote_index = _FakeIndex(events, "remote")
+    engine = _fake_hierarchy_engine(
+        local_index,
+        remote_index,
+        _FakeMempool(events),
+        _FakeChannel(events),
+        object(),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to restart local radix tree"):
+        engine.reset()
+
+    assert not local_index.started
+    assert not remote_index.started
+
+
+@pytest.mark.skipif(not dist_available(), reason="FlexKV was built without distributed cache support")
+def test_local_radix_reset_releases_leases_and_discards_pending_publish():
+    tree = LocalRadixTree(
+        tokens_per_block=4,
+        max_num_blocks=8,
+        swap_block_threshold=0,
+    )
+    physical_blocks = torch.tensor([0, 1], dtype=torch.int64)
+    block_hashes = torch.tensor([11, 22], dtype=torch.int64)
+
+    node = tree.insert(physical_blocks, block_hashes, num_blocks=2, num_insert_blocks=2)
+    assert node is not None
+    assert tree.lease_pool_free_size() < tree.lease_pool_capacity()
+
+    assert tree._c.insert_and_publish(node)
+    assert tree.pending_queue_size() == 1
+
+    tree.reset()
+
+    assert tree.total_cached_blocks() == 0
+    assert tree.pending_queue_size() == 0
+    assert tree.lease_pool_free_size() == tree.lease_pool_capacity()
+
+    node = tree.insert(physical_blocks, block_hashes, num_blocks=2, num_insert_blocks=2)
+    assert node is not None
+    assert tree.lease_pool_free_size() < tree.lease_pool_capacity()
+
+
+@pytest.mark.skipif(not dist_available(), reason="FlexKV was built without distributed cache support")
+def test_local_radix_reset_keeps_tree_and_leases_when_redis_delete_fails():
+    tree = LocalRadixTree(
+        tokens_per_block=4,
+        max_num_blocks=8,
+        swap_block_threshold=0,
+    )
+    physical_blocks = torch.tensor([0, 1], dtype=torch.int64)
+    block_hashes = torch.tensor([33, 44], dtype=torch.int64)
+    node = tree.insert(physical_blocks, block_hashes, num_blocks=2, num_insert_blocks=2)
+    assert node is not None
+
+    channel = RedisMetaChannel(
+        host="127.0.0.1",
+        port=1,
+        node_id=7,
+        local_ip="127.0.0.1",
+        blocks_key="RESET_TEST",
+    )
+    tree.set_meta_channel(channel)
+    assert tree._c.insert_and_publish(node)
+
+    cached_blocks = tree.total_cached_blocks()
+    free_leases = tree.lease_pool_free_size()
+
+    with pytest.raises(RuntimeError, match="Redis block metadata"):
+        tree.reset()
+
+    assert tree.pending_queue_size() == 0
+    assert tree.total_cached_blocks() == cached_blocks
+    assert tree.lease_pool_free_size() == free_leases
+
+
+@pytest.mark.skipif(not dist_available(), reason="FlexKV was built without distributed cache support")
+def test_distributed_radix_reset_leaves_an_empty_index():
+    tree = DistributedRadixTree(
+        tokens_per_block=4,
+        max_num_blocks=8,
+        node_id=1,
+    )
+
+    tree.reset()
+
+    assert tree.is_empty()

--- a/tests/test_kvmanager.py
+++ b/tests/test_kvmanager.py
@@ -62,6 +62,7 @@ def run_tp_client(dp_client_id,
         device_id = tp_rank + dp_client_id * model_config.tp_size
         tp_client = KVTPClient(server_recv_port,
                                dp_client_id=dp_client_id, pp_rank=0,
+                               intra_client_id=tp_rank,
                                device_id=device_id)
 
         gpu_kv_layout = create_gpu_kv_layout(model_config, cache_config, num_gpu_blocks, gpu_layout_type)
@@ -784,6 +785,7 @@ def run_tp_client_with_indexer(dp_client_id,
         tp_client = KVTPClient(
             gpu_register_port=server_recv_port + "_gpu_register",
             dp_client_id=dp_client_id, pp_rank=0,
+            intra_client_id=tp_rank,
             device_id=device_id,
         )
         tp_client.register_to_server(

--- a/tests/test_kvmanager_client_api.py
+++ b/tests/test_kvmanager_client_api.py
@@ -1,0 +1,122 @@
+"""``KVManager`` must only call methods its two backends actually expose.
+
+``KVManager`` dispatches every public operation to one of two objects that
+share no base class: ``KVDPClient`` (server_client_mode) or ``KVTaskEngine``.
+Nothing checks that the two agree, so renaming a method on one side --
+``cancel_task`` -> ``cancel_tasks`` -- leaves the other call site raising
+AttributeError at runtime, and only in the mode that CI happens not to
+exercise.
+
+Each test drives the real ``KVManager`` method against an autospecced
+backend, which raises AttributeError for any method the real class does not
+define.  That is what makes this catch a rename rather than restating one.
+"""
+from unittest.mock import create_autospec
+
+import pytest
+
+from flexkv.kvmanager import KVManager
+from flexkv.kvtask import KVTaskEngine
+from flexkv.server.client import KVDPClient
+
+pytestmark = pytest.mark.unit
+
+
+def _manager(server_client_mode: bool) -> KVManager:
+    """A KVManager with both backends stubbed and no real resources."""
+    manager = KVManager.__new__(KVManager)
+    manager.server_client_mode = server_client_mode
+    manager.server_launch_mode = "embedded"
+    manager.owns_mps = False
+    manager.server_handle = None
+    # spec_set: attribute access outside the real class raises, so a call to a
+    # method that was renamed away fails here instead of silently passing.
+    manager.dp_client = create_autospec(KVDPClient, spec_set=True, instance=True)
+    manager.kv_task_engine = create_autospec(
+        KVTaskEngine, spec_set=True, instance=True
+    )
+    return manager
+
+
+@pytest.mark.parametrize("server_client_mode", [True, False],
+                         ids=["server_client_mode", "engine_mode"])
+def test_cancel_reaches_backend(server_client_mode):
+    """Regression: KVManager.cancel called the removed ``cancel_task``."""
+    manager = _manager(server_client_mode)
+
+    manager.cancel(7)
+
+    backend = manager.dp_client if server_client_mode else manager.kv_task_engine
+    backend.cancel_tasks.assert_called_once_with([7])
+    # The scalar overload must reach the backend as a list.
+    other = manager.kv_task_engine if server_client_mode else manager.dp_client
+    assert not other.method_calls
+
+
+@pytest.mark.parametrize("server_client_mode", [True, False],
+                         ids=["server_client_mode", "engine_mode"])
+def test_cancel_accepts_a_list(server_client_mode):
+    manager = _manager(server_client_mode)
+
+    manager.cancel([1, 2, 3])
+
+    backend = manager.dp_client if server_client_mode else manager.kv_task_engine
+    backend.cancel_tasks.assert_called_once_with([1, 2, 3])
+
+
+@pytest.mark.parametrize("server_client_mode", [True, False],
+                         ids=["server_client_mode", "engine_mode"])
+def test_wait_reaches_backend(server_client_mode):
+    manager = _manager(server_client_mode)
+    # KVManager.wait is annotated -> Dict, and the Cython build enforces it,
+    # so the stub has to return a real dict.
+    manager.dp_client.wait.return_value = {}
+    manager.kv_task_engine.wait.return_value = {}
+
+    manager.wait(5, timeout=1.0)
+
+    backend = manager.dp_client if server_client_mode else manager.kv_task_engine
+    assert backend.wait.call_count == 1
+
+
+@pytest.mark.parametrize("server_client_mode", [True, False],
+                         ids=["server_client_mode", "engine_mode"])
+def test_is_ready_reaches_backend(server_client_mode):
+    manager = _manager(server_client_mode)
+
+    manager.is_ready()
+
+    backend = manager.dp_client if server_client_mode else manager.kv_task_engine
+    assert backend.is_ready.call_count == 1
+
+
+@pytest.mark.parametrize("server_client_mode", [True, False],
+                         ids=["server_client_mode", "engine_mode"])
+def test_start_reaches_backend(server_client_mode):
+    manager = _manager(server_client_mode)
+
+    manager.start()
+
+    if server_client_mode:
+        manager.dp_client.start_server_and_register.assert_called_once_with()
+    else:
+        manager.kv_task_engine.start.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "server_client_mode,server_launch_mode",
+    [(True, "embedded"), (True, "external"), (False, "embedded")],
+    ids=["server_client-embedded", "server_client-external", "engine_mode"],
+)
+def test_shutdown_reaches_backend(server_client_mode, server_launch_mode):
+    manager = _manager(server_client_mode)
+    manager.server_launch_mode = server_launch_mode
+
+    manager.shutdown()
+
+    if not server_client_mode:
+        manager.kv_task_engine.shutdown.assert_called_once_with()
+    elif server_launch_mode == "external":
+        manager.dp_client.unregister.assert_called_once_with()
+    else:
+        manager.dp_client.shutdown.assert_called_once_with()

--- a/tests/test_registration_key.py
+++ b/tests/test_registration_key.py
@@ -1,5 +1,8 @@
 import sys
 import types
+from types import SimpleNamespace
+
+import zmq
 
 from flexkv.common.config import ModelConfig, RankInfo
 from flexkv.server.request import RegisterTPClientRequest
@@ -39,6 +42,82 @@ def _empty_transfer_manager() -> TransferManager:
     manager.swa_layer_groups = None
     manager.model_config = ModelConfig()
     return manager
+
+
+def test_sleep_wake_remaps_after_all_gpu_registrations():
+    manager = _empty_transfer_manager()
+    manager.expected_gpus = 2
+    manager._gpu_suspended = False
+    manager._pending_resume_registrations = {}
+    manager.all_gpu_blocks = {(0, 0): ["old0"], (0, 1): ["old1"]}
+    manager.all_gpu_layouts = {(0, 0): "layout0", (0, 1): "layout1"}
+    manager.gpu_worker_key_mapping = {(0, 0): "worker", (0, 1): "worker"}
+
+    gpu_handles = {
+        0: SimpleNamespace(data=["old0"], kv_layout="layout0"),
+        1: SimpleNamespace(data=["old1"], kv_layout="layout1"),
+    }
+    manager.storage_engine = SimpleNamespace(
+        get_storage_handle=lambda _device_type, device_id: gpu_handles[device_id]
+    )
+    calls = []
+    manager.transfer_engine = SimpleNamespace(
+        suspend_gpu_mappings=lambda: calls.append("suspend") or 4,
+        resume_gpu_mappings=lambda groups: calls.append(("resume", groups)) or 4,
+    )
+
+    suspended = manager.handle_gpu_control({"type": "suspend_gpu"})
+    assert suspended == {"ok": True, "released_mappings": 4}
+
+    first = _request(0, 0, 0)
+    first.handles = ["new0"]
+    second = _request(0, 1, 1)
+    second.handles = ["new1"]
+    partial = manager.handle_gpu_control(
+        {"type": "resume_gpu", "registration": first}
+    )
+    assert partial["ready"] is False
+    assert calls == ["suspend"]
+
+    complete = manager.handle_gpu_control(
+        {"type": "resume_gpu", "registration": second}
+    )
+    assert complete["ready"] is True
+    assert complete["imported_mappings"] == 4
+    assert manager._gpu_suspended is False
+    assert gpu_handles[0].data == ["new0"]
+    assert gpu_handles[1].data == ["new1"]
+    assert calls[1][0] == "resume"
+
+
+def test_gpu_control_edge_drains_all_queued_requests():
+    class FakeSocket:
+        def __init__(self, requests):
+            self.requests = list(requests)
+            self.responses = []
+
+        def recv_pyobj(self, _flags):
+            if not self.requests:
+                raise zmq.Again()
+            return self.requests.pop(0)
+
+        def send_pyobj(self, response):
+            self.responses.append(response)
+
+    manager = _empty_transfer_manager()
+    manager.gpu_control_socket = FakeSocket(
+        [{"worker": worker} for worker in range(8)]
+    )
+    manager.handle_gpu_control = lambda request: {
+        "ok": True,
+        "worker": request["worker"],
+    }
+
+    assert manager.drain_gpu_control_requests() == 8
+    assert [
+        response["worker"]
+        for response in manager.gpu_control_socket.responses
+    ] == list(range(8))
 
 
 def test_intra_client_id_flattens_pp_and_effective_tp_rank():

--- a/tests/test_registration_key.py
+++ b/tests/test_registration_key.py
@@ -1,0 +1,79 @@
+import sys
+import types
+
+from flexkv.common.config import ModelConfig, RankInfo
+from flexkv.server.request import RegisterTPClientRequest
+
+
+# Registration tests do not need the CUDA/liburing transfer workers.
+transfer_engine_module = types.ModuleType("flexkv.transfer.transfer_engine")
+transfer_engine_module.TransferEngine = object
+sys.modules["flexkv.transfer.transfer_engine"] = transfer_engine_module
+
+from flexkv.transfer_manager import TransferManager
+
+
+def _request(dp_client_id: int, intra_client_id: int, device_id: int):
+    return RegisterTPClientRequest(
+        dp_client_id=dp_client_id,
+        pp_rank=0,
+        intra_client_id=intra_client_id,
+        device_id=device_id,
+        handles=[],
+        gpu_layout=object(),
+    )
+
+
+def _empty_transfer_manager() -> TransferManager:
+    manager = TransferManager.__new__(TransferManager)
+    manager.all_gpu_layouts = {}
+    manager.all_gpu_blocks = {}
+    manager.gpu_worker_key_mapping = {}
+    manager.gpu_device_id_mapping = {}
+    manager.all_gpu_layouts_per_group = {}
+    manager.all_gpu_blocks_per_group = {}
+    manager.all_swa_gpu_blocks = {}
+    manager.all_swa_gpu_layouts = {}
+    manager.all_swa_gpu_layouts_per_group = {}
+    manager.all_swa_gpu_blocks_per_group = {}
+    manager.swa_layer_groups = None
+    manager.model_config = ModelConfig()
+    return manager
+
+
+def test_intra_client_id_flattens_pp_and_effective_tp_rank():
+    model_config = ModelConfig(tp_size=4, pp_size=2, attn_cp_size=2)
+    rank_info = RankInfo(
+        model_config=model_config,
+        pp_rank=1,
+        tp_rank=3,
+        attn_cp_rank=1,
+    )
+
+    assert model_config.effective_tp_size == 4
+    assert rank_info.effective_tp_rank == 3
+    assert rank_info.intra_client_id == 7
+
+
+def test_registration_key_distinguishes_replicas_from_cuda_device_id():
+    manager = _empty_transfer_manager()
+    first = _request(dp_client_id=0, intra_client_id=0, device_id=0)
+    second = _request(dp_client_id=1, intra_client_id=0, device_id=0)
+
+    manager._handle_gpu_blocks_registration(first)
+    manager._handle_gpu_blocks_registration(second)
+
+    assert set(manager.all_gpu_blocks) == {(0, 0), (1, 0)}
+    assert manager.gpu_device_id_mapping == {(0, 0): 0, (1, 0): 0}
+
+
+def test_duplicate_registration_key_is_rejected():
+    manager = _empty_transfer_manager()
+    first = _request(dp_client_id=2, intra_client_id=3, device_id=4)
+    duplicate = _request(dp_client_id=2, intra_client_id=3, device_id=5)
+
+    manager._handle_gpu_blocks_registration(first)
+    manager._handle_gpu_blocks_registration(duplicate)
+
+    assert len(manager.all_gpu_blocks) == 1
+    assert manager.gpu_device_id_mapping[(2, 3)] == 4

--- a/tests/test_reset_cache.py
+++ b/tests/test_reset_cache.py
@@ -1,0 +1,216 @@
+"""Tests for the KV-cache reset path (KVTaskEngine.reset_cache / KVManager.reset).
+
+This is the feature that lets vLLM's reset_prefix_cache(reset_connector=True)
+propagate down to FlexKV so that KV computed against stale weights (e.g. after a
+verl RL weight update) is fully invalidated.
+
+Layout:
+  - Level A (this file): in-process, no GPU needed for the pure-reset assertions.
+    * test_reset_empty_is_noop            — idempotent / cheap short-circuit
+    * test_reset_after_put_clears_match   — put -> match hits -> reset -> match misses
+                                            (GPU: registers TP client, mirrors test_kvmanager.py)
+  - Level A server-client (test_reset_cache_server_client): reset over ZMQ IPC.
+
+Run:
+    pytest -s tests/test_reset_cache.py
+GPU-dependent cases self-skip when no CUDA device is present.
+"""
+import time
+
+import pytest
+import torch
+import multiprocessing as mp
+
+from flexkv.common.config import ModelConfig, CacheConfig
+from flexkv.common.request import KVResponseStatus
+from flexkv.kvmanager import KVManager
+from flexkv.common.debug import flexkv_logger
+
+from common_utils import (
+    generate_request_pair,
+    block_ids_2_slot_mapping,
+    skip_if_insufficient_gpus,
+    create_gpu_kv_layout,
+)
+
+# Reuse the TP-client boot helpers from the main kvmanager test.
+from test_kvmanager import run_tp_client, shutdown_tp_client
+
+
+# ---------------------------------------------------------------------------
+# Small configs (kept independent of the shared fixtures so this file can be
+# run in isolation).
+# ---------------------------------------------------------------------------
+def _model_config():
+    return ModelConfig(
+        num_layers=4,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        use_mla=False,
+        tp_size=1,
+        dp_size=1,
+    )
+
+
+def _cache_config(**overrides):
+    cfg = dict(
+        tokens_per_block=16,
+        enable_cpu=True,
+        enable_ssd=False,
+        enable_remote=False,
+        num_cpu_blocks=1024,
+    )
+    cfg.update(overrides)
+    return CacheConfig(**cfg)
+
+
+def _cpu_engine(kvmanager):
+    """Convenience accessor for the CPU tier engine (for white-box assertions)."""
+    return kvmanager.kv_task_engine.cache_engine.cpu_cache_engine
+
+
+# ---------------------------------------------------------------------------
+# Level A — pure reset behavior
+# ---------------------------------------------------------------------------
+def test_reset_empty_is_noop():
+    """reset() on a fresh manager must be a cheap no-op and not raise.
+
+    Covers the §2.5 idempotency requirement: because verl triggers reset up to
+    3x per weight update, reset on an already-empty cache must be safe/cheap.
+    """
+    kvm = KVManager(model_config=_model_config(), cache_config=_cache_config(), dp_client_id=0)
+    kvm.start()
+    try:
+        # No in-flight tasks, empty tree -> should return immediately.
+        kvm.reset()
+        kvm.reset()  # second call must also be fine (idempotent)
+    finally:
+        kvm.shutdown()
+
+
+def test_reset_after_put_clears_match():
+    """Full behavioral test: put KV, confirm it matches, reset, confirm it no
+    longer matches (prefix tree dropped) and the mempool is fully freed.
+
+    Requires 1 GPU because put/get transfers go through a registered TP client
+    (same pattern as tests/test_kvmanager.py).
+    """
+    skip_if_insufficient_gpus(1)
+
+    model_config = _model_config()
+    cache_config = _cache_config(num_cpu_blocks=1024)
+    tokens_per_block = cache_config.tokens_per_block
+    num_gpu_blocks = 128
+    block_per_request = 16
+    gpu_layout_type = 0
+
+    kvm = KVManager(model_config=model_config, cache_config=cache_config, dp_client_id=0)
+    kvm.start()
+
+    # Boot a single TP client that registers GPU blocks with FlexKV.
+    mp_ctx = mp.get_context("spawn")
+    parent_conn, child_conn = mp_ctx.Pipe()
+    tp_proc = mp_ctx.Process(
+        target=run_tp_client,
+        args=(0, 0, kvm.gpu_register_port, model_config, cache_config,
+              num_gpu_blocks, child_conn, gpu_layout_type),
+        daemon=True,
+    )
+    tp_proc.start()
+    # Drain the pipe (the helper sends shared GPU block handles back).
+    try:
+        parent_conn.recv()
+    except Exception:
+        pass
+
+    try:
+        while not kvm.is_ready():
+            time.sleep(0.5)
+            flexkv_logger.info("waiting for flexkv to be ready")
+
+        token_ids, block_ids, _ = generate_request_pair(
+            0, block_per_request, num_gpu_blocks, tokens_per_block, dp_size=1
+        )
+        slot_mapping = block_ids_2_slot_mapping(block_ids, tokens_per_block)
+
+        # 1. PUT a prefix and wait until it lands in the CPU tier.
+        put_id = kvm.put_async(token_ids=token_ids, slot_mapping=slot_mapping, token_mask=None)
+        res = kvm.wait([put_id], completely=True)
+        assert res[put_id].status == KVResponseStatus.SUCCESS
+
+        # 2. Before reset: get_match should find the cached prefix.
+        _, matched_before = kvm.get_match(token_ids=token_ids, token_mask=None)
+        assert matched_before.sum().item() > 0, "expected a cache hit before reset"
+
+        # 3. RESET (the feature under test).
+        kvm.reset()
+
+        # 4. After reset: same tokens must NOT match (prefix tree dropped).
+        _, matched_after = kvm.get_match(token_ids=token_ids, token_mask=None)
+        assert matched_after.sum().item() == 0, (
+            f"expected 0 cache hits after reset, got {matched_after.sum().item()}"
+        )
+
+        # 5. White-box: CPU mempool fully freed (all blocks returned).
+        mempool = _cpu_engine(kvm).mempool
+        # num_free_blocks should be back to total capacity right after a reset.
+        assert mempool.num_free_blocks == mempool.num_total_blocks, (
+            f"mempool not fully freed after reset: "
+            f"free={mempool.num_free_blocks} total={mempool.num_total_blocks}"
+        )
+    finally:
+        shutdown_tp_client([tp_proc])
+        kvm.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Level A (server-client) — reset over ZMQ IPC
+# ---------------------------------------------------------------------------
+def test_reset_cache_server_client(monkeypatch):
+    """reset() must work (not no-op-error) in server-client mode via ResetRequest.
+
+    We force server-client mode with FLEXKV_SERVER_CLIENT_MODE=1 and assert the
+    round-trip completes without raising. Requires 1 GPU for the TP client that
+    the server needs to become ready.
+    """
+    skip_if_insufficient_gpus(1)
+    monkeypatch.setenv("FLEXKV_SERVER_CLIENT_MODE", "1")
+    # NOTE: GLOBAL_CONFIG_FROM_ENV is read at import time; if it was already
+    # imported, also flip the flag directly.
+    from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
+    monkeypatch.setattr(GLOBAL_CONFIG_FROM_ENV, "server_client_mode", True, raising=False)
+
+    model_config = _model_config()
+    cache_config = _cache_config()
+    num_gpu_blocks = 128
+    gpu_layout_type = 0
+
+    kvm = KVManager(model_config=model_config, cache_config=cache_config, dp_client_id=0)
+    assert kvm.server_client_mode, "expected server-client mode to be active"
+    kvm.start()
+
+    mp_ctx = mp.get_context("spawn")
+    parent_conn, child_conn = mp_ctx.Pipe()
+    tp_proc = mp_ctx.Process(
+        target=run_tp_client,
+        args=(0, 0, kvm.gpu_register_port, model_config, cache_config,
+              num_gpu_blocks, child_conn, gpu_layout_type),
+        daemon=True,
+    )
+    tp_proc.start()
+    try:
+        parent_conn.recv()
+    except Exception:
+        pass
+
+    try:
+        while not kvm.is_ready():
+            time.sleep(0.5)
+        # The key assertion: this used to be a hard no-op error
+        # ("clear_cache is not supported in server client mode").
+        # Now it must complete the ZMQ round-trip without raising.
+        kvm.reset()
+    finally:
+        shutdown_tp_client([tp_proc])
+        kvm.shutdown()

--- a/tests/test_reset_cache_vllm_e2e.py
+++ b/tests/test_reset_cache_vllm_e2e.py
@@ -1,40 +1,27 @@
-"""Level B: end-to-end vLLM + FlexKV cache-reset test.
+""" End-to-end vLLM + FlexKV cache-reset test.
 
-Exercises the EXACT call verl makes after a weight update
-(vllm_async_server.py clear_kv_cache: `reset_prefix_cache(reset_connector=True)`)
-against a real vLLM engine configured with the FlexKV connector, and asserts —
-via vLLM's own Prometheus counters — that FlexKV's EXTERNAL prefix cache is
-actually invalidated (not the silent base-class no-op).
+Exercises the EXACT call verl makes to clear_kv_cache after a weight update: `reset_prefix_cache(reset_connector=True)`
 
-Why counters and not RequestOutput.num_cached_tokens:
-    num_cached_tokens = local_gpu_hits + external(FlexKV)_hits, summed — it
-    cannot isolate FlexKV. vLLM keeps them as SEPARATE cumulative counters:
-        vllm:prefix_cache_hits / _queries            -> local GPU
-        vllm:external_prefix_cache_hits / _queries   -> KV connector (FlexKV)
-    We diff the EXTERNAL counters around each generate() to get per-run hits.
-    (reset_prefix_cache does NOT zero these counters, so we must diff, not read
-    absolute values.)
+Using a vLLM engine configured with the FlexKV connector.
+
+vllm:prefix_cache_hits / _queries            -> local GPU
+vllm:external_prefix_cache_hits / _queries   -> KV connector (FlexKV)
+
+We diff the EXTERNAL counters around each generate() to get per-run hits.
+(reset_prefix_cache does NOT zero these counters, so we must diff, not read absolute values.)
 
 Test protocol (why it proves the reset works):
-    warm  : generate(A)                      -> FlexKV gets populated
+    warm  : generate                           -> FlexKV gets populated
     CLEAR : reset_prefix_cache(reset_connector=True) [+ reset_mm_cache]  (verl call)
-    run1  : generate(A)  -> external hits ~= 0   (FlexKV was cleared)
-    run2  : generate(A)  -> external hits  > 0   (run1 re-populated FlexKV)
-    Assert: run1 external hit-rate is ~0 AND run2 > run1.
-    If the reset did NOT reach FlexKV, run1 would already hit -> test fails.
-
-Requirements:
-  - 1 GPU
-  - vLLM >= 0.13.0 (older versions don't forward reset_connector)
-  - FlexKV installed/importable (with the reset_cache changes in this branch)
-  - A small model (default: Qwen/Qwen2.5-0.5B-Instruct)
-  - FlexKV cache config: set FLEXKV_CPU_CACHE_GB (e.g. 8) or FLEXKV_CONFIG_PATH.
-    If neither is set, this test defaults FLEXKV_CPU_CACHE_GB=8.
+    run1  : generate     -> external hits ~= 0   (FlexKV was cleared)
+    run2  : generate     -> external hits  > 0   (run1 re-populated FlexKV)
 
 Run:
-    FLEXKV_CPU_CACHE_GB=8 pytest -s tests/test_reset_cache_vllm_e2e.py
+    FLEXKV_CPU_CACHE_GB=64 pytest -s tests/test_reset_cache_vllm_e2e.py
 """
+
 import os
+import time
 
 import pytest
 
@@ -42,26 +29,17 @@ torch = pytest.importorskip("torch")
 vllm = pytest.importorskip("vllm")
 pytest.importorskip("flexkv")
 
-from packaging import version
-
 # Default matches the user's `vllm serve` command; override with FLEXKV_TEST_MODEL.
-MODEL = os.environ.get("FLEXKV_TEST_MODEL", "/raid/model/Qwen3-8B")
-MAX_MODEL_LEN = int(os.environ.get("FLEXKV_TEST_MAX_MODEL_LEN", "8192"))
+MODEL = "/raid/model/Qwen3-8B"
+MAX_MODEL_LEN = "8192"
 
 # Prometheus counter names (vllm/v1/metrics/loggers.py).
 _EXT_HITS = "vllm:external_prefix_cache_hits"
 _EXT_QUERIES = "vllm:external_prefix_cache_queries"
-_LOCAL_HITS = "vllm:prefix_cache_hits"
-
 
 def _skip_if_no_gpu():
     if not torch.cuda.is_available():
         pytest.skip("no CUDA device")
-
-
-def _skip_if_vllm_too_old():
-    if version.parse(vllm.__version__) < version.parse("0.13.0"):
-        pytest.skip(f"vLLM {vllm.__version__} < 0.13.0 does not forward reset_connector")
 
 
 def _counter(llm, name):
@@ -72,32 +50,48 @@ def _counter(llm, name):
     return 0
 
 
-def _reset_kwargs():
-    """Mirror verl's _RESET_PREFIX_CACHE_KWARGS gating (vllm_async_server.py:59-62)."""
-    kw = {}
-    if version.parse(vllm.__version__) >= version.parse("0.13.0"):
-        kw["reset_connector"] = True
-    return kw
-
-
 def _verl_clear(llm):
-    """Reproduce verl's clear_kv_cache() (vllm_async_server.py:809-820)."""
-    ok = llm.reset_prefix_cache(**_reset_kwargs())
-    if version.parse(vllm.__version__) >= version.parse("0.9.0"):
-        llm.reset_mm_cache()
+    """Reproduce verl's clear_kv_cache() (vllm_async_server.py:809-820).
+
+    The llm fixture already skips vLLM < 0.13.0, so reset_connector is always
+    forwarded and reset_mm_cache always exists here.
+    """
+    ok = llm.reset_prefix_cache(reset_connector=True)
+    llm.reset_mm_cache()
     # reset_encoder_cache is multimodal-only; skipped for a text model.
     return ok
 
 
-def _run_A(llm, prompt, sp):
-    """Generate once; return per-run deltas (ext_hits, ext_queries, local_hits)."""
-    eh0, eq0, lh0 = (_counter(llm, _EXT_HITS),
-                     _counter(llm, _EXT_QUERIES),
-                     _counter(llm, _LOCAL_HITS))
-    llm.generate([prompt], sp)
+def generate(llm, prompts, sp):
+    """Generate the whole batch once; return per-run external-counter deltas.
+
+    Returns (ext_hits, ext_queries) as counter deltas around the generate()
+    call. Sleeps afterwards so FlexKV's async put has time to land before the
+    next run reads it back.
+    """
+    eh0, eq0 = _counter(llm, _EXT_HITS), _counter(llm, _EXT_QUERIES)
+    llm.generate(prompts, sp)
+    # time.sleep(5)  # let FlexKV's async put/get drain before measuring next run
     return (_counter(llm, _EXT_HITS) - eh0,
-            _counter(llm, _EXT_QUERIES) - eq0,
-            _counter(llm, _LOCAL_HITS) - lh0)
+            _counter(llm, _EXT_QUERIES) - eq0)
+
+
+def _reset_local_prefix_cache(llm, retries=50, delay=0.1):
+    """Reset ONLY the local GPU prefix cache (FlexKV kept), tolerating FlexKV's
+    async D2H put.
+
+    Unlike the verl clear (reset_connector=True), this path keeps FlexKV, so we
+    must NOT free GPU blocks out from under an in-flight save. After generate()
+    returns, FlexKV's put may still be draining and vLLM holds those blocks under
+    delayed free, so reset_prefix_cache() returns False until the saves land and
+    the engine's next steps free the blocks. Poll until the reset succeeds rather
+    than sleeping a fixed interval.
+    """
+    for _ in range(retries):
+        if llm.reset_prefix_cache() is not False:
+            return True
+        time.sleep(delay)
+    return False
 
 
 @pytest.fixture(scope="module")
@@ -116,7 +110,6 @@ def flexkv_config():
 @pytest.fixture(scope="module")
 def llm(flexkv_config):
     _skip_if_no_gpu()
-    _skip_if_vllm_too_old()
     from vllm import LLM
     from vllm.config import KVTransferConfig
 
@@ -142,39 +135,54 @@ def llm(flexkv_config):
     del llm
 
 
-# A long prompt so it spans many KV blocks and actually gets offloaded to FlexKV.
-_PROMPT_A = "Tell me about the history of the Roman Empire in detail. " * 40
+# A batch of long prompts so each spans many KV blocks and actually gets
+# offloaded to FlexKV. `turn` is the fixed dataset index so re-sending the same
+# batch produces identical prompts (a prerequisite for prefix-cache hits).
+_DATASET = [
+    "你有什么爱好？",
+    "你有什么特长？",
+    "你有什么兴趣？",
+    "你有什么梦想？",
+    "你有什么愿望？",
+    "你有什么期待？",
+    "你有什么计划？",
+    "你有什么遗憾？",
+]
+PROMPTS = [f"[{turn}] {prompt * 800}" for turn, prompt in enumerate(_DATASET)]
 
 
 def test_reset_prefix_cache_reset_connector_succeeds(llm):
     """Smoke: the exact verl call returns without error (wire is connected)."""
     from vllm import SamplingParams
 
-    llm.generate([_PROMPT_A], SamplingParams(max_tokens=8, temperature=0))
+    llm.generate(PROMPTS, SamplingParams(max_tokens=8, temperature=0))
+    # time.sleep(5)  # drain FlexKV's async D2H put -> quiesced boundary before reset
     ok = _verl_clear(llm)
     # Scheduler treats only a literal False as failure.
     assert ok is not False
 
 
 def test_flexkv_populates_before_asserting_reset(llm):
-    """Sanity: without any reset, re-running A must produce EXTERNAL hits.
+    """Sanity: with FlexKV warm but the LOCAL cache cleared, a re-run must hit
+    FlexKV.
 
-    If this fails, FlexKV isn't actually engaged (prompt too short / connector
-    not mounted), and the reset test below would be meaningless. This guards
-    against a false-pass where '0 hits after reset' is really '0 hits ever'.
+    The local GPU prefix cache would otherwise serve the whole prefix and
+    starve the connector of queries (observed as ext=0/32). Clearing ONLY the
+    local cache (reset_connector NOT set) forces the next run to miss locally
+    and query FlexKV for the full prefix. If external hits stay 0 here, the
+    connector isn't really working and the reset test below is meaningless.
     """
     from vllm import SamplingParams
 
     sp = SamplingParams(max_tokens=8, temperature=0)
-    _run_A(llm, _PROMPT_A, sp)                 # populate FlexKV
-    llm.reset_prefix_cache(**_reset_kwargs())  # clear LOCAL only-ish; also clears FlexKV
-    # After clear FlexKV is empty; this run repopulates it (few/no ext hits)...
-    _run_A(llm, _PROMPT_A, sp)
-    # ...and THIS run should hit FlexKV (no reset in between).
-    eh, eq, _ = _run_A(llm, _PROMPT_A, sp)
+    generate(llm, PROMPTS, sp)                       # populate FlexKV (+ local)
+    # Clear LOCAL only (keep FlexKV) so the next run can't be served from GPU.
+    # Poll: FlexKV's async put may still hold GPU blocks under delayed free.
+    assert _reset_local_prefix_cache(llm), "local prefix cache reset failed"
+    eh, eq = generate(llm, PROMPTS, sp)              # cold local -> full ext query
     assert eh > 0, (
-        f"no external FlexKV hits even without reset (hits={eh}/{eq}); FlexKV not "
-        f"engaged — check prompt length / connector mount before trusting reset test"
+        f"no external FlexKV hits with warm FlexKV + cold local (hits={eh}/{eq}); "
+        f"FlexKV not engaged — check connector mount / get-put matching"
     )
 
 
@@ -187,20 +195,35 @@ def test_reset_invalidates_flexkv_hits(llm):
 
     sp = SamplingParams(max_tokens=8, temperature=0)
 
-    # warm: make sure A is in FlexKV before we clear.
-    _run_A(llm, _PROMPT_A, sp)
+    def _rate(h, q):
+        return h / max(q, 1)
 
-    # CLEAR: exactly what verl's clear_kv_cache does.
+    # warm: make sure A is in FlexKV before we clear.
+    ehw, eqw = generate(llm, PROMPTS, sp)
+
+    # CLEAR: exactly what verl's clear_kv_cache does (drops LOCAL + FlexKV).
     _verl_clear(llm)
 
-    # run1: right after clear -> FlexKV empty -> external hits ~= 0.
-    eh1, eq1, _ = _run_A(llm, _PROMPT_A, sp)
-    # run2: no clear in between -> run1 refilled FlexKV -> external hits climb.
-    eh2, eq2, _ = _run_A(llm, _PROMPT_A, sp)
+    # run1: local was just cleared -> full ext query; FlexKV also cleared -> ~0
+    # hits. This is the run that proves the reset reached FlexKV.
+    eh1, eq1 = generate(llm, PROMPTS, sp)
 
-    print(f"[reset-test] run1 ext={eh1}/{eq1}  run2 ext={eh2}/{eq2}")
+    # run2: run1 refilled FlexKV, but it ALSO refilled the local GPU cache, which
+    # would serve the whole prefix and starve the connector (ext=0/32). Clear
+    # LOCAL only (keep FlexKV) so run2 is forced to query FlexKV for the full
+    # prefix and can actually register hits.
+    # Poll: FlexKV's async put may still hold GPU blocks under delayed free.
+    assert _reset_local_prefix_cache(llm), "local prefix cache reset failed"
+    eh2, eq2 = generate(llm, PROMPTS, sp)
 
-    rate1 = eh1 / max(eq1, 1)
+    print(
+        f"[reset-test] FlexKV hit-rate  "
+        f"warm={_rate(ehw, eqw):.2f} ({ehw}/{eqw})  "
+        f"run1={_rate(eh1, eq1):.2f} ({eh1}/{eq1})  "
+        f"run2={_rate(eh2, eq2):.2f} ({eh2}/{eq2})"
+    )
+
+    rate1 = _rate(eh1, eq1)
     # Assert 1: cleared cache does not serve stale external hits.
     assert rate1 < 0.1, (
         f"external FlexKV hit-rate after clear is {rate1:.2f} (hits={eh1}/{eq1}); "

--- a/tests/test_reset_cache_vllm_e2e.py
+++ b/tests/test_reset_cache_vllm_e2e.py
@@ -44,7 +44,9 @@ pytest.importorskip("flexkv")
 
 from packaging import version
 
-MODEL = os.environ.get("FLEXKV_TEST_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+# Default matches the user's `vllm serve` command; override with FLEXKV_TEST_MODEL.
+MODEL = os.environ.get("FLEXKV_TEST_MODEL", "/raid/model/Qwen3-8B")
+MAX_MODEL_LEN = int(os.environ.get("FLEXKV_TEST_MAX_MODEL_LEN", "8192"))
 
 # Prometheus counter names (vllm/v1/metrics/loggers.py).
 _EXT_HITS = "vllm:external_prefix_cache_hits"
@@ -118,12 +120,19 @@ def llm(flexkv_config):
     from vllm import LLM
     from vllm.config import KVTransferConfig
 
+    # Mirror the user's `vllm serve` command as closely as the offline LLM API
+    # allows (same model, TP, prefix caching, chunked prefill, FlexKV connector).
     llm = LLM(
         model=MODEL,
-        enforce_eager=True,
-        gpu_memory_utilization=0.5,
-        enable_prefix_caching=True,   # required: no reuse without it
-        disable_log_stats=False,      # required: get_metrics() asserts otherwise
+        tensor_parallel_size=1,
+        trust_remote_code=True,           # Qwen3 needs this
+        max_model_len=MAX_MODEL_LEN,      # 8192, matches --max_model_len
+        max_num_seqs=128,                 # matches --max-num-seqs
+        max_num_batched_tokens=8192,      # matches --max-num-batched-tokens
+        gpu_memory_utilization=0.5,       # matches --gpu-memory-utilization
+        enable_prefix_caching=True,       # matches --enable-prefix-caching (required)
+        enable_chunked_prefill=True,      # matches --enable-chunked-prefill
+        disable_log_stats=False,          # required: get_metrics() asserts otherwise
         kv_transfer_config=KVTransferConfig(
             kv_connector="FlexKVConnectorV1",
             kv_role="kv_both",

--- a/tests/test_reset_cache_vllm_e2e.py
+++ b/tests/test_reset_cache_vllm_e2e.py
@@ -1,30 +1,40 @@
-"""Level B: end-to-end vLLM + FlexKV reset test.
+"""Level B: end-to-end vLLM + FlexKV cache-reset test.
 
-This exercises the EXACT call verl makes after a weight update
-(vllm_async_server.py: `await self.engine.reset_prefix_cache(reset_connector=True)`)
-against a real vLLM engine configured with the FlexKV connector, and asserts
-that FlexKV's external cache is actually invalidated (not the §3 silent
-false-success).
+Exercises the EXACT call verl makes after a weight update
+(vllm_async_server.py clear_kv_cache: `reset_prefix_cache(reset_connector=True)`)
+against a real vLLM engine configured with the FlexKV connector, and asserts —
+via vLLM's own Prometheus counters — that FlexKV's EXTERNAL prefix cache is
+actually invalidated (not the silent base-class no-op).
 
-We use the OFFLINE `LLM` (synchronous) rather than the async server because it
-exposes the identical `reset_prefix_cache(reset_connector=...)` API with far
-less setup — the connector code path hit is the same one verl drives.
+Why counters and not RequestOutput.num_cached_tokens:
+    num_cached_tokens = local_gpu_hits + external(FlexKV)_hits, summed — it
+    cannot isolate FlexKV. vLLM keeps them as SEPARATE cumulative counters:
+        vllm:prefix_cache_hits / _queries            -> local GPU
+        vllm:external_prefix_cache_hits / _queries   -> KV connector (FlexKV)
+    We diff the EXTERNAL counters around each generate() to get per-run hits.
+    (reset_prefix_cache does NOT zero these counters, so we must diff, not read
+    absolute values.)
+
+Test protocol (why it proves the reset works):
+    warm  : generate(A)                      -> FlexKV gets populated
+    CLEAR : reset_prefix_cache(reset_connector=True) [+ reset_mm_cache]  (verl call)
+    run1  : generate(A)  -> external hits ~= 0   (FlexKV was cleared)
+    run2  : generate(A)  -> external hits  > 0   (run1 re-populated FlexKV)
+    Assert: run1 external hit-rate is ~0 AND run2 > run1.
+    If the reset did NOT reach FlexKV, run1 would already hit -> test fails.
 
 Requirements:
   - 1 GPU
   - vLLM >= 0.13.0 (older versions don't forward reset_connector)
-  - FlexKV installed/importable
+  - FlexKV installed/importable (with the reset_cache changes in this branch)
   - A small model (default: Qwen/Qwen2.5-0.5B-Instruct)
-  - FLEXKV_CONFIG_PATH pointing at a JSON with a cpu cache_config, e.g.:
-        {"cache_config": {"enable_cpu": true, "num_cpu_blocks": 4096}}
-    (this fixture writes one automatically to a temp file if unset)
+  - FlexKV cache config: set FLEXKV_CPU_CACHE_GB (e.g. 8) or FLEXKV_CONFIG_PATH.
+    If neither is set, this test defaults FLEXKV_CPU_CACHE_GB=8.
 
 Run:
-    pytest -s tests/test_reset_cache_vllm_e2e.py
+    FLEXKV_CPU_CACHE_GB=8 pytest -s tests/test_reset_cache_vllm_e2e.py
 """
-import json
 import os
-import tempfile
 
 import pytest
 
@@ -35,6 +45,11 @@ pytest.importorskip("flexkv")
 from packaging import version
 
 MODEL = os.environ.get("FLEXKV_TEST_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+
+# Prometheus counter names (vllm/v1/metrics/loggers.py).
+_EXT_HITS = "vllm:external_prefix_cache_hits"
+_EXT_QUERIES = "vllm:external_prefix_cache_queries"
+_LOCAL_HITS = "vllm:prefix_cache_hits"
 
 
 def _skip_if_no_gpu():
@@ -47,21 +62,57 @@ def _skip_if_vllm_too_old():
         pytest.skip(f"vLLM {vllm.__version__} < 0.13.0 does not forward reset_connector")
 
 
-@pytest.fixture(scope="module")
-def flexkv_config_path(tmp_path_factory):
-    """Ensure FLEXKV_CONFIG_PATH points at a minimal CPU-only cache config."""
-    existing = os.environ.get("FLEXKV_CONFIG_PATH")
-    if existing:
-        return existing
-    cfg = {"cache_config": {"enable_cpu": True, "num_cpu_blocks": 4096}}
-    p = tmp_path_factory.mktemp("flexkv") / "flexkv_config.json"
-    p.write_text(json.dumps(cfg))
-    os.environ["FLEXKV_CONFIG_PATH"] = str(p)
-    return str(p)
+def _counter(llm, name):
+    """Read a cumulative Prometheus counter value (0 if absent)."""
+    for m in llm.get_metrics():
+        if m.name == name:
+            return getattr(m, "value", 0)
+    return 0
+
+
+def _reset_kwargs():
+    """Mirror verl's _RESET_PREFIX_CACHE_KWARGS gating (vllm_async_server.py:59-62)."""
+    kw = {}
+    if version.parse(vllm.__version__) >= version.parse("0.13.0"):
+        kw["reset_connector"] = True
+    return kw
+
+
+def _verl_clear(llm):
+    """Reproduce verl's clear_kv_cache() (vllm_async_server.py:809-820)."""
+    ok = llm.reset_prefix_cache(**_reset_kwargs())
+    if version.parse(vllm.__version__) >= version.parse("0.9.0"):
+        llm.reset_mm_cache()
+    # reset_encoder_cache is multimodal-only; skipped for a text model.
+    return ok
+
+
+def _run_A(llm, prompt, sp):
+    """Generate once; return per-run deltas (ext_hits, ext_queries, local_hits)."""
+    eh0, eq0, lh0 = (_counter(llm, _EXT_HITS),
+                     _counter(llm, _EXT_QUERIES),
+                     _counter(llm, _LOCAL_HITS))
+    llm.generate([prompt], sp)
+    return (_counter(llm, _EXT_HITS) - eh0,
+            _counter(llm, _EXT_QUERIES) - eq0,
+            _counter(llm, _LOCAL_HITS) - lh0)
 
 
 @pytest.fixture(scope="module")
-def llm(flexkv_config_path):
+def flexkv_config():
+    """Ensure FlexKV has a CPU-cache config.
+
+    FlexKV reads either FLEXKV_CPU_CACHE_GB (simplest) or FLEXKV_CONFIG_PATH
+    (yaml/json). If the user set neither, default to a small CPU cache via the
+    env-var route (per docs/vllm_adapter/README_en.md).
+    """
+    if os.environ.get("FLEXKV_CONFIG_PATH") or os.environ.get("FLEXKV_CPU_CACHE_GB"):
+        return
+    os.environ["FLEXKV_CPU_CACHE_GB"] = "8"
+
+
+@pytest.fixture(scope="module")
+def llm(flexkv_config):
     _skip_if_no_gpu()
     _skip_if_vllm_too_old()
     from vllm import LLM
@@ -71,7 +122,8 @@ def llm(flexkv_config_path):
         model=MODEL,
         enforce_eager=True,
         gpu_memory_utilization=0.5,
-        enable_prefix_caching=True,
+        enable_prefix_caching=True,   # required: no reuse without it
+        disable_log_stats=False,      # required: get_metrics() asserts otherwise
         kv_transfer_config=KVTransferConfig(
             kv_connector="FlexKVConnectorV1",
             kv_role="kv_both",
@@ -81,96 +133,73 @@ def llm(flexkv_config_path):
     del llm
 
 
-def _reset_kwargs():
-    """Mirror verl's _RESET_PREFIX_CACHE_KWARGS gating."""
-    kw = {}
-    if version.parse(vllm.__version__) >= version.parse("0.13.0"):
-        kw["reset_connector"] = True
-    return kw
+# A long prompt so it spans many KV blocks and actually gets offloaded to FlexKV.
+_PROMPT_A = "Tell me about the history of the Roman Empire in detail. " * 40
 
 
 def test_reset_prefix_cache_reset_connector_succeeds(llm):
-    """Smoke: the exact verl call must return without error.
-
-    Weak assertion (returns True / no exception) — proves the reset_cache()
-    override is wired end-to-end (not the base-class no-op path). Stronger
-    behavioral assertion is in the next test.
-    """
+    """Smoke: the exact verl call returns without error (wire is connected)."""
     from vllm import SamplingParams
 
-    prompt = "The capital of France is " * 40  # long enough to span many blocks
-    llm.generate([prompt], SamplingParams(max_tokens=8, temperature=0))
-
-    # ★ This is the verl call (vllm_async_server.py clear_kv_cache line 815).
-    ok = llm.reset_prefix_cache(**_reset_kwargs())
-    # vLLM's reset_prefix_cache returns True on success; scheduler treats only a
-    # literal False as failure. With the FlexKV reset_cache() override wired,
-    # this should be truthy.
+    llm.generate([_PROMPT_A], SamplingParams(max_tokens=8, temperature=0))
+    ok = _verl_clear(llm)
+    # Scheduler treats only a literal False as failure.
     assert ok is not False
 
 
-def test_reset_invalidates_flexkv_hits(llm):
-    """Behavioral: after reset, re-running the same prompt must NOT get external
-    (FlexKV) cache hits — proving the offloaded KV was actually dropped.
+def test_flexkv_populates_before_asserting_reset(llm):
+    """Sanity: without any reset, re-running A must produce EXTERNAL hits.
 
-    We compare FlexKV connector stats across two runs of the same prompt with a
-    reset in between. Without a working reset, the 2nd run would hit FlexKV.
-
-    NOTE: connector stats plumbing differs across vLLM versions; if stats are
-    unavailable this test degrades to a structural check and is skipped with a
-    clear message rather than silently passing.
+    If this fails, FlexKV isn't actually engaged (prompt too short / connector
+    not mounted), and the reset test below would be meaningless. This guards
+    against a false-pass where '0 hits after reset' is really '0 hits ever'.
     """
     from vllm import SamplingParams
 
-    prompt = "Tell me about the history of the Roman Empire. " * 40
     sp = SamplingParams(max_tokens=8, temperature=0)
-
-    # Warm-up run -> FlexKV gets populated on request_finished.
-    llm.generate([prompt], sp)
-
-    # Reset BOTH the local prefix cache and (via reset_connector) FlexKV.
-    llm.reset_prefix_cache(**_reset_kwargs())
-
-    # Re-run the identical prompt. If FlexKV was correctly invalidated, the
-    # connector must recompute (0 external matched tokens) rather than load
-    # stale blocks.
-    #
-    # Observing "external matched tokens" requires connector stats; the exact
-    # accessor is version-specific. We surface whatever the engine exposes and
-    # assert it does not indicate a fresh external hit. If we can't read it,
-    # skip loudly (do not false-pass).
-    stats = _try_get_connector_prefix_hits(llm)
-    if stats is None:
-        pytest.skip(
-            "connector prefix-cache stats not accessible on this vLLM build; "
-            "use the FlexKV-side spy (see README) to assert reset_cache() was called"
-        )
-    external_hits_after_reset = stats
-    assert external_hits_after_reset == 0, (
-        f"expected 0 external FlexKV hits after reset, got {external_hits_after_reset}"
+    _run_A(llm, _PROMPT_A, sp)                 # populate FlexKV
+    llm.reset_prefix_cache(**_reset_kwargs())  # clear LOCAL only-ish; also clears FlexKV
+    # After clear FlexKV is empty; this run repopulates it (few/no ext hits)...
+    _run_A(llm, _PROMPT_A, sp)
+    # ...and THIS run should hit FlexKV (no reset in between).
+    eh, eq, _ = _run_A(llm, _PROMPT_A, sp)
+    assert eh > 0, (
+        f"no external FlexKV hits even without reset (hits={eh}/{eq}); FlexKV not "
+        f"engaged — check prompt length / connector mount before trusting reset test"
     )
 
 
-def _try_get_connector_prefix_hits(llm):
-    """Best-effort read of external (connector) prefix-cache hit count.
+def test_reset_invalidates_flexkv_hits(llm):
+    """Behavioral: verl's clear must drop FlexKV so the next A does NOT hit it.
 
-    Returns an int, or None if the metric can't be located on this vLLM build.
-    Kept intentionally defensive: vLLM's stats API is still moving.
+    Protocol: warm -> CLEAR -> run1 (expect ~0 ext hits) -> run2 (expect > run1).
     """
-    try:
-        # V1 engine path: metrics live on the engine core's scheduler stats.
-        # This is best-effort and may need adjustment for your vLLM version.
-        engine = getattr(llm, "llm_engine", None)
-        if engine is None:
-            return None
-        # Try a few known-ish locations; return None if none present.
-        get_metrics = getattr(engine, "get_metrics", None)
-        if callable(get_metrics):
-            metrics = get_metrics()
-            for m in metrics:
-                name = getattr(m, "name", "")
-                if "connector" in name and "hit" in name:
-                    return int(getattr(m, "value", 0))
-        return None
-    except Exception:
-        return None
+    from vllm import SamplingParams
+
+    sp = SamplingParams(max_tokens=8, temperature=0)
+
+    # warm: make sure A is in FlexKV before we clear.
+    _run_A(llm, _PROMPT_A, sp)
+
+    # CLEAR: exactly what verl's clear_kv_cache does.
+    _verl_clear(llm)
+
+    # run1: right after clear -> FlexKV empty -> external hits ~= 0.
+    eh1, eq1, _ = _run_A(llm, _PROMPT_A, sp)
+    # run2: no clear in between -> run1 refilled FlexKV -> external hits climb.
+    eh2, eq2, _ = _run_A(llm, _PROMPT_A, sp)
+
+    print(f"[reset-test] run1 ext={eh1}/{eq1}  run2 ext={eh2}/{eq2}")
+
+    rate1 = eh1 / max(eq1, 1)
+    # Assert 1: cleared cache does not serve stale external hits.
+    assert rate1 < 0.1, (
+        f"external FlexKV hit-rate after clear is {rate1:.2f} (hits={eh1}/{eq1}); "
+        f"reset did NOT propagate to FlexKV (stale KV still served)"
+    )
+    # Assert 2: cache is functional again afterwards (proves we measured a real
+    # cache, not a permanently-dead one).
+    assert eh2 > eh1, (
+        f"external hits did not recover after refill (run1={eh1}, run2={eh2}); "
+        f"FlexKV may not be working at all"
+    )

--- a/tests/test_reset_cache_vllm_e2e.py
+++ b/tests/test_reset_cache_vllm_e2e.py
@@ -29,9 +29,11 @@ torch = pytest.importorskip("torch")
 vllm = pytest.importorskip("vllm")
 pytest.importorskip("flexkv")
 
+from vllm import SamplingParams  # noqa: E402  (guarded by importorskip above)
+
 # Default matches the user's `vllm serve` command; override with FLEXKV_TEST_MODEL.
 MODEL = "/raid/model/Qwen3-8B"
-MAX_MODEL_LEN = "8192"
+MAX_MODEL_LEN = 8192
 
 # Prometheus counter names (vllm/v1/metrics/loggers.py).
 _EXT_HITS = "vllm:external_prefix_cache_hits"
@@ -66,8 +68,8 @@ def generate(llm, prompts, sp):
     """Generate the whole batch once; return per-run external-counter deltas.
 
     Returns (ext_hits, ext_queries) as counter deltas around the generate()
-    call. Sleeps afterwards so FlexKV's async put has time to land before the
-    next run reads it back.
+    call. Callers that need FlexKV's async put to land before the next read use
+    _reset_local_prefix_cache(), which polls instead of sleeping a fixed time.
     """
     eh0, eq0 = _counter(llm, _EXT_HITS), _counter(llm, _EXT_QUERIES)
     llm.generate(prompts, sp)
@@ -125,6 +127,7 @@ def llm(flexkv_config):
         gpu_memory_utilization=0.5,       # matches --gpu-memory-utilization
         enable_prefix_caching=True,       # matches --enable-prefix-caching (required)
         enable_chunked_prefill=True,      # matches --enable-chunked-prefill
+        enable_sleep_mode=True,           # verl frees GPU mem between rollouts (sleep/wake)
         disable_log_stats=False,          # required: get_metrics() asserts otherwise
         kv_transfer_config=KVTransferConfig(
             kv_connector="FlexKVConnectorV1",
@@ -153,8 +156,6 @@ PROMPTS = [f"[{turn}] {prompt * 800}" for turn, prompt in enumerate(_DATASET)]
 
 def test_reset_prefix_cache_reset_connector_succeeds(llm):
     """Smoke: the exact verl call returns without error (wire is connected)."""
-    from vllm import SamplingParams
-
     llm.generate(PROMPTS, SamplingParams(max_tokens=8, temperature=0))
     # time.sleep(5)  # drain FlexKV's async D2H put -> quiesced boundary before reset
     ok = _verl_clear(llm)
@@ -172,8 +173,6 @@ def test_flexkv_populates_before_asserting_reset(llm):
     and query FlexKV for the full prefix. If external hits stay 0 here, the
     connector isn't really working and the reset test below is meaningless.
     """
-    from vllm import SamplingParams
-
     sp = SamplingParams(max_tokens=8, temperature=0)
     generate(llm, PROMPTS, sp)                       # populate FlexKV (+ local)
     # Clear LOCAL only (keep FlexKV) so the next run can't be served from GPU.
@@ -191,8 +190,6 @@ def test_reset_invalidates_flexkv_hits(llm):
 
     Protocol: warm -> CLEAR -> run1 (expect ~0 ext hits) -> run2 (expect > run1).
     """
-    from vllm import SamplingParams
-
     sp = SamplingParams(max_tokens=8, temperature=0)
 
     def _rate(h, q):
@@ -234,4 +231,69 @@ def test_reset_invalidates_flexkv_hits(llm):
     assert eh2 > eh1, (
         f"external hits did not recover after refill (run1={eh1}, run2={eh2}); "
         f"FlexKV may not be working at all"
+    )
+
+
+def test_sleep_wake_drops_flexkv_but_stays_mounted(llm):
+    """Characterize FlexKV's behavior across vLLM sleep(level=1)/wake.
+
+    level=1 DISCARDS the KV cache -- this is not FlexKV-specific, it's how vLLM's
+    CuMem sleep works. Chain (paths in the sibling vllm checkout):
+      gpu_worker.sleep -> SleepModeBackend.suspend:
+          allocator.sleep(offload_tags=("weights",) if level == 1 else ())
+      CuMemAllocator.sleep: tags in offload_tags are copied to a CPU backup;
+          every other allocation is unmap_and_release'd WITHOUT backup, i.e.
+          "discarded directly" (see its docstring + log line).
+      The KV cache is allocated under tag="kv_cache" (gpu_worker
+          _maybe_get_memory_pool_context(tag="kv_cache")), which is NOT in
+          ("weights",) at level=1 -> the GPU KV cache is dropped on sleep.
+    The FlexKV connector also has no sleep/wake hook (vllm_v1_adapter.py), and
+    the GPU KV buffers it registered are among those unmapped, so post-wake
+    lookups miss. Net effect matches verl's post-weight-update clear.
+
+    Observable contract after sleep(level=1)/wake:
+      - connector stays MOUNTED and is still queried (queries > 0), but
+      - all prior content misses (hits == 0 on the first post-wake run), then
+      - a second post-wake run re-hits, proving clean re-population (not
+        permanently dead / no stale-pointer corruption).
+
+    If a future vLLM tags the KV cache for offload at level=1, or FlexKV adds a
+    sleep/wake hook that preserves its cache, flip the run1 hit assertion.
+
+    Protocol: warm -> sleep(level=1) -> wake_up -> run1 (expect 0 hits, but
+    queried) -> run2 (expect hits > 0, re-populated).
+    """
+    sp = SamplingParams(max_tokens=8, temperature=0)
+
+    # warm: populate FlexKV (+ local GPU cache).
+    generate(llm, PROMPTS, sp)
+    # Drain FlexKV's async D2H put before we free GPU blocks out from under it.
+    assert _reset_local_prefix_cache(llm), "local prefix cache reset failed"
+
+    # sleep: free GPU KV memory (level=1 keeps weights on GPU; verl's default).
+    llm.sleep(level=1)
+    llm.wake_up()
+
+    # run1: local GPU cache is cold after sleep -> full ext query. FlexKV's
+    # content was dropped by sleep/wake, so this misses (hits == 0) while still
+    # querying (queries > 0) -> connector is mounted, just empty.
+    eh1, eq1 = generate(llm, PROMPTS, sp)
+    assert eq1 > 0, (
+        f"connector not queried after wake (hits={eh1}/{eq1}); "
+        f"FlexKV unmounted by sleep/wake rather than just emptied"
+    )
+    assert eh1 == 0, (
+        f"unexpected external hits after sleep/wake (hits={eh1}/{eq1}); "
+        f"FlexKV now PRESERVES content across sleep -- update this test's "
+        f"expectation (see docstring)"
+    )
+
+    # run2: run1 re-populated FlexKV. Clear LOCAL only so run2 is forced to
+    # query FlexKV for the full prefix and can register hits -> proves the
+    # connector cleanly recovered (no stale-pointer corruption / permadeath).
+    assert _reset_local_prefix_cache(llm), "local prefix cache reset failed"
+    eh2, eq2 = generate(llm, PROMPTS, sp)
+    assert eh2 > 0, (
+        f"external hits did not recover after sleep/wake refill "
+        f"(run1={eh1}/{eq1}, run2={eh2}/{eq2}); FlexKV broken post-wake"
     )

--- a/tests/test_reset_cache_vllm_e2e.py
+++ b/tests/test_reset_cache_vllm_e2e.py
@@ -1,0 +1,176 @@
+"""Level B: end-to-end vLLM + FlexKV reset test.
+
+This exercises the EXACT call verl makes after a weight update
+(vllm_async_server.py: `await self.engine.reset_prefix_cache(reset_connector=True)`)
+against a real vLLM engine configured with the FlexKV connector, and asserts
+that FlexKV's external cache is actually invalidated (not the §3 silent
+false-success).
+
+We use the OFFLINE `LLM` (synchronous) rather than the async server because it
+exposes the identical `reset_prefix_cache(reset_connector=...)` API with far
+less setup — the connector code path hit is the same one verl drives.
+
+Requirements:
+  - 1 GPU
+  - vLLM >= 0.13.0 (older versions don't forward reset_connector)
+  - FlexKV installed/importable
+  - A small model (default: Qwen/Qwen2.5-0.5B-Instruct)
+  - FLEXKV_CONFIG_PATH pointing at a JSON with a cpu cache_config, e.g.:
+        {"cache_config": {"enable_cpu": true, "num_cpu_blocks": 4096}}
+    (this fixture writes one automatically to a temp file if unset)
+
+Run:
+    pytest -s tests/test_reset_cache_vllm_e2e.py
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+torch = pytest.importorskip("torch")
+vllm = pytest.importorskip("vllm")
+pytest.importorskip("flexkv")
+
+from packaging import version
+
+MODEL = os.environ.get("FLEXKV_TEST_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+
+
+def _skip_if_no_gpu():
+    if not torch.cuda.is_available():
+        pytest.skip("no CUDA device")
+
+
+def _skip_if_vllm_too_old():
+    if version.parse(vllm.__version__) < version.parse("0.13.0"):
+        pytest.skip(f"vLLM {vllm.__version__} < 0.13.0 does not forward reset_connector")
+
+
+@pytest.fixture(scope="module")
+def flexkv_config_path(tmp_path_factory):
+    """Ensure FLEXKV_CONFIG_PATH points at a minimal CPU-only cache config."""
+    existing = os.environ.get("FLEXKV_CONFIG_PATH")
+    if existing:
+        return existing
+    cfg = {"cache_config": {"enable_cpu": True, "num_cpu_blocks": 4096}}
+    p = tmp_path_factory.mktemp("flexkv") / "flexkv_config.json"
+    p.write_text(json.dumps(cfg))
+    os.environ["FLEXKV_CONFIG_PATH"] = str(p)
+    return str(p)
+
+
+@pytest.fixture(scope="module")
+def llm(flexkv_config_path):
+    _skip_if_no_gpu()
+    _skip_if_vllm_too_old()
+    from vllm import LLM
+    from vllm.config import KVTransferConfig
+
+    llm = LLM(
+        model=MODEL,
+        enforce_eager=True,
+        gpu_memory_utilization=0.5,
+        enable_prefix_caching=True,
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="FlexKVConnectorV1",
+            kv_role="kv_both",
+        ),
+    )
+    yield llm
+    del llm
+
+
+def _reset_kwargs():
+    """Mirror verl's _RESET_PREFIX_CACHE_KWARGS gating."""
+    kw = {}
+    if version.parse(vllm.__version__) >= version.parse("0.13.0"):
+        kw["reset_connector"] = True
+    return kw
+
+
+def test_reset_prefix_cache_reset_connector_succeeds(llm):
+    """Smoke: the exact verl call must return without error.
+
+    Weak assertion (returns True / no exception) — proves the reset_cache()
+    override is wired end-to-end (not the base-class no-op path). Stronger
+    behavioral assertion is in the next test.
+    """
+    from vllm import SamplingParams
+
+    prompt = "The capital of France is " * 40  # long enough to span many blocks
+    llm.generate([prompt], SamplingParams(max_tokens=8, temperature=0))
+
+    # ★ This is the verl call (vllm_async_server.py clear_kv_cache line 815).
+    ok = llm.reset_prefix_cache(**_reset_kwargs())
+    # vLLM's reset_prefix_cache returns True on success; scheduler treats only a
+    # literal False as failure. With the FlexKV reset_cache() override wired,
+    # this should be truthy.
+    assert ok is not False
+
+
+def test_reset_invalidates_flexkv_hits(llm):
+    """Behavioral: after reset, re-running the same prompt must NOT get external
+    (FlexKV) cache hits — proving the offloaded KV was actually dropped.
+
+    We compare FlexKV connector stats across two runs of the same prompt with a
+    reset in between. Without a working reset, the 2nd run would hit FlexKV.
+
+    NOTE: connector stats plumbing differs across vLLM versions; if stats are
+    unavailable this test degrades to a structural check and is skipped with a
+    clear message rather than silently passing.
+    """
+    from vllm import SamplingParams
+
+    prompt = "Tell me about the history of the Roman Empire. " * 40
+    sp = SamplingParams(max_tokens=8, temperature=0)
+
+    # Warm-up run -> FlexKV gets populated on request_finished.
+    llm.generate([prompt], sp)
+
+    # Reset BOTH the local prefix cache and (via reset_connector) FlexKV.
+    llm.reset_prefix_cache(**_reset_kwargs())
+
+    # Re-run the identical prompt. If FlexKV was correctly invalidated, the
+    # connector must recompute (0 external matched tokens) rather than load
+    # stale blocks.
+    #
+    # Observing "external matched tokens" requires connector stats; the exact
+    # accessor is version-specific. We surface whatever the engine exposes and
+    # assert it does not indicate a fresh external hit. If we can't read it,
+    # skip loudly (do not false-pass).
+    stats = _try_get_connector_prefix_hits(llm)
+    if stats is None:
+        pytest.skip(
+            "connector prefix-cache stats not accessible on this vLLM build; "
+            "use the FlexKV-side spy (see README) to assert reset_cache() was called"
+        )
+    external_hits_after_reset = stats
+    assert external_hits_after_reset == 0, (
+        f"expected 0 external FlexKV hits after reset, got {external_hits_after_reset}"
+    )
+
+
+def _try_get_connector_prefix_hits(llm):
+    """Best-effort read of external (connector) prefix-cache hit count.
+
+    Returns an int, or None if the metric can't be located on this vLLM build.
+    Kept intentionally defensive: vLLM's stats API is still moving.
+    """
+    try:
+        # V1 engine path: metrics live on the engine core's scheduler stats.
+        # This is best-effort and may need adjustment for your vLLM version.
+        engine = getattr(llm, "llm_engine", None)
+        if engine is None:
+            return None
+        # Try a few known-ish locations; return None if none present.
+        get_metrics = getattr(engine, "get_metrics", None)
+        if callable(get_metrics):
+            metrics = get_metrics()
+            for m in metrics:
+                name = getattr(m, "name", "")
+                if "connector" in name and "hit" in name:
+                    return int(getattr(m, "value", 0))
+        return None
+    except Exception:
+        return None

--- a/tests/test_transfer_worker_device_selection.py
+++ b/tests/test_transfer_worker_device_selection.py
@@ -1,0 +1,68 @@
+import pytest
+import torch
+
+from flexkv.transfer import worker
+
+
+class RegistrationStopped(Exception):
+    pass
+
+
+def stop_at_first_host_registration(monkeypatch, events):
+    monkeypatch.setattr(
+        worker.torch.cuda,
+        "set_device",
+        lambda device: events.append(("set_device", device)),
+    )
+
+    def register(_tensor):
+        events.append(("register", None))
+        raise RegistrationStopped
+
+    monkeypatch.setattr(worker, "cudaHostRegister", register)
+
+
+def test_gpu_cpu_worker_selects_device_before_host_registration(monkeypatch):
+    events = []
+    stop_at_first_host_registration(monkeypatch, events)
+
+    with pytest.raises(RegistrationStopped):
+        worker.GPUCPUTransferWorker(
+            worker_id=0,
+            transfer_conn=None,
+            finished_ops_queue=None,
+            op_buffer_tensor=torch.empty(0),
+            gpu_blocks=[],
+            cpu_blocks=torch.empty(0),
+            gpu_kv_layout=None,
+            cpu_kv_layout=None,
+            dtype=torch.bfloat16,
+            gpu_device_id=3,
+        )
+
+    assert events == [("set_device", 3), ("register", None)]
+
+
+def test_tp_worker_selects_registered_device_before_host_registration(monkeypatch):
+    events = []
+    stop_at_first_host_registration(monkeypatch, events)
+    handle = type("Handle", (), {"device": torch.device("cuda:4")})()
+
+    with pytest.raises(RegistrationStopped):
+        worker.tpGPUCPUTransferWorker(
+            worker_id=0,
+            transfer_conn=None,
+            finished_ops_queue=None,
+            op_buffer_tensor=torch.empty(0),
+            gpu_blocks=[[handle], [handle]],
+            cpu_blocks=torch.empty(0),
+            gpu_kv_layouts=[],
+            cpu_kv_layout=None,
+            dtype=torch.bfloat16,
+            tp_group_size=2,
+        )
+
+    assert events == [
+        ("set_device", 4),
+        ("register", None),
+    ]

--- a/tests/test_vllm_abort_offload_directive.py
+++ b/tests/test_vllm_abort_offload_directive.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from vllm.v1.engine import FinishReason
+
+from flexkv.integration.vllm.vllm_v1_adapter import FlexKVSchedulerConnector
+
+
+def _connector() -> FlexKVSchedulerConnector:
+    connector = object.__new__(FlexKVSchedulerConnector)
+    connector.req_id_to_task_dict = {}
+    connector.maybe_skip_put = False
+    connector.flexkv_stats = Mock()
+    connector._put_match = Mock(return_value=(-1, 0, 0))
+    return connector
+
+
+def _request(reason: FinishReason, offload: bool):
+    return SimpleNamespace(
+        request_id="request-0",
+        is_finished=lambda: True,
+        get_finished_reason=lambda: reason,
+        offload_kv_on_finish=offload,
+        num_tokens=32,
+    )
+
+
+def test_abort_without_vllm_directive_does_not_enter_put_path():
+    connector = _connector()
+
+    delayed = connector.request_finished(
+        _request(FinishReason.ABORT, offload=False), [0, 1]
+    )
+
+    assert delayed is False
+    connector._put_match.assert_not_called()
+
+
+def test_abort_with_vllm_directive_enters_existing_put_path():
+    connector = _connector()
+
+    delayed = connector.request_finished(
+        _request(FinishReason.ABORT, offload=True), [0, 1]
+    )
+
+    assert delayed is False
+    connector._put_match.assert_called_once()
+    connector.flexkv_stats.record_put.assert_called_once()
+
+
+def test_normal_finish_remains_eligible_for_put():
+    connector = _connector()
+
+    delayed = connector.request_finished(
+        _request(FinishReason.STOP, offload=False), [0, 1]
+    )
+
+    assert delayed is False
+    connector._put_match.assert_called_once()
+    connector.flexkv_stats.record_put.assert_called_once()

--- a/tests/test_vmm_register.py
+++ b/tests/test_vmm_register.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import ctypes
 import multiprocessing as mp
 import os
+from types import SimpleNamespace
 from typing import Optional
 
 import pytest
@@ -67,6 +68,44 @@ def _fabric_supported(device_id: int = 0) -> bool:
         ctypes.byref(flag), ctypes.c_int(128), ctypes.c_int(device_id)
     ) if hasattr(libcuda, "cuDeviceGetAttribute") else 1
     return res == CUDA_SUCCESS and flag.value != 0
+
+
+def test_release_vmm_tensor_unmaps_and_frees_address(monkeypatch):
+    calls = []
+    fake_libcuda = SimpleNamespace(
+        cuMemUnmap=lambda base, size: calls.append(
+            ("unmap", base.value, size.value)
+        ) or CUDA_SUCCESS,
+        cuMemAddressFree=lambda base, size: calls.append(
+            ("free", base.value, size.value)
+        ) or CUDA_SUCCESS,
+    )
+    tensor = SimpleNamespace(data_ptr=lambda: 0x1200)
+    monkeypatch.setattr(memory_handle, "libcuda", fake_libcuda)
+    monkeypatch.setitem(
+        memory_handle._IMPORTED_VMM_MAPPINGS, 0x1200, (0x1000, 4096)
+    )
+
+    assert memory_handle.release_vmm_tensor(tensor) is True
+    assert calls == [("unmap", 0x1000, 4096), ("free", 0x1000, 4096)]
+    assert 0x1200 not in memory_handle._IMPORTED_VMM_MAPPINGS
+    assert memory_handle.release_vmm_tensor(tensor) is False
+
+
+def test_release_exported_vmm_handle_closes_fd(monkeypatch):
+    closed = []
+    handle = object.__new__(TensorSharedHandle)
+    handle._exported_vmm_fd = 51
+    handle._exported_vmm_fd_key = 7
+    monkeypatch.setitem(memory_handle._VMM_FD_SERVER_STATE["fd_by_key"], 7, 51)
+    memory_handle._EXPORTED_VMM_FDS.append(51)
+    monkeypatch.setattr(memory_handle.os, "close", closed.append)
+
+    assert handle.release_exported_vmm_handle() is True
+    assert closed == [51]
+    assert 7 not in memory_handle._VMM_FD_SERVER_STATE["fd_by_key"]
+    assert 51 not in memory_handle._EXPORTED_VMM_FDS
+    assert handle.release_exported_vmm_handle() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vmm_register.py
+++ b/tests/test_vmm_register.py
@@ -1,0 +1,285 @@
+"""End-to-end tests for VMM-backed TensorSharedHandle sharing.
+
+These exercise the path FlexKV needs when vLLM's ``enable_sleep_mode`` is on:
+KV cache tensors are allocated via ``cuMemCreate`` + ``cuMemMap`` (CUDA VMM),
+which the legacy ``cudaIpcGetMemHandle`` API cannot export. FlexKV instead
+uses ``cuMemExportToShareableHandle`` with a fabric handle so the resulting
+bytes still fit through the existing ZMQ control plane.
+
+Requires:
+  * CUDA-capable GPU
+  * libcuda + libcudart present at load time
+  * Driver + hardware that expose ``CU_MEM_HANDLE_TYPE_FABRIC`` (H100+
+    with nvidia-imex running); FD-only setups skip cleanly.
+
+Tests that need a second process spawn one with ``multiprocessing.spawn``
+so the importer gets a distinct CUDA context, matching FlexKV's real
+KVManager topology.
+"""
+from __future__ import annotations
+
+import ctypes
+import multiprocessing as mp
+import os
+from typing import Optional
+
+import pytest
+import torch
+
+from flexkv.common import memory_handle
+from flexkv.common.memory_handle import (
+    CUDA_SUCCESS,
+    CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
+    CU_MEM_ALLOCATION_TYPE_PINNED,
+    CU_MEM_HANDLE_TYPE_FABRIC,
+    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+    CU_MEM_LOCATION_TYPE_DEVICE,
+    CUmemAccessDesc,
+    CUmemAllocationProp,
+    TensorSharedHandle,
+    _is_vmm_pointer,
+    libcuda,
+)
+
+
+# ---------------------------------------------------------------------------
+# GPU / driver availability
+# ---------------------------------------------------------------------------
+
+
+def _cuda_available() -> bool:
+    return torch.cuda.is_available() and libcuda is not None
+
+
+requires_cuda_vmm = pytest.mark.skipif(
+    not _cuda_available(),
+    reason="requires a CUDA GPU + libcuda for VMM primitives",
+)
+
+
+def _fabric_supported(device_id: int = 0) -> bool:
+    """Query CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED."""
+    if libcuda is None:
+        return False
+    # 128 = CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED
+    flag = ctypes.c_int(0)
+    res = libcuda.cuDeviceGetAttribute(
+        ctypes.byref(flag), ctypes.c_int(128), ctypes.c_int(device_id)
+    ) if hasattr(libcuda, "cuDeviceGetAttribute") else 1
+    return res == CUDA_SUCCESS and flag.value != 0
+
+
+# ---------------------------------------------------------------------------
+# Detection helper
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda_vmm
+def test_is_vmm_pointer_false_for_cudamalloc() -> None:
+    """Legacy cudaMalloc allocations must be reported as non-VMM."""
+    t = torch.zeros(1024, dtype=torch.uint8, device="cuda:0")
+    assert _is_vmm_pointer(t.data_ptr()) is False
+
+
+@requires_cuda_vmm
+def test_is_vmm_pointer_true_for_vmm() -> None:
+    """A cuMemCreate/cuMemMap allocation must be reported as VMM."""
+    va, alloc_size, mem_handle = _vmm_alloc(bytes_=2 * 1024 * 1024, device_id=0)
+    try:
+        assert _is_vmm_pointer(va) is True
+    finally:
+        _vmm_free(va, alloc_size, mem_handle)
+
+
+# ---------------------------------------------------------------------------
+# Full round-trip through TensorSharedHandle
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda_vmm
+def test_vmm_export_produces_fabric_or_skips() -> None:
+    """Exporting a VMM tensor should yield a fabric handle when supported.
+
+    On boxes without fabric (older drivers / no imex), the exporter is
+    expected to raise NotImplementedError with a message pointing users at
+    sleep_mode; skip rather than fail there.
+    """
+    if not _fabric_supported():
+        pytest.skip("fabric handle type not supported on this device")
+
+    va, alloc_size, mem_handle = _vmm_alloc_shareable_fabric(
+        bytes_=2 * 1024 * 1024, device_id=0
+    )
+    try:
+        # Wrap the VA range as a torch tensor via the existing zero-copy
+        # helper so we exercise the same code path FlexKV uses.
+        tensor = TensorSharedHandle._create_tensor_from_cuda_ptr(
+            va,
+            shape=(alloc_size,),
+            dtype=torch.uint8,
+            device=torch.device("cuda:0"),
+        )
+        handle = TensorSharedHandle(tensor)
+        assert handle.handle_type == "vmm_fabric"
+        assert handle.ipc_handle is not None
+        assert len(handle.ipc_handle) == 64
+        assert handle.vmm_allocation_size == alloc_size
+        assert handle.vmm_granularity > 0
+        assert handle.offset == 0
+    finally:
+        _vmm_free(va, alloc_size, mem_handle)
+
+
+@requires_cuda_vmm
+def test_vmm_round_trip_across_processes() -> None:
+    """Import in a subprocess should see the same memory (writes propagate)."""
+    if not _fabric_supported():
+        pytest.skip("fabric handle type not supported on this device")
+
+    # Preferable to use spawn so the child has a fresh CUDA context.
+    ctx = mp.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe()
+    proc = ctx.Process(
+        target=_vmm_importer_child,
+        args=(child_conn,),
+        daemon=True,
+    )
+    proc.start()
+    try:
+        va, alloc_size, mem_handle = _vmm_alloc_shareable_fabric(
+            bytes_=2 * 1024 * 1024, device_id=0
+        )
+        try:
+            tensor = TensorSharedHandle._create_tensor_from_cuda_ptr(
+                va,
+                shape=(alloc_size,),
+                dtype=torch.uint8,
+                device=torch.device("cuda:0"),
+            )
+            # Pre-write a sentinel so the child can verify visibility.
+            tensor.fill_(0x5A)
+            torch.cuda.synchronize()
+
+            handle = TensorSharedHandle(tensor)
+            parent_conn.send({
+                "handle_type": handle.handle_type,
+                "ipc_handle": handle.ipc_handle,
+                "shape": handle.tensor_shape,
+                "dtype": str(handle.tensor_dtype),
+                "device_id": 0,
+                "offset": handle.offset,
+                "size": handle.vmm_allocation_size,
+                "granularity": handle.vmm_granularity,
+            })
+
+            reply = parent_conn.recv()
+            assert reply["status"] == "ok", reply
+            assert reply["first_byte"] == 0x5A
+        finally:
+            _vmm_free(va, alloc_size, mem_handle)
+    finally:
+        proc.join(timeout=30)
+        assert proc.exitcode == 0, f"child exit code = {proc.exitcode}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: raw driver-API allocation without depending on vLLM
+# ---------------------------------------------------------------------------
+
+
+def _vmm_alloc(bytes_: int, device_id: int):
+    """Allocate a legacy VMM range (no shareable handle) for detection tests."""
+    return _vmm_alloc_shareable(bytes_, device_id, handle_type=0)
+
+
+def _vmm_alloc_shareable_fabric(bytes_: int, device_id: int):
+    return _vmm_alloc_shareable(
+        bytes_, device_id, handle_type=CU_MEM_HANDLE_TYPE_FABRIC
+    )
+
+
+def _vmm_alloc_shareable(bytes_: int, device_id: int, handle_type: int):
+    assert libcuda is not None
+    prop = CUmemAllocationProp()
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = device_id
+    prop.requestedHandleTypes = handle_type
+
+    granularity = ctypes.c_size_t()
+    _check(libcuda.cuMemGetAllocationGranularity(
+        ctypes.byref(granularity),
+        ctypes.byref(prop),
+        ctypes.c_int(0),  # MINIMUM
+    ))
+    align = int(granularity.value)
+    aligned = ((bytes_ + align - 1) // align) * align
+
+    mem_handle = ctypes.c_void_p()
+    _check(libcuda.cuMemCreate(
+        ctypes.byref(mem_handle),
+        ctypes.c_size_t(aligned),
+        ctypes.byref(prop),
+        ctypes.c_ulonglong(0),
+    ))
+    va = ctypes.c_ulonglong(0)
+    _check(libcuda.cuMemAddressReserve(
+        ctypes.byref(va),
+        ctypes.c_size_t(aligned),
+        ctypes.c_size_t(align),
+        ctypes.c_ulonglong(0),
+        ctypes.c_ulonglong(0),
+    ))
+    _check(libcuda.cuMemMap(
+        ctypes.c_ulonglong(va.value),
+        ctypes.c_size_t(aligned),
+        ctypes.c_ulonglong(0),
+        mem_handle,
+        ctypes.c_ulonglong(0),
+    ))
+    access = CUmemAccessDesc()
+    access.location.type = CU_MEM_LOCATION_TYPE_DEVICE
+    access.location.id = device_id
+    access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+    _check(libcuda.cuMemSetAccess(
+        ctypes.c_ulonglong(va.value),
+        ctypes.c_size_t(aligned),
+        ctypes.byref(access),
+        ctypes.c_size_t(1),
+    ))
+    return va.value, aligned, mem_handle
+
+
+def _vmm_free(va: int, size: int, mem_handle) -> None:
+    assert libcuda is not None
+    libcuda.cuMemUnmap(ctypes.c_ulonglong(va), ctypes.c_size_t(size))
+    libcuda.cuMemAddressFree(ctypes.c_ulonglong(va), ctypes.c_size_t(size))
+    libcuda.cuMemRelease(mem_handle)
+
+
+def _check(res: int) -> None:
+    if res != CUDA_SUCCESS:
+        raise RuntimeError(f"driver call returned CUresult={res}")
+
+
+def _vmm_importer_child(conn) -> None:
+    """Subprocess entry point: import handle, verify data, echo back."""
+    try:
+        msg = conn.recv()
+        handle = TensorSharedHandle(
+            data=msg["ipc_handle"],
+            device_id=msg["device_id"],
+            tensor_shape=msg["shape"],
+            tensor_dtype=msg["dtype"],
+            offset=msg["offset"],
+            handle_type=msg["handle_type"],
+            vmm_allocation_size=msg["size"],
+            vmm_granularity=msg["granularity"],
+        )
+        tensor = handle.get_tensor()
+        torch.cuda.synchronize()
+        first_byte = int(tensor[0].item())
+        conn.send({"status": "ok", "first_byte": first_byte})
+    except Exception as exc:  # noqa: BLE001
+        conn.send({"status": "error", "error": repr(exc)})
+        raise


### PR DESCRIPTION
## 概述

本 PR 补充 RL dynamic resource 场景所需的 FlexKV 侧支持，目标是在 vLLM sleep/wake 生命周期中使用节点级 external FlexKV server。主要能力包括：区分 policy update cache reset 与 dynamic sleep、按 vLLM 显式指令保存 aborted request KV、支持同节点多 replica GPU registration，以及让 imported VMM mapping 正确跟随 exporter allocation 的生命周期。

此外，本 PR 也修复了节点内及跨节点 KV reuse 验证过程中发现的控制面和分布式 metadata 问题。

## 主要改动

提交仍按问题拆分，便于独立 review 和回溯；下面按功能目标聚类说明，并保留对应 commit。

1. **支持 RL policy update 时清理旧 KV cache**
   - 贯通 `reset_cache()`，明确 reset 只失效 external cache index、memory pool 和相关 request bookkeeping，并处理 reset 与异步 transfer completion 并发发生的情况；同时通过分层 reset barrier 清理跨节点 Redis block metadata，避免物理 block 重用后残留旧索引。
   - 补充单元测试和 vLLM E2E 测试，验证旧 cache 被清除，reset 后仍可重新写入和命中。
   - Commits: `83d62f4`, `3ec4143`, `303982b`, `da49b9e`, `51f321f`, `d09aa4d`

2. **支持 CUDA VMM 和 vLLM sleep/wake 生命周期**
   - 支持注册由 CUDA VMM/CuMemAllocator 创建的 GPU tensor，并通过共享 allocation handle 在 FlexKV 进程中建立 zero-copy mapping。
   - sleep 前 drain transfer 并释放 imported mapping；wake 后基于新的 KV tensor handle 重新注册和映射，同时保留 CPU 中已经 offload 的 KV。
   - 补充 sleep mode、VMM registration 和 mapping lifecycle 测试；host registration 的 device-selection 提交在当前 upstream 上仅保留回归测试。
   - Commits: `f3a279b`, `0df2acc`, `dcef4fc`, `46bfdbb`

3. **支持 dynamic abort KV checkpoint**
   - FlexKV 只在 vLLM 显式要求时保存 aborted request KV，普通 abort 不会隐式 offload。
   - Commits: `fc6f28f`

4. **支持节点级 external server 和多 replica 注册**
   - 使用 `(dp_client_id, intra_client_id)` 作为 registration identity，避免多个 replica 的 local device ID 相互覆盖；`device_id` 仍只负责选择本地 CUDA device。
   - 将共享 server 生命周期与单个 client 解耦，使同节点多个 vLLM replica 可以共享一个独立管理的 FlexKV server。
   - Commits: `ebc9ece`, `452f83f`

5. **修复 RL 并发调度和 layout 兼容问题**
   - 对齐 cancel API；串行化共享 ZeroMQ socket 上的 `launch_tasks()` / `try_wait()` 控制面 RPC；单 task 不使用 batch protocol。
   - 将 `layer_groups` 作为可选属性处理，兼容普通 single-group layout，同时保留 upstream multi-group 路径。
   - Commits: `a449e35`, `19291c8`, `1ba75e2`, `251d7b9`

6. **完善跨节点 metadata 生命周期和 transfer-only 构建**
   - 随 node heartbeat 续租 transfer endpoint metadata，避免 RL 初始化较长时 endpoint 信息提前过期。
   - transfer-only Mooncake 构建显式关闭未使用的 Rust store，减少额外依赖。
   - Commits: `d5cca66`, `0049861`