### PR TITLE
[feature] pipeline FlexKV loads layer by layer in vLLM

### DIFF
--- a/docs/vllm_adapter/README_en.md
+++ b/docs/vllm_adapter/README_en.md
@@ -88,6 +88,34 @@ VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
         '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
 ```
 
+### Experimental Layer-wise KV Loading
+
+Layer-wise loading overlaps FlexKV H2D transfer for layer `N+1` with vLLM
+compute for layer `N`, reducing TTFT when external KV transfer is on the
+critical path.
+
+```bash
+VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve MODEL \
+  --kv-transfer-config \
+  '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both",\
+"kv_connector_extra_config":{"use_layerwise":true}}'
+```
+
+`use_layerwise=true` is required so vLLM selects PIECEWISE CUDA graph mode;
+the per-layer eventfd waits cannot execute correctly inside a captured full
+CUDA graph. For safety, setting `FLEXKV_ENABLE_LAYERWISE_TRANSFER=1` alone is
+ignored by the vLLM adapter. Until the matching vLLM wrapper change is merged upstream, apply
+`examples/vllm_adaption/vllm_main-flexkv-layerwise-wrapper.patch` to vLLM.
+
+The feature currently pipelines GET/H2D only. PUT remains request-level async.
+Context parallelism (`context_parallel_size > 1`) is not supported yet because
+vLLM's runtime DCP/PCP rank has not been mapped into FlexKV's eventfd index.
+GDS is also unsupported in this mode because the fused layer-wise graph uses
+CPU/SSD/remote staging rather than direct `DISK2D` operations.
+If a layer does not become ready within
+`FLEXKV_LAYERWISE_WAIT_TIMEOUT_S` (default `60` seconds), the forward fails
+instead of hanging indefinitely.
+
 ### Using Older vLLM (Patch Required)
 
 If you need to use FlexKV with vLLM < 0.17.2, apply the corresponding patch manually:

--- a/docs/vllm_adapter/README_zh.md
+++ b/docs/vllm_adapter/README_zh.md
@@ -88,6 +88,32 @@ VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve Qwen3/Qwen3-32B \
         '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
 ```
 
+### 实验性 Layer-wise KV 加载
+
+Layer-wise 加载可让 FlexKV 搬运第 `N+1` 层 KV 的同时，vLLM 计算第 `N`
+层，从而在外部 KV 传输位于关键路径时降低 TTFT。
+
+```bash
+VLLM_USE_V1=1 python -m vllm.entrypoints.cli.main serve MODEL \
+  --kv-transfer-config \
+  '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both",\
+"kv_connector_extra_config":{"use_layerwise":true}}'
+```
+
+必须设置 `use_layerwise=true`，使 vLLM 选择 PIECEWISE CUDA Graph 模式；
+逐层 eventfd 等待无法在完整 CUDA Graph 捕获/回放中正确执行。为保证安全，
+仅设置 `FLEXKV_ENABLE_LAYERWISE_TRANSFER=1` 会被 vLLM adapter 忽略。在对应的
+vLLM wrapper 改动合入上游前，请给 vLLM 应用
+`examples/vllm_adaption/vllm_main-flexkv-layerwise-wrapper.patch`。
+
+当前仅对 GET/H2D 做逐层流水；PUT 仍是请求级异步。
+当前暂不支持 Context Parallel（`context_parallel_size > 1`），因为 vLLM
+运行时 DCP/PCP rank 尚未映射到 FlexKV 的 eventfd 索引空间。该模式也暂不
+支持 GDS，因为融合后的 layer-wise graph 使用 CPU/SSD/remote staging，而
+不是直接 `DISK2D`。如果某一层在
+`FLEXKV_LAYERWISE_WAIT_TIMEOUT_S`（默认 `60` 秒）内未就绪，forward 会失败，
+而不是永久卡住。
+
 ### 使用旧版 vLLM（需 patch）
 
 如需在 vLLM < 0.17.2 上使用 FlexKV，请手动 apply 对应版本的 patch：

--- a/examples/vllm_adaption/vllm_main-flexkv-layerwise-wrapper.patch
+++ b/examples/vllm_adaption/vllm_main-flexkv-layerwise-wrapper.patch
@@ -1,0 +1,43 @@
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/flexkv_connector.py
+@@ -55,0 +56,5 @@
++    @classmethod
++    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
++        """Layer-wise eventfd waits must execute between CUDA graph pieces."""
++        return bool(extra_config.get("use_layerwise", False))
++
+@@ -78,0 +84,8 @@
++    def bind_connector_metadata(self, connector_metadata: KVConnectorMetadata) -> None:
++        super().bind_connector_metadata(connector_metadata)
++        self._flexkv_connector.bind_connector_metadata(connector_metadata)
++
++    def clear_connector_metadata(self) -> None:
++        self._flexkv_connector.clear_connector_metadata()
++        super().clear_connector_metadata()
++
+--- a/tests/v1/kv_connector/unit/test_flexkv_connector.py
++++ b/tests/v1/kv_connector/unit/test_flexkv_connector.py
+@@ -232,0 +233,23 @@
++
++class TestFlexKVLayerwiseContract:
++    def test_piecewise_cudagraph_required_only_for_layerwise(self):
++        from vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector import (
++            FlexKVConnectorV1,
++        )
++
++        assert FlexKVConnectorV1.requires_piecewise_for_cudagraph(
++            {"use_layerwise": True})
++        assert not FlexKVConnectorV1.requires_piecewise_for_cudagraph({})
++
++    def test_metadata_bind_and_clear_are_delegated(self):
++        impl = MagicMock()
++        connector = _build_connector(_make_vllm_config(), impl)
++        metadata = MagicMock()
++
++        connector.bind_connector_metadata(metadata)
++        assert connector._get_connector_metadata() is metadata
++        impl.bind_connector_metadata.assert_called_once_with(metadata)
++
++        connector.clear_connector_metadata()
++        impl.clear_connector_metadata.assert_called_once()
++        assert not connector.has_connector_metadata()

--- a/flexkv/integration/vllm/layerwise_sync.py
+++ b/flexkv/integration/vllm/layerwise_sync.py
@@ -37,6 +37,18 @@ def _linux_eventfd(initval: int = 0, flags: int = _EFD_SEMAPHORE) -> int:
     return int(fd)
 
 
+def _settle_eventfd(fd: int, timeout_s: float) -> bool:
+    """Consume one pending eventfd unit, waiting at most timeout_s."""
+    try:
+        ready, _, _ = select.select([fd], [], [], timeout_s)
+        if not ready:
+            return False
+        os.read(fd, 8)
+        return True
+    except OSError:
+        return True
+
+
 def _read_eventfd(fd: int) -> int:
     timeout_s = float(os.getenv("FLEXKV_LAYERWISE_WAIT_TIMEOUT_S", "60"))
     ready, _, _ = select.select([fd], [], [], timeout_s)
@@ -97,11 +109,30 @@ class LayerwiseStepCoordinator:
         return bool(needs_load and not self.enabled)
 
     def launch_kwargs(self, metadata: LayerwiseLoadMetadata) -> dict[str, object]:
+        # A no-load step carries counter_id=-1. Clamping that to 0 would make
+        # the data plane signal counter 0 -- which a concurrent real load may
+        # own -- so its layers could see units that belong to no transfer.
+        # Only a metadata that actually has a load may drive a layer-wise
+        # launch; otherwise fall back to the non-layer-wise path.
+        if not metadata.enabled or not metadata.has_load:
+            return {
+                "as_batch": metadata.enabled,
+                "layerwise_transfer": False,
+                "counter_id": 0,
+            }
+        self._validate_launch_counter(metadata.counter_id)
         return {
             "as_batch": metadata.enabled,
             "layerwise_transfer": metadata.enabled,
-            "counter_id": max(metadata.counter_id, 0),
+            "counter_id": metadata.counter_id,
         }
+
+    def _validate_launch_counter(self, counter_id: int) -> None:
+        if counter_id < 0 or counter_id >= self.num_counters:
+            raise ValueError(
+                f"layer-wise launch counter_id={counter_id} outside "
+                f"[0, {self.num_counters})"
+            )
 
 
 class LayerwiseCounterPool:
