### PR TITLE
[bugfix] Accept sequence token IDs from SGLang

### DIFF
--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -34,7 +34,7 @@ import socket
 import struct
 import time
 from dataclasses import dataclass, replace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -461,7 +461,7 @@ class FlexKVConnector:
 
     def lookup_kv(
         self,
-        token_ids: List[int],
+        token_ids: Sequence[int],
         token_mask: torch.Tensor,
         rid: Optional[str] = None,
         sglang_req_id: Any = _SGLANG_REQ_ID_UNSET,

--- a/tests/test_sglang_connector.py
+++ b/tests/test_sglang_connector.py
@@ -1,0 +1,33 @@
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from flexkv.integration.sglang.comm import FlexKVScatterChannel
+from flexkv.integration.sglang.connector import FlexKVConnector
+
+
+def test_lookup_accepts_sglang_array_token_ids():
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = 1
+    connector.kv_manager = None
+    connector._sync_ctx = SimpleNamespace(
+        is_sync_leader=False,
+        needs_sync=True,
+        scatter=MagicMock(return_value={"task_id": -1, "hit": 0}),
+    )
+    connector._pending_lookups = {}
+    connector._pending_lookup_contexts = {}
+    connector._new_op_context = MagicMock(
+        return_value=SimpleNamespace(task_id=-1)
+    )
+    connector._log_cache_op = MagicMock()
+    token_ids = array("q", [1, 2, 3, 4])
+
+    assert connector.lookup_kv(
+        token_ids,
+        torch.ones(len(token_ids), dtype=torch.bool),
+        rid="request",
+    ) == (-1, 0)
+    connector._log_cache_op.assert_called_once()


### PR DESCRIPTION
## Summary

- accept generic integer sequences in `FlexKVConnector.lookup_kv`
- preserve the existing NumPy conversion and lookup behavior
- add a regression test using the `array.array` token IDs passed by newer SGLang

## Root cause

FlexKV release builds Cython-compile `flexkv/**/*.py`. With `token_ids` annotated as `List[int]`, Cython adds an exact-list argument check. Newer SGLang passes token IDs as `array.array`, so lookup fails before `np.asarray(token_ids, dtype=np.int64)` can normalize the input:

```text
TypeError: Argument 'token_ids' has incorrect type (expected list, got array.array)
```

Annotating the existing read-only input as `Sequence[int]` keeps the API contract accurate and lets the existing conversion accept both lists and SGLang arrays.

## Validation

- `git diff --check`
- `python3 -m compileall -q flexkv/integration/sglang/connector.py tests/test_sglang_connector.py`
- full ROCm `gfx942` release build with the same connector change succeeded
- release/Cython SGLang protocol regression suite: `5 passed`
- DSV4Flash TP8 forced-eviction E2E restored 5,888 tokens; restored token IDs and output SHA-256 exactly matched the no-FlexKV baseline
