### PR TITLE
fix(performance): enable interleaved multi-SSD transfers in transfer_kv_blocks_gds

### DIFF
--- a/benchmarks/benchmark_workers.py
+++ b/benchmarks/benchmark_workers.py
@@ -158,7 +158,6 @@ def create_cpu_gpu_worker(
             cpu_kv_layout=cpu_handle.kv_layout,
             dtype=model_config.dtype,
             tp_group_size=model_config.tp_size,
-            dp_group_id=0,
             use_ce_transfer_h2d=use_ce_transfer,
             use_ce_transfer_d2h=use_ce_transfer,
             transfer_num_cta_h2d=transfer_num_cta,
@@ -316,7 +315,6 @@ def create_gpu_ssd_worker(
             ssd_kv_layout=ssd_handle.kv_layout,
             dtype=model_config.dtype,
             tp_group_size=model_config.tp_size,
-            dp_group_id=0,
         )
     return (
         worker_handle,

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -693,6 +693,7 @@ void transfer_kv_blocks_gds(
             max_block_partition = gpu_blocks.size();
     } 
 
+    size_t task_index = 0;
     for (size_t j = 0; j < max_block_partition; j++) {
         for (int device_id = 0; device_id < num_devices; device_id++) {
             const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
@@ -702,7 +703,7 @@ void transfer_kv_blocks_gds(
             const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
             const int gpu_block_id = gpu_blocks[j];
             const int ssd_block_id = ssd_blocks[j];
-            const int slot_id = (device_id * gpu_blocks.size() + j) % num_slots;
+            const int slot_id = static_cast<int>(task_index++ % num_slots);
             
             futures.push_back(gds_manager.enqueue_task([&, device_id, gpu_block_id, ssd_block_id, slot_id, gpu_id]() {
                 // Set correct CUDA device for this worker thread

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -689,7 +689,7 @@ void transfer_kv_blocks_gds(
     size_t max_block_partition = 0;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
-        size_t max_block_partition = std::max(max_block_partition, gpu_blocks.size());
+        max_block_partition = std::max(max_block_partition, gpu_blocks.size());
     }
 
     size_t task_index = 0;

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -685,13 +685,23 @@ void transfer_kv_blocks_gds(
     
     std::vector<std::future<void>> futures;
     futures.reserve(num_transfers);
-    
+
+    size_t max_block_partition = 0;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
-        const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
-        const std::vector<std::string>& file_list = gds_manager.get_file_paths(device_id);
-        
-        for (size_t j = 0; j < gpu_blocks.size(); j++) {
+        if (max_block_partition < gpu_blocks.size())
+            max_block_partition = gpu_blocks.size();
+    } 
+
+    for (size_t j = 0; j < max_block_partition; j++) {
+        for (int device_id = 0; device_id < num_devices; device_id++) {
+            const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
+            if (gpu_blocks.size() <= j)
+                continue;
+
+            const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
+            const std::vector<std::string>& file_list = gds_manager.get_file_paths(device_id);
+
             const int gpu_block_id = gpu_blocks[j];
             const int ssd_block_id = ssd_blocks[j];
             const int slot_id = (device_id * gpu_blocks.size() + j) % num_slots;

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -689,7 +689,8 @@ void transfer_kv_blocks_gds(
     size_t max_block_partition = 0;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
-        size_t max_block_partition = std::max(max_block_partition, gpu_blocks.size())
+        size_t max_block_partition = std::max(max_block_partition, gpu_blocks.size());
+    }
 
     size_t task_index = 0;
     for (size_t j = 0; j < max_block_partition; j++) {
@@ -699,6 +700,7 @@ void transfer_kv_blocks_gds(
                 continue;
 
             const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
+            assert(ssd_blocks.size() == gpu_blocks.size());
             const int gpu_block_id = gpu_blocks[j];
             const int ssd_block_id = ssd_blocks[j];
             const int slot_id = static_cast<int>(task_index++ % num_slots);

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -689,9 +689,7 @@ void transfer_kv_blocks_gds(
     size_t max_block_partition = 0;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         const std::vector<int>& gpu_blocks = gpu_blocks_partition[device_id];
-        if (max_block_partition < gpu_blocks.size())
-            max_block_partition = gpu_blocks.size();
-    } 
+        size_t max_block_partition = std::max(max_block_partition, gpu_blocks.size())
 
     size_t task_index = 0;
     for (size_t j = 0; j < max_block_partition; j++) {

--- a/csrc/gds/gds_manager.cpp
+++ b/csrc/gds/gds_manager.cpp
@@ -700,8 +700,6 @@ void transfer_kv_blocks_gds(
                 continue;
 
             const std::vector<int>& ssd_blocks = ssd_blocks_partition[device_id];
-            const std::vector<std::string>& file_list = gds_manager.get_file_paths(device_id);
-
             const int gpu_block_id = gpu_blocks[j];
             const int ssd_block_id = ssd_blocks[j];
             const int slot_id = (device_id * gpu_blocks.size() + j) % num_slots;
@@ -709,6 +707,7 @@ void transfer_kv_blocks_gds(
             futures.push_back(gds_manager.enqueue_task([&, device_id, gpu_block_id, ssd_block_id, slot_id, gpu_id]() {
                 // Set correct CUDA device for this worker thread
                 cudaSetDevice(gpu_id);
+                const std::vector<std::string>& file_list = gds_manager.get_file_paths(device_id);
                 
                 std::lock_guard<std::mutex> slot_lock(slot_mutexes[slot_id]);
                 // Sync stream to ensure previous kernel on this slot completed

--- a/tests/test_kv_transfer_correctness.py
+++ b/tests/test_kv_transfer_correctness.py
@@ -22,9 +22,10 @@ import pytest
 import torch
 import gc
 
-from flexkv.c_ext import TPTransferThreadGroup, LayerwiseTransferGroup
+from flexkv.c_ext import TPTransferThreadGroup, LayerwiseTransferGroup, TPGDSTransferThreadGroup
 from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.storage.allocator import SSDAllocator
 
 
 # Skip conditions
@@ -1830,6 +1831,14 @@ def _setup_ssd_file(layout, num_blocks_per_file, tmpdir):
         os.fsync(f.fileno())
     return {0: [fpath]}
 
+def _setup_ssd_files(layout, dtype, cache_dirs):
+    ssd_handle = SSDAllocator.allocate(
+        layout=layout,
+        dtype=dtype,
+        cache_dir=cache_dirs,
+        max_file_size_gb=GLOBAL_CONFIG_FROM_ENV.max_file_size_gb,
+    )
+    return ssd_handle.get_file_list(), ssd_handle.num_blocks_per_file
 
 def _fill_cpu_kv(cpu_tensor, layout, num_layers, num_blocks, tpb, num_heads,
                  head_dim, kv_dim, seed=42):
@@ -2353,6 +2362,114 @@ def test_ssd_transfer_layerwise_disk2h(data_config, cpu_layout_name, ssd_io_opt,
     del ioctx, group
     shutil.rmtree(tmpdir, ignore_errors=True)
 
+@pytest.fixture
+def ssd_cache_dirs(tmp_path):
+    raw = os.getenv("FLEXKV_TEST_SSD_CACHE_DIRS")
+    return [p.strip() for p in raw.split(";") if p.strip()]
+
+def make_tp_gds_group(gpu_blocks,
+                      ssd_files,
+                      num_layers,
+                      gpu_kv_layout,
+                      num_gpus):
+    gpu_block_ptrs_flat = []
+    for gpu_tensors in gpu_blocks:
+        for t in gpu_tensors:
+            gpu_block_ptrs_flat.append(t.data_ptr())
+
+    tp_gds = TPGDSTransferThreadGroup(num_gpus,
+                                      gpu_block_ptrs_flat,
+                                      num_layers, # num_tensors_per_gpu
+                                      ssd_files,
+                                      num_layers,
+                                      [gpu_kv_layout.get_kv_stride() * ES] * num_gpus,
+                                      [gpu_kv_layout.get_block_stride() * ES] * num_gpus,
+                                      [gpu_kv_layout.get_layer_stride() * ES] * num_gpus,
+                                      [gpu_kv_layout.get_chunk_size() * ES] * num_gpus,
+                                      list(range(num_gpus))
+                                      )
+
+    return tp_gds
+
+@pytest.mark.parametrize("data_config", MHA_SIZES)
+def test_mha_gds(data_config, ssd_cache_dirs):
+    num_layers, num_blocks, tpb, num_heads, head_dim = data_config
+    is_mla = (num_heads == 1)
+    assert is_mla is False
+    kv_dim = 1 if is_mla else 2
+    num_gpus = NUM_GPUS
+
+    ssd_layout_name = "BLOCKFIRST"
+
+    gpu_layout, ssd_layout, _, kv_dim, heads_per_rank = make_layouts(
+        num_layers, num_blocks, tpb, num_heads, head_dim,
+        ssd_layout_name, is_mla, num_gpus)
+
+    all_gpu = [make_gpu_tensors(num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim, g)
+               for g in range(num_gpus)]
+
+    files, num_blocks_per_file = _setup_ssd_files(ssd_layout, DTYPE, ssd_cache_dirs)
+
+    ssd_block_stride_in_bytes = ssd_layout.get_block_stride() * ES
+    ssd_tp_stride_in_bytes = (ssd_layout.get_block_stride() * ES // num_gpus
+                              if not is_mla else ssd_layout.get_block_stride() * ES)
+    if not is_mla:
+        ssd_layout = ssd_layout.div_head(num_gpus)
+
+    tp_gds = make_tp_gds_group(all_gpu, files, num_layers, gpu_layout, num_gpus)
+
+    gpu_block_ids = block_ids(num_blocks)
+    ssd_block_ids = block_ids(num_blocks)
+    ssd_block_ids = ssd_block_ids[torch.randperm(ssd_block_ids.size(0))]
+
+    for g in range(num_gpus):
+        fill_gpu(all_gpu[g], g, num_layers, num_blocks, tpb, heads_per_rank, head_dim, kv_dim)
+
+    sync_all(num_gpus)
+
+    tp_gds.tp_group_transfer(gpu_block_ids,
+                             ssd_block_ids,
+                             ssd_layout.get_layer_stride() * ES,
+                             ssd_layout.get_kv_stride() * ES,
+                             ssd_block_stride_in_bytes,
+                             ssd_tp_stride_in_bytes,
+                             num_blocks_per_file,
+                             False,
+                             0, num_layers,
+                             is_mla)
+
+
+    for g in range(num_gpus):
+        for l in range(num_layers):
+            all_gpu[g][l].zero_()
+    sync_all(num_gpus)
+
+    tp_gds.tp_group_transfer(gpu_block_ids,
+                             ssd_block_ids,
+                             ssd_layout.get_layer_stride() * ES,
+                             ssd_layout.get_kv_stride() * ES,
+                             ssd_block_stride_in_bytes,
+                             ssd_tp_stride_in_bytes,
+                             num_blocks_per_file,
+                             True,
+                             0, num_layers,
+                             is_mla)
+
+    expected_gpu = 0 if is_mla else None
+    for g in range(num_gpus):
+        src_g = expected_gpu if expected_gpu is not None else g
+        for layer in [0, num_layers - 1]:
+            for block in range(num_blocks):
+                for kv in range(kv_dim):
+                    for hd_idx in [0, head_dim - 1]:
+                        exp = expected_val(src_g, layer, block, 0, hd_idx, kv)
+                        act = all_gpu[g][layer][kv, block, 0, 0, hd_idx].item()
+                        assert abs(act - exp) < 1e-3, \
+                            f"Non-MLA round-trip mismatch: layout={ssd_layout_name} " \
+                            f"gpu={g} layer={layer} block={block} kv={kv} hd={hd_idx}: " \
+                            f"expected={exp:.6f} got={act:.6f}"
+
+    del tp_gds
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Problem

The previous implementation iterated over NVMe devices in the outer loop and blocks in the inner loop. This caused the transfer logic to fully drain all blocks on one SSD before moving to the next. On multi-SSD machines, this resulted in serialized I/O patterns where only one disk was active at any given time, severely limiting the aggregate bandwidth to that of a single drive.

## Solution
This PR reorders the loop structure to iterate over blocks in the outer loop and devices in the inner loop. By interleaving transfers across all available SSDs, we ensure that multiple disks are active concurrently. This change allows the system to leverage the combined bandwidth of all drives, resulting in near-linear scaling of KV block transfer throughput on multi-disk setups.

## Result

8x H200 + 4x Samsung PM9A3 (R6900MB/s , W4100MB/s)

```
(kvcache) lwn@qb-prod-gpu693:~/haha/FlexKV$ /usr/local/cuda/gds/tools/gdscheck.py  -t 
Optimal GPU/NIC topology
GPU0 (0000:19:00.0): has a distance 3 from "brainpf7" (0000:18:00.0)
GPU1 (0000:2a:00.0): has a distance 3 from "brainpf6" (0000:29:00.0)
GPU2 (0000:3b:00.0): has a distance 3 from "brainpf5" (0000:3a:00.0)
GPU3 (0000:5d:00.0): has a distance 3 from "brainpf4" (0000:5c:00.0)
GPU4 (0000:9b:00.0): has a distance 3 from "brainpf3" (0000:9a:00.0)
GPU5 (0000:ab:00.0): has a distance 3 from "brainpf2" (0000:aa:00.0)
GPU6 (0000:bb:00.0): has a distance 3 from "brainpf1" (0000:ba:00.0)
GPU7 (0000:db:00.0): has a distance 3 from "brainpf0" (0000:da:00.0)
Optimal GPU/NVMe topology
GPU0 (0000:19:00.0): has a distance 3 from └─nvme2n1p2 (0000:1a:00.0)
GPU1 (0000:2a:00.0): has a distance 3 from nvme3n1 (0000:2b:00.0)
GPU3 (0000:5d:00.0): has a distance 3 from nvme4n1 (0000:5e:00.0)
GPU5 (0000:ab:00.0): has a distance 3 from nvme0n1 (0000:ac:00.0)
GPU7 (0000:db:00.0): has a distance 3 from nvme1n1 (0000:dc:00.0)
GPU2 (0000:3b:00.0): has a distance 134 from └─nvme2n1p2 (0000:1a:00.0)
GPU4 (0000:9b:00.0): has a distance 134 from nvme0n1 (0000:ac:00.0)
GPU6 (0000:bb:00.0): has a distance 134 from nvme0n1 (0000:ac:00.0)
(kvcache) lwn@qb-prod-gpu693:~/haha/FlexKV$ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0         7:0    0  63.9M  1 loop /snap/core20/2318
loop1         7:1    0    87M  1 loop /snap/lxd/29351
loop2         7:2    0  38.8M  1 loop /snap/snapd/21759
nvme1n1     259:0    0   3.5T  0 disk /home/lwn/FlexKV/nvme3
nvme0n1     259:1    0   3.5T  0 disk /home/lwn/FlexKV/nvme2
nvme3n1     259:2    0   3.5T  0 disk /home/lwn/FlexKV/nvme0
nvme4n1     259:3    0   3.5T  0 disk /home/lwn/FlexKV/nvme1
nvme2n1     259:4    0 894.3G  0 disk 
├─nvme2n1p1 259:5    0     1G  0 part /boot/efi
└─nvme2n1p2 259:6    0 893.2G  0 part /
```

Run python `./benchmarks/benchmark_workers.py --transfer-type D2DISK --num-blocks 128` and `python ./benchmarks/benchmark_workers.py --transfer-type DISK2D --num-blocks 128` in the root directory of FlexKV.

Content of the example_config.yml file:
```
num_layers: 80
num_kv_heads: 8
head_size: 128
dtype: bfloat16
use_mla: false
tp_size: 8
dp_size: 1
tokens_per_block: 128

cpu_cache_gb: 8
ssd_cache_gb: 16
ssd_cache_dir: /home/lwn/FlexKV/nvme0;/home/lwn/FlexKV/nvme1;/home/lwn/FlexKV/nvme2;/home/lwn/FlexKV/nvme3
enable_gds: true
```

Avg Bandwidth:
| Transfer Type | Before Patch | After Patch | Speedup |
| :--- | :--- | :--- | :--- |
| DISK2D | 7.86 GB/s | 19.88 GB/s | 2.53× |
| D2DISK | 4.81 GB/s | 12.60 GB/s | 2.62× |