@@ -120,6 +151,7 @@ class LayerwiseCounterPool:
         fd_factory: Callable[[], int] = _linux_eventfd,
         fd_reader: Callable[[int], int] = _read_eventfd,
         fd_closer: Callable[[int], None] = os.close,
+        fd_settler: Callable[[int, float], bool] = _settle_eventfd,
     ) -> None:
         if not layer_names:
             raise ValueError("layer_names must not be empty")
@@ -136,6 +168,10 @@ class LayerwiseCounterPool:
         self.num_counters = num_counters
         self._fd_reader = fd_reader
         self._fd_closer = fd_closer
+        # Retained for compatibility with external test fixtures that inject a
+        # settler. Reusing an incomplete asynchronous counter is unsafe, so
+        # this pool deliberately no longer invokes it.
+        self._fd_settler = fd_settler
         self._fds = [
             [fd_factory() for _ in range(self.num_layers)]
             for _ in range(num_counters)
@@ -164,6 +200,10 @@ class LayerwiseCounterPool:
                 "layer-wise counter pool is unusable after a prior wait failure"
             ) from self._failed_error
         if self._active_counter >= 0:
+            # Eventfd units carry no generation. The data plane writes them
+            # asynchronously, so an incomplete forward cannot be safely
+            # reclaimed without an explicit producer-quiescence acknowledgement
+            # or per-generation descriptors.
             raise RuntimeError(
                 "received new layer-wise metadata before the previous "
                 f"counter {self._active_counter} finished"
@@ -210,16 +250,23 @@ class LayerwiseCounterPool:
         tp_size_per_node: int,
         timeout_s: float = 360.0,
         retry_interval_s: float = 0.05,
+        cancel_event: threading.Event | None = None,
     ) -> None:
         """Send all counter eventfds to the LayerwiseTransferWorker.
 
         This method is intended to run in a background thread before GPU-cache
         registration, because registration may start a worker that blocks while
         waiting for this handshake.
+
+        ``cancel_event`` lets a caller abandon the retry loop early. Shutdown
+        needs it: otherwise this thread keeps retrying for the full timeout_s
+        while holding eventfds that the caller wants to close.
         """
         deadline = time.monotonic() + timeout_s
         last_error: BaseException | None = None
         while time.monotonic() < deadline:
+            if cancel_event is not None and cancel_event.is_set():
+                return
             try:
                 with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
                     sock.connect(socket_path)
@@ -243,7 +290,13 @@ class LayerwiseCounterPool:
                     return
             except (OSError, RuntimeError, TimeoutError) as exc:
                 last_error = exc
-                time.sleep(retry_interval_s)
+                if cancel_event is not None:
+                    # Interruptible sleep: a plain time.sleep() would ignore a
+                    # cancel that arrives during the backoff.
+                    if cancel_event.wait(retry_interval_s):
+                        return
+                else:
+                    time.sleep(retry_interval_s)
         raise RuntimeError(
             f"timed out sending layer-wise eventfds to {socket_path}: {last_error}"
         )

