### PR TITLE
[bugfix] harden worker drain shutdown and EOF handling

### DIFF
--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -538,11 +538,17 @@ class TransferWorkerBase(ABC):
                 # continue would otherwise drop the first op forever (which
                 # stalls D2H → H2REMOTE and leaves mooncake PutStart=0).
                 batch_ops = [op]
-                shutdown_after_batch = False
+                stop_after_batch = False
                 while self.transfer_conn.poll(timeout=0):
-                    op = self.transfer_conn.recv()
+                    try:
+                        op = self.transfer_conn.recv()
+                    except EOFError:
+                        # A closed pipe is readable. Preserve the batch already
+                        # received, then exit after reporting its completions.
+                        stop_after_batch = True
+                        break
                     if op is None:
-                        shutdown_after_batch = True
+                        stop_after_batch = True
                         break
                     if not isinstance(op, dict):
                         op._received_ns = time.perf_counter_ns()
@@ -617,13 +623,12 @@ class TransferWorkerBase(ABC):
                         # stays compatible.
                         self.finished_ops_queue.put(
                             (op.transfer_op_id, False, None))
-                if shutdown_after_batch:
-                    if hasattr(self, "shutdown") and callable(self.shutdown):
-                        try:
-                            self.shutdown()
-                        except Exception as e:
-                            flexkv_logger.error(f"Error when shut down worker: {e}")
-                    break
+                if stop_after_batch:
+                    # _worker_process owns the single shutdown() call in its
+                    # finally block. Calling subclass shutdown here can repeat
+                    # external unregister work before super()'s idempotence
+                    # guard is reached.
+                    return
             except EOFError:
                 flexkv_logger.warning(
                     f"[worker {self.worker_id}] transfer pipe EOF; exiting run loop"

--- a/tests/test_worker_run_loop_shutdown.py
+++ b/tests/test_worker_run_loop_shutdown.py
@@ -1,0 +1,111 @@
+"""Worker run-loop shutdown/EOF regression tests.
+
+The first-op batching regression is already fixed on upstream main. These tests
+cover the two remaining edges: an EOF while draining must not discard the
+already-received batch, and a drained shutdown sentinel must not call subclass
+shutdown before ``_worker_process`` performs its single cleanup in ``finally``.
+"""
+
+import types
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+pytest.importorskip("flexkv.c_ext", reason="requires compiled c_ext")
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+class _FakeOp:
+    def __init__(self, op_id):
+        from flexkv.common.transfer import TransferType
+
+        self.transfer_op_id = op_id
+        self.transfer_graph_id = 0
+        self.transfer_type = TransferType.H2D
+        self.valid_block_num = 1
+
+
+class _EOFAfterDrainPipe:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def poll(self, timeout=0):
+        if self.items:
+            return True
+        if timeout == 0:
+            return True
+        raise EOFError
+
+    def recv(self):
+        if self.items:
+            return self.items.pop(0)
+        raise EOFError
+
+
+class _SentinelPipe:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def poll(self, timeout=0):
+        if self.items:
+            return True
+        if timeout and timeout > 0:
+            raise EOFError
+        return False
+
+    def recv(self):
+        return self.items.pop(0)
+
+
+def _worker(pipe, monkeypatch):
+    from flexkv.transfer import worker as worker_module
+
+    monkeypatch.setattr(
+        worker_module.trace,
+        "build_worker_metrics",
+        lambda *_args, **_kwargs: {"test": True},
+    )
+    launched = []
+    shutdowns = []
+    instance = types.SimpleNamespace(
+        worker_id=0,
+        transfer_conn=pipe,
+        finished_ops_queue=_FakeQueue(),
+        kv_dim=2,
+        _bytes_per_block=1,
+        launch_transfer=lambda op: launched.append(op.transfer_op_id) or True,
+        shutdown=lambda: shutdowns.append(True),
+    )
+    instance.run = types.MethodType(
+        worker_module.TransferWorkerBase.run, instance)
+    return instance, launched, shutdowns
+
+
+def test_eof_during_drain_runs_received_batch(monkeypatch):
+    worker, launched, shutdowns = _worker(
+        _EOFAfterDrainPipe([_FakeOp(1), _FakeOp(2)]), monkeypatch)
+
+    worker.run()
+
+    assert launched == [1, 2]
+    assert [item[0] for item in worker.finished_ops_queue.items] == [1, 2]
+    assert shutdowns == []
+
+
+def test_drained_sentinel_defers_shutdown_to_worker_process(monkeypatch):
+    worker, launched, shutdowns = _worker(
+        _SentinelPipe([_FakeOp(1), _FakeOp(2), None]), monkeypatch)
+
+    worker.run()
+
+    assert launched == [1, 2]
+    assert [item[0] for item in worker.finished_ops_queue.items] == [1, 2]
+    assert shutdowns == []


### PR DESCRIPTION
## Summary

Harden the worker batch-drain shutdown path without changing upstream's current
control-message, transfer-result, or tracing behavior.

Upstream already fixed the original first/single-op batching regression. Two
edge cases remain:

1. `multiprocessing.Connection.poll()` reports a peer-closed pipe as readable.
   If `recv()` raises EOF while draining, the already-received batch was dropped
   before its completions were reported.
2. A `None` sentinel drained after real ops called subclass `shutdown()` inside
   `run()`, then `_worker_process.finally` called it again. Some subclasses run
   external unregister work before the base idempotence guard, so cleanup could
   execute twice.

## Fix

- Catch EOF inside the drain loop, process the accumulated batch, then return.
- Treat a drained sentinel the same way: process prior ops and let
  `_worker_process` own the single shutdown call.
- Preserve upstream dictionary control ops, trace metrics, and
  `WorkerTransferResult` handling unchanged.

## Verification

- Focused regression tests drive the real `TransferWorkerBase.run` with fake
  pipes and upstream-style result tuples.
- AST execution verifies already-received ops complete across drain EOF.
- Python compile, ruff, and `git diff --check` pass for newly added code; the
  remaining worker.py lint findings are identical to upstream main.
