### PR TITLE
fix: Avoid FlexKV assert by canceling PutTask with empty block_ids

### DIFF
--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -438,24 +438,39 @@ class FlexKVSchedulerConnector:
         self.flexkv_stats.record_put(num_all_tokens=request.num_tokens,
                                      num_unmatched_tokens=num_unmatched_tokens)
 
-        if len(block_ids) == 0:
-            return False # adapt for vLLM when it gives empty list
-
         if not self._need_to_put(num_all_tokens=request.num_tokens,
                                 num_matched_tokens=num_matched_tokens,
                                 num_unmatched_tokens=num_unmatched_tokens):
             return False
 
+        # compute slot mapping
+        num_matched_blocks = num_matched_tokens // self.block_size
+        num_unmatched_blocks = num_unmatched_tokens // self.block_size
+        block_ids_to_put = block_ids[
+            num_matched_blocks : num_matched_blocks + num_unmatched_blocks
+        ]
+
+        # vLLM >= 0.25 returns only the blocks covering num_computed_tokens,
+        # after pruning out-of-window prefix blocks -- see
+        # Scheduler._connector_finished(). On abort / preemption / lookahead
+        # over-allocation this is shorter than the put plan (possibly empty).
+        # Slicing truncates silently and blows the src/dst size assert in
+        # TransferOpGraph.set_gpu_blocks(), so bail out instead.
+        if len(block_ids_to_put) != num_unmatched_blocks:
+            logger.warning(
+                "FlexKV put for req %s expects %d blocks but vLLM provided %d "
+                "(total %d); cancelling put.",
+                request.request_id, num_unmatched_blocks,
+                len(block_ids_to_put), len(block_ids))
+            return False
+
         # prepare to launch task
         task: FlexKVPutTask = self.tasks_to_cancel.pop(task_id)
         self.tasks_to_launch[task_id] = task
-
-        # compute slot mapping
-        # num_blocks_to_put = (num_matched_tokens+num_unmatched_tokens) // self.block_size
-        num_matched_blocks = num_matched_tokens // self.block_size
-        num_unmatched_tokens = num_unmatched_tokens // self.block_size
-        block_ids_to_put = block_ids[num_matched_blocks:num_matched_blocks+num_unmatched_tokens]
-        task.slot_mapping = np.array(block_ids_to_put).repeat(self.block_size)*self.block_size
+        task.slot_mapping = (
+            np.array(block_ids_to_put, dtype=np.int64).repeat(self.block_size)
+            * self.block_size
+        )
 
         return True
 

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -438,6 +438,9 @@ class FlexKVSchedulerConnector:
         self.flexkv_stats.record_put(num_all_tokens=request.num_tokens,
                                      num_unmatched_tokens=num_unmatched_tokens)
 
+        if len(block_ids) == 0:
+            return False # adapt for vLLM when it gives empty list
+
         if not self._need_to_put(num_all_tokens=request.num_tokens,
                                 num_matched_tokens=num_matched_tokens,
                                 num_unmatched_tokens=num_unmatched_tokens):


### PR DESCRIPTION
## Background

I encountered a probabilistic assertion failure in FlexKV while running a replay of the Mooncake trace at 1x speedup on my setup (8x H200 + 4 NVMe + GDS, official vLLM 0.25.0, tencent/Hy3 model).

```
#!/bin/bash -x

# FLEXKV_ONLY_PUT_TO_NVME is my custom flag to disable CPU offloading
# I implemented _put_impl_local myself to merge D2H-H2DISK into D2DISK

FLEXKV_USE_CE_TRANSFER_H2D=0 \
FLEXKV_USE_CE_TRANSFER_D2H=0 \
FLEXKV_ONLY_PUT_TO_NVME=1 \
FLEXKV_CONFIG_PATH="./flexkv_config.json" \
VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm \
  vllm serve \
    --model "/home/lwn/FlexKV/nvme0/test0811" \
    --host "0.0.0.0" \
    --port "8000" \
    --tensor-parallel-size "8" \
    --dtype "auto" \
    --tool-call-parser hy_v3 \
    --reasoning-parser hy_v3 \
    --enable-auto-tool-choice \
    --served-model-name my_model \
    --block-size 128 \
    --kv-transfer-config '{"kv_connector":"FlexKVConnectorV1", "kv_role":"kv_both"}' 
```

`flexkv_config.json`:
```
{
  "cpu_cache_gb": 4,
  "enable_mps": false,
  "ssd_cache_gb": 4096,
  "enable_gds": true,
  "ssd_cache_dir": "/home/lwn/FlexKV/nvme0;/home/lwn/FlexKV/nvme1;/home/lwn/FlexKV/nvme2;/home/lwn/FlexKV/nvme3"
}
```


## Problem


FlexKV probabilistically triggers the following assertion. Essentially, during launch_tasks, when setting slot mappings for a D2DISK operation within a FlexKV Put task, it finds that the block_ids recorded in the task are empty, causing set_slot_mappings to fail. I traced it back to vLLM 0.25.0 calling the KVConnector's request_finished method with empty block_ids.

