### PR TITLE
[feature] add StreamingLLM sink-aware eviction

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -930,16 +930,17 @@ PYBIND11_MODULE(c_ext, m) {
   py::class_<flexkv::CRadixTreeIndex>(m, "CRadixTreeIndex")
       .def(py::init([](int tokens_per_block, unsigned int max_num_blocks,
                        int hit_reward_seconds, std::string eviction_policy,
-                       int protected_threshold) {
+                       int protected_threshold, int sink_block_count) {
              auto policy = flexkv::parse_eviction_policy(eviction_policy);
              return new flexkv::CRadixTreeIndex(
                  tokens_per_block, max_num_blocks, hit_reward_seconds, policy,
-                 protected_threshold);
+                 protected_threshold, sink_block_count);
            }),
            py::arg("tokens_per_block"), py::arg("max_num_blocks") = 1000000,
            py::arg("hit_reward_seconds") = 0,
            py::arg("eviction_policy") = "lru",
-           py::arg("protected_threshold") = 2)
+           py::arg("protected_threshold") = 2,
+           py::arg("sink_block_count") = 0)
       .def("is_empty", &flexkv::CRadixTreeIndex::is_empty)
       .def("reset", &flexkv::CRadixTreeIndex::reset)
       .def("lock", &flexkv::CRadixTreeIndex::lock, py::arg("node"))

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -999,16 +999,18 @@ PYBIND11_MODULE(c_ext, m) {
       .def("size", &flexkv::CRadixNode::size)
       .def("has_block_node_ids", &flexkv::CRadixNode::has_block_node_ids)
       // Structural / lock accessors — needed to assert the node-mount SWA
-      // invariants (I1/I2/I3) from Python against the production CRadixTreeIndex
-      // path (see tests/test_swa_node_mount.py). Previously only bound for
-      // the P2P LocalRadixTree, so the non-P2P DSv4 build had no way to read
-      // them and the C++ node-mount SWA path went untested.
+      // invariants (I1/I2/I3) from Python against the production
+      // CRadixTreeIndex path (see tests/test_swa_node_mount.py). Previously
+      // only bound for the P2P LocalRadixTree, so the non-P2P DSv4 build had no
+      // way to read them and the C++ node-mount SWA path went untested.
       .def("is_leaf", &flexkv::CRadixNode::is_leaf)
       .def("num_children", &flexkv::CRadixNode::get_num_children)
       .def("get_lock_cnt", &flexkv::CRadixNode::get_lock_cnt)
       .def("lock", &flexkv::CRadixNode::lock)
       .def("unlock", &flexkv::CRadixNode::unlock)
       .def("has_swa", &flexkv::CRadixNode::has_swa)
+      .def_property_readonly("block_offset",
+                             &flexkv::CRadixNode::get_block_offset)
       .def_property_readonly("parent", &flexkv::CRadixNode::get_parent,
                              py::return_value_policy::reference)
       // ===== SWA accessors (node-attached SWA state) =====

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -939,8 +939,7 @@ PYBIND11_MODULE(c_ext, m) {
            py::arg("tokens_per_block"), py::arg("max_num_blocks") = 1000000,
            py::arg("hit_reward_seconds") = 0,
            py::arg("eviction_policy") = "lru",
-           py::arg("protected_threshold") = 2,
-           py::arg("sink_block_count") = 0)
+           py::arg("protected_threshold") = 2, py::arg("sink_block_count") = 0)
       .def("is_empty", &flexkv::CRadixTreeIndex::is_empty)
       .def("reset", &flexkv::CRadixTreeIndex::reset)
       .def("lock", &flexkv::CRadixTreeIndex::lock, py::arg("node"))
@@ -964,9 +963,9 @@ PYBIND11_MODULE(c_ext, m) {
                &flexkv::CRadixTreeIndex::evict),
            py::arg("evicted_blocks"), py::arg("evicted_block_hashes"),
            py::arg("num_evicted"), py::call_guard<py::gil_scoped_release>())
-      .def("remove_unready_leaf",
-           &flexkv::CRadixTreeIndex::remove_unready_leaf, py::arg("node"),
-           py::arg("freed_blocks"), py::call_guard<py::gil_scoped_release>())
+      .def("remove_unready_leaf", &flexkv::CRadixTreeIndex::remove_unready_leaf,
+           py::arg("node"), py::arg("freed_blocks"),
+           py::call_guard<py::gil_scoped_release>())
       .def("total_cached_blocks", &flexkv::CRadixTreeIndex::total_cached_blocks)
       .def("total_unready_blocks",
            &flexkv::CRadixTreeIndex::total_unready_blocks)

--- a/csrc/dist/distributed_radix_tree.cpp
+++ b/csrc/dist/distributed_radix_tree.cpp
@@ -363,7 +363,12 @@ RefRadixTree* DistributedRadixTree::remote_tree_refresh() {
       }
     }
   }
-  
+
+  // The remote index is assembled through bulk subtree attachment/merge paths
+  // that intentionally bypass normal insert(). Re-establish the cached-offset
+  // invariant once after the rebuild; this is off the request hot path.
+  new_index->rebuild_block_offsets();
+
   return new_index;
 }
 

--- a/csrc/dist/local_radix_tree.cpp
+++ b/csrc/dist/local_radix_tree.cpp
@@ -177,6 +177,13 @@ CRadixNode *LocalRadixTree::insert(torch::Tensor &physical_block_ids,
   current_block_count += new_node->size();
   new_node->set_parent(last_node);
   last_node->set_child(new_node->get_head_hash(), new_node);
+  // Keep the shared CRadixNode offset invariant in sync with the base insert.
+  // LocalRadixTree currently constructs the base with sink_block_count=0, but
+  // nodes should remain structurally valid if sink-aware eviction is enabled
+  // here later.
+  new_node->set_block_offset(
+      is_root(last_node) ? 0
+                         : last_node->get_block_offset() + last_node->size());
 
   add_node(new_node);
   add_leaf(new_node);

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -469,19 +469,27 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks,
       candidates.push_back(node);
     }
   }
