### PR TITLE
perf(sglang): reapply async store slot mapping to main

### DIFF
--- a/flexkv/integration/sglang/comm.py
+++ b/flexkv/integration/sglang/comm.py
@@ -54,6 +54,7 @@ class FlexKVScatterChannel(str, Enum):
     RESET = "reset"
     STORE_START = "store_start"
     STORE_RESET = "store_reset"
+    STORE_READY = "store_ready"
 
 
 _SCATTER_CHANNEL_OFFSETS = {
@@ -65,6 +66,7 @@ _SCATTER_CHANNEL_OFFSETS = {
     FlexKVScatterChannel.RESET: 6,
     FlexKVScatterChannel.STORE_START: 7,
     FlexKVScatterChannel.STORE_RESET: 8,
+    FlexKVScatterChannel.STORE_READY: 9,
 }
 _SCATTER_CHANNEL_TYPES = {
     FlexKVScatterChannel.LOOKUP: dict,
@@ -75,6 +77,7 @@ _SCATTER_CHANNEL_TYPES = {
     FlexKVScatterChannel.RESET: dict,
     FlexKVScatterChannel.STORE_START: dict,
     FlexKVScatterChannel.STORE_RESET: dict,
+    FlexKVScatterChannel.STORE_READY: list,
 }
 
 

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -1023,11 +1023,13 @@ class FlexKVConnector:
     def supports_async_store_slot_mapping(self) -> bool:
         """Whether a leader-only pinned slot copy is valid for this topology.
 
-        Cross-node PP receivers need their own stage-local mapping, and SWA
-        needs a GPU-side full-to-SWA translation. Keep those paths on the
-        synchronous implementation until they have an explicit sideband.
+        PP stages need their own stage-local mapping, and SWA needs a GPU-side
+        full-to-SWA translation. Keep those paths on the synchronous
+        implementation until they have an explicit sideband.
         """
-        return not bool(getattr(self._sync_ctx, "is_cross_node_pp", False)) and (
+        # TODO: add stage-local mapping sidebands for PP and carry
+        # the GPU full-to-SWA translation in the asynchronous store protocol.
+        return not bool(getattr(self._sync_ctx, "is_pp_active", False)) and (
             self._swa_kv_pool is None
         )
 

--- a/flexkv/integration/sglang/connector.py
+++ b/flexkv/integration/sglang/connector.py
@@ -33,6 +33,7 @@ import signal
 import socket
 import struct
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -263,6 +264,9 @@ class FlexKVConnector:
         self.enable_layerwise = bool(
             int(os.environ.get("FLEXKV_ENABLE_LAYERWISE_TRANSFER", "0"))
         )
+        self._profile_store_stages = os.getenv(
+            "FLEXKV_PROFILE_STORE_STAGES", "0"
+        ).strip().lower() in {"1", "true", "yes", "on"}
         self._layerwise_socket = build_layerwise_eventfd_socket_path(
             dp_client_id=self.rank_info.dp_client_id,
             pp_rank=self.rank_info.pp_rank,
@@ -1010,6 +1014,33 @@ class FlexKVConnector:
     # Public API — store
     # ------------------------------------------------------------------
 
+    @property
+    def is_store_sync_leader(self) -> bool:
+        """Whether this rank owns the authoritative FlexKV store decision."""
+        return bool(self._sync_ctx.is_sync_leader)
+
+    @property
+    def supports_async_store_slot_mapping(self) -> bool:
+        """Whether a leader-only pinned slot copy is valid for this topology.
+
+        Cross-node PP receivers need their own stage-local mapping, and SWA
+        needs a GPU-side full-to-SWA translation. Keep those paths on the
+        synchronous implementation until they have an explicit sideband.
+        """
+        return not bool(getattr(self._sync_ctx, "is_cross_node_pp", False)) and (
+            self._swa_kv_pool is None
+        )
+
+    def sync_ready_store_rids(self, ready_rids: List[str]) -> List[str]:
+        """Fan out the leader's ready pinned-copy set to every cache rank."""
+        payload = list(ready_rids) if self._sync_ctx.is_sync_leader else []
+        if self._sync_ctx.needs_sync:
+            payload = self._sync_ctx.scatter(
+                payload,
+                channel=FlexKVScatterChannel.STORE_READY,
+            )
+        return list(payload)
+
     def store_kv(
         self,
         rid: str,
@@ -1028,7 +1059,8 @@ class FlexKVConnector:
         nothing needed to be written.
         """
         context = self._new_op_context("store", rid, sglang_req_id)
-        token_ids_np = np.asarray(token_ids, dtype=np.int64)
+        with self._store_profile_scope("flexkv.connector.store.tokens_to_numpy"):
+            token_ids_np = np.asarray(token_ids, dtype=np.int64)
         n = len(token_ids_np)
         if n != len(kv_indices):
             raise ValueError(
@@ -1053,18 +1085,24 @@ class FlexKVConnector:
             if aligned_len < n:
                 token_ids_np = token_ids_np[:aligned_len]
                 kv_indices = kv_indices[:aligned_len]
+                n = aligned_len
 
         store_start = {
             "rid": rid,
             "task_id": -1,
             "active": False,
+            "slot_count": n,
+            "unmatched_count": 0,
             "unmatched_mask": [],
             "error": "",
         }
         if self._sync_ctx.is_sync_leader and self.kv_manager is not None:
             match_error: Optional[Exception] = None
             try:
-                res = self.kv_manager.put_match(token_ids=token_ids_np, token_mask=None)
+                with self._store_profile_scope("flexkv.connector.store.put_match"):
+                    res = self.kv_manager.put_match(
+                        token_ids=token_ids_np, token_mask=None
+                    )
             except Exception as exc:  # noqa: BLE001
                 match_error = exc
                 res = None
@@ -1080,33 +1118,55 @@ class FlexKVConnector:
                 )
             else:
                 fkv_task_id, unmatched_mask = res
+                # TP/CP followers only need the task id to retain their local
+                # radix-node ownership.  Broadcasting one Python bool per
+                # prompt token made the common TP-only write-through path
+                # serialize/deserialise tens of thousands of objects per
+                # request.  Only cross-node PP receivers need the mask to
+                # construct their stage-local slot mapping.
+                needs_remote_mask = bool(
+                    getattr(self._sync_ctx, "is_cross_node_pp", False)
+                )
+                unmatched_count = int(np.count_nonzero(unmatched_mask))
                 mask_list = (
                     unmatched_mask.tolist()
-                    if hasattr(unmatched_mask, "tolist")
+                    if needs_remote_mask and hasattr(unmatched_mask, "tolist")
                     else list(unmatched_mask)
+                    if needs_remote_mask
+                    else []
                 )
                 store_start.update(
-                    task_id=int(fkv_task_id), unmatched_mask=mask_list
+                    task_id=int(fkv_task_id),
+                    unmatched_count=unmatched_count,
+                    unmatched_mask=mask_list,
                 )
                 context.task_id = int(fkv_task_id)
-                unmatched_count = int(sum(bool(item) for item in mask_list))
                 if unmatched_count > 0:
-                    filtered = kv_indices[unmatched_mask]
-                    slot_mapping_cpu = self._to_cpu_int64(filtered)
-                    swa_slot_mapping = self._build_swa_slot_mapping(filtered)
+                    with self._store_profile_scope(
+                        "flexkv.connector.store.filter_slot_mapping"
+                    ):
+                        filtered = kv_indices[unmatched_mask]
+                    with self._store_profile_scope(
+                        "flexkv.connector.store.slot_mapping_to_cpu"
+                    ):
+                        slot_mapping_cpu = self._to_cpu_int64(filtered)
+                        swa_slot_mapping = self._build_swa_slot_mapping(filtered)
                     swa_slots = (
                         0
                         if swa_slot_mapping is None
                         else int(swa_slot_mapping.numel())
                     )
                     try:
-                        self.kv_manager.launch(
-                            task_ids=[fkv_task_id],
-                            slot_mappings=[slot_mapping_cpu],
-                            swa_slot_mappings=[swa_slot_mapping],
-                            as_batch=False,
-                            layerwise_transfer=False,
-                        )
+                        with self._store_profile_scope(
+                            "flexkv.connector.store.kvmanager_launch"
+                        ):
+                            self.kv_manager.launch(
+                                task_ids=[fkv_task_id],
+                                slot_mappings=[slot_mapping_cpu],
+                                swa_slot_mappings=[swa_slot_mapping],
+                                as_batch=False,
+                                layerwise_transfer=False,
+                            )
                     except Exception as exc:  # noqa: BLE001
                         store_start["error"] = str(exc)
                         self._log_cache_op(
@@ -1141,10 +1201,11 @@ class FlexKVConnector:
                     )
 
         if self._sync_ctx.needs_sync:
-            store_start = self._sync_ctx.scatter(
-                store_start,
-                channel=FlexKVScatterChannel.STORE_START,
-            )
+            with self._store_profile_scope("flexkv.connector.store.scatter_start"):
+                store_start = self._sync_ctx.scatter(
+                    store_start,
+                    channel=FlexKVScatterChannel.STORE_START,
+                )
         if store_start.get("rid") != rid:
             raise RuntimeError(
                 "[FlexKV] store-start rid mismatch: "
@@ -1158,16 +1219,22 @@ class FlexKVConnector:
             return -1
 
         fkv_task_id = int(store_start["task_id"])
+        slot_count = int(store_start.get("slot_count", -1))
         mask_list = store_start.get("unmatched_mask", [])
-        if fkv_task_id < 0 or len(mask_list) != len(kv_indices):
+        if fkv_task_id < 0 or slot_count != len(kv_indices):
             raise RuntimeError(
                 "[FlexKV] invalid store-start payload: "
-                f"task_id={fkv_task_id}, mask_len={len(mask_list)}, "
+                f"task_id={fkv_task_id}, slot_count={slot_count}, "
                 f"slot_len={len(kv_indices)}"
             )
 
         # Cross-node PP needs the local PP stage's physical slot mapping.
         if self._sync_ctx.should_send_slot_mapping_to_remote:
+            if len(mask_list) != len(kv_indices):
+                raise RuntimeError(
+                    "[FlexKV] invalid cross-node store mask: "
+                    f"mask_len={len(mask_list)}, slot_len={len(kv_indices)}"
+                )
             unmatched_mask = torch.as_tensor(
                 mask_list, dtype=torch.bool, device=kv_indices.device
             )
@@ -1645,9 +1712,9 @@ class FlexKVConnector:
 
         SGLang intentionally allocates a ``(0, page_stride)`` tensor for a
         skip-topk layer because that layer reuses the preceding layer's
-        indexer cache. FlexKV keeps one physical indexer slot per model layer,
-        so its pointer table must alias the preceding buffer instead of
-        exporting a null ``data_ptr()``.
+        indexer cache.  FlexKV keeps one physical indexer slot per model layer
+        (matching HiCache sizing), so its pointer table must alias the same
+        preceding buffer instead of exporting a null ``data_ptr()``.
         """
         resolved: List[torch.Tensor] = []
         previous: Optional[torch.Tensor] = None
@@ -2009,6 +2076,11 @@ class FlexKVConnector:
         if tensor.is_cuda:
             tensor = tensor.cpu()
         return tensor.to(torch.int64)
+
+    def _store_profile_scope(self, name: str):
+        if not getattr(self, "_profile_store_stages", False):
+            return nullcontext()
+        return torch.profiler.record_function(name)
 
     def _wait_kv_manager_ready(self, poll_interval: float = 10.0) -> None:
         assert self.kv_manager is not None

--- a/tests/test_glm_dsa_indexer_geometry.py
+++ b/tests/test_glm_dsa_indexer_geometry.py
@@ -68,7 +68,6 @@ def test_connector_rejects_leading_skip_topk_placeholder():
     with pytest.raises(RuntimeError, match="leading skip-topk"):
         FlexKVConnector._alias_empty_indexer_buffers([skipped])
 
-
 def test_corrected_glm_dsa_block_arithmetic():
     groups = _groups(PAGE_SIZE)
     layout = KVCacheLayout(

--- a/tests/test_glm_dsa_indexer_geometry.py
+++ b/tests/test_glm_dsa_indexer_geometry.py
@@ -68,6 +68,7 @@ def test_connector_rejects_leading_skip_topk_placeholder():
     with pytest.raises(RuntimeError, match="leading skip-topk"):
         FlexKVConnector._alias_empty_indexer_buffers([skipped])
 
+
 def test_corrected_glm_dsa_block_arithmetic():
     groups = _groups(PAGE_SIZE)
     layout = KVCacheLayout(

--- a/tests/test_sglang_store_protocol.py
+++ b/tests/test_sglang_store_protocol.py
@@ -27,6 +27,21 @@ def _follower_connector(payload):
     return connector
 
 
+def test_async_store_slot_mapping_support_is_topology_driven():
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector._sync_ctx = SimpleNamespace(is_pp_active=False)
+    connector._swa_kv_pool = None
+
+    assert connector.supports_async_store_slot_mapping is True
+
+    connector._sync_ctx.is_pp_active = True
+    assert connector.supports_async_store_slot_mapping is False
+
+    connector._sync_ctx.is_pp_active = False
+    connector._swa_kv_pool = object()
+    assert connector.supports_async_store_slot_mapping is False
+
+
 def test_store_start_tracks_task_on_nonleader_rank():
     payload = {
         "rid": "request",

--- a/tests/test_sglang_store_protocol.py
+++ b/tests/test_sglang_store_protocol.py
@@ -32,7 +32,9 @@ def test_store_start_tracks_task_on_nonleader_rank():
         "rid": "request",
         "task_id": 17,
         "active": True,
-        "unmatched_mask": [True, False, True, False],
+        "slot_count": 4,
+        "unmatched_count": 2,
+        "unmatched_mask": [],
         "error": "",
     }
     connector = _follower_connector(payload)
@@ -46,11 +48,41 @@ def test_store_start_tracks_task_on_nonleader_rank():
             "rid": "request",
             "task_id": -1,
             "active": False,
+            "slot_count": 4,
+            "unmatched_count": 0,
             "unmatched_mask": [],
             "error": "",
         },
         channel=FlexKVScatterChannel.STORE_START,
     )
+
+
+def test_store_leader_accepts_pinned_sideband_cpu_mapping():
+    connector = FlexKVConnector.__new__(FlexKVConnector)
+    connector.page_size = 1
+    connector._swa_kv_pool = None
+    connector._profile_store_stages = False
+    connector.kv_manager = MagicMock()
+    connector.kv_manager.put_match.return_value = (
+        17,
+        np.asarray([True, False, True, False], dtype=np.bool_),
+    )
+    connector._sync_ctx = SimpleNamespace(
+        is_sync_leader=True,
+        needs_sync=False,
+        should_send_slot_mapping_to_remote=False,
+        is_cross_node_pp=False,
+    )
+    connector._inflight_stores = {}
+    connector._inflight_store_contexts = {}
+    connector._new_op_context = MagicMock(return_value=SimpleNamespace(task_id=-1))
+    connector._log_cache_op = MagicMock()
+    cpu_mapping = torch.tensor([4, 5, 8, 9], dtype=torch.int64)
+
+    assert connector.store_kv("request", [1, 2, 3, 4], cpu_mapping) == 17
+    launch = connector.kv_manager.launch.call_args.kwargs
+    assert launch["slot_mappings"][0].tolist() == [4, 8]
+    assert launch["swa_slot_mappings"] == [None]
 
 
 def test_lookup_accepts_sglang_array_token_ids():
@@ -201,6 +233,13 @@ def test_store_completion_clears_nonleader_tracking():
     assert connector._inflight_stores == {}
     assert connector._inflight_store_contexts == {}
     connector._sync_ctx.scatter.assert_called_once_with([], channel=FlexKVScatterChannel.STORE_COMPLETION)
+
+
+def test_store_ready_uses_leader_payload_and_dedicated_channel():
+    connector = _follower_connector(["request"])
+
+    assert connector.sync_ready_store_rids(["ignored-on-follower"]) == ["request"]
+    connector._sync_ctx.scatter.assert_called_once_with([], channel=FlexKVScatterChannel.STORE_READY)
 
 
 def test_store_reset_waits_for_leader_drain_on_follower():


### PR DESCRIPTION
## Summary

- reapply the pinned CPU slot-mapping sideband used by deferred Store launch
- restore Store-ready synchronization and stage profiling for the async path
- enable the capability only for supported non-SWA, non-pipeline-parallel topologies

## Why this PR is needed

#280 merged into main at dc4a5c3 after the async Store commits had been reverted from its branch. #282 was then merged back into fix/production-cache-transfer-config at 56ad327, after #280 had already landed, so the #282 changes never reached main.

SGLang #31781 already calls FlexKVConnector.sync_ready_store_rids. As a result, combining that SGLang PR with current FlexKV main raises an AttributeError because the connector API is missing.

This PR replays the same three commits from #282 directly on the latest main. It intentionally contains only the async Store protocol split and does not bring in unrelated changes.

## Validation

- patch generated against main has the same stable patch ID as #282: 934053de22f16962504115053502ab7f59f3c219
- Python syntax compilation passed for all changed Python files
- git diff --check passed
- targeted pytest collection is blocked locally because torch is unavailable; CI validation is required

No stable performance improvement is claimed by this PR.