```
(EngineCore pid=56382) [FLEXKV] INFO 08-23 22:29:25.870 [cache_engine.py:2332] [FlexKV-SEGV-DEBUG] cache_engine create D2DISK op (local_put) request_id=2269, op_id=1594, graph_id=3709, dp_client_id=0, num_blocks=55, gpu_src: count=55, min=0, max=0, dtype=int64, ssd_dst: count=55, min=43048, max=43102, dtype=int64
(EngineCore pid=56382) WARING@!!!! []   graph_ids = []
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233] EngineCore encountered a fatal error.
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233] Traceback (most recent call last):
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 1224, in run_engine_core
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     engine_core.run_busy_loop()
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 1265, in run_busy_loop
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     self._process_engine_step()
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 1304, in _process_engine_step
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     outputs, model_executed = self.step_fn()
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 547, in step_with_batch_queue
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/core/sched/scheduler.py", line 1116, in schedule
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     meta = self._build_kv_connector_meta(self.connector, scheduler_output)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/core/sched/scheduler.py", line 1138, in _build_kv_connector_meta
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     return connector.build_connector_meta(scheduler_output)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py", line 219, in build_connector_meta
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     return self._flexkv_connector.build_connector_meta(scheduler_output)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/integration/vllm/vllm_v1_adapter.py", line 1012, in build_connector_meta
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     self.connector.launch_tasks()
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/integration/vllm/vllm_v1_adapter.py", line 579, in launch_tasks
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     launched_put_task_ids = self.flexkv_manager.launch(task_ids=put_task_ids,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/kvmanager.py", line 310, in launch
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     return self.kv_task_engine.launch_tasks(
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/kvtask.py", line 1048, in launch_tasks
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     self.set_slot_mappings(task_ids, slot_mappings, swa_slot_mappings)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/kvtask.py", line 516, in set_slot_mappings
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     self._set_slot_mapping_impl(task_id, slot_mapping, swa_slot_mapping)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/kvtask.py", line 540, in _set_slot_mapping_impl
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     task.graph.set_gpu_blocks(graph_ids, swa_graph_ids)
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]   File "/home/lwn/haha/FlexKV/flexkv/common/transfer.py", line 364, in set_gpu_blocks
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]     assert op.src_block_ids.size == op.dst_block_ids.size, \
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233] AssertionError: src_block_ids.size=0, dst_block_ids.size=55, op=TransferOp(op_id=1594, graph_id=3709, transfer_type=<TransferType.D2DISK: 'D2DISK'>, src_block_ids=array([], dtype=float64), dst_block_ids=array([43048, 43049, 43050, 43051, 43052, 43053, 43054, 43055, 43056,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43057, 43058, 43059, 43060, 43061, 43062, 43063, 43064, 43065,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43066, 43067, 43068, 43069, 43070, 43071, 43072, 43073, 43074,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43075, 43076, 43077, 43078, 43079, 43080, 43081, 43082, 43083,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43084, 43085, 43086, 43087, 43088, 43089, 43090, 43091, 43092,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43093, 43094, 43095, 43096, 43097, 43098, 43099, 43100, 43101,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43102]), predecessors=set(), successors=set(), status=<TransferOpStatus.PENDING: 0>, dp_client_id=0, src_slot_id=-1, dst_slot_id=-1, valid_block_num=55, remote_node_ids=None, src_block_node_ids=None, pending_count=0, is_swa=False, mooncake_store_block_hashes=None, mooncake_store_swa_block_hashes=None), target = [], graph={1594: TransferOp(op_id=1594, graph_id=3709, transfer_type=<TransferType.D2DISK: 'D2DISK'>, src_block_ids=array([], dtype=float64), dst_block_ids=array([43048, 43049, 43050, 43051, 43052, 43053, 43054, 43055, 43056,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43057, 43058, 43059, 43060, 43061, 43062, 43063, 43064, 43065,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43066, 43067, 43068, 43069, 43070, 43071, 43072, 43073, 43074,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43075, 43076, 43077, 43078, 43079, 43080, 43081, 43082, 43083,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43084, 43085, 43086, 43087, 43088, 43089, 43090, 43091, 43092,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43093, 43094, 43095, 43096, 43097, 43098, 43099, 43100, 43101,
(EngineCore pid=56382) ERROR 08-23 22:29:25 [core.py:1233]        43102]), predecessors=set(), successors=set(), status=<TransferOpStatus.PENDING: 0>, dp_client_id=0, src_slot_id=-1, dst_slot_id=-1, valid_block_num=55, remote_node_ids=None, src_block_node_ids=None, pending_count=0, is_swa=False, mooncake_store_block_hashes=None, mooncake_store_swa_block_hashes=None)}
(APIServer pid=55817) ERROR 08-23 22:29:25 [async_llm.py:704] AsyncLLM output_handler failed.
(APIServer pid=55817) ERROR 08-23 22:29:25 [async_llm.py:704] Traceback (most recent call last):
(APIServer pid=55817) ERROR 08-23 22:29:25 [async_llm.py:704]   File "/home/lwn/.venv/env/kvcache/lib/python3.10/site-packages/vllm/v1/engine/async_llm.py", line 660, in output_handler
(APIServer pid=55817) ERROR 08-23 22:29:25 [async_llm.py:704]     outputs = await engine_core.get_output_async()
(APIServer pid=55817) Earnings.warn('resource_tracker: There appear to be %d '
```