-  // Fallback: if every evictable leaf is a sink block, we must still make
-  // progress, so allow evicting the lowest-priority sink block.
-  if (candidates.empty()) {
-    candidates = std::move(sink_candidates);
-  }
-
   std::priority_queue<CRadixNode *, std::vector<CRadixNode *>,
                       CRadixNode::Compare>
       candidate(CRadixNode::Compare(), std::move(candidates));
+  std::priority_queue<CRadixNode *, std::vector<CRadixNode *>,
+                      CRadixNode::Compare>
+      sink_candidate(CRadixNode::Compare(), std::move(sink_candidates));
 
-  while ((has_evicted < num_evicted) && candidate.size()) {
-    auto node = candidate.top();
-    candidate.pop();
+  while (has_evicted < num_evicted &&
+         (!candidate.empty() || !sink_candidate.empty())) {
+    // Prefer every available non-sink block. Only fall back to sinks when the
+    // normal heap is empty; this decision is re-evaluated after each cascade
+    // because deleting a child can expose a new sink parent.
+    const bool use_sink_fallback = candidate.empty();
+    CRadixNode *node;
+    if (use_sink_fallback) {
+      node = sink_candidate.top();
+      sink_candidate.pop();
+    } else {
+      node = candidate.top();
+      candidate.pop();
+    }
 
     if (node->size() > num_evicted - has_evicted) {
       auto [blocks, block_hashes] = node->shrink(num_evicted - has_evicted);
@@ -512,7 +520,11 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks,
         add_leaf(parent);
       }
       if (parent != nullptr && parent->evictable()) {
-        candidate.push(parent);
+        if (is_sink_block(parent)) {
+          sink_candidate.push(parent);
+        } else {
+          candidate.push(parent);
+        }
       }
     }
   }

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -455,13 +455,24 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks,
   // Optimization: Batch build the priority queue to reduce overhead from O(N
   // log N) to O(N)
   std::vector<CRadixNode *> candidates;
