### PR TITLE
fix(build): remove non-UAPI <linux/ioprio.h> to fix SSD compilation

### DIFF
--- a/csrc/transfer_ssd.h
+++ b/csrc/transfer_ssd.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <errno.h>
 #include <liburing.h>
-#include <linux/ioprio.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
+#include <fcntl.h>
 #include <torch/extension.h>
 #include <unistd.h>
 #include <vector>


### PR DESCRIPTION
## Summary

This PR fixes a compilation failure in the SSD component caused by including
the non-UAPI kernel header `linux/ioprio.h`.

## Problem

The code previously included `<linux/ioprio.h>` directly. This header is an
internal kernel header and is **not** part of the kernel UAPI (user-space API).
As a result, builds on systems without full kernel source/headers installed
(or with mismatched kernel headers) fail with errors like:

    fatal error: linux/ioprio.h: No such file or directory

This particularly breaks compilation of the SSD-related code paths.

## Solution

Replace the `#include <linux/ioprio.h>` directive with `#include <fcntl.h>`,
which provides the necessary declarations / syscall wrappers for I/O priority
operations in user space without depending on internal kernel headers.