### PR TITLE
fix(glm): correct DSA indexer transfer geometry

### DIFF
--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -1824,9 +1824,14 @@ class FlexKVConnector:
             LayerGroupSpec(
                 num_layers=len(indexer_buffers),
                 num_kv_heads=1,
+                # GLM DSA stores one flattened index+scale row per complete
+                # KV page: [num_pages, page_size * (head + scale)]. The
+                # physical GPU layout therefore has tokens_per_block=1.
+                # Describe that row as one page so the worker does not
+                # multiply it by page_size a second time.
                 head_size=indexer_buffers[0].shape[1],
                 layer_indices=list(range(len(indexer_buffers))),
-                compress_ratio=1,
+                compress_ratio=self.page_size,
                 dtype=indexer_buffers[0].dtype,
             ),
         ]

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -74,6 +74,28 @@ def import_tensor_handles(
     if handles:
         ensure_cuda_device(handles[0].device)
     return [h.get_tensor() for h in handles]
+
+
+def _validate_multi_group_chunk_layout(
+    group_chunk_size: int,
+    layout_chunk_size: int,
+    group_index: int,
+    group_tpb: int,
+    layout_tpb: int,
+    head_size: int,
+    compress_ratio: int,
+) -> None:
+    """Reject a transfer descriptor that disagrees with GPU storage."""
+    if group_chunk_size != layout_chunk_size:
+        raise ValueError(
+            "Multi-group chunk/layout mismatch for group "
+            f"{group_index}: group_chunk={group_chunk_size} B, "
+            f"layout_chunk={layout_chunk_size} B, "
+            f"group_tpb={group_tpb}, layout_tpb={layout_tpb}, "
+            f"head_size={head_size}, compress_ratio={compress_ratio}"
+        )
+
+
 from flexkv.transfer.compression.common.strategy import (
     CompressionStrategy,
     NullCompressionStrategy,
@@ -874,6 +896,20 @@ class GPUCPUTransferWorker(TransferWorkerBase):  # this worker only supports non
             # GPU strides: compute from actual tensor to handle different
             # attention backend layouts (flash_attn vs triton/flashinfer).
             gpu_chunk_size = chunk_elements * dtype_size_g
+            # Fail closed before submitting a native transfer if the
+            # declarative LayerGroupSpec disagrees with the actual tensor
+            # layout. This catches page-packed GLM DSA indexer buffers
+            # (tpb=1, one 8448-byte row) being described as tpb=64.
+            layout_chunk_size = gpu_layout.get_chunk_size() * dtype_size_g
+            _validate_multi_group_chunk_layout(
+                gpu_chunk_size,
+                layout_chunk_size,
+                gi,
+                tpb_g,
+                gpu_layout.tokens_per_block,
+                g.head_size,
+                g.compress_ratio,
+            )
             t0 = group_gpu_blocks[0]
             gpu_strides = self._get_gpu_strides_from_tensor(t0, tpb_g, dtype_size_g, self.kv_dim)
             if gpu_strides is not None:

--- a/tests/test_glm_dsa_indexer_geometry.py
+++ b/tests/test_glm_dsa_indexer_geometry.py
@@ -1,0 +1,99 @@
+"""Regression tests for GLM DSA page-packed indexer transfer geometry."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from flexkv.common.config import LayerGroupSpec
+from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+from flexkv.integration.sglang.connector import FlexKVConnector
+from flexkv.transfer.worker import _validate_multi_group_chunk_layout
+
+
+PAGE_SIZE = 64
+INDEX_HEAD_SIZE = 8448
+MAIN_HEAD_SIZE = 576
+NUM_LAYERS = 78
+
+
+def _groups(compress_ratio: int):
+    return [
+        LayerGroupSpec(
+            num_layers=NUM_LAYERS,
+            num_kv_heads=1,
+            head_size=MAIN_HEAD_SIZE,
+            layer_indices=list(range(NUM_LAYERS)),
+            compress_ratio=1,
+            dtype=torch.bfloat16,
+        ),
+        LayerGroupSpec(
+            num_layers=NUM_LAYERS,
+            num_kv_heads=1,
+            head_size=INDEX_HEAD_SIZE,
+            layer_indices=list(range(NUM_LAYERS)),
+            compress_ratio=compress_ratio,
+            dtype=torch.uint8,
+        ),
+    ]
+
+
+def test_connector_describes_one_indexer_row_per_page():
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = PAGE_SIZE
+    connector.rank_info = SimpleNamespace(num_layers_per_pp_stage=NUM_LAYERS)
+
+    specs = connector._build_indexer_layer_group_specs(
+        [torch.empty((1, 1, MAIN_HEAD_SIZE), dtype=torch.bfloat16)],
+        [torch.empty((1, INDEX_HEAD_SIZE), dtype=torch.uint8)] * NUM_LAYERS,
+    )
+
+    assert specs[1].head_size == INDEX_HEAD_SIZE
+    assert specs[1].compress_ratio == PAGE_SIZE
+
+
+def test_corrected_glm_dsa_block_arithmetic():
+    groups = _groups(PAGE_SIZE)
+    layout = KVCacheLayout(
+        type=KVCacheLayoutType.BLOCKFIRST,
+        num_layer=NUM_LAYERS,
+        num_block=1,
+        tokens_per_block=PAGE_SIZE,
+        num_head=1,
+        head_size=MAIN_HEAD_SIZE,
+        # GLM combined-KV stores one KV stream per group in this pool.
+        kv_dim=1,
+        layer_groups=groups,
+    )
+    # GLM combined-KV has kv_dim=1; the final factor is BF16 bytes.
+    main = NUM_LAYERS * PAGE_SIZE * MAIN_HEAD_SIZE * 2
+    indexer = NUM_LAYERS * INDEX_HEAD_SIZE
+    assert main == 5_750_784
+    assert indexer == 658_944
+    assert layout.get_block_stride() == 6_409_728
+    assert layout.kv_shape == torch.Size([1, 6_409_728])
+
+
+def test_old_ratio_1_geometry_is_rejected_before_transfer():
+    with pytest.raises(ValueError, match="group_chunk=540672.*layout_chunk=8448"):
+        _validate_multi_group_chunk_layout(
+            PAGE_SIZE * INDEX_HEAD_SIZE,
+            INDEX_HEAD_SIZE,
+            group_index=1,
+            group_tpb=PAGE_SIZE,
+            layout_tpb=1,
+            head_size=INDEX_HEAD_SIZE,
+            compress_ratio=1,
+        )
+
+
+def test_corrected_geometry_passes_fail_fast_check():
+    _validate_multi_group_chunk_layout(
+        INDEX_HEAD_SIZE,
+        INDEX_HEAD_SIZE,
+        group_index=1,
+        group_tpb=1,
+        layout_tpb=1,
+        head_size=INDEX_HEAD_SIZE,
+        compress_ratio=PAGE_SIZE,
+    )


### PR DESCRIPTION
## 问题


GLM DSA indexer 的物理布局是“每个完整 KV page 对应一行 index + scale 数据”。旧 connector 将该组声明为 `compress_ratio=1`，worker 会再次乘以 page size，导致声明几何与真实 tensor layout 相差 64 倍，并可能越界提交 native transfer。

## 解决方案

- 将 indexer layer group 的 `compress_ratio` 修正为 `page_size`，使物理 `tokens_per_block=1`。
- 在 multi-group worker 提交 native transfer 前核对声明 chunk 与真实 tensor layout，不一致时 fail closed。
- 增加 GLM DSA connector、block stride 和旧错误几何回归测试；正确单 block 大小为 `6,409,728 B`。