--- a/flexkv/integration/vllm/layerwise_sync.py
+++ b/flexkv/integration/vllm/layerwise_sync.py
@@ -1,0 +1,267 @@
+"""Worker-side synchronization primitives for vLLM layer-wise KV loading.
+
+The FlexKV data plane signals completion of each layer through Linux eventfds.
+This module intentionally has no torch/vLLM/c_ext dependency so its counter
+state machine and Unix-domain-socket handshake can be tested on CPU-only hosts.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import select
+import socket
+import struct
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+
+_EFD_SEMAPHORE = 0x1
+
+
+def _linux_eventfd(initval: int = 0, flags: int = _EFD_SEMAPHORE) -> int:
+    eventfd_fn = getattr(os, "eventfd", None)
+    if eventfd_fn is not None:
+        return int(eventfd_fn(initval, flags))
+
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.eventfd.argtypes = [ctypes.c_uint, ctypes.c_int]
+    libc.eventfd.restype = ctypes.c_int
+    fd = libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
+    if fd < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return int(fd)
+
+
+def _read_eventfd(fd: int) -> int:
+    timeout_s = float(os.getenv("FLEXKV_LAYERWISE_WAIT_TIMEOUT_S", "60"))
+    ready, _, _ = select.select([fd], [], [], timeout_s)
+    if not ready:
+        raise TimeoutError(
+            f"timed out after {timeout_s}s waiting for layer-wise KV load")
+    payload = os.read(fd, 8)
+    if len(payload) != 8:
+        raise OSError(errno.EIO, f"short eventfd read: {len(payload)} bytes")
+    return int(struct.unpack("Q", payload)[0])
+
+
+def _send_fds(sock: socket.socket, fds: Sequence[int], counter_id: int) -> None:
+    packed_fds = struct.pack(f"{len(fds)}i", *fds)
+    sock.sendmsg(
+        [struct.pack("i", counter_id)],
+        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, packed_fds)],
+    )
+
+
+@dataclass(frozen=True)
+class LayerwiseLoadMetadata:
+    """Serializable scheduler-to-worker metadata for one model step."""
+
+    enabled: bool = False
+    counter_id: int = -1
+    has_load: bool = False
+
+
+class LayerwiseStepCoordinator:
+    """Scheduler-side deterministic counter assignment."""
+
+    def __init__(self, enabled: bool, num_counters: int = 3) -> None:
+        if num_counters <= 0:
+            raise ValueError("num_counters must be positive")
+        self.enabled = enabled
+        self.num_counters = num_counters
+        self._next_counter = 0
+
+    def build_metadata(self, has_load: bool) -> LayerwiseLoadMetadata:
+        if not self.enabled or not has_load:
+            return LayerwiseLoadMetadata(enabled=self.enabled)
+        counter_id = self._next_counter
+        self._next_counter = (self._next_counter + 1) % self.num_counters
+        return LayerwiseLoadMetadata(
+            enabled=True,
+            counter_id=counter_id,
+            has_load=True,
+        )
+
+    def external_match_is_async(self, needs_load: bool) -> bool:
+        """Whether vLLM should enter WAITING_FOR_REMOTE_KVS.
+
+        Layer-wise loads must run in the same model step so attention-layer
+        hooks can wait on their eventfds. Non-layer-wise loads retain the
+        existing whole-transfer async behavior.
+        """
+        return bool(needs_load and not self.enabled)
+
+    def launch_kwargs(self, metadata: LayerwiseLoadMetadata) -> dict[str, object]:
+        return {
+            "as_batch": metadata.enabled,
+            "layerwise_transfer": metadata.enabled,
+            "counter_id": max(metadata.counter_id, 0),
+        }
+
+
+class LayerwiseCounterPool:
+    """Triple-buffered per-layer eventfd synchronization.
+
+    The scheduler chooses a counter id for each layer-wise batch and sends it
+    through connector metadata. The worker binds that id at forward start;
+    each attention layer then consumes exactly one semaphore unit from its
+    eventfd. A counter can only be reused after its final layer was consumed.
+    """
+
+    def __init__(
+        self,
+        layer_names: Sequence[str],
+        num_counters: int = 3,
+        fd_factory: Callable[[], int] = _linux_eventfd,
+        fd_reader: Callable[[int], int] = _read_eventfd,
+        fd_closer: Callable[[int], None] = os.close,
+    ) -> None:
+        if not layer_names:
+            raise ValueError("layer_names must not be empty")
+        if len(set(layer_names)) != len(layer_names):
+            raise ValueError("layer_names must be unique")
+        if num_counters <= 0:
+            raise ValueError("num_counters must be positive")
+
+        self.layer_names = tuple(layer_names)
+        self.layer_to_index = {
+            layer_name: index for index, layer_name in enumerate(self.layer_names)
+        }
+        self.num_layers = len(self.layer_names)
+        self.num_counters = num_counters
+        self._fd_reader = fd_reader
+        self._fd_closer = fd_closer
+        self._fds = [
+            [fd_factory() for _ in range(self.num_layers)]
+            for _ in range(num_counters)
+        ]
+        self._waited = [[False] * self.num_layers for _ in range(num_counters)]
+        self._active_counter = -1
+        self._lock = threading.Lock()
+        self._closed = False
+        self._failed_error: BaseException | None = None
+
+    @property
+    def fds(self) -> tuple[tuple[int, ...], ...]:
+        return tuple(tuple(counter_fds) for counter_fds in self._fds)
+
+    def release(self, counter_id: int) -> None:
+        self._validate_counter(counter_id)
+        with self._lock:
+            self._waited[counter_id] = [False] * self.num_layers
+            if self._active_counter == counter_id:
+                self._active_counter = -1
+
+    def bind(self, metadata: LayerwiseLoadMetadata) -> None:
+        """Bind the counter used by the current vLLM forward step."""
+        if self._failed_error is not None:
+            raise RuntimeError(
+                "layer-wise counter pool is unusable after a prior wait failure"
+            ) from self._failed_error
+        if self._active_counter >= 0:
+            raise RuntimeError(
+                "received new layer-wise metadata before the previous "
+                f"counter {self._active_counter} finished"
+            )
+        if not metadata.enabled or not metadata.has_load:
+            self._active_counter = -1
+            return
+        self._validate_counter(metadata.counter_id)
+        with self._lock:
+            self._waited[metadata.counter_id] = [False] * self.num_layers
+            self._active_counter = metadata.counter_id
+
+    def wait(self, layer_name: str) -> None:
+        counter_id = self._active_counter
+        if counter_id < 0:
+            return
+        try:
+            layer_index = self.layer_to_index[layer_name]
+        except KeyError as exc:
+            raise KeyError(
+                f"unknown layer_name={layer_name!r}; registered layers="
+                f"{self.layer_names!r}"
+            ) from exc
+
+        with self._lock:
+            if self._waited[counter_id][layer_index]:
+                return
+        try:
+            self._fd_reader(self._fds[counter_id][layer_index])
+        except BaseException as exc:
+            self._failed_error = exc
+            self._active_counter = -1
+            raise
+        with self._lock:
+            self._waited[counter_id][layer_index] = True
+            finished = all(self._waited[counter_id])
+        if finished:
+            self.release(counter_id)
+
+    def send_to_worker(
+        self,
+        socket_path: str,
+        tp_rank_per_node: int,
+        tp_size_per_node: int,
+        timeout_s: float = 360.0,
+        retry_interval_s: float = 0.05,
+    ) -> None:
+        """Send all counter eventfds to the LayerwiseTransferWorker.
+
+        This method is intended to run in a background thread before GPU-cache
+        registration, because registration may start a worker that blocks while
+        waiting for this handshake.
+        """
+        deadline = time.monotonic() + timeout_s
+        last_error: BaseException | None = None
+        while time.monotonic() < deadline:
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                    sock.connect(socket_path)
+                    sock.sendall(
+                        struct.pack(
+                            "iiii",
+                            tp_rank_per_node,
+                            tp_size_per_node,
+                            self.num_layers,
+                            self.num_counters,
+                        )
+                    )
+                    for counter_id, fds in enumerate(self._fds):
+                        _send_fds(sock, fds, counter_id)
+                    sock.settimeout(min(30.0, max(1.0, timeout_s)))
+                    ack = sock.recv(1)
+                    if ack != b"\x01":
+                        raise RuntimeError(
+                            f"LayerwiseTransferWorker rejected eventfds: {ack!r}"
+                        )
+                    return
+            except (OSError, RuntimeError, TimeoutError) as exc:
+                last_error = exc
+                time.sleep(retry_interval_s)
+        raise RuntimeError(
+            f"timed out sending layer-wise eventfds to {socket_path}: {last_error}"
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for counter_fds in self._fds:
+            for fd in counter_fds:
+                self._fd_closer(fd)
+        self._fds.clear()
+
+    def _validate_counter(self, counter_id: int) -> None:
+        if counter_id < 0 or counter_id >= self.num_counters:
+            raise ValueError(
+                f"counter_id={counter_id} outside [0, {self.num_counters})"
+            )
+
+    def __del__(self) -> None:
+        self.close()

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import time
 from typing import TYPE_CHECKING, Optional, Literal, Iterable, Any, List
 from dataclasses import dataclass, field
@@ -9,14 +10,20 @@ import torch
 
 from flexkv.kvmanager import KVManager
 from flexkv.server.client import KVTPClient
-from flexkv.common.config import LayerGroupSpec, RankInfo
+from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV, LayerGroupSpec, RankInfo
 from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.common.request import KVResponseStatus
 from flexkv.common.debug import flexkv_logger
 from flexkv.integration.stats import FlexKVStats
 from flexkv.integration.config import FlexKVConfig
 from flexkv.integration.dynamo.collector import KVEventCollector
+from flexkv.integration.vllm.layerwise_sync import (
+    LayerwiseCounterPool,
+    LayerwiseLoadMetadata,
+    LayerwiseStepCoordinator,
+)
 from flexkv.transfer_manager import TransferManagerOnRemote
+from flexkv.transfer.layerwise import build_layerwise_eventfd_socket_path
 
 # vllm
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -155,6 +162,14 @@ class FlexKVResponse:
 
 
 @dataclass
+class FlexKVConnectorMetadata(KVConnectorMetadata):
+    """Scheduler-to-worker state for one vLLM model step."""
+
+    layerwise: LayerwiseLoadMetadata = field(
+        default_factory=LayerwiseLoadMetadata)
+
+
+@dataclass
 class FlexKVTask(ABC):
     task_id: int = 0
     request: "Request" = 0
@@ -231,6 +246,7 @@ class FlexKVSchedulerConnector:
         self,
         flexkv_config: FlexKVConfig,
         rank_info: "RankInfo",
+        enable_layerwise_transfer: Optional[bool] = None,
     ):
         logger.info(f"Start init FlexKVSchedulerConnector with {flexkv_config}, {rank_info}")
         self.server_recv_port = flexkv_config.server_recv_port
@@ -258,11 +274,25 @@ class FlexKVSchedulerConnector:
         # unlaunched tasks
         self.tasks_to_launch: dict[int, FlexKVTask] = {}
         self.tasks_to_cancel: dict[int, FlexKVTask] = {}
+        # A very short request may finish after its final layer eventfd but
+        # before the GET graph's completion callback is observed. vLLM calls
+        # request_finished only once, so retain enough state to create the PUT
+        # after the GET tail completes instead of losing the generated suffix.
+        self.deferred_layerwise_puts: dict[
+            str, tuple[Any, list[int]]
+        ] = {}
 
         self.flexkv_stats = FlexKVStats(int(os.getenv('FLEXKV_NUM_LOG_INTERVAL_REQUESTS', '200')))
         self.failed_block_ids: set[int] = set()
 
         self.maybe_skip_put = os.getenv('FLEXKV_MAYBE_SKIP_PUT', '0') == '1'
+        self.enable_layerwise_transfer = (
+            bool(int(os.getenv('FLEXKV_ENABLE_LAYERWISE_TRANSFER', '0')))
+            if enable_layerwise_transfer is None
+            else enable_layerwise_transfer
+        )
+        self.layerwise_steps = LayerwiseStepCoordinator(
+            self.enable_layerwise_transfer)
 
         # only support local batching for now
         self.enable_batch = (not self.cache_config.enable_kv_sharing
@@ -518,8 +548,14 @@ class FlexKVSchedulerConnector:
             True if a FlexKV transfer still needs the request's blocks and
             vLLM must defer freeing them; False if the blocks can be freed.
         """
-        # An existing FlexKV task still owns these blocks, so keep them alive.
+        # A GET task still owns the blocks until its graph completion callback
+        # runs. In layer-wise mode this is normally only a short tail after the
+        # final eventfd; query_finished_task() will return this finished request
+        # id so vLLM can release the deferred blocks.
         if request.request_id in self.req_id_to_task_dict:
+            if self.enable_layerwise_transfer:
+                self.deferred_layerwise_puts[request.request_id] = (
+                    request, list(block_ids))
             return True
 
         finish_reason = request.get_finished_reason()
