### PR TITLE
docs(sglang): pin radix restore ownership fix

### DIFF
--- a/flexkv/integration/sglang/README.md
+++ b/flexkv/integration/sglang/README.md
@@ -7,12 +7,12 @@
 There are two different SGLang integration paths. Choose the one that matches
 your model.
 
-> Status last checked: August 6, 2026.
+> Status last checked: August 26, 2026.
 
 | Use case | SGLang version | Patch required? |
 | --- | --- | --- |
 | Standard models | SGLang `v0.5.16` or later, or a recent `main` | No |
-| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781), pinned to commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | No local patch; use the pinned SGLang commit |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781) plus the [radix-restore follow-up](https://github.com/XingLiu1/sglang/pull/3), pinned to commit [`2764e91`](https://github.com/XingLiu1/sglang/commit/2764e9198ec258a26be89bea633d432d18a5f926) | No local patch; use the pinned SGLang commit |
 
 ### Standard models: use upstream SGLang directly
 
@@ -40,8 +40,20 @@ alone:
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 git fetch origin pull/31781/head
-git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
+git remote add xingliu https://github.com/XingLiu1/sglang.git
+git fetch xingliu fix/flexkv-radix-restore-ownership
+git checkout -b flexkv-dsv4 2764e9198ec258a26be89bea633d432d18a5f926
 ```
+
+The follow-up keeps layerwise restore ownership with the admitted request until
+normal cache completion. This avoids attaching GPU slots to the radix tree
+during pre-admission prefix lookup and prevents duplicate-prefix requests from
+leaving a stale evictable leaf. The functionally identical pre-format commit
+passed the focused tests on MI308X; the final pin only adds Black formatting.
+Its preceding candidate also passed the reduced/full Day 675 crash
+validation; that candidate differed only by a defensive check in generic
+`radix_cache.py`, which was removed during final review. The full replay was not
+repeated after that review-only removal.
 
 Use this with the current FlexKV `main` branch:
 

--- a/flexkv/integration/sglang/README_zh.md
+++ b/flexkv/integration/sglang/README_zh.md
@@ -6,12 +6,12 @@
 
 SGLang 目前有两条不同的 FlexKV 集成路径，请根据模型选择。
 
-> 状态最后确认日期：2026 年 8 月 6 日。
+> 状态最后确认日期：2026 年 8 月 26 日。
 
 | 使用场景 | SGLang 版本 | 是否需要 patch |
 | --- | --- | --- |
 | 普通模型 | SGLang `v0.5.16` 及以上版本，或较新的 `main` | 不需要 |
-| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781)，固定到 commit [`ee0465a`](https://github.com/sgl-project/sglang/commit/ee0465a09196421a6e4d53a3103eccdef1dd32ac) | 不需要本地 patch；使用指定的 SGLang commit |
+| DeepSeek V4 | SGLang PR [#31781](https://github.com/sgl-project/sglang/pull/31781) 及其 [radix restore 后续修复](https://github.com/XingLiu1/sglang/pull/3)，固定到 commit [`2764e91`](https://github.com/XingLiu1/sglang/commit/2764e9198ec258a26be89bea633d432d18a5f926) | 不需要本地 patch；使用指定的 SGLang commit |
 
 ### 普通模型：直接使用 SGLang 官方版本
 
@@ -38,8 +38,18 @@ SGLang 正式版本或 `main`，而应拉取该 PR 并固定到下面的 commit�
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 git fetch origin pull/31781/head
-git checkout -b flexkv-dsv4 ee0465a09196421a6e4d53a3103eccdef1dd32ac
+git remote add xingliu https://github.com/XingLiu1/sglang.git
+git fetch xingliu fix/flexkv-radix-restore-ownership
+git checkout -b flexkv-dsv4 2764e9198ec258a26be89bea633d432d18a5f926
 ```
+
+该后续修复会让 layerwise restore 的所有权一直保留在已 admission 的请求上，直到正常的
+cache completion；避免在 admission 前的 prefix lookup 阶段把 GPU slot 挂入 radix tree，
+从而防止相同 prefix 的并发请求留下失效但仍可被驱逐的叶子节点。与当前固定 commit
+功能一致的格式化前版本已在 MI308X 通过针对性单测，最终 pin 只补充 Black 格式化；它的
+前一候选还通过了 Day 675 缩小规模和全量崩溃验证。两者仅
+相差通用 `radix_cache.py` 中一处纯防御校验，该改动在最终 review 时已移除，移除后未重复
+执行全量回放。
 
 同时使用当前 FlexKV `main` 分支：
 


### PR DESCRIPTION
## 问题

DeepSeek V4 的 SGLang 兼容说明仍固定在旧的 #31781 commit，没有包含 layerwise restore ownership / radix duplicate 修复。继续按原文档部署可能复现相同 prefix 并发请求留下 stale evictable leaf 的问题。

## 解决方案

- 更新中英文 SGLang 集成文档的兼容状态日期。
- 将 DeepSeek V4 pin 更新到独立 stacked PR [XingLiu1/sglang#3](https://github.com/XingLiu1/sglang/pull/3) 的 commit `2764e91`。
- 补充可复现的 fetch/checkout 命令和修复边界说明。

修复代码位于 SGLang，因此本 PR 不重复修改 FlexKV core 或 legacy connector patch。

## 验证

- `git diff --check` 通过。
- 格式化前、功能一致的 SGLang commit `9e356b8` 的针对性测试：`5 passed`；最终 pin `2764e91` 只补充 Black 格式化。
- 前一候选的 `.42` Day 675 崩溃验证：warmup `90/90`，formal `675/675`，0 失败；它仅比当前 commit 多通用 `radix_cache.py` 的纯防御校验。按 review 意见移除该校验后未重跑完整 Day 675。

验证范围为兼容性文档和崩溃修复引用，不包含正常输出长度下的性能验收。