+  std::vector<CRadixNode *> sink_candidates;
   candidates.reserve(leaf_list.size());
   for (auto node : leaf_list) {
-    // StreamingLLM: skip attention-sink blocks (first sink_block_count_ blocks
-    // from the root) — they are always attended to and must never be evicted.
-    if (node->evictable() && !is_sink_block(node)) {
+    if (!node->evictable())
+      continue;
+    // StreamingLLM: protect attention-sink blocks (first sink_block_count_
+    // blocks from the root). They are always attended to and should be evicted
+    // only as a last resort when no non-sink block is available.
+    if (is_sink_block(node)) {
+      sink_candidates.push_back(node);
+    } else {
       candidates.push_back(node);
     }
+  }
+  // Fallback: if every evictable leaf is a sink block, we must still make
+  // progress, so allow evicting the lowest-priority sink block.
+  if (candidates.empty()) {
+    candidates = std::move(sink_candidates);
   }
 
   std::priority_queue<CRadixNode *, std::vector<CRadixNode *>,

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -135,6 +135,12 @@ CRadixNode *CRadixNode::split(int prefix_length) {
 
   set_parent(new_node);
 
+  // Offset maintenance (O(1)): new_node is the PREFIX half and keeps this
+  // node's original offset; `this` is the SUFFIX half and now starts
+  // new_node->size() blocks later.  Read the old offset before overwriting.
+  new_node->set_block_offset(get_block_offset());
+  set_block_offset(new_node->get_block_offset() + new_node->size());
+
   // SWA (node-mount, I0/I4): the SWA snapshot lives on the node's LAST page.
   // After the split, `this` is the SUFFIX half and still owns that original
   // last page, so its SWA (slot / tombstone / lock / SWA-LRU membership) stays
@@ -374,6 +380,11 @@ CRadixNode *CRadixTreeIndex::insert(torch::Tensor &physical_block_ids,
 
   new_node->set_parent(last_node);
   last_node->set_child(new_node->get_head_hash(), new_node);
+  // O(1) offset: blocks preceding new_node == offset+size of its parent.
+  // (last_node may be the root, whose offset and size are both 0.)
+  new_node->set_block_offset(
+      is_root(last_node) ? 0
+                         : last_node->get_block_offset() + last_node->size());
 
   add_node(new_node);
   add_leaf(new_node);

--- a/csrc/radix_tree.cpp
+++ b/csrc/radix_tree.cpp
@@ -457,7 +457,9 @@ int CRadixTreeIndex::evict(torch::Tensor &evicted_blocks,
   std::vector<CRadixNode *> candidates;
   candidates.reserve(leaf_list.size());
   for (auto node : leaf_list) {
-    if (node->evictable()) {
+    // StreamingLLM: skip attention-sink blocks (first sink_block_count_ blocks
+    // from the root) — they are always attended to and must never be evicted.
+    if (node->evictable() && !is_sink_block(node)) {
       candidates.push_back(node);
     }
   }

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -441,7 +441,7 @@ public:
     freed_swa_slots.clear();
   }
 
-  bool is_root(CRadixNode *node) { return node == root; }
+  bool is_root(CRadixNode *node) const { return node == root; }
 
   CRadixNode *get_root() { return root; }
 

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -301,6 +301,9 @@ protected:
   int node_count;
   int hit_reward_seconds;
   std::unique_ptr<IEvictionStrategy> strategy_;
+  // StreamingLLM: number of leading blocks (attention sinks) protected from
+  // eviction. 0 disables the protection.
+  int sink_block_count_ = 0;
 
   // SWA slots that were freed because their node was deleted/invalidated by a
   // structural change (split / merge / evict). The Python side drains this and
@@ -353,12 +356,14 @@ public:
   CRadixTreeIndex(int tokens_per_block, int max_num_blocks = 1000000,
                   int hit_reward_seconds = 0,
                   EvictionPolicy eviction_policy = EvictionPolicy::LRU,
-                  int protected_threshold = 2) {
+                  int protected_threshold = 2,
+                  int sink_block_count = 0) {
     this->tokens_per_block = tokens_per_block;
     this->max_num_blocks = max_num_blocks;
     this->node_count = 0;
     this->hit_reward_seconds = hit_reward_seconds;
     this->strategy_ = create_eviction_strategy(eviction_policy, protected_threshold);
+    this->sink_block_count_ = sink_block_count;
 
     root = new CRadixNode(this, true, 0);
     node_list.push_back(root);
@@ -371,6 +376,26 @@ public:
     swa_lru_tail = new CRadixNode(this, true, 0);
     swa_lru_head->set_swa_lru_next(swa_lru_tail);
     swa_lru_tail->set_swa_lru_prev(swa_lru_head);
+  }
+
+
+  // Compute the total number of blocks preceding *node* (sum of sizes of all
+  // ancestors).  Used by StreamingLLM sink-token protection.
+  int get_block_offset_from_root(CRadixNode *node) const {
+    int offset = 0;
+    CRadixNode *cur = node->get_parent();
+    while (cur != nullptr && !is_root(cur)) {
+      offset += cur->size();
+      cur = cur->get_parent();
+    }
+    return offset;
+  }
+
+  // True if *node* falls within the first sink_block_count_ blocks and should
+  // be protected from eviction (StreamingLLM attention sinks).
+  bool is_sink_block(CRadixNode *node) const {
+    if (sink_block_count_ <= 0) return false;
+    return get_block_offset_from_root(node) < sink_block_count_;
   }
 
   const IEvictionStrategy *get_strategy() const { return strategy_.get(); }

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -28,6 +28,13 @@ private:
   uint64_t creation_time;
   int hit_count;
   int leaf_vector_index = -1;
+  // Cached sum of ancestor sizes (blocks preceding this node). Maintained
+  // incrementally in split() and CRadixTreeIndex::insert so StreamingLLM sink
+  // checks are O(1) instead of an O(depth) walk to root. split()/merge_child
+  // preserve the block count along every root->descendant path, so only the
+  // split node itself and freshly-inserted nodes ever need updating (no
+  // subtree refresh). Mirror of Python RadixNode.block_offset.
+  int block_offset_ = 0;
 
   // ===== SWA (Sliding Window Attention) fields =====
   // SWA snapshot state attached to this node. Mirrors the Python RadixNode
@@ -109,6 +116,10 @@ public:
   void set_leaf_vector_index(int index) { leaf_vector_index = index; }
 
   int get_leaf_vector_index() { return leaf_vector_index; }
+
+  void set_block_offset(int offset) { block_offset_ = offset; }
+
+  int get_block_offset() const { return block_offset_; }
 
   // ===== SWA accessors =====
   int get_swa_host_slot() { return swa_host_slot; }
@@ -377,9 +388,17 @@ public:
     swa_lru_tail->set_swa_lru_prev(swa_lru_head);
   }
 
-  // Compute the total number of blocks preceding *node* (sum of sizes of all
-  // ancestors).  Used by StreamingLLM sink-token protection.
+  // Number of blocks preceding *node* (sum of sizes of all ancestors).  Used
+  // by StreamingLLM sink-token protection.  O(1): maintained incrementally in
+  // CRadixNode::split and CRadixTreeIndex::insert (was an O(depth) walk called
+  // per candidate on every eviction).  See walk_block_offset_from_root for the
+  // reference computation used by debug asserts / tests.
   int get_block_offset_from_root(CRadixNode *node) const {
+    return node->get_block_offset();
+  }
+
+  // Reference O(depth) computation; not on the hot path.
+  int walk_block_offset_from_root(CRadixNode *node) const {
     int offset = 0;
     CRadixNode *cur = node->get_parent();
     while (cur != nullptr && !is_root(cur)) {
@@ -439,6 +458,28 @@ public:
     swa_lru_head->set_swa_lru_next(swa_lru_tail);
     swa_lru_tail->set_swa_lru_prev(swa_lru_head);
     freed_swa_slots.clear();
+  }
+
+  // Recompute cached offsets after bulk tree construction/re-parenting.
+  // Normal insert/split maintain offsets incrementally in O(1); distributed
+  // rebuilds attach and merge whole subtrees through several custom paths, so
+  // one O(nodes) pass at the end is simpler and keeps the node invariant exact.
+  void rebuild_block_offsets() {
+    root->set_block_offset(0);
+    std::vector<CRadixNode *> stack{root};
+    while (!stack.empty()) {
+      CRadixNode *parent = stack.back();
+      stack.pop_back();
+      const int child_offset =
+          is_root(parent) ? 0 : parent->get_block_offset() + parent->size();
+      parent->for_each_child([&](HashType, CRadixNode *child) {
+        if (child == nullptr) {
+          return;
+        }
+        child->set_block_offset(child_offset);
+        stack.push_back(child);
+      });
+    }
   }
 
   bool is_root(CRadixNode *node) const { return node == root; }

--- a/csrc/radix_tree.h
+++ b/csrc/radix_tree.h
@@ -356,8 +356,7 @@ public:
   CRadixTreeIndex(int tokens_per_block, int max_num_blocks = 1000000,
                   int hit_reward_seconds = 0,
                   EvictionPolicy eviction_policy = EvictionPolicy::LRU,
-                  int protected_threshold = 2,
-                  int sink_block_count = 0) {
+                  int protected_threshold = 2, int sink_block_count = 0) {
     this->tokens_per_block = tokens_per_block;
     this->max_num_blocks = max_num_blocks;
     this->node_count = 0;
@@ -378,7 +377,6 @@ public:
     swa_lru_tail->set_swa_lru_prev(swa_lru_head);
   }
 
-
   // Compute the total number of blocks preceding *node* (sum of sizes of all
   // ancestors).  Used by StreamingLLM sink-token protection.
   int get_block_offset_from_root(CRadixNode *node) const {
@@ -394,7 +392,8 @@ public:
   // True if *node* falls within the first sink_block_count_ blocks and should
   // be protected from eviction (StreamingLLM attention sinks).
   bool is_sink_block(CRadixNode *node) const {
-    if (sink_block_count_ <= 0) return false;
+    if (sink_block_count_ <= 0)
+      return false;
     return get_block_offset_from_root(node) < sink_block_count_;
   }
 

--- a/flexkv/cache/cache_engine.py
+++ b/flexkv/cache/cache_engine.py
@@ -281,7 +281,8 @@ class CacheEngineAccel:
                  event_collector: Optional[KVEventCollector] = None,
                  metrics_collector = None,
                  protected_threshold = 2,
-                 swa_config: Optional["SWAPoolConfig"] = None):
+                 swa_config: Optional["SWAPoolConfig"] = None,
+                 sink_block_count: int = 0):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -295,11 +296,14 @@ class CacheEngineAccel:
         if not isinstance(protected_threshold, int) or protected_threshold < 1:
             raise ValueError(f"Invalid protected_threshold: {protected_threshold}. "
                               f"protected_threshold must be an integer >= 1")
+        if not isinstance(sink_block_count, int) or sink_block_count < 0:
+            raise ValueError(f"Invalid sink_block_count: {sink_block_count}. "
+                              f"sink_block_count must be a non-negative integer")
 
         self.device_type = device_type
 
         self.index = CRadixTreeIndex(tokens_per_block, num_total_blocks, hit_reward_seconds, eviction_policy,
-                                     protected_threshold)
+                                     protected_threshold, sink_block_count)
 
         self.mempool = Mempool(num_total_blocks=num_total_blocks)
 
@@ -612,7 +616,8 @@ class CacheEngine:
                  event_collector: Optional[KVEventCollector] = None,
                  metrics_collector = None,
                  protected_threshold = 2,
-                 swa_config: Optional["SWAPoolConfig"] = None):
+                 swa_config: Optional["SWAPoolConfig"] = None,
+                 sink_block_count: int = 0):
         if not isinstance(device_type, DeviceType):
             raise ValueError(f"Unknown device type: {device_type}")
         if num_total_blocks <= 0:
