### PR TITLE
fix(sglang): synchronize async cache task ownership

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,8 @@ jobs:
 
           echo "Running ${#unit_test_files[@]} CPU unit test files against the built wheel."
           cd "$RUNNER_TEMP"
-          timeout 10m python -m pytest -q --maxfail=1 "${unit_test_files[@]}"
+          # Keep pytest's configured pythonpath from shadowing the installed wheel.
+          timeout 10m python -m pytest -q --maxfail=1 -o pythonpath= "${unit_test_files[@]}"
 
       - name: Get Date and Time
         if: github.event_name == 'push'

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -1256,6 +1256,8 @@ class GlobalCacheEngine:
         ssd_node_to_unlock = ssd_matched_result.last_ready_node
         remote_node_to_unlock = remote_matched_result.last_ready_node
         cpu_blocks_to_free = np.array([], dtype=np.int64)
+        cpu_node_to_ready = None
+        ssd_node_to_ready = None
 
         if fragment23_num_blocks > 0:
             num_extra_required_blocks = fragment23_num_blocks
@@ -1289,6 +1291,7 @@ class GlobalCacheEngine:
                                                                     block_mask_start,
                                                                   is_ready=False,
                                                                   match_result=cpu_matched_result)
+                cpu_node_to_ready = cpu_node_to_unlock
             else:
                 cpu_blocks_to_free = fragment23_cpu_blocks
 
@@ -1369,6 +1372,49 @@ class GlobalCacheEngine:
                                                                     block_mask_start,
                                                                 is_ready=False,
                                                                 match_result=ssd_matched_result)