## Solution

Since my development environment is about to expire, I didn't dive deeper into root-causing this issue. As a workaround, I added a guard clause in request_finished: when an empty block_ids is detected, the corresponding PutTask is canceled immediately, which avoids the assertion failure entirely.

The root cause could be either a task lifecycle management bug introduced by my custom FlexKV modifications, or improper KVConnector invocation on the vLLM side. Could the team please review this PR and advise on whether it should be accepted? My gut feeling is that this is more likely a vLLM-side issue.
For context, here's my custom _put_impl_local implementation:

```
    def _put_impl_local_gds_only(self,
            request_id: int,
            sequence_meta: SequenceMeta,
            block_mask_start: int,
            block_mask_end: int,
            gpu_block_ids: np.ndarray,
            temp_cache_strategy: CacheStrategy,
            dp_client_id: int) \
                -> PutTransferPlan:

        if self.index_accel:
            cpu_matched_result, ssd_matched_result = self.match_local_accel(sequence_meta,
                                                                            temp_cache_strategy=temp_cache_strategy,
                                                                            is_put=True)
        else:
            cpu_matched_result, ssd_matched_result = self.match_local(sequence_meta,
                                                                      temp_cache_strategy=temp_cache_strategy,
                                                                      is_put=True)
        cpu_matched_blocks = cpu_matched_result.physical_blocks[
            :cpu_matched_result.num_matched_blocks][block_mask_start:block_mask_end]
        ssd_matched_blocks = ssd_matched_result.physical_blocks[
            :ssd_matched_result.num_matched_blocks][block_mask_start:block_mask_end]



        nr_ssd_hit_blks = len(ssd_matched_blocks)
        nr_ssd_unhit_blks = len(gpu_block_ids) - nr_ssd_hit_blks

        assert len(gpu_block_ids) >= nr_ssd_hit_blks, f"{gpu_block_ids} {ssd_matched_blocks}"
        assert block_mask_start == 0, f"block_mask_start"


        if nr_ssd_unhit_blks == 0:
            return self._empty_put_return(request_id)

        src_gpu_blks = gpu_block_ids[nr_ssd_hit_blks:]

        dst_ssd_blks = self.ssd_cache_engine.take(
            num_required_blocks=nr_ssd_unhit_blks,
            protected_node = ssd_matched_result.last_node,
            strict=False
        )

        if len(dst_ssd_blks) < nr_ssd_unhit_blks:
            self.ssd_cache_engine.recycle(dst_ssd_blks)
            return self._empty_put_return(request_id)

        assert self.swa_op_constructor.enabled is False

        transfer_graph = TransferOpGraph()
        finished_ops_ids = []
        op_node_to_ready = {}

        op_d2disk = TransferOp(
            graph_id = transfer_graph.graph_id,
            transfer_type = TransferType.D2DISK,
            src_block_ids = src_gpu_blks,
            dst_block_ids = dst_ssd_blks,
            dp_client_id = dp_client_id,
        )
        flexkv_logger.info(
            "[FlexKV-SEGV-DEBUG] cache_engine create D2DISK op (local_put) "
            f"request_id={request_id}, op_id={op_d2disk.op_id}, "
            f"graph_id={transfer_graph.graph_id}, dp_client_id={dp_client_id}, "
            f"num_blocks={nr_ssd_unhit_blks}, "
            f"{summarize_id_tensor('gpu_src', src_gpu_blks)}, "
            f"{summarize_id_tensor('ssd_dst', dst_ssd_blks)}"
        )
        transfer_graph.add_transfer_op(op_d2disk)
        finished_ops_ids.append(op_d2disk.op_id)

        """insert and lock"""
        ssd_node_to_unlock = self.ssd_cache_engine.insert(
            sequence_meta,
            dst_ssd_blks,
            is_ready=False,
            match_result=ssd_matched_result,
        )
        op_node_to_ready[op_d2disk.op_id] = (DeviceType.SSD, ssd_node_to_unlock, ssd_node_to_unlock.size())
        node_to_unlock = {}
        node_to_unlock[DeviceType.SSD] = (ssd_node_to_unlock, ssd_node_to_unlock.size())

        op_callback_dict = self._build_op_callback_dict(op_node_to_ready)

        skipped_gpu_blocks = nr_ssd_hit_blks
        swa_slots_to_free = []
        return PutTransferPlan(
            transfer_graph=transfer_graph,
            finished_ops_ids=finished_ops_ids,
            node_to_unlock=node_to_unlock,
            op_callback_dict=op_callback_dict,
            buffer_to_free={},
            num_gpu_blocks_to_transfer=nr_ssd_unhit_blks,
            skipped_gpu_blocks=skipped_gpu_blocks,
            swa_slots_to_free=swa_slots_to_free,
        )
```