@@ -626,13 +631,17 @@ class CacheEngine:
         if not isinstance(protected_threshold, int) or protected_threshold < 1:
             raise ValueError(f"Invalid protected_threshold: {protected_threshold}. "
                               f"protected_threshold must be an integer >= 1")
+        if not isinstance(sink_block_count, int) or sink_block_count < 0:
+            raise ValueError(f"Invalid sink_block_count: {sink_block_count}. "
+                              f"sink_block_count must be a non-negative integer")
 
         self.device_type = device_type
 
         self.index = RadixTreeIndex(tokens_per_block=tokens_per_block,
                                     hit_reward_seconds=hit_reward_seconds,
                                     eviction_policy=eviction_policy,
-                                    protected_threshold=protected_threshold)
+                                    protected_threshold=protected_threshold,
+                                    sink_block_count=sink_block_count)
 
         self.mempool = Mempool(num_total_blocks=num_total_blocks)
 
@@ -936,6 +945,7 @@ class GlobalCacheEngine:
         self.hit_reward_seconds = GLOBAL_CONFIG_FROM_ENV.hit_reward_seconds
         self.eviction_policy = GLOBAL_CONFIG_FROM_ENV.eviction_policy
         self.protected_threshold = GLOBAL_CONFIG_FROM_ENV.slru_protected_threshold
+        self.sink_block_count = GLOBAL_CONFIG_FROM_ENV.sink_block_count
 
         # Initialize metrics collector for cache engine monitoring (before creating CacheEngines)
         self._metrics_collector = get_global_collector()
