### PR TITLE
[test] set _cache_tree_lock in test_global_prefetch_ready engine fixture

### DIFF
--- a/tests/test_global_prefetch_ready.py
+++ b/tests/test_global_prefetch_ready.py
@@ -1,3 +1,4 @@
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -35,6 +36,7 @@ def _prefetch_engine(*, use_mooncake: bool):
     engine.index_accel = False
     engine.use_mooncake_store_backend = use_mooncake
     engine._metrics_collector = None
+    engine._cache_tree_lock = threading.RLock()
 
     cpu_root = MagicMock()
     remote_node = MagicMock()


### PR DESCRIPTION
## Problem

`Build Wheel` CI fails at the CPU unit-test step on main with:

```
FAILED tests/test_global_prefetch_ready.py::test_remote_prefetch_publishes_cpu_node_and_waits_for_remote2h
AttributeError: 'GlobalCacheEngine' object has no attribute '_cache_tree_lock'
```

(Same failure in main's run for #254 — run 32369361828 — so this is pre-existing on main and unrelated to #267, where it is currently the only remaining red.)

## Root cause

#263/#264 added `GlobalCacheEngine._cache_tree_lock` (used by the `_synchronized_cache_tree` decorator on `put`/`get`/`reset`) and updated the other `__new__`-based fixtures — `test_mooncake_deferred_put`, `test_mooncake_deferred_insert`, `test_mooncake_prefetch_compute_split` — but missed `test_global_prefetch_ready.py`. Its fixture builds the engine via `GlobalCacheEngine.__new__` (bypassing `__init__`), so the lock never exists and the `put()` call inside `_get_impl_global` crashes.

## Solution

Set the lock in the fixture exactly like the other three files do:

```python
engine._cache_tree_lock = threading.RLock()
```

## Verification

- The file's 2 tests pass locally after the fix.
- Full CPU unit suite (same collection as CI: all `pytest.mark.unit` files): 222 passed / 20 skipped / 0 genuine failures — the only local failures were traced to a stale local `c_ext` build missing `remove_unready_leaf` (present in `csrc/radix_tree.cpp`; CI builds fresh from source).
- `test_gds_get_planning.py` (the other missed `__new__` fixture) is unaffected: it only calls `_get_impl_local`, which is not decorated.

Signed-off-by: staryxchen <staryxchen@tencent.com>