@@ -675,12 +711,13 @@ class FlexKVSchedulerConnector:
         self.flexkv_manager.cancel(task_ids=list(self.tasks_to_cancel.keys()))
         self.tasks_to_cancel.clear()
 
-    def launch_tasks(self) -> None:
+    def launch_tasks(self) -> LayerwiseLoadMetadata:
         """
         Launch tasks in self.tasks_to_launch
         """
         if len(self.tasks_to_launch) == 0:
-            return
+            return LayerwiseLoadMetadata(
+                enabled=self.enable_layerwise_transfer)
         task_launch_time = time.perf_counter()
         get_task_ids: list[int] = []
         get_slot_mappings: list[np.ndarray] = []
@@ -700,13 +737,26 @@ class FlexKVSchedulerConnector:
                 put_slot_mappings.append(task.slot_mapping)
                 put_tasks_to_launch.append(task)
         if get_task_ids:
+            layerwise_metadata = self.layerwise_steps.build_metadata(True)
+            layerwise_launch = self.layerwise_steps.launch_kwargs(
+                layerwise_metadata)
             launched_get_task_ids = self.flexkv_manager.launch(task_ids=get_task_ids,
                                        slot_mappings=get_slot_mappings,
-                                       as_batch=self.enable_batch and len(get_task_ids) > 1)
+                                       as_batch=(
+                                           bool(layerwise_launch["as_batch"])
+                                           or (self.enable_batch
+                                               and len(get_task_ids) > 1)),
+                                       layerwise_transfer=bool(
+                                           layerwise_launch[
+                                               "layerwise_transfer"]),
+                                       counter_id=int(
+                                           layerwise_launch["counter_id"]))
             if len(launched_get_task_ids) == 1 and len(get_tasks_to_launch) > 1:
                 self.get_tasks[launched_get_task_ids[0]] = get_tasks_to_launch
             elif len(launched_get_task_ids) == len(get_tasks_to_launch):
-                for launched_task_id, task in zip(launched_get_task_ids, get_tasks_to_launch):
+                for launched_task_id, task in zip(
+                    launched_get_task_ids, get_tasks_to_launch, strict=True
+                ):
                     self.get_tasks[launched_task_id] = [task]
             else:
                 raise ValueError("KVTaskManager returned unexpected number of launched get task ids.")
@@ -717,11 +767,17 @@ class FlexKVSchedulerConnector:
             if len(launched_put_task_ids) == 1 and len(put_tasks_to_launch) > 1:
                 self.put_tasks[launched_put_task_ids[0]] = put_tasks_to_launch
             elif len(launched_put_task_ids) == len(put_tasks_to_launch):
-                for launched_task_id, task in zip(launched_put_task_ids, put_tasks_to_launch):
+                for launched_task_id, task in zip(
+                    launched_put_task_ids, put_tasks_to_launch, strict=True
+                ):
                     self.put_tasks[launched_task_id] = [task]
             else:
                 raise ValueError("KVTaskManager returned unexpected number of launched put task ids.")
         self.tasks_to_launch.clear()
+        return (
+            layerwise_metadata if get_task_ids
+            else self.layerwise_steps.build_metadata(False)
+        )
 
     def query_finished_task(self) -> tuple[set[str], set[str]]:
         """
@@ -744,7 +800,9 @@ class FlexKVSchedulerConnector:
             success = (response.status == KVResponseStatus.SUCCESS)
             if task_id in self.get_tasks:
                 tasks = self.get_tasks.pop(task_id)
-                finished_recving.update(task.request.request_id for task in tasks)
+                if not self.enable_layerwise_transfer:
+                    finished_recving.update(
+                        task.request.request_id for task in tasks)
             else:
                 tasks = self.put_tasks.pop(task_id)
                 finished_sending.update(task.request.request_id for task in tasks)
@@ -758,6 +816,15 @@ class FlexKVSchedulerConnector:
                         self.failed_block_ids.update(task.block_ids)
                 # responses_to_return.append(FlexKVResponse(task_id=task_id, task_type=task.task_type,
                 #                                             request=task.request, success=success))
+                deferred = self.deferred_layerwise_puts.pop(
+                    task.request.request_id, None)
+                if deferred is not None:
+                    request, block_ids = deferred
+                    if (not success
+                            or not self.request_finished(request, block_ids)):
+                        # No PUT was needed (or the request ended abnormally);
+                        # release the blocks that vLLM deferred for the GET.
+                        finished_sending.add(request.request_id)
         self.flexkv_stats.record_faild(num_failed_requests=num_failed_tasks)
         return finished_sending, finished_recving
 
@@ -819,6 +886,7 @@ class FlexKVWorkerConnector:
         self,
         flexkv_config: FlexKVConfig,
         rank_info: "RankInfo",
+        enable_layerwise_transfer: Optional[bool] = None,
     ):
         from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
 
@@ -850,6 +918,14 @@ class FlexKVWorkerConnector:
             intra_client_id=rank_info.intra_client_id,
             device_id=rank_info.local_rank,
         )
+        self.enable_layerwise_transfer = (
+            bool(int(os.getenv('FLEXKV_ENABLE_LAYERWISE_TRANSFER', '0')))
+            if enable_layerwise_transfer is None
+            else enable_layerwise_transfer
+        )
+        self.layerwise_counter_pool: Optional[LayerwiseCounterPool] = None
+        self._layerwise_sender_thread: Optional[threading.Thread] = None
+        self._layerwise_sender_error: Optional[BaseException] = None
         logger.info("Finish init FlexKVWorkerConnector")
 
     def register_to_server(
@@ -865,6 +941,9 @@ class FlexKVWorkerConnector:
                 indexer_kv_caches[layer_name] = tensor
             else:
                 main_kv_caches[layer_name] = tensor
+
+        if self.enable_layerwise_transfer:
+            self._start_layerwise_eventfd_sender(tuple(main_kv_caches))
 
         # Build main KV cache layout.
         #
@@ -992,6 +1071,7 @@ class FlexKVWorkerConnector:
                 resume=resume,
             )
 
+        self._finish_layerwise_eventfd_sender()
         logger.info("Finish register kv_caches")
         self._registered_kv_caches = dict(kv_caches)
 
@@ -1003,7 +1083,90 @@ class FlexKVWorkerConnector:
             raise RuntimeError("KV caches were not registered before wake")
         self.register_to_server(self._registered_kv_caches, resume=True)
 
+    def _start_layerwise_eventfd_sender(
+        self, layer_names: tuple[str, ...]
+    ) -> None:
+        """Start the eventfd handshake before GPU registration can block.
+
+        Registering GPU caches may cause the FlexKV server to construct a
+        LayerwiseTransferWorker, whose initialization waits for eventfds.  The
+        sender therefore has to run concurrently with register_to_server().
+        """
+        if self.layerwise_counter_pool is not None:
+            if self.layerwise_counter_pool.layer_names != layer_names:
+                raise ValueError(
+                    "KV cache layer order changed after layerwise setup: "
+                    f"{self.layerwise_counter_pool.layer_names!r} -> "
+                    f"{layer_names!r}"
+                )
+            return
+
+        pool = LayerwiseCounterPool(layer_names)
+        self.layerwise_counter_pool = pool
+        socket_path = build_layerwise_eventfd_socket_path(
+            dp_client_id=self.rank_info.dp_client_id,
+            pp_rank=self.rank_info.pp_rank,
+            model_config=self.rank_info.model_config,
+        )
+        effective_tp_size = (
+            self.rank_info.model_config.effective_tp_size_per_node)
+        effective_tp_rank = (
+            self.rank_info.effective_tp_rank % effective_tp_size)
+
+        def _send() -> None:
+            try:
+                pool.send_to_worker(
+                    socket_path=socket_path,
+                    tp_rank_per_node=effective_tp_rank,
+                    tp_size_per_node=effective_tp_size,
+                )
+            except BaseException as exc:
+                self._layerwise_sender_error = exc
+
+        self._layerwise_sender_thread = threading.Thread(
+            target=_send,
+            name="flexkv-vllm-layerwise-eventfd",
+            daemon=True,
+        )
+        self._layerwise_sender_thread.start()
+
+    def _finish_layerwise_eventfd_sender(self) -> None:
+        if self._layerwise_sender_thread is None:
+            return
+        self._layerwise_sender_thread.join()
+        self._layerwise_sender_thread = None
+        if self._layerwise_sender_error is not None:
+            raise RuntimeError(
+                "layerwise eventfd handshake failed"
+            ) from self._layerwise_sender_error
+
+    def bind_layerwise_metadata(
+        self, metadata: LayerwiseLoadMetadata
+    ) -> None:
+        if self.layerwise_counter_pool is None:
+            if metadata.has_load:
+                raise RuntimeError(
+                    "received layerwise load metadata before KV caches/eventfds "
+                    "were registered"
+                )
+            return
+        if self._layerwise_sender_error is not None:
+            raise RuntimeError(
+                "layerwise eventfd handshake failed"
+            ) from self._layerwise_sender_error
+        self.layerwise_counter_pool.bind(metadata)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        if self.layerwise_counter_pool is not None:
+            self.layerwise_counter_pool.wait(layer_name)
+
+    def shutdown(self) -> None:
+        if self.layerwise_counter_pool is not None:
+            self.layerwise_counter_pool.close()
+            self.layerwise_counter_pool = None
+
     def __del__(self):
+        self.shutdown()
         if hasattr(self, "remote_transfer_manager_process") and \
             self.remote_transfer_manager_process is not None:
             self.remote_transfer_manager_process.join()
@@ -1017,9 +1180,45 @@ class FlexKVConnectorV1Impl:
         flexkv_config = FlexKVConfig.from_env()
         rank_info = flexkv_config.post_init_from_vllm_config(
             vllm_config, kv_cache_config)
+        transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+        layerwise_from_vllm = (
+            transfer_config.get_from_extra_config("use_layerwise", False)
+            if transfer_config is not None
+            else False
+        )
+        env_layerwise = bool(
+            int(os.getenv('FLEXKV_ENABLE_LAYERWISE_TRANSFER', '0')))
+        if env_layerwise and not layerwise_from_vllm:
+            logger.warning(
+                "Ignoring FLEXKV_ENABLE_LAYERWISE_TRANSFER=1 for vLLM because "
+                "kv_connector_extra_config.use_layerwise is false. The vLLM "
+                "wrapper must select PIECEWISE CUDA graph mode before per-layer "
+                "eventfd waits are safe."
+            )
+        self.enable_layerwise_transfer = bool(layerwise_from_vllm)
+        if (self.enable_layerwise_transfer
+                and rank_info.model_config.cp_size != 1):
+            raise NotImplementedError(
+                "vLLM FlexKV layer-wise transfer currently requires "
+                "context_parallel_size=1; runtime DCP/PCP rank mapping is not "
+                "yet wired into the eventfd index space"
+            )
+        if self.enable_layerwise_transfer and flexkv_config.cache_config.enable_gds:
+            raise NotImplementedError(
+                "vLLM FlexKV layer-wise transfer is incompatible with GDS; "
+                "the fused LAYERWISE graph expects CPU/SSD/remote staging, not "
+                "DISK2D operations"
+            )
+        # TransferEngine reads the process-global config, while the vLLM
+        # connector reads kv_connector_extra_config. Keep both sides on one
+        # authoritative value before KVManager/TransferEngine construction.
+        GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer = (
+            self.enable_layerwise_transfer)
+        self._bound_metadata: Optional[FlexKVConnectorMetadata] = None
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector = FlexKVSchedulerConnector(flexkv_config, rank_info)
+            self.connector = FlexKVSchedulerConnector(
+                flexkv_config, rank_info, self.enable_layerwise_transfer)
             # Track scheduled requests to detect preemptions in build_connector_meta
             self.previous_scheduled_req_ids: set[str] = set()
         elif role == KVConnectorRole.WORKER:
@@ -1050,13 +1249,13 @@ class FlexKVConnectorV1Impl:
                     f"FlexKV: could not derive ranks from vllm process groups: "
                     f"{_e}. device_id will collide across workers and GPU "
                     f"registration will hang at 1/N.")
-            self.connector = FlexKVWorkerConnector(flexkv_config, rank_info)
+            self.connector = FlexKVWorkerConnector(
+                flexkv_config, rank_info, self.enable_layerwise_transfer)
         else:
             raise ValueError(f"Unrecognized KVConnectorRole: {role}.")
 
     def shutdown(self):
-        if self.role == KVConnectorRole.SCHEDULER:
-            self.connector.shutdown()
+        self.connector.shutdown()
 
     def reset_cache(self) -> Optional[bool]:
         """Reset the FlexKV cache. Only meaningful on the scheduler side