@@ -971,6 +981,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             else:
                 self.cpu_cache_engine = CacheEngine(
@@ -985,6 +996,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             self.cache_engines[DeviceType.CPU] = self.cpu_cache_engine
         if cache_config.enable_ssd:
@@ -1004,6 +1016,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             else:
                 self.ssd_cache_engine = CacheEngine(
@@ -1018,6 +1031,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             self.cache_engines[DeviceType.SSD] = self.ssd_cache_engine
         if cache_config.enable_remote:
@@ -1043,6 +1057,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             else:
                 self.remote_cache_engine = CacheEngine(
@@ -1057,6 +1072,7 @@ class GlobalCacheEngine:
                     metrics_collector=self._metrics_collector,
                     protected_threshold=self.protected_threshold,
                     swa_config=cache_config.swa,
+                    sink_block_count=self.sink_block_count,
                 )
             self.cache_engines[DeviceType.REMOTE] = self.remote_cache_engine
 

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -602,20 +602,22 @@ class RadixTreeIndex:
             # evicted only as a last resort when no non-sink block is available.
             is_sink = (self.sink_block_count > 0 and
                        self._get_block_offset_from_root(node) < self.sink_block_count)
-            priority = self._get_eviction_priority(node)
             if is_sink:
-                sink_candidates.append((priority, node))
+                sink_candidates.append(
+                    (self._get_raw_eviction_priority(node), node))
             else:
-                candidates.append((priority, node))
-        # Fallback: if every evictable leaf is a sink block, we must still make
-        # progress, so allow evicting the lowest-priority sink block.
-        if not candidates:
-            candidates = sink_candidates
+                candidates.append((self._get_eviction_priority(node), node))
         heapq.heapify(candidates)
+        heapq.heapify(sink_candidates)
         evicted_blocks = np.array([], dtype=np.int64)
         evicted_block_hashes = np.array([], dtype=np.int64)
-        while len(evicted_blocks) < num_evicted and candidates:
-            priority, node = heapq.heappop(candidates)
+        while (len(evicted_blocks) < num_evicted
+               and (candidates or sink_candidates)):
+            # Re-evaluate fallback after every structural mutation: a child
+            # eviction may expose a sink parent while non-sink work remains.
+            use_sink_fallback = not candidates
+            heap = sink_candidates if use_sink_fallback else candidates
+            priority, node = heapq.heappop(heap)
             if node.size() > num_evicted - len(evicted_blocks):
                 physical_blocks, _block_hashes = node.shrink(num_evicted - len(evicted_blocks))
                 # SWA: node survives but its trailing page changed, so its old
@@ -643,8 +645,21 @@ class RadixTreeIndex:
                         physical_blocks = np.concatenate([physical_blocks, cascade_blocks])
                         _block_hashes = np.concatenate([_block_hashes, cascade_hashes])
                 if parent is not None and parent.evictable():
-                    priority = self._get_eviction_priority(parent)
-                    heapq.heappush(candidates, (priority, parent))
+                    is_sink_parent = (
+                        self.sink_block_count > 0
+                        and self._get_block_offset_from_root(parent)
+                        < self.sink_block_count
+                    )
+                    if is_sink_parent:
+                        heapq.heappush(
+                            sink_candidates,
+                            (self._get_raw_eviction_priority(parent), parent),
+                        )
+                    else:
+                        heapq.heappush(
+                            candidates,
+                            (self._get_eviction_priority(parent), parent),
+                        )
 
             evicted_blocks = np.concatenate([evicted_blocks, physical_blocks])
             evicted_block_hashes = np.concatenate([evicted_block_hashes, _block_hashes])
@@ -843,22 +858,23 @@ class RadixTreeIndex:
         return offset
 
     def _get_eviction_priority(self, node: RadixNode):
-        """Get the eviction priority for a node based on the configured policy.
+        """Get eviction priority including attention-sink protection.
 
         Lower priority values are evicted first (min-heap).
 
         Nodes within the first ``sink_block_count`` blocks from the root are
         treated as attention sinks (StreamingLLM) and given maximum priority so
-        they are never evicted.
+        they are never evicted except in the explicit all-sink fallback.
         """
         # StreamingLLM: protect attention sinks (first N blocks) from eviction.
         if self.sink_block_count > 0:
             offset = self._get_block_offset_from_root(node)
             if offset < self.sink_block_count:
-                # Return a value larger than any real priority so the node is
-                # never selected for eviction (min-heap: larger = evicted later).
                 return float('inf')
+        return self._get_raw_eviction_priority(node)
 
+    def _get_raw_eviction_priority(self, node: RadixNode):
+        """Get policy priority without attention-sink protection."""
         if self.eviction_policy == "lru":
             return node.grace_time
         elif self.eviction_policy == "lfu":

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -593,16 +593,24 @@ class RadixTreeIndex:
 
     def evict(self, num_evicted: int) -> Tuple[np.ndarray, np.ndarray]:
         candidates = []
+        sink_candidates = []
         for node in self.leaf_nodes.values():
-            if node.evictable():
-                # StreamingLLM: skip attention-sink blocks (first sink_block_count
-                # blocks from the root) — they are always attended to and must
-                # never be evicted.
-                if self.sink_block_count > 0 and \
-                        self._get_block_offset_from_root(node) < self.sink_block_count:
-                    continue
-                priority = self._get_eviction_priority(node)
+            if not node.evictable():
+                continue
+            # StreamingLLM: protect attention-sink blocks (first sink_block_count
+            # blocks from the root). They are always attended to and should be
+            # evicted only as a last resort when no non-sink block is available.
+            is_sink = (self.sink_block_count > 0 and
+                       self._get_block_offset_from_root(node) < self.sink_block_count)
+            priority = self._get_eviction_priority(node)
+            if is_sink:
+                sink_candidates.append((priority, node))
+            else:
                 candidates.append((priority, node))
+        # Fallback: if every evictable leaf is a sink block, we must still make
+        # progress, so allow evicting the lowest-priority sink block.
+        if not candidates:
+            candidates = sink_candidates
         heapq.heapify(candidates)
         evicted_blocks = np.array([], dtype=np.int64)
         evicted_block_hashes = np.array([], dtype=np.int64)

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -81,6 +81,13 @@ class RadixNode:
     hit_count: int = 0
     creation_time: float = 0.0
     last_access_time: float = 0.0
+    # Cached sum of ancestor sizes (blocks preceding this node). Maintained
+    # incrementally in split() and RadixTreeIndex.insert so StreamingLLM sink
+    # checks are O(1) instead of an O(depth) walk to root. split()/merge_child
+    # preserve the block count along every root->descendant path, so only the
+    # split node itself and freshly-inserted nodes ever need updating (no
+    # subtree refresh). Root and freshly-created nodes start at 0.
+    block_offset: int = 0
 
     parent: Optional['RadixNode'] = None
     children: Dict[Optional[HashType], 'RadixNode'] = field(default_factory=dict)
@@ -180,6 +187,11 @@ class RadixNode:
         new_node.parent = self.parent
         self.parent = new_node
         new_node.children[self.head_hash()] = self
+        # Offset maintenance (O(1)): new_node is the PREFIX half and keeps this
+        # node's original offset; self is the SUFFIX half and now starts
+        # new_node.size() blocks later. Read the old offset before overwriting.
+        new_node.block_offset = self.block_offset
+        self.block_offset = new_node.block_offset + new_node.size()
         # self keeps its SWA and its SWA-LRU membership unchanged (its last page
         # is unchanged), so no SWA-LRU surgery is needed here.
         return new_node
@@ -534,6 +546,10 @@ class RadixTreeIndex:
         new_node.parent = last_node
         last_node.children[new_node.head_hash()] = new_node
         self.leaf_nodes[new_node.head_hash()] = new_node
+        # O(1) offset: blocks preceding new_node == offset+size of its parent.
+        # (last_node may be the root, whose offset and size are both 0.)
+        new_node.block_offset = (0 if last_node.is_root()
+                                 else last_node.block_offset + last_node.size())
 
         return new_node
 
@@ -846,10 +862,19 @@ class RadixTreeIndex:
 
 
     def _get_block_offset_from_root(self, node: RadixNode) -> int:
-        """Compute the total number of blocks preceding *node* (i.e. the sum of
-        sizes of all ancestors).  Nodes whose offset is below
-        ``sink_block_count`` are treated as attention sinks and protected from
-        eviction (StreamingLLM)."""
+        """Total number of blocks preceding *node* (the sum of sizes of all
+        ancestors).  Nodes whose offset is below ``sink_block_count`` are
+        treated as attention sinks and protected from eviction (StreamingLLM).
+
+        O(1): the value is maintained incrementally in ``RadixNode.split`` and
+        ``RadixTreeIndex.insert``.  It used to be an O(depth) walk to root,
+        called per candidate on every eviction; see ``_walk_block_offset`` for
+        the reference computation used by tests/asserts."""
+        return node.block_offset
+
+    def _walk_block_offset(self, node: RadixNode) -> int:
+        """Reference O(depth) offset used to validate the cached value in
+        tests/debug asserts.  Not used on the hot path."""
         offset = 0
         cur = node.parent
         while cur is not None and not cur.is_root():

--- a/flexkv/cache/radixtree.py
+++ b/flexkv/cache/radixtree.py
@@ -212,7 +212,7 @@ class RadixNode:
 class RadixTreeIndex:
     def __init__(self, tokens_per_block: int, max_num_blocks: int = 1000000,
                  hit_reward_seconds: int = 0, eviction_policy: str = "lru",
-                 protected_threshold: int = 2):
+                 protected_threshold: int = 2, sink_block_count: int = 0):
         self.root_node: RadixNode = RadixNode(block_hashes=np.array([], dtype=np.int64),
                                               physical_blocks=np.array([], dtype=np.int64),
                                               is_ready=True,
@@ -228,6 +228,9 @@ class RadixTreeIndex:
         self.hit_reward_seconds = hit_reward_seconds
         self.eviction_policy = eviction_policy
         self.protected_threshold = protected_threshold
+        # StreamingLLM: protect the first N blocks (attention sinks) from eviction.
+        # Sink tokens always receive high attention scores and should never be evicted.
+        self.sink_block_count = sink_block_count
 
         # ===== SWA-only LRU (intrusive doubly-linked list w/ sentinels) =====
         # head side = MRU, tail side = LRU. Nodes carrying a live SWA slot are on
@@ -592,6 +595,12 @@ class RadixTreeIndex:
         candidates = []
         for node in self.leaf_nodes.values():
             if node.evictable():
+                # StreamingLLM: skip attention-sink blocks (first sink_block_count
+                # blocks from the root) — they are always attended to and must
+                # never be evicted.
+                if self.sink_block_count > 0 and \
+                        self._get_block_offset_from_root(node) < self.sink_block_count:
+                    continue
                 priority = self._get_eviction_priority(node)
                 candidates.append((priority, node))
         heapq.heapify(candidates)
@@ -812,11 +821,36 @@ class RadixTreeIndex:
             self.record_freed_swa_slot(cur)
 
 
+
+    def _get_block_offset_from_root(self, node: RadixNode) -> int:
+        """Compute the total number of blocks preceding *node* (i.e. the sum of
+        sizes of all ancestors).  Nodes whose offset is below
+        ``sink_block_count`` are treated as attention sinks and protected from
+        eviction (StreamingLLM)."""
+        offset = 0
+        cur = node.parent
+        while cur is not None and not cur.is_root():
+            offset += cur.size()
+            cur = cur.parent
+        return offset
+
     def _get_eviction_priority(self, node: RadixNode):
         """Get the eviction priority for a node based on the configured policy.
 
         Lower priority values are evicted first (min-heap).
+
+        Nodes within the first ``sink_block_count`` blocks from the root are
+        treated as attention sinks (StreamingLLM) and given maximum priority so
+        they are never evicted.
         """
+        # StreamingLLM: protect attention sinks (first N blocks) from eviction.
+        if self.sink_block_count > 0:
+            offset = self._get_block_offset_from_root(node)
+            if offset < self.sink_block_count:
+                # Return a value larger than any real priority so the node is
+                # never selected for eviction (min-heap: larger = evicted later).
+                return float('inf')
+
         if self.eviction_policy == "lru":
             return node.grace_time
         elif self.eviction_policy == "lfu":

--- a/flexkv/common/config.py
+++ b/flexkv/common/config.py
@@ -624,6 +624,9 @@ class SWAPoolConfig:
 class CacheConfig:
     tokens_per_block: int = 16
     eviction_policy: str = "lru"
+    # StreamingLLM: number of leading blocks (attention sinks) protected from
+    # eviction. 0 disables the protection.
+    sink_block_count: int = 0
     enable_cpu: bool = True
     enable_ssd: bool = False
     enable_gds: bool = False # Requires enable_ssd=True
@@ -797,6 +800,7 @@ GLOBAL_CONFIG_FROM_ENV: Namespace = Namespace(
     hit_reward_seconds=int(os.getenv('FLEXKV_HIT_REWARD_SECONDS', 0)),
     eviction_policy=os.getenv('FLEXKV_EVICTION_POLICY', 'lru'),
     slru_protected_threshold=int(os.getenv('FLEXKV_SLRU_PROTECTED_THRESHOLD', 2)),
+    sink_block_count=int(os.getenv('FLEXKV_SINK_BLOCK_COUNT', 0)),
 
     enable_mps=bool(int(os.getenv('FLEXKV_ENABLE_MPS', 1))),
 

--- a/tests/test_sink_token_eviction.py
+++ b/tests/test_sink_token_eviction.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from flexkv.cache.radixtree import RadixNode, RadixTreeIndex
+
+
+pytestmark = pytest.mark.unit
+
+
+def _node(block_hash, physical_block, grace_time, parent):
+    node = RadixNode(
+        block_hashes=np.array([block_hash], dtype=np.int64),
+        physical_blocks=np.array([physical_block], dtype=np.int64),
+        is_ready=True,
+        lock_cnt=0,
+        grace_time=grace_time,
+        parent=parent,
+    )
+    parent.children[node.head_hash()] = node
+    # P2 caches the ancestor-block offset on each node; pre-P2 trees simply
+    # ignore this dynamically-added attribute and continue using the walk.
+    parent_offset = getattr(parent, "block_offset", 0)
+    node.block_offset = (
+        0 if parent.is_root() else parent_offset + parent.size())
+    return node
+
+
+def test_dynamic_fallback_prefers_all_non_sink_work_before_sink_parents():
+    idx = RadixTreeIndex(tokens_per_block=1, sink_block_count=1)
+
+    parent_a = _node(10, 100, 0.1, idx.root_node)
+    child_a = _node(11, 101, 1.0, parent_a)
+    parent_b = _node(20, 200, 0.2, idx.root_node)
+    child_b = _node(21, 201, 2.0, parent_b)
+    idx.leaf_nodes = {
+        child_a.head_hash(): child_a,
+        child_b.head_hash(): child_b,
+    }
+
+    evicted, _ = idx.evict(3)
+
+    # Both offset=1 non-sink leaves must be consumed before either offset=0
+    # sink parent. After they are exhausted, fallback may evict the oldest sink
+    # parent to satisfy the remaining demand.
+    assert evicted.tolist() == [101, 201, 100]
+    assert parent_b.parent is idx.root_node
+
+
+def test_all_sink_fallback_uses_raw_eviction_policy_priority():
+    idx = RadixTreeIndex(tokens_per_block=1, sink_block_count=1)
+    newer = _node(10, 100, 2.0, idx.root_node)
+    older = _node(20, 200, 1.0, idx.root_node)
+    idx.leaf_nodes = {
+        newer.head_hash(): newer,
+        older.head_hash(): older,
+    }
+
+    evicted, _ = idx.evict(1)
+
+    assert evicted.tolist() == [200]

--- a/tests/test_swa_node_mount.py
+++ b/tests/test_swa_node_mount.py
@@ -54,6 +54,83 @@ def _phys(*xs):
     return np.array(xs, dtype=np.int64)
 
 
+def _walk_block_offset(node):
+    """Reference O(depth) computation for cached-offset tests."""
+    offset = 0
+    cur = node.parent
+    while cur is not None and not cur.is_root():
+        offset += cur.size()
+        cur = cur.parent
+    return offset
+
+
+def _assert_cached_offsets(idx):
+    stack = [idx.root_node]
+    while stack:
+        node = stack.pop()
+        if not node.is_root():
+            assert node.block_offset == _walk_block_offset(node)
+            assert idx._get_block_offset_from_root(node) == node.block_offset
+        stack.extend(node.children.values())
+
+
+def _insert_tokens(idx, token_ids, next_physical_block):
+    seq = _seq(token_ids)
+    match = idx.match_prefix(seq, update_cache_info=False)
+    num_new_blocks = seq.num_blocks - match.num_matched_blocks
+    physical = np.arange(
+        next_physical_block,
+        next_physical_block + num_new_blocks,
+        dtype=np.int64,
+    )
+    node = idx.insert(seq, physical, is_ready=True, match_result=match)
+    return node, next_physical_block + num_new_blocks
+
+
+def test_py_cached_block_offset_survives_split_and_branch_insert():
+    idx = RadixTreeIndex(tokens_per_block=TPB, sink_block_count=2)
+    next_physical = 0
+
+    # First insert is one four-block leaf at offset 0.
+    leaf, next_physical = _insert_tokens(
+        idx, [1, 2, 3, 4, 5, 6, 7, 8], next_physical)
+    assert leaf is not None and leaf.block_offset == 0
+
+    # Sharing two blocks and diverging forces leaf.split(2): the new prefix
+    # keeps offset 0, while both suffix branches start at offset 2.
+    branch, next_physical = _insert_tokens(
+        idx, [1, 2, 3, 4, 9, 10, 11, 12], next_physical)
+    assert branch is not None and branch.block_offset == 2
+
+    prefix = branch.parent
+    assert prefix is not None and prefix.block_offset == 0
+    assert sorted(child.block_offset for child in prefix.children.values()) == [2, 2]
+    _assert_cached_offsets(idx)
+
+
+def test_py_cached_block_offset_matches_walk_for_random_prefix_tree():
+    rng = random.Random(20260823)
+    idx = RadixTreeIndex(tokens_per_block=TPB, sink_block_count=4)
+    next_physical = 0
+    sequences = []
+
+    for request_id in range(200):
+        if sequences and rng.random() < 0.8:
+            base = list(rng.choice(sequences))
+            prefix_blocks = rng.randrange(0, len(base) // TPB + 1)
+            token_ids = base[:prefix_blocks * TPB]
+        else:
+            token_ids = []
+
+        new_blocks = rng.randint(1, 8)
+        start = 1_000_000 + request_id * 100
+        token_ids.extend(range(start, start + new_blocks * TPB))
+        sequences.append(tuple(token_ids))
+
+        _, next_physical = _insert_tokens(idx, token_ids, next_physical)
+        _assert_cached_offsets(idx)
+
+
 def test_py_match_returns_last_swa_node():
     idx = RadixTreeIndex(tokens_per_block=TPB)
     n1 = idx.insert(_seq([1, 2, 3, 4, 5, 6, 7, 8]), _phys(0, 1, 2, 3), is_ready=True)
@@ -374,9 +451,10 @@ def test_promote_swa_ignores_dead_node():
 
 c_ext = pytest.importorskip("flexkv.c_ext")
 
-_CEXT_OK = "swa_host_slot" in dir(c_ext.CRadixNode) and all(
+_CEXT_OK = all(
     n in dir(c_ext.CRadixNode)
-    for n in ("is_leaf", "get_lock_cnt", "has_swa", "lock", "unlock")
+    for n in ("swa_host_slot", "is_leaf", "get_lock_cnt", "has_swa", "lock",
+              "unlock", "block_offset")
 )
 _cext_reason = "CRadixNode SWA/structural bindings not present (rebuild c_ext)"
 cext = pytest.mark.skipif(not _CEXT_OK, reason=_cext_reason)
@@ -485,16 +563,20 @@ def test_cpp_partial_node_match_hides_tail_swa():
 def test_cpp_split_preserves_swa_on_suffix():
     t = _tree()
     n = _insert(t, [1, 2, 3, 4, 5, 6, 7, 8], 0)
+    assert n.block_offset == 0
     t.set_swa(n, 200)
     # Diverge after 2 blocks -> split the 4-block node into prefix(2)+suffix(2).
     s2 = [1, 2, 3, 4, 55, 66, 77, 88]
     m = t.match_prefix(_hashes(s2), 4, False)
     assert m.num_matched_blocks == 2
-    _insert(t, s2, 8, match=m)
+    branch = _insert(t, s2, 8, match=m)
     # original node is now the suffix half and KEEPS its slot; nothing freed.
     assert n.swa_host_slot == 200 and not n.swa_tombstone and n.size() == 2
     parent = n.parent
     assert parent is not None and parent.swa_host_slot == -1 and parent.swa_tombstone
+    assert parent.block_offset == 0
+    assert n.block_offset == 2
+    assert branch is not None and branch.block_offset == 2
     assert t.drain_freed_swa_slots() == []
     mr = t.match_prefix(_hashes([1, 2, 3, 4, 5, 6, 7, 8]), 4, False)
     assert mr.last_swa_node is not None and mr.swa_hit_blocks == 4


### PR DESCRIPTION
## Summary

Add complete StreamingLLM attention-sink protection to FlexKV's radix-tree
external cache eviction, including correctness fixes and O(1) classification.

This PR intentionally keeps the feature, fallback correctness, and its hot-path
optimization together as four reviewable commits:

1. protect the first configured number of logical blocks;
2. guarantee allocation progress when all remaining candidates are sinks;
3. preserve protection when cascade eviction exposes a sink parent, with
   dynamic normal/sink heaps;
4. cache each node's root block offset so sink classification is O(1).

## Configuration

```bash
export FLEXKV_SINK_BLOCK_COUNT=N
```

`N=0` (default) preserves existing behavior.

## Correctness

- Non-sink candidates are always exhausted before fallback considers sinks.
- Fallback is re-evaluated after every structural mutation, so a newly exposed
  sink parent cannot enter the normal heap and allocation cannot stop early.
- Fallback orders sink candidates by the configured policy instead of assigning
  every sink infinite priority.
- Python and C++ implementations preserve identical split/insert/merge offset
  invariants; distributed bulk rebuild runs one off-hot-path offset pass.

## Performance

Before: sink classification walked ancestors for every eviction candidate,
`O(candidates * tree_depth)` on the serialized control plane.

After: each node stores its block offset, maintained in O(1) on insert/split;
classification is a single integer read. A CPU lookup-only microbenchmark at
`depth=256`, `4096` candidates measured ~81.7x speedup for this predicate
(not an end-to-end eviction claim).

## Verification

- Deterministic dynamic-fallback tests: all non-sinks precede sink parents, and
  all-sink fallback follows raw policy priority.
- Randomized real-Python radix differential test: 229,404 cached-offset checks,
  zero failures.
- Standalone C++ offset model: 24,000 randomized mutation checks, zero failures.
- C++ radix/local syntax checks pass with CPU libtorch after adapting only two
  pre-existing Torch 2.13 API differences in temporary copies.
- Combined integration rehearsal with worker fix, vLLM layer-wise loading, and
  decayed LFU passes all available CPU/static tests.
