### PR TITLE
[bugfix] rename store-drain responses var to fix Cython redeclaration build failure

### DIFF
--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -1509,11 +1509,11 @@ class FlexKVConnector:
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
             inflight = list(self._inflight_stores.items())
             task_ids = [fk_tid for _, fk_tid in inflight if fk_tid >= 0]
-            responses: Dict[int, Any] = {}
+            store_responses: Dict[int, Any] = {}
             wait_error = ""
             if task_ids:
                 try:
-                    responses = self.kv_manager.wait(
+                    store_responses = self.kv_manager.wait(
                         task_ids, timeout=30.0, completely=True
                     ) or {}
                 except Exception as exc:  # noqa: BLE001
@@ -1522,7 +1522,7 @@ class FlexKVConnector:
             for rid, fk_tid in inflight:
                 if fk_tid < 0:
                     continue
-                response = responses.get(fk_tid)
+                response = store_responses.get(fk_tid)
                 status = _status_value(response)
                 if response is None or not _is_terminal_status(status):
                     unsafe.append(fk_tid)


### PR DESCRIPTION
## Problem

The `Build Wheel` CI job fails on `main` (e.g. on #265) with:

```
Error compiling Cython file:
flexkv/integration/sglang/connector.py:1512:12: 'responses' redeclared
Cython.Compiler.Errors.CompileError: flexkv/integration/sglang/connector.py
```

`FlexKVConnector.reset()` declares `responses` twice in the same scope:

1. **Load-drain block** (~L1435): `responses = self.kv_manager.wait(...)` — Cython infers the type from `KVManager.wait()`'s return annotation `Dict[int, KVResponse]`
2. **Store-drain block** (L1512): `responses: Dict[int, Any] = {}` — annotation conflicts with the earlier inferred declaration

This is valid pure Python but rejected by Cython in release builds, which Cythonize all `flexkv/**/*.py`. The failure was introduced by #263/#264 and blocks the wheel-build check for every subsequent PR.

Note: debug builds (`FLEXKV_DEBUG=1`, the default for local dev) skip Cython entirely, which is why this wasn't caught before merge.

## Solution

Rename the store-drain occurrence to `store_responses` (3 lines). It waits on *store* task ids, so the distinct name is also semantically clearer. No behavior change.

Verified: `cython -3` with the exact `setup.py` compiler directives now compiles the file cleanly.

## Checklist

- [x] No open PR already fixes this (searched `cython`, `connector`, `redeclared`, `build wheel`)
- [x] Fix is 3-line rename, zero behavior change

Signed-off-by: staryxchen <staryxchen@tencent.com>