### PR TITLE
fix(layerwise): stop double-reading opaque multi-group blocks from SSD

### DIFF
--- a/csrc/layerwise.cpp
+++ b/csrc/layerwise.cpp
@@ -1370,6 +1370,20 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
   }
 
   // Step 0a: main-KV SSD -> CPU (opaque multi-group block).
+  //
+  // kv_dim is deliberately 1 here, NOT the model's kv_dim. A multi-group
+  // block_stride already accounts for both K and V (see
+  // KVCacheLayout._compute_kv_shape: bytes_per_block multiplies by kv_dim),
+  // and the strides below declare the whole block as one opaque region
+  // (layer_stride == chunk_size == block_stride, kv_stride == 0). Passing
+  // kv_dim=2 makes transfer_blocks_impl loop the kv axis with a zero stride,
+  // so every path (layer-major batch / vectored / baseline) issues the exact
+  // same read twice -- identical fd, offset, cpu_ptr and size. The data stays
+  // correct because a re-read is idempotent, but SSD read traffic doubles.
+  //
+  // The write side already passes 1 (CPUSSDDiskTransferWorker multi-group), so
+  // the on-disk image is a single opaque block with no K/V split to iterate,
+  // and Step 0b below does the same for multi-group SWA.
   if (enable_ssd_ && ssd_block_ids.numel() > 0) {
     const int64_t block_stride = groups_[0].cpu_block_stride;
     char ssd_range_name[128];
@@ -1391,7 +1405,7 @@ void LayerwiseTransferGroup::layerwise_transfer_multi_group(
         /*chunk_size_in_bytes=*/block_stride,
         /*block_stride_in_bytes=*/block_stride,
         /*is_read=*/true, num_blocks_per_file, round_robin,
-        num_threads_per_device, kv_dim,
+        num_threads_per_device, /*kv_dim=*/1,
         /*ssd_io_opt=*/ssd_io_opt_);
     nvtxRangePop();
   }

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -1842,6 +1842,10 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
             # the kernel issue exactly one pread/pwrite of block_stride bytes
             # per block, sidestepping the sub-4KiB chunk hazard for highly
             # compressed groups (e.g. DSv4 indexer at compress_ratio=128).
+            #
+            # kv_dim=1 for the same reason: block_stride already covers K and V,
+            # and kv_stride is 0, so looping the kv axis would repeat the very
+            # same I/O.
             one_layer_id = torch.tensor([0], dtype=torch.int32)
             transfer_kv_blocks_ssd(
                 self.ioctx,
@@ -1859,7 +1863,7 @@ class CPUSSDDiskTransferWorker(TransferWorkerBase):
                 self.num_blocks_per_file,
                 self.round_robin,
                 32,
-                True,
+                1,  # kv_dim
                 ssd_io_opt=GLOBAL_CONFIG_FROM_ENV.ssd_io_opt,
             )
         else:


### PR DESCRIPTION
layerwise_transfer_multi_group's Step 0a forwards the model's kv_dim into transfer_kv_blocks_ssd, but that call describes the whole block as a single opaque byte-flat extent:

    cpu_layer_stride == ssd_layer_stride == chunk_size == block_stride
    cpu_kv_stride    == ssd_kv_stride    == 0

block_stride already includes the kv_dim factor -- KVCacheLayout's bytes_per_block multiplies num_layers * kv_dim * ... -- so there is no K/V axis left on disk to iterate. With kv_stride == 0, transfer_blocks_impl's second kv iteration re-issues byte-for-byte the same I/O: same fd, same file offset, same destination pointer, same length.

Reads stay correct because a re-read is idempotent, which is exactly why this hid; the only symptom is 2x SSD read traffic on the layerwise SSD->Host path for heterogeneous-layer-group models. All three sub-paths of transfer_blocks_impl are affected (layer-major batch, vectored preadv, and the baseline fragmented path); Step 0a's strides skip the block-first path because enable_block_first_transfer requires block_stride > layer_stride.

The fix is at the call site, not on layerwise.py's kv_dim parameter: that same parameter also feeds the three H2D transfer_kv_blocks calls further down, which genuinely need 2. Lowering it there would silently transfer only K -- no error, just wrong output.

Also passes an explicit int for the multi-group SSD write in CPUSSDDiskTransferWorker, which was handing a bool to an int kv_dim parameter. Same value, no behavior change.

Verified on hardware by counting bytes at the syscall layer (/proc/self/io rchar, which unlike read_bytes is immune to the page cache): kv_dim=1 moves exactly one block_stride per block on every sub-path, while kv_dim=2 moves exactly 2x that for byte-identical results.