@@ -1065,6 +1264,14 @@ class FlexKVConnectorV1Impl:
         if self.role == KVConnectorRole.SCHEDULER:
             return self.connector.reset_cache()
         return None
+
+    def bind_connector_metadata(
+        self, metadata: FlexKVConnectorMetadata
+    ) -> None:
+        self._bound_metadata = metadata
+
+    def clear_connector_metadata(self) -> None:
+        self._bound_metadata = None
 
     # ==============================
     # Worker-side methods
@@ -1085,7 +1292,23 @@ class FlexKVConnectorV1Impl:
             the same.
 
         """
-        pass
+        if self.role != KVConnectorRole.WORKER:
+            return
+        metadata = kwargs.get("connector_metadata")
+        if metadata is None:
+            metadata = self._bound_metadata
+        if metadata is None:
+            # vLLM binds metadata on the outer FlexKVConnectorV1 wrapper before
+            # delegating this hook to the installed FlexKV implementation.
+            from vllm.distributed.kv_transfer import get_kv_transfer_group
+            outer_connector = get_kv_transfer_group()
+            metadata = outer_connector._get_connector_metadata()
+        if not isinstance(metadata, FlexKVConnectorMetadata):
+            raise TypeError(
+                "expected FlexKVConnectorMetadata, got "
+                f"{type(metadata).__name__}"
+            )
+        self.connector.bind_layerwise_metadata(metadata.layerwise)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """
@@ -1098,7 +1321,8 @@ class FlexKVConnectorV1Impl:
         Args:
             layer_name: the name of that layer
         """
-        pass
+        if self.role == KVConnectorRole.WORKER:
+            self.connector.wait_for_layer_load(layer_name)
 
     def save_kv_layer(self, layer_name: str, kv_layer: torch.Tensor,
                       attn_metadata: "AttentionMetadata", **kwargs) -> None:
@@ -1181,8 +1405,15 @@ class FlexKVConnectorV1Impl:
             the number of tokens that can be loaded from the
             external KV cache beyond what is already computed.
         """