+                ssd_node_to_ready = ssd_node_to_unlock
+
+        # A prefetch has no H2D op, so its terminal op must be the host-stage
+        # transfer itself.  The global path also inserts REMOTE2H/DISK2H
+        # destinations into the CPU radix as ``is_ready=False``.  Publish that
+        # node only after every host-stage fragment is complete; otherwise the
+        # unready nodes accumulate, cannot be evicted, and eventually exhaust
+        # the CPU pool.  A virtual join preserves parallel SSD and remote IO.
+        op_callback_dict = {}
+        host_finished_ops_ids = [
+            op.op_id for op in (op_disk2h, op_remote2h) if op is not None
+        ]
+        host_ready_op_id = -1
+        if host_finished_ops_ids:
+            transfer_graph, host_ready_op_id = add_virtual_op_for_multiple_finished_ops(
+                transfer_graph, host_finished_ops_ids, dp_client_id
+            )
+            if not enable_gpu:
+                finished_ops_ids.append(host_ready_op_id)
+        if cpu_node_to_ready is not None:
+            assert host_ready_op_id >= 0
+            self._append_op_callback(
+                op_callback_dict,
+                host_ready_op_id,
+                partial(
+                    self._op_callback,
+                    device_type=DeviceType.CPU,
+                    node_to_ready=cpu_node_to_ready,
+                    ready_length=cpu_node_to_ready.size(),
+                ),
+            )
+        if ssd_node_to_ready is not None:
+            assert op_h2disk is not None
+            self._append_op_callback(
+                op_callback_dict,
+                op_h2disk.op_id,
+                partial(
+                    self._op_callback,
+                    device_type=DeviceType.SSD,
+                    node_to_ready=ssd_node_to_ready,
+                    ready_length=ssd_node_to_ready.size(),
+                ),
+            )
         if enable_gpu:
             op_h2d = TransferOp(
                 graph_id = transfer_graph.graph_id,
@@ -1394,7 +1440,6 @@ class GlobalCacheEngine:
 
         buffer_to_free = {DeviceType.CPU: cpu_blocks_to_free}
         num_gpu_blocks_to_transfer = len(fragment123_gpu_blocks) if enable_gpu else 0
-        op_callback_dict = {}
         if swa_reservation is not None:
             assert num_gpu_blocks_to_transfer > 0
             finished_ops_ids.append(swa_reservation.h2d_id)

--- a/flexkv/integration/sglang/comm.py
+++ b/flexkv/integration/sglang/comm.py
@@ -40,11 +40,7 @@ import torch.distributed as dist
 
 logger = logging.getLogger(__name__)
 
-# PP-channel command tags (used by ``scatter_pp`` payloads). Sender and
-# receiver assert on these to catch protocol drift early.
-CMD_PUT_META = 2
 CMD_LAYERWISE = 3
-CMD_STORE_COMPLETE = 5
 
 
 class FlexKVScatterChannel(str, Enum):
@@ -56,6 +52,8 @@ class FlexKVScatterChannel(str, Enum):
     PREFETCH_START = "prefetch_start"
     PREFETCH_PROGRESS = "prefetch_progress"
     RESET = "reset"
+    STORE_START = "store_start"
+    STORE_RESET = "store_reset"
 
 
 _SCATTER_CHANNEL_OFFSETS = {
@@ -65,6 +63,8 @@ _SCATTER_CHANNEL_OFFSETS = {
     FlexKVScatterChannel.PREFETCH_START: 4,
     FlexKVScatterChannel.PREFETCH_PROGRESS: 5,
     FlexKVScatterChannel.RESET: 6,
+    FlexKVScatterChannel.STORE_START: 7,
+    FlexKVScatterChannel.STORE_RESET: 8,
 }
 _SCATTER_CHANNEL_TYPES = {
     FlexKVScatterChannel.LOOKUP: dict,
@@ -73,6 +73,8 @@ _SCATTER_CHANNEL_TYPES = {
     FlexKVScatterChannel.PREFETCH_START: dict,
     FlexKVScatterChannel.PREFETCH_PROGRESS: dict,
     FlexKVScatterChannel.RESET: dict,
+    FlexKVScatterChannel.STORE_START: dict,
+    FlexKVScatterChannel.STORE_RESET: dict,
 }
 
 

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -1267,8 +1267,19 @@ class FlexKVConnector:
         prefetch_error: Optional[Exception] = None
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
             try:
-                task_id = self.kv_manager.prefetch_async(
+                prefetch_result = self.kv_manager.prefetch_async(
                     token_ids=np.asarray(token_ids, dtype=np.int64)
+                )
+                # KVManager currently returns
+                # ``(task_id, actual_prefetch_tokens)`` even though older
+                # versions annotated this API as returning an int.  Accept
+                # both shapes so the SGLang connector remains compatible
+                # across FlexKV versions and never scatters a tuple as the
+                # task id.
+                task_id = (
+                    prefetch_result[0]
+                    if isinstance(prefetch_result, tuple)
+                    else prefetch_result
                 )
             except Exception as exc:  # noqa: BLE001
                 prefetch_error = exc

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -41,8 +41,6 @@ import torch
 
 from flexkv.integration.sglang.comm import (
     CMD_LAYERWISE,
-    CMD_PUT_META,
-    CMD_STORE_COMPLETE,
     FlexKVComm,
     FlexKVLayerDoneCounter,
     FlexKVScatterChannel,
@@ -995,11 +993,10 @@ class FlexKVConnector:
     ) -> int:
         """Schedule a write back from GPU into FlexKV.
 
-        On the sync leader this runs ``put_match`` to discover which
-        tokens are NOT yet in FlexKV's CPU cache (= the "unmatched"
-        slice), then ``launch`` on those. On non-leaders the unmatched
-        mask is received over the PP fan-out so cross-node PP can
-        forward its slot mappings.
+        The sync leader runs ``put_match`` and ``launch``. Its result is
+        fanned out to every PP/CP/TP rank so every rank retains ownership
+        of the source GPU slots until the store completes. A remote PP
+        stage leader also forwards its local slot mapping.
 
         Returns the FlexKV task id of the in-flight store, or -1 if
         nothing needed to be written.
@@ -1018,7 +1015,6 @@ class FlexKVConnector:
         if self.page_size > 1:
             aligned_len = (n // self.page_size) * self.page_size
             if aligned_len == 0:
-                self._send_pp_put_meta(-1, [])
                 self._log_cache_op(
                     context,
                     "complete",
@@ -1032,7 +1028,13 @@ class FlexKVConnector:
                 token_ids_np = token_ids_np[:aligned_len]
                 kv_indices = kv_indices[:aligned_len]
 
-        fkv_task_id = -1
+        store_start = {
+            "rid": rid,
+            "task_id": -1,
+            "active": False,
+            "unmatched_mask": [],
+            "error": "",
+        }
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
             match_error: Optional[Exception] = None
             try:
@@ -1041,7 +1043,6 @@ class FlexKVConnector:
                 match_error = exc
                 res = None
             if res is None:
-                self._send_pp_put_meta(-1, [])
                 self._log_cache_op(
                     context,
                     "complete",
@@ -1051,90 +1052,115 @@ class FlexKVConnector:
                     reason="no_response" if match_error is None else None,
                     error=str(match_error) if match_error is not None else None,
                 )
-                return -1
-            fkv_task_id, unmatched_mask = res
-            context.task_id = fkv_task_id
-
-            self._send_pp_put_meta(fkv_task_id, unmatched_mask)
-
-            unmatched_count = int(unmatched_mask.sum())
-            if unmatched_count > 0:
-                filtered = kv_indices[unmatched_mask]
-                slot_mapping_cpu = self._to_cpu_int64(filtered)
-                swa_slot_mapping = self._build_swa_slot_mapping(filtered)
-                swa_slots = (
-                    0 if swa_slot_mapping is None else int(swa_slot_mapping.numel())
+            else:
+                fkv_task_id, unmatched_mask = res
+                mask_list = (
+                    unmatched_mask.tolist()
+                    if hasattr(unmatched_mask, "tolist")
+                    else list(unmatched_mask)
                 )
-                try:
-                    self.kv_manager.launch(
-                        task_ids=[fkv_task_id],
-                        slot_mappings=[slot_mapping_cpu],
-                        swa_slot_mappings=[swa_slot_mapping],
-                        as_batch=False,
-                        layerwise_transfer=False,
+                store_start.update(
+                    task_id=int(fkv_task_id), unmatched_mask=mask_list
+                )
+                context.task_id = int(fkv_task_id)
+                unmatched_count = int(sum(bool(item) for item in mask_list))
+                if unmatched_count > 0:
+                    filtered = kv_indices[unmatched_mask]
+                    slot_mapping_cpu = self._to_cpu_int64(filtered)
+                    swa_slot_mapping = self._build_swa_slot_mapping(filtered)
+                    swa_slots = (
+                        0
+                        if swa_slot_mapping is None
+                        else int(swa_slot_mapping.numel())
                     )
-                except Exception as exc:  # noqa: BLE001
+                    try:
+                        self.kv_manager.launch(
+                            task_ids=[fkv_task_id],
+                            slot_mappings=[slot_mapping_cpu],
+                            swa_slot_mappings=[swa_slot_mapping],
+                            as_batch=False,
+                            layerwise_transfer=False,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        store_start["error"] = str(exc)
+                        self._log_cache_op(
+                            context,
+                            "complete",
+                            "failed",
+                            direction="D2H",
+                            transfer_mode="no-layerwise",
+                            stage="launch",
+                            error=str(exc),
+                        )
+                    else:
+                        store_start["active"] = True
+                        self._log_cache_op(
+                            context,
+                            "launch",
+                            "running",
+                            direction="D2H",
+                            transfer_mode="no-layerwise",
+                            tokens=unmatched_count,
+                            slots=int(slot_mapping_cpu.numel()),
+                            swa_slots=swa_slots,
+                        )
+                else:
                     self._log_cache_op(
                         context,
                         "complete",
-                        "failed",
+                        "skipped",
                         direction="D2H",
-                        transfer_mode="no-layerwise",
-                        stage="launch",
-                        error=str(exc),
+                        reason="already_cached",
+                        tokens=0,
                     )
-                    raise
-                self._log_cache_op(
-                    context,
-                    "launch",
-                    "running",
-                    direction="D2H",
-                    transfer_mode="no-layerwise",
-                    tokens=unmatched_count,
-                    slots=int(slot_mapping_cpu.numel()),
-                    swa_slots=swa_slots,
-                )
-                self._inflight_stores[rid] = fkv_task_id
-                self._inflight_store_contexts[rid] = context
-                return fkv_task_id
-            self._log_cache_op(
-                context,
-                "complete",
-                "skipped",
-                direction="D2H",
-                reason="already_cached",
-                tokens=0,
+
+        if self._sync_ctx.needs_sync:
+            store_start = self._sync_ctx.scatter(
+                store_start,
+                channel=FlexKVScatterChannel.STORE_START,
             )
+        if store_start.get("rid") != rid:
+            raise RuntimeError(
+                "[FlexKV] store-start rid mismatch: "
+                f"local={rid!r}, leader={store_start.get('rid')!r}"
+            )
+        if store_start.get("error"):
+            raise RuntimeError(
+                f"[FlexKV] store launch failed: {store_start['error']}"
+            )
+        if not store_start.get("active"):
             return -1
 
-        # Non-leader path: receive the unmatched mask + maybe forward
-        # slot_mapping to the remote-side TransferManager.
-        if self._sync_ctx.is_pp_receiver:
-            payload = self._sync_ctx.scatter_pp(None)
-            if payload.get("cmd") != CMD_PUT_META:
-                raise RuntimeError(
-                    f"Tag mismatch: expected CMD_PUT_META, got {payload.get('cmd')}"
-                )
-            fkv_task_id = int(payload["fkv_task_id"])
-            mask_list = payload.get("unmatched_mask", [])
-            unmatched_mask = torch.tensor(mask_list, dtype=torch.bool)
-            if (
-                int(unmatched_mask.sum()) > 0
-                and fkv_task_id >= 0
-                and self._sync_ctx.should_send_slot_mapping_to_remote
-            ):
-                filtered = kv_indices[unmatched_mask]
-                slot_mapping_cpu = self._to_cpu_int64(filtered)
-                self._send_slot_mapping_to_remote(fkv_task_id, slot_mapping_cpu)
-                self._inflight_stores[rid] = fkv_task_id
-                context.task_id = fkv_task_id
-                self._inflight_store_contexts[rid] = context
+        fkv_task_id = int(store_start["task_id"])
+        mask_list = store_start.get("unmatched_mask", [])
+        if fkv_task_id < 0 or len(mask_list) != len(kv_indices):
+            raise RuntimeError(
+                "[FlexKV] invalid store-start payload: "
+                f"task_id={fkv_task_id}, mask_len={len(mask_list)}, "
+                f"slot_len={len(kv_indices)}"
+            )
+
+        # Cross-node PP needs the local PP stage's physical slot mapping.
+        if self._sync_ctx.should_send_slot_mapping_to_remote:
+            unmatched_mask = torch.as_tensor(
+                mask_list, dtype=torch.bool, device=kv_indices.device
+            )
+            filtered = kv_indices[unmatched_mask]
+            self._send_slot_mapping_to_remote(
+                fkv_task_id, self._to_cpu_int64(filtered)
+            )
+
+        # This is deliberately done on every rank. SGLang uses the returned
+        # positive task id to keep radix-node locks (and GPU slots) alive.
+        context.task_id = fkv_task_id
+        self._inflight_stores[rid] = fkv_task_id
+        self._inflight_store_contexts[rid] = context
         return fkv_task_id
 
     def check_completed_stores(self) -> List[str]:
         """Return rids whose stores have completed since the last call."""
         completed_rids: List[str] = []
-        completed_dict: Dict[int, Any] = {}
+        completed_by_rid: Dict[str, Any] = {}
 
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
             if self._inflight_stores:
@@ -1159,50 +1185,36 @@ class FlexKVConnector:
                     )
                     completed_dict = {}
                 for fk_tid, response in completed_dict.items():
+                    status = _status_value(response)
+                    if not _is_terminal_status(status):
+                        continue
                     rid = fk_to_rid[fk_tid]
                     completed_rids.append(rid)
-                    self._inflight_stores.pop(rid, None)
-                    context = self._pop_context(
-                        "_inflight_store_contexts", rid, "store", fk_tid
-                    )
-                    status = _status_value(response)
-                    self._log_cache_op(
-                        context,
-                        "complete",
-                        status,
-                        direction="D2H",
-                        transfer_mode="no-layerwise",
-                    )
-
-        if self._sync_ctx.is_pp_sender:
-            self._sync_ctx.scatter_pp(
-                {
-                    "cmd": CMD_STORE_COMPLETE,
-                    "completed_fk_ids": list(completed_dict),
-                }
-            )
-        elif self._sync_ctx.is_pp_receiver:
-            payload = self._sync_ctx.scatter_pp(None)
-            if payload.get("cmd") != CMD_STORE_COMPLETE:
-                raise RuntimeError(
-                    f"Tag mismatch: expected CMD_STORE_COMPLETE, got "
-                    f"{payload.get('cmd')}"
-                )
-            fk_ids = payload.get("completed_fk_ids", [])
-            if fk_ids and self._inflight_stores:
-                fk_to_rid = {v: k for k, v in self._inflight_stores.items()}
-                for fk_tid in fk_ids:
-                    if fk_tid in fk_to_rid:
-                        rid = fk_to_rid[fk_tid]
-                        completed_rids.append(rid)
-                        self._inflight_stores.pop(rid, None)
-                        getattr(self, "_inflight_store_contexts", {}).pop(rid, None)
+                    completed_by_rid[rid] = response
 
         if self._sync_ctx.needs_sync:
             completed_rids = self._sync_ctx.scatter(
                 completed_rids,
                 channel=FlexKVScatterChannel.STORE_COMPLETION,
             )
+        for rid in completed_rids:
+            fk_tid = self._inflight_stores.pop(rid, None)
+            if fk_tid is None:
+                continue
+            if self._sync_ctx.is_sync_leader:
+                context = self._pop_context(
+                    "_inflight_store_contexts", rid, "store", fk_tid
+                )
+                response = completed_by_rid.get(rid)
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    _status_value(response),
+                    direction="D2H",
+                    transfer_mode="no-layerwise",
+                )
+            else:
+                getattr(self, "_inflight_store_contexts", {}).pop(rid, None)
         return completed_rids
 
     def wait_store(self, rid: str, timeout: float = 30.0) -> bool:
@@ -1455,28 +1467,58 @@ class FlexKVConnector:
         self._completed_layerwise.clear()
         self._launched_load_tids.clear()
         getattr(self, "_launched_load_contexts", {}).clear()
+        # Store completion protects source GPU slots. Followers must not
+        # return from reset and let SGLang free those slots before the leader
+        # has observed a terminal (completely drained) response.
+        store_reset_status = {"ok": True, "error": ""}
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
-            for rid, fk_tid in list(self._inflight_stores.items()):
-                if fk_tid >= 0:
-                    context = self._pop_context(
-                        "_inflight_store_contexts", rid, "store", fk_tid
-                    )
-                    error = None
-                    try:
-                        responses = self.kv_manager.wait([fk_tid], timeout=20.0) or {}
-                        status = _status_value(responses.get(fk_tid))
-                    except Exception as exc:  # noqa: BLE001
-                        status = "failed"
-                        error = str(exc)
-                    self._log_cache_op(
-                        context,
-                        "complete",
-                        status,
-                        direction="D2H",
-                        transfer_mode="no-layerwise",
-                        source="reset",
-                        error=error,
-                    )
+            inflight = list(self._inflight_stores.items())
+            task_ids = [fk_tid for _, fk_tid in inflight if fk_tid >= 0]
+            responses: Dict[int, Any] = {}
+            wait_error = ""
+            if task_ids:
+                try:
+                    responses = self.kv_manager.wait(
+                        task_ids, timeout=30.0, completely=True
+                    ) or {}
+                except Exception as exc:  # noqa: BLE001
+                    wait_error = str(exc)
+            unsafe = []
+            for rid, fk_tid in inflight:
+                if fk_tid < 0:
+                    continue
+                response = responses.get(fk_tid)
+                status = _status_value(response)
+                if response is None or not _is_terminal_status(status):
+                    unsafe.append(fk_tid)
+                context = self._pop_context(
+                    "_inflight_store_contexts", rid, "store", fk_tid
+                )
+                self._log_cache_op(
+                    context,
+                    "complete",
+                    status,
+                    direction="D2H",
+                    transfer_mode="no-layerwise",
+                    source="reset",
+                    error=wait_error or None,
+                )
+            if unsafe or wait_error:
+                store_reset_status = {
+                    "ok": False,
+                    "error": (
+                        "store tasks were not safely drained during reset: "
+                        f"task_ids={unsafe}, error={wait_error or 'missing response'}"
+                    ),
+                }
+        if self._sync_ctx.needs_sync:
+            store_reset_status = self._sync_ctx.scatter(
+                store_reset_status,
+                channel=FlexKVScatterChannel.STORE_RESET,
+                blocking=True,
+            )
+        if not store_reset_status["ok"]:
+            raise RuntimeError(f"[FlexKV] {store_reset_status['error']}")
         self._inflight_stores.clear()
         getattr(self, "_inflight_store_contexts", {}).clear()
         if self.layer_done_counter is not None:
@@ -2117,21 +2159,6 @@ class FlexKVConnector:
             len(layer_groups),
             bool(swa_buffers),
             len(self._dsv4_state_groups),
-        )
-
-    def _send_pp_put_meta(self, fkv_task_id: int, unmatched_mask) -> None:
-        if not self._sync_ctx.is_pp_active:
-            return
-        if hasattr(unmatched_mask, "tolist"):
-            mask_list = unmatched_mask.tolist()
-        else:
-            mask_list = list(unmatched_mask)
-        self._sync_ctx.scatter_pp(
-            {
-                "cmd": CMD_PUT_META,
-                "fkv_task_id": fkv_task_id,
-                "unmatched_mask": mask_list,
-            }
         )
 
     def _send_slot_mapping_to_remote(

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -553,6 +553,30 @@ class FlexKVConnector:
         #   3. hit_length == 0 → no work to do; FlexKV already marked the
         #      empty graph COMPLETED inside get_match, cancel would warn.
         if hit_length > 0 and rid is not None and fkv_task_id >= 0:
+            # SGLang can call match_prefix more than once for the same request
+            # before init_load_back consumes the held lookup.  Replacing the
+            # rid entry without cancelling the old FlexKV task loses its only
+            # handle while that task still pins its matched CPU radix leaf.
+            # Under remote-hit pressure this leaked one leaf lock per duplicate
+            # lookup until every historical leaf became unevictable.
+            replaced_task_id = self._pending_lookups.pop(rid, -1)
+            replaced_context = self._pending_lookup_contexts.pop(rid, None)
+            if (
+                replaced_task_id >= 0
+                and replaced_task_id != fkv_task_id
+                and self._sync_ctx.is_sync_leader
+            ):
+                assert self.kv_manager is not None
+                self.kv_manager.cancel([replaced_task_id])
+            if replaced_context is not None:
+                replaced_context.operation = "load"
+                self._log_cache_op(
+                    replaced_context,
+                    "complete",
+                    "cancelled",
+                    reason="lookup_replaced",
+                    replacement_task_id=fkv_task_id,
+                )
             self._pending_lookups[rid] = fkv_task_id
             self._pending_lookup_contexts[rid] = context
         elif hit_length > 0 and fkv_task_id >= 0 and self._sync_ctx.is_sync_leader:

--- a/tests/run_sglang_store_protocol_distributed.py
+++ b/tests/run_sglang_store_protocol_distributed.py
@@ -1,0 +1,94 @@
+"""Two-rank Gloo smoke test for the SGLang store ownership protocol.
+
+Run manually with::
+
+    torchrun --standalone --nproc-per-node=2 \
+        tests/run_sglang_store_protocol_distributed.py
+"""
+
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from flexkv.integration.sglang.comm import FlexKVComm
+from flexkv.integration.sglang.connector import FlexKVConnector
+
+
+class _FakeKVManager:
+    def put_match(self, *, token_ids, token_mask):
+        del token_mask
+        return 17, np.ones(len(token_ids), dtype=np.bool_)
+
+    def launch(self, **kwargs):
+        del kwargs
+
+    def try_wait(self, *, task_ids):
+        assert task_ids == [17]
+        return {17: SimpleNamespace(status=SimpleNamespace(value="success"))}
+
+
+def main() -> None:
+    dist.init_process_group(backend="gloo")
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    rank_info = SimpleNamespace(
+        model_config=SimpleNamespace(
+            pp_size=1,
+            attn_tp_size=world_size,
+            attn_cp_size=1,
+        ),
+        pp_rank=0,
+        attn_tp_rank=rank,
+        attn_cp_rank=0,
+        pp_size_per_node=1,
+    )
+    comm = FlexKVComm(
+        rank_info,
+        rank,
+        attn_tp_group=dist.group.WORLD,
+        world_group=dist.group.WORLD,
+    )
+
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = 1
+    connector._sync_ctx = comm
+    connector.kv_manager = _FakeKVManager() if rank == 0 else None
+    connector._inflight_stores = {}
+    connector._inflight_store_contexts = {}
+    connector._build_swa_slot_mapping = lambda _indices: None
+    connector._log_cache_op = lambda *_args, **_kwargs: None
+
+    task_id = connector.store_kv(
+        "request",
+        [1, 2, 3, 4],
+        torch.arange(4, dtype=torch.int64),
+    )
+    assert task_id == 17
+    assert connector._inflight_stores == {"request": 17}
+
+    completed = connector.check_completed_stores()
+    assert completed == ["request"]
+    assert connector._inflight_stores == {}
+    print(
+        json.dumps(
+            {
+                "rank": rank,
+                "task_id": task_id,
+                "completed": completed,
+                "tracked_after_completion": connector._inflight_stores,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    comm.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_global_prefetch_ready.py
+++ b/tests/test_global_prefetch_ready.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from flexkv.cache.cache_engine import GlobalCacheEngine
+from flexkv.cache.radixtree import MatchResult
+from flexkv.common.block import SequenceMeta
+from flexkv.common.transfer import TransferType
+
+
+pytestmark = pytest.mark.unit
+
+
+def _match(blocks=(), *, last_node=None):
+    physical_blocks = np.asarray(blocks, dtype=np.int64)
+    return MatchResult(
+        num_ready_matched_blocks=len(physical_blocks),
+        num_matched_blocks=len(physical_blocks),
+        last_ready_node=last_node,
+        last_node=last_node,
+        physical_blocks=physical_blocks,
+    )
+
+
+def test_remote_prefetch_publishes_cpu_node_and_waits_for_remote2h():
+    engine = GlobalCacheEngine.__new__(GlobalCacheEngine)
+    engine.cache_config = SimpleNamespace(
+        enable_cpu=True,
+        enable_ssd=False,
+        enable_remote=True,
+        enable_kv_sharing=False,
+    )
+    engine.index_accel = False
+    engine.use_mooncake_store_backend = True
+    engine._metrics_collector = None
+
+    cpu_root = MagicMock()
+    remote_node = MagicMock()
+    cpu_node = MagicMock()
+    cpu_node.size.return_value = 2
+    engine.cpu_cache_engine = MagicMock()
+    engine.cpu_cache_engine.take.return_value = np.asarray([10, 11], dtype=np.int64)
+    engine.cpu_cache_engine.insert.return_value = cpu_node
+    engine.ssd_cache_engine = None
+    engine.remote_cache_engine = MagicMock()
+    engine.match_all = MagicMock(
+        return_value=(
+            _match(last_node=cpu_root),
+            _match(),
+            _match([20, 21], last_node=remote_node),
+        )
+    )
+
+    sequence = SequenceMeta(
+        token_ids=np.arange(32, dtype=np.int64),
+        tokens_per_block=16,
+    )
+    strategy = SimpleNamespace(ignore_gpu=True, ignore_remote=False)
+
+    plan = engine._get_impl_global(
+        request_id=1,
+        sequence_meta=sequence,
+        block_mask_start=0,
+        block_mask_end=2,
+        gpu_block_ids=np.asarray([0, 0], dtype=np.int64),
+        temp_cache_strategy=strategy,
+        dp_client_id=0,
+    )
+
+    remote2h = [
+        op
+        for op in plan.transfer_graph._op_map.values()
+        if op.transfer_type == TransferType.REMOTE2H
+    ]
+    assert len(remote2h) == 1
+    assert plan.finished_ops_ids == [remote2h[0].op_id]
+    assert remote2h[0].op_id in plan.op_callback_dict
+
+    plan.op_callback_dict[remote2h[0].op_id]()
+    engine.cpu_cache_engine.set_ready.assert_called_once_with(cpu_node, True, 2)

--- a/tests/test_sglang_store_protocol.py
+++ b/tests/test_sglang_store_protocol.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from flexkv.integration.sglang.comm import FlexKVScatterChannel
+from flexkv.integration.sglang.connector import FlexKVConnector
+
+
+def _follower_connector(payload):
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = 1
+    connector.kv_manager = None
+    connector._sync_ctx = SimpleNamespace(
+        is_sync_leader=False,
+        needs_sync=True,
+        should_send_slot_mapping_to_remote=False,
+        scatter=MagicMock(return_value=payload),
+    )
+    connector._inflight_stores = {}
+    connector._inflight_store_contexts = {}
+    connector._new_op_context = MagicMock(
+        return_value=SimpleNamespace(task_id=-1)
+    )
+    connector._log_cache_op = MagicMock()
+    return connector
+
+
+def test_store_start_tracks_task_on_nonleader_rank():
+    payload = {
+        "rid": "request",
+        "task_id": 17,
+        "active": True,
+        "unmatched_mask": [True, False, True, False],
+        "error": "",
+    }
+    connector = _follower_connector(payload)
+
+    task_id = connector.store_kv(
+        "request", [1, 2, 3, 4], torch.arange(4, dtype=torch.int64)
+    )
+
+    assert task_id == 17
+    assert connector._inflight_stores == {"request": 17}
+    connector._sync_ctx.scatter.assert_called_once_with(
+        {
+            "rid": "request",
+            "task_id": -1,
+            "active": False,
+            "unmatched_mask": [],
+            "error": "",
+        },
+        channel=FlexKVScatterChannel.STORE_START,
+    )
+
+
+def test_store_completion_clears_nonleader_tracking():
+    connector = _follower_connector(["request"])
+    connector._sync_ctx.is_sync_leader = False
+    connector._inflight_stores = {"request": 17}
+    connector._inflight_store_contexts = {"request": object()}
+
+    assert connector.check_completed_stores() == ["request"]
+    assert connector._inflight_stores == {}
+    assert connector._inflight_store_contexts == {}
+    connector._sync_ctx.scatter.assert_called_once_with(
+        [], channel=FlexKVScatterChannel.STORE_COMPLETION
+    )
+
+
+def test_store_reset_waits_for_leader_drain_on_follower():
+    connector = _follower_connector(None)
+    connector._sync_ctx.scatter.side_effect = [
+        {"ok": True, "error": ""},
+        {"ok": True, "error": ""},
+    ]
+    connector._launched_load_tids = []
+    connector._pending_lookups = {}
+    connector._pending_lookup_contexts = {}
+    connector._prefetch_contexts = {}
+    connector._ongoing_prefetches = {}
+    connector._inflight_loads = {}
+    connector._completed_layerwise = {}
+    connector._launched_load_contexts = {}
+    connector._inflight_stores = {"request": 17}
+    connector._inflight_store_contexts = {"request": object()}
+    connector.layer_done_counter = None
+
+    connector.reset()
+
+    assert connector._sync_ctx.scatter.call_args_list[1].kwargs == {
+        "channel": FlexKVScatterChannel.STORE_RESET,
+        "blocking": True,
+    }
+    assert connector._inflight_stores == {}

--- a/tests/test_sglang_store_protocol.py
+++ b/tests/test_sglang_store_protocol.py
@@ -54,6 +54,29 @@ def test_store_start_tracks_task_on_nonleader_rank():
     )
 
 
+def test_prefetch_start_extracts_task_id_from_current_manager_result():
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector._prefetch_enabled = True
+    connector.kv_manager = MagicMock()
+    connector.kv_manager.prefetch_async.return_value = (23, 256)
+    connector._sync_ctx = SimpleNamespace(
+        is_sync_leader=True,
+        needs_sync=False,
+    )
+    connector._ongoing_prefetches = {}
+    connector._prefetch_contexts = {}
+    context = SimpleNamespace(task_id=-1)
+    connector._new_op_context = MagicMock(return_value=context)
+    connector._log_cache_op = MagicMock()
+
+    task_id = connector.prefetch_async("request", [1, 2, 3])
+
+    assert task_id == 23
+    assert context.task_id == 23
+    assert connector._ongoing_prefetches == {"request": 23}
+    assert connector._prefetch_contexts == {"request": context}
+
+
 def test_store_completion_clears_nonleader_tracking():
     connector = _follower_connector(["request"])
     connector._sync_ctx.is_sync_leader = False

--- a/tests/test_sglang_store_protocol.py
+++ b/tests/test_sglang_store_protocol.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import torch
 
 from flexkv.integration.sglang.comm import FlexKVScatterChannel
@@ -75,6 +76,52 @@ def test_prefetch_start_extracts_task_id_from_current_manager_result():
     assert context.task_id == 23
     assert connector._ongoing_prefetches == {"request": 23}
     assert connector._prefetch_contexts == {"request": context}
+
+
+def test_duplicate_lookup_cancels_replaced_held_task():
+    """A repeated SGLang match for one rid must not orphan the first lock."""
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = 1
+    connector._swa_kv_pool = None
+    connector.kv_manager = MagicMock()
+    connector.kv_manager.get_match.side_effect = [
+        (41, np.ones(4, dtype=np.bool_)),
+        (42, np.ones(4, dtype=np.bool_)),
+    ]
+    connector._sync_ctx = SimpleNamespace(
+        is_sync_leader=True,
+        needs_sync=False,
+    )
+    connector._pending_lookups = {}
+    connector._pending_lookup_contexts = {}
+    contexts = [
+        SimpleNamespace(task_id=-1, operation="lookup"),
+        SimpleNamespace(task_id=-1, operation="lookup"),
+    ]
+    connector._new_op_context = MagicMock(side_effect=contexts)
+    connector._log_cache_op = MagicMock()
+
+    mask = torch.ones(4, dtype=torch.bool)
+    assert connector.lookup_kv([1, 2, 3, 4], mask, rid="same") == (41, 4)
+    assert connector.lookup_kv([1, 2, 3, 4], mask, rid="same") == (42, 4)
+
+    connector.kv_manager.cancel.assert_called_once_with([41])
+    assert connector._pending_lookups == {"same": 42}
+    assert connector._pending_lookup_contexts == {"same": contexts[1]}
+    assert contexts[0].operation == "load"
+    assert any(
+        call.args[1:3] == ("complete", "cancelled")
+        and call.kwargs.get("reason") == "lookup_replaced"
+        for call in connector._log_cache_op.call_args_list
+    )
+
+    connector.release_pending("same")
+    assert connector.kv_manager.cancel.call_args_list == [
+        (([41],), {}),
+        (([42],), {}),
+    ]
+    assert connector._pending_lookups == {}
+    assert connector._pending_lookup_contexts == {}
 
 
 def test_store_completion_clears_nonleader_tracking():


### PR DESCRIPTION
## 问题

本 PR 修复 SGLang 接入 FlexKV 时的几个异步任务生命周期问题。

主要问题是：同一个 SGLang 请求在 `load` 前可能多次执行 `lookup`。新的 lookup 会覆盖旧的 READY GET task，但旧 task 没有被取消，导致它持有的 CPU Radix leaf 一直无法解锁。Mooncake 命中较多、请求并发较高并且服务长时间运行时，这些锁会不断累积，最终使 CPU cache 无法继续 eviction。

同时修复三个相关但独立的问题：

- 异步 store 的 task ownership 只在 leader 上完整维护，可能导致 TP/CP/PP 各 rank 提前释放 GPU source slots 或状态不一致；
- `KVManager.prefetch_async()` 当前返回 `(task_id, actual_prefetch_tokens)`，connector 仍按整数处理；
- REMOTE2H/DISK2H prefetch 完成后，CPU/SSD Radix node 没有在 host-stage terminal callback 中标记为 ready，长期运行后会形成不可淘汰节点。

## 解决方案

- 同一个请求产生新的 lookup task 前，先取消并清理旧 task，释放其 Radix node lock；
- 在所有参与 rank 间同步 store start、completion 和 reset 状态，确保异步 D2H 完成前各 rank 都继续持有源 GPU slots；
- 兼容整数和 tuple 两种 prefetch 返回值；
- 在全局 prefetch 的 host-stage terminal callback 中统一发布 CPU/SSD node ready 状态；
- 保持现有 PP-only `scatter_pp` API 不变，生产 store 协议使用 hierarchical scatter。

配套的 SGLang PR 将 store completion polling 从按 rank 本地条件触发的 `evict()` 移到同步 scheduler hook，避免各 rank scatter 调用序列不一致：
https://github.com/sgl-project/sglang/pull/31781

## 验证

- 相关 focused regression tests 通过；
- 两 rank Gloo store protocol 测试通过；
- H20 TP8 DeepSeek-V4 + Mooncake CPU-cache 场景验证通过，覆盖真实 GPU eviction、H2REMOTE/REMOTE2H、cache hit 和输出 token 一致性；
- 验证中未发现请求错误、输出不一致、scatter/desync、hang 或 traceback。