-        return self.connector.get_num_new_matched_tokens(
+        matched_tokens, needs_load = self.connector.get_num_new_matched_tokens(
             request, num_computed_tokens)
+        # Layer-wise loads enter the same model step. Per-layer eventfds,
+        # consumed by wait_for_layer_load(), provide the data dependency
+        # instead of WAITING_FOR_REMOTE_KVS.
+        return (
+            matched_tokens,
+            self.connector.layerwise_steps.external_match_is_async(needs_load),
+        )
 
     def update_state_after_alloc(self, request: "Request",
                                  blocks: "KVCacheBlocks",
@@ -1227,7 +1458,7 @@ class FlexKVConnectorV1Impl:
             self.connector.handle_preemptions(preempted_req_ids)
 
         self.connector.cancel_tasks()
-        self.connector.launch_tasks()
+        layerwise_metadata = self.connector.launch_tasks()
 
         # Optional: Synchronous wait for get tasks to ensure data consistency.
         # This is a safety fallback because currently FlexKV worker does not support
@@ -1235,7 +1466,7 @@ class FlexKVConnectorV1Impl:
         if os.getenv('FLEXKV_SYNC_GET', '0') == '1':
             self.connector.wait_for_all_get_tasks()
 
-        return KVConnectorMetadata()
+        return FlexKVConnectorMetadata(layerwise=layerwise_metadata)
 
     def update_connector_output(self, connector_output: "KVConnectorOutput"):
         """

--- a/flexkv/integration/vllm/vllm_v1_adapter.py
+++ b/flexkv/integration/vllm/vllm_v1_adapter.py
@@ -926,6 +926,7 @@ class FlexKVWorkerConnector:
         self.layerwise_counter_pool: Optional[LayerwiseCounterPool] = None
         self._layerwise_sender_thread: Optional[threading.Thread] = None
         self._layerwise_sender_error: Optional[BaseException] = None
+        self._layerwise_sender_cancel = threading.Event()
         logger.info("Finish init FlexKVWorkerConnector")
 
     def register_to_server(
@@ -1071,7 +1072,22 @@ class FlexKVWorkerConnector:
                 resume=resume,
             )
 
-        self._finish_layerwise_eventfd_sender()
+        # NOTE: deliberately NOT joining the eventfd sender here.
+        #
+        # In vLLM the worker registers its KV caches from inside
+        # EngineCore._initialize_kv_caches() -> initialize_from_config(), which
+        # runs BEFORE the Scheduler (and therefore before
+        # FlexKVSchedulerConnector -> KVManager.start() -> TransferManager ->
+        # LayerwiseTransferWorker) is ever constructed. The eventfd listener
+        # that this handshake connects to is created by that worker, so joining
+        # the sender thread here deadlocks: the engine cannot proceed to build
+        # the scheduler that would bind the socket. It fails only when
+        # send_to_worker() gives up after timeout_s, which is what surfaced as
+        # "timed out sending layer-wise eventfds ... No such file or directory".
+        #
+        # KV-cache registration is fire-and-forget by design (KVTPClient sends
+        # with zmq.NOBLOCK), so the handshake is joined lazily at first use
+        # instead -- see _require_layerwise_eventfds().
         logger.info("Finish register kv_caches")
         self._registered_kv_caches = dict(kv_caches)
 
@@ -1119,6 +1135,7 @@ class FlexKVWorkerConnector:
                     socket_path=socket_path,
                     tp_rank_per_node=effective_tp_rank,
                     tp_size_per_node=effective_tp_size,
+                    cancel_event=self._layerwise_sender_cancel,
                 )
             except BaseException as exc:
                 self._layerwise_sender_error = exc
@@ -1130,15 +1147,45 @@ class FlexKVWorkerConnector:
         )
         self._layerwise_sender_thread.start()
 
-    def _finish_layerwise_eventfd_sender(self) -> None:
+    def _finish_layerwise_eventfd_sender(self, timeout: Optional[float] = None
+                                         ) -> bool:
+        """Join the handshake thread. Returns True once it has completed.
+
+        With ``timeout=None`` this blocks until the handshake finishes (or the
+        sender's own deadline expires) and raises on failure. With a timeout it
+        returns False if the handshake is still in flight, leaving the thread
+        running so a later call can pick it up.
+        """
         if self._layerwise_sender_thread is None:
-            return
-        self._layerwise_sender_thread.join()
+            return True
+        self._layerwise_sender_thread.join(timeout)
+        if self._layerwise_sender_thread.is_alive():
+            return False
         self._layerwise_sender_thread = None
         if self._layerwise_sender_error is not None:
             raise RuntimeError(
                 "layerwise eventfd handshake failed"
             ) from self._layerwise_sender_error
+        return True
+
+    def _cancel_layerwise_eventfd_sender(self) -> None:
+        """Ask the handshake thread to stop retrying and return promptly.
+
+        Without this the sender keeps retrying until its own deadline (360s by
+        default), which is far longer than any sane shutdown grace period.
+        """
+        self._layerwise_sender_cancel.set()
+
+    def _require_layerwise_eventfds(self) -> None:
+        """Ensure the eventfd handshake completed before the first layer-wise load.
+
+        Called from bind_layerwise_metadata() on the step that actually carries
+        a layer-wise load. By then the scheduler exists, so the
+        LayerwiseTransferWorker has had a chance to bind the socket. Blocks (and
+        raises) rather than letting a forward pass wait on eventfds the data
+        plane never received.
+        """
+        self._finish_layerwise_eventfd_sender()
 
     def bind_layerwise_metadata(
         self, metadata: LayerwiseLoadMetadata
@@ -1150,6 +1197,14 @@ class FlexKVWorkerConnector:
                     "were registered"
                 )
             return
+        if metadata.has_load:
+            # First real load: the handshake must be done before any attention
+            # layer blocks on an eventfd the worker never received.
+            self._require_layerwise_eventfds()
+        else:
+            # Opportunistic progress check on idle/no-load steps so a handshake
+            # failure surfaces promptly instead of at the first load.
+            self._finish_layerwise_eventfd_sender(timeout=0.0)
         if self._layerwise_sender_error is not None:
             raise RuntimeError(
                 "layerwise eventfd handshake failed"
@@ -1162,7 +1217,29 @@ class FlexKVWorkerConnector:
 
     def shutdown(self) -> None:
         if self.layerwise_counter_pool is not None:
-            self.layerwise_counter_pool.close()
+            # The sender thread still holds these fds; closing them underneath
+            # it would make sendmsg(SCM_RIGHTS) fail or, worse, hand the peer a
+            # descriptor number that has since been recycled onto an unrelated
+            # file. So cancel first, then join, and only close once the thread
+            # is actually gone -- a bounded join whose result we ignore is not
+            # enough, because the sender retries for its full deadline.
+            self._cancel_layerwise_eventfd_sender()
+            try:
+                finished = self._finish_layerwise_eventfd_sender(timeout=5.0)
+            except Exception as exc:  # noqa: BLE001 - shutdown must not raise
+                logger.warning(
+                    f"layerwise eventfd handshake failed during shutdown: {exc}")
+                finished = True
+            if finished:
+                self.layerwise_counter_pool.close()
+            else:
+                # Cancellation did not take within the grace period. Leaking a
+                # handful of eventfds for the remaining life of the process is
+                # strictly better than closing fds a live thread is about to
+                # pass over a socket.
+                logger.warning(
+                    "layerwise eventfd sender still running at shutdown; "
+                    "leaving its descriptors open to avoid reuse-after-close")
             self.layerwise_counter_pool = None
 
     def __del__(self):
@@ -1214,6 +1291,16 @@ class FlexKVConnectorV1Impl:
         # authoritative value before KVManager/TransferEngine construction.
         GLOBAL_CONFIG_FROM_ENV.enable_layerwise_transfer = (
             self.enable_layerwise_transfer)
+        # The in-process assignment above does NOT survive a process boundary:
+        # TransferManager and every transfer worker are created with
+        # mp.get_context('spawn'), so the child re-imports flexkv and rebuilds
+        # GLOBAL_CONFIG_FROM_ENV from the environment alone. Without this
+        # export, transfer_engine._init_workers() reads
+        # enable_layerwise_transfer=False in the child and never constructs the
+        # LayerwiseTransferWorker (hence never binds the eventfd socket), while
+        # the parent still thinks layer-wise is on.
+        os.environ['FLEXKV_ENABLE_LAYERWISE_TRANSFER'] = (
+            '1' if self.enable_layerwise_transfer else '0')
         self._bound_metadata: Optional[FlexKVConnectorMetadata] = None
 
         if role == KVConnectorRole.SCHEDULER:

--- a/tests/test_vllm_layerwise_sync.py
+++ b/tests/test_vllm_layerwise_sync.py
@@ -4,6 +4,7 @@ import socket
 import struct
 import tempfile
 import threading
+import time
 
 import pytest
 
@@ -25,6 +26,8 @@ def _short_socket_path(prefix):
 
 
 class _FakeFDs:
+    """Stand-in for the eventfd layer."""
+
     def __init__(self):
         self.next_fd = 10
         self.reads = []
@@ -110,7 +113,8 @@ def test_counter_pool_rejects_unknown_layer_and_counter():
         pool.wait("layer.99")
 
 
-def test_failed_wait_poisons_pool_to_prevent_stale_counter_reuse():
+def test_failed_wait_rejects_future_binds():
+    """A failed wait cannot safely reuse a generationless eventfd."""
     attempts = []
 
     def flaky_read(fd):
@@ -129,23 +133,104 @@ def test_failed_wait_poisons_pool_to_prevent_stale_counter_reuse():
     pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
     with pytest.raises(TimeoutError):
         pool.wait("layer.0")
-    with pytest.raises(RuntimeError, match="unusable"):
-        pool.bind(
-            LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    with pytest.raises(RuntimeError, match="prior wait failure"):
+        pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    with pytest.raises(RuntimeError, match="prior wait failure"):
+        pool.bind(LayerwiseLoadMetadata(enabled=True, has_load=False))
     assert attempts == [10]
 
 
-def test_bind_rejects_new_step_until_previous_counter_finishes():
+def test_bind_rejects_incomplete_forward():
+    """An incomplete forward cannot safely reuse asynchronous eventfds."""
     pool, fake = _pool(layer_names=("a", "b"))
     metadata = LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True)
     pool.bind(metadata)
     pool.wait("a")
-    with pytest.raises(RuntimeError, match="previous"):
+    with pytest.raises(RuntimeError, match="previous counter 0 finished"):
         pool.bind(metadata)
-    pool.wait("b")
-    pool.bind(metadata)
-    pool.wait("a")
-    assert fake.reads == [10, 11, 10]
+    assert fake.reads == [10]
+
+
+@pytest.mark.skipif(
+    os.uname().sysname != "Linux",
+    reason="requires Linux eventfd support",
+)
+def test_late_eventfd_signal_cannot_recover_an_incomplete_forward():
+    """A late producer signal must not make a later batch bindable."""
+    pool = LayerwiseCounterPool(("l0", "l1"), num_counters=2)
+    try:
+        pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+        os.write(pool.fds[0][0], struct.pack("Q", 1))
+        pool.wait("l0")
+
+        # The missing completion from the abandoned batch lands after the
+        # forward stops. It remains quarantined with its old descriptor set.
+        os.write(pool.fds[0][1], struct.pack("Q", 1))
+        with pytest.raises(RuntimeError, match="previous counter 0 finished"):
+            pool.bind(LayerwiseLoadMetadata(
+                enabled=True, counter_id=1, has_load=True))
+    finally:
+        pool.close()
+
+
+def test_completed_forward_releases_counter_for_later_batches():
+    """A fully consumed batch may safely advance and reuse the ring."""
+    pool, fake = _pool(layer_names=("l0", "l1"))
+    md = lambda cid: LayerwiseLoadMetadata(  # noqa: E731
+        enabled=True, counter_id=cid, has_load=True)
+    for counter_id in (0, 1, 0):
+        pool.bind(md(counter_id))
+        pool.wait("l0")
+        pool.wait("l1")
+
+    assert fake.reads == [10, 11, 12, 13, 10, 11]
+
+
+def test_wait_timeout_rejects_future_binds():
+    """A timeout cannot safely reuse a generationless eventfd."""
+    def timed_out_reader(_fd):
+        raise TimeoutError("simulated")
+
+    fake = _FakeFDs()
+    pool = LayerwiseCounterPool(
+        ("l0", "l1"),
+        fd_factory=fake.create,
+        fd_reader=timed_out_reader,
+        fd_closer=fake.close,
+    )
+    pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    with pytest.raises(TimeoutError):
+        pool.wait("l0")
+    with pytest.raises(RuntimeError, match="prior wait failure"):
+        pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+
+
+def test_send_to_worker_returns_promptly_when_cancelled():
+    """Shutdown must be able to stop the handshake before its own deadline.
+
+    Nothing is listening on this path, so send_to_worker() would otherwise retry
+    for the full timeout_s while holding fds the caller wants to close.
+    """
+    pool, _ = _pool(layer_names=("a",))
+    cancel = threading.Event()
+    finished = threading.Event()
+
+    def run():
+        pool.send_to_worker(
+            _short_socket_path("flexkv-cancel-"),
+            tp_rank_per_node=0,
+            tp_size_per_node=1,
+            timeout_s=300.0,
+            retry_interval_s=0.05,
+            cancel_event=cancel,
+        )
+        finished.set()
+
+    threading.Thread(target=run, daemon=True).start()
+    time.sleep(0.2)
+    assert not finished.is_set()
+    cancel.set()
+    assert finished.wait(5.0), "send_to_worker ignored the cancel event"
 
 
 def test_counter_pool_close_is_idempotent():

--- a/tests/test_vllm_layerwise_sync.py
+++ b/tests/test_vllm_layerwise_sync.py
@@ -1,0 +1,278 @@
+import array
+import os
+import socket
+import struct
+import tempfile
+import threading
+
+import pytest
+
+from flexkv.integration.vllm.layerwise_sync import (
+    LayerwiseCounterPool,
+    LayerwiseLoadMetadata,
+    LayerwiseStepCoordinator,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _short_socket_path(prefix):
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=".sock", dir="/tmp")
+    os.close(fd)
+    os.unlink(path)
+    return path
+
+
+class _FakeFDs:
+    def __init__(self):
+        self.next_fd = 10
+        self.reads = []
+        self.closed = []
+
+    def create(self):
+        fd = self.next_fd
+        self.next_fd += 1
+        return fd
+
+    def read(self, fd):
+        self.reads.append(fd)
+        return 1
+
+    def close(self, fd):
+        self.closed.append(fd)
+
+
+def _pool(layer_names=("layer.0", "layer.1", "layer.2")):
+    fake = _FakeFDs()
+    pool = LayerwiseCounterPool(
+        layer_names,
+        fd_factory=fake.create,
+        fd_reader=fake.read,
+        fd_closer=fake.close,
+    )
+    return pool, fake
+
+
+def test_step_coordinator_round_robins_only_load_steps():
+    coordinator = LayerwiseStepCoordinator(enabled=True, num_counters=3)
+    assert coordinator.build_metadata(False) == LayerwiseLoadMetadata(enabled=True)
+    assert [coordinator.build_metadata(True).counter_id for _ in range(5)] == [
+        0, 1, 2, 0, 1]
+
+    disabled = LayerwiseStepCoordinator(enabled=False)
+    assert disabled.build_metadata(True) == LayerwiseLoadMetadata(enabled=False)
+    assert coordinator.external_match_is_async(True) is False
+    assert disabled.external_match_is_async(True) is True
+    assert disabled.external_match_is_async(False) is False
+    assert coordinator.launch_kwargs(
+        LayerwiseLoadMetadata(enabled=True, counter_id=2, has_load=True)
+    ) == {
+        "as_batch": True,
+        "layerwise_transfer": True,
+        "counter_id": 2,
+    }
+
+
+def test_counter_pool_waits_once_per_layer_and_releases_on_last_layer():
+    pool, fake = _pool()
+    pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=1, has_load=True))
+
+    pool.wait("layer.0")
+    pool.wait("layer.0")
+    pool.wait("layer.1")
+    assert fake.reads == [13, 14]
+
+    pool.wait("layer.2")
+    assert fake.reads == [13, 14, 15]
+
+    # Last-layer completion releases the active counter; later hooks are no-op.
+    pool.wait("layer.0")
+    assert fake.reads == [13, 14, 15]
+
+
+def test_counter_pool_disabled_or_empty_metadata_is_noop():
+    pool, fake = _pool()
+    pool.bind(LayerwiseLoadMetadata(enabled=False))
+    pool.wait("layer.0")
+    pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=-1, has_load=False))
+    pool.wait("layer.1")
+    assert fake.reads == []
+
+
+def test_counter_pool_rejects_unknown_layer_and_counter():
+    pool, _ = _pool()
+    with pytest.raises(ValueError, match="counter_id"):
+        pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=9, has_load=True))
+
+    pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    with pytest.raises(KeyError, match="unknown layer_name"):
+        pool.wait("layer.99")
+
+
+def test_failed_wait_poisons_pool_to_prevent_stale_counter_reuse():
+    attempts = []
+
+    def flaky_read(fd):
+        attempts.append(fd)
+        if len(attempts) == 1:
+            raise TimeoutError("simulated")
+        return 1
+
+    fake = _FakeFDs()
+    pool = LayerwiseCounterPool(
+        ("layer.0",),
+        fd_factory=fake.create,
+        fd_reader=flaky_read,
+        fd_closer=fake.close,
+    )
+    pool.bind(LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    with pytest.raises(TimeoutError):
+        pool.wait("layer.0")
+    with pytest.raises(RuntimeError, match="unusable"):
+        pool.bind(
+            LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True))
+    assert attempts == [10]
+
+
+def test_bind_rejects_new_step_until_previous_counter_finishes():
+    pool, fake = _pool(layer_names=("a", "b"))
+    metadata = LayerwiseLoadMetadata(enabled=True, counter_id=0, has_load=True)
+    pool.bind(metadata)
+    pool.wait("a")
+    with pytest.raises(RuntimeError, match="previous"):
+        pool.bind(metadata)
+    pool.wait("b")
+    pool.bind(metadata)
+    pool.wait("a")
+    assert fake.reads == [10, 11, 10]
+
+
+def test_counter_pool_close_is_idempotent():
+    pool, fake = _pool(layer_names=("a", "b"))
+    expected_fds = [fd for counter in pool.fds for fd in counter]
+    pool.close()
+    pool.close()
+    assert fake.closed == expected_fds
+
+
+def test_send_to_worker_matches_layerwise_worker_wire_contract():
+    socket_path = _short_socket_path("flexkv-lw-")
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(1)
+
+    received = {}
+
+    def receive():
+        conn, _ = server.accept()
+        with conn:
+            metadata = conn.recv(16)
+            received["metadata"] = struct.unpack("iiii", metadata)
+            counters = {}
+            for _ in range(3):
+                msg, ancdata, _flags, _addr = conn.recvmsg(
+                    4, socket.CMSG_SPACE(2 * struct.calcsize("i")))
+                counter_id = struct.unpack("i", msg)[0]
+                for level, kind, data in ancdata:
+                    if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+                        fds = array.array("i")
+                        fds.frombytes(data[:2 * fds.itemsize])
+                        counters[counter_id] = list(fds)
+            received["counters"] = counters
+            conn.sendall(b"\x01")
+
+    server_thread = threading.Thread(target=receive)
+    server_thread.start()
+
+    owned_write_fds = []
+
+    def pipe_fd():
+        read_fd, write_fd = os.pipe()
+        owned_write_fds.append(write_fd)
+        return read_fd
+
+    pool = LayerwiseCounterPool(
+        ("layer.0", "layer.1"),
+        fd_factory=pipe_fd,
+        fd_reader=lambda _fd: 1,
+    )
+    try:
+        pool.send_to_worker(
+            socket_path,
+            tp_rank_per_node=1,
+            tp_size_per_node=2,
+            timeout_s=2,
+            retry_interval_s=0.01,
+        )
+    finally:
+        server_thread.join(timeout=2)
+        server.close()
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
+        for fds in received.get("counters", {}).values():
+            for fd in fds:
+                os.close(fd)
+        pool.close()
+        for fd in owned_write_fds:
+            os.close(fd)
+
+    assert received["metadata"] == (1, 2, 2, 3)
+    assert set(received["counters"]) == {0, 1, 2}
+    assert all(len(fds) == 2 for fds in received["counters"].values())
+
+
+def test_send_to_worker_retries_after_nack():
+    socket_path = _short_socket_path("flexkv-retry-")
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(2)
+    attempts = []
+
+    def receive():
+        for ack in (b"\x00", b"\x01"):
+            conn, _ = server.accept()
+            with conn:
+                conn.recv(16)
+                for _ in range(3):
+                    _msg, ancdata, _flags, _addr = conn.recvmsg(
+                        4, socket.CMSG_SPACE(struct.calcsize("i")))
+                    for level, kind, data in ancdata:
+                        if (level == socket.SOL_SOCKET
+                                and kind == socket.SCM_RIGHTS):
+                            fds = array.array("i")
+                            fds.frombytes(data[:fds.itemsize])
+                            for fd in fds:
+                                os.close(fd)
+                attempts.append(ack)
+                conn.sendall(ack)
+
+    thread = threading.Thread(target=receive)
+    thread.start()
+    write_fds = []
+
+    def pipe_fd():
+        read_fd, write_fd = os.pipe()
+        write_fds.append(write_fd)
+        return read_fd
+
+    pool = LayerwiseCounterPool(
+        ("layer.0",), fd_factory=pipe_fd, fd_reader=lambda _fd: 1)
+    try:
+        pool.send_to_worker(
+            socket_path,
+            tp_rank_per_node=0,
+            tp_size_per_node=1,
+            timeout_s=2,
+            retry_interval_s=0.01,
+        )
+    finally:
+        thread.join(timeout=2)
+        server.close()
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
+        pool.close()
+        for fd in write_fds:
+            os.close(fd)
+
+    assert attempts == [b"\x00", b"\x01"]


### PR DESCRIPTION
## Summary

Wire FlexKV's existing layer-wise transfer/eventfd data plane into the vLLM V1
connector so external KV GETs overlap model execution layer by layer.

Before this change, FlexKV returned `is_async=True`; vLLM put the request in
`WAITING_FOR_REMOTE_KVS` and ran no forward pass until the entire transfer
finished. The worker-side `start_load_kv()` and `wait_for_layer_load()` hooks
were no-ops, so the existing LayerwiseTransferWorker could not provide overlap.

## Design

- Scheduler launches all GETs in the step as one fused LAYERWISE graph.
- A triple-buffered `counter_id` is included in concrete scheduler metadata.
- Worker sends per-layer eventfds to LayerwiseTransferWorker before cache
  registration can deadlock waiting for the handshake.
- `start_load_kv()` binds the step counter; each attention layer consumes one
  eventfd in `wait_for_layer_load(layer_name)`.
- Layerwise matches return `is_async=False`, allowing the request to enter the
  same forward step instead of WAITING_FOR_REMOTE_KVS.

Expected timing changes from roughly `T_transfer + T_forward` to first-layer
startup plus `sum(max(T_transfer_layer, T_compute_layer))`.

## Safety

- Enabled only by `kv_connector_extra_config.use_layerwise=true`; env-only
  enablement is ignored because vLLM must select PIECEWISE CUDA graph mode.
- Context parallelism and GDS fail fast until their rank/graph contracts are
  implemented for this path.
- Per-layer waits have a configurable timeout and poison the counter pool after
  failure, preventing stale eventfd tokens from satisfying a later step.
- A new step cannot bind while the previous counter is active.
- Short requests that finish before the GET graph completion tail retain their
  blocks and defer PUT creation until the GET response is observed.
- Failed deferred GETs release blocks without issuing a PUT.

## vLLM wrapper change

`examples/vllm_adaption/vllm_main-flexkv-layerwise-wrapper.patch` adds:

- `requires_piecewise_for_cudagraph()` for `use_layerwise`;
- metadata bind/clear delegation into the installed FlexKV implementation;
- upstream unit coverage for both behaviors.

This small change should be submitted to vLLM separately.

## Verification

- 9 CPU-only tests pass:
  - counter round-robin and launch policy;
  - exactly-once per-layer waits;
  - no-load behavior and invalid metadata;
  - stale-step rejection and timeout poisoning;
  - fd cleanup;
  - real SCM_RIGHTS wire protocol;
  - NACK/reconnect/ACK retry.
- AST execution of the real adapter methods verifies:
  - layerwise hit returns `is_async=False`;
  - launch uses `as_batch=True`, `layerwise_transfer=True`, matching counter id;
  - deferred GET completion creates PUT and keeps blocks pinned;
  - failed deferred GET releases blocks without PUT.
- vLLM wrapper patch applies cleanly to current upstream source and compiles.
- Independent targeted review: APPROVE after four high-risk findings were fixed.

GPU end-to-end validation is still required for TTFT measurement and CUDA
layer/eventfd timing; existing LayerwiseTransferGroup GPU tests cover the data
plane independently.
