### PR TITLE
fix(nvcomp): two guards that reject valid transfers

### DIFF
--- a/csrc/compression/ans/ans_bindings.cpp
+++ b/csrc/compression/ans/ans_bindings.cpp
@@ -32,7 +32,7 @@ static size_t transfer_kv_blocks_ans_binding(
     int64_t chunk_size_in_bytes,
     int start_layer_id,
     int num_layers,
-    bool kv_dim,
+    int kv_dim,
     int gpu_block_type,
     int64_t cpu_size_table_ptr,
     int64_t cpu_size_table_block_stride,
@@ -43,6 +43,13 @@ static size_t transfer_kv_blocks_ans_binding(
               "cpu_block_id_tensor must be int64");
   TORCH_CHECK(gpu_tensor_ptrs_tensor.dtype() == torch::kInt64,
               "gpu_tensor_ptrs_tensor must be int64");
+  // This parameter was declared ``bool`` here (and only here -- every other
+  // kv_dim in the tree is int), so pybind11 folded MHA's 2 down to true and
+  // the implicit widening handed the kernel a 1. Half of every MHA batch
+  // then silently did not exist. Fail loudly on anything unexpected rather
+  // than degrade again.
+  TORCH_CHECK(kv_dim == 1 || kv_dim == 2,
+              "kv_dim must be 1 (MLA) or 2 (MHA/GQA), got ", kv_dim);
 
   int num_blocks = gpu_block_id_tensor.numel();
   int64_t *gpu_block_ids = static_cast<int64_t*>(gpu_block_id_tensor.data_ptr());
@@ -127,7 +134,7 @@ static size_t transfer_kv_blocks_ans_comp_binding(
     int64_t chunk_size_in_bytes,
     int start_layer_id,
     int num_layers,
-    bool kv_dim,
+    int kv_dim,
     int gpu_block_type,
     int64_t cpu_size_table_ptr,
     int64_t cpu_size_table_block_stride,
@@ -157,7 +164,7 @@ static size_t transfer_kv_blocks_ans_decomp_binding(
     int64_t chunk_size_in_bytes,
     int start_layer_id,
     int num_layers,
-    bool kv_dim,
+    int kv_dim,
     int gpu_block_type,
     int64_t cpu_size_table_ptr,
     int64_t cpu_size_table_block_stride,

--- a/csrc/compression/ans/nvcomp_ans_tp.cpp
+++ b/csrc/compression/ans/nvcomp_ans_tp.cpp
@@ -125,8 +125,17 @@ size_t TPTransferThreadGroup::tp_group_transfer_ans(
   (void)use_ce_transfer;
 
   ensure_nvcomp_initialized();
+  // A rank stride is required exactly when the table is actually indexed by
+  // rank below: the MHA branch does `ptr + i * rank_stride`, which only moves
+  // when there is more than one rank.  Head-sharded KV on a single GPU gets
+  // the canonical 3-D table (rank_stride == 0, i == 0), which is what
+  // ``NvcompGpuCpuStrategy.attach`` binds -- it asks for 4 dims only when
+  // ``num_kv_heads > 1 && num_gpus > 1``.  Demanding a non-zero stride for
+  // every MHA shape made this guard stricter than its own use, and rejected
+  // every tp==1 MHA transfer before a single byte moved.
   if (cpu_size_table_tp_ptr == 0 ||
-      (num_kv_heads > 1 && cpu_size_table_tp_rank_stride == 0) ||
+      (num_kv_heads > 1 && num_gpus_ > 1 &&
+       cpu_size_table_tp_rank_stride == 0) ||
       cpu_size_table_block_stride == 0 ||
       cpu_size_table_layer_stride == 0) {
     throw std::runtime_error(

--- a/flexkv/transfer/compression/ans/ans_strategy.py
+++ b/flexkv/transfer/compression/ans/ans_strategy.py
@@ -190,22 +190,29 @@ class NvcompGpuCpuTpStrategy(CompressionStrategy):
             message=f"NvcompGpuCpuTpStrategy.run[{transfer_type.name}]",
             color="purple")
         try:
+            # Keyword args past the block-id tensors.  #257 inserted
+            # ``num_kv_heads`` between ``kv_dim`` and the size-table group, so
+            # a positional call silently shifts the four table arguments by one
+            # and comes up one short -- a TypeError before any byte moves.  The
+            # unit tests are the only other caller and they pass it; this is
+            # the live TP+nvcomp path.
             return int(worker.tp_transfer_thread_group.tp_group_transfer_ans(
                 gpu_block_id_list, cpu_block_id_list,
-                worker.cpu_kv_stride_in_bytes,
-                worker.cpu_layer_stride_in_bytes,
-                worker.cpu_block_stride_in_bytes,
-                worker.cpu_tp_stride_in_bytes,
-                transfer_num_cta,
-                transfer_type == TransferType.H2D,
-                use_ce_transfer,
-                0,
-                worker.num_layers,
-                worker.kv_dim,
-                self._table_ptr,
-                self._table_rank_stride,
-                self._table_block_stride,
-                self._table_layer_stride,
+                cpu_kv_stride_in_bytes=worker.cpu_kv_stride_in_bytes,
+                cpu_layer_stride_in_bytes=worker.cpu_layer_stride_in_bytes,
+                cpu_block_stride_in_bytes=worker.cpu_block_stride_in_bytes,
+                cpu_tp_stride_in_bytes=worker.cpu_tp_stride_in_bytes,
+                transfer_num_cta=transfer_num_cta,
+                is_host_to_device=transfer_type == TransferType.H2D,
+                use_ce_transfer=use_ce_transfer,
+                layer_id=0,
+                layer_granularity=worker.num_layers,
+                kv_dim=worker.kv_dim,
+                num_kv_heads=worker.num_kv_heads,
+                cpu_size_table_tp_ptr=self._table_ptr,
+                cpu_size_table_tp_rank_stride=self._table_rank_stride,
+                cpu_size_table_block_stride=self._table_block_stride,
+                cpu_size_table_layer_stride=self._table_layer_stride,
             ))
         finally:
             nvtx.end_range(nvtx_range)

--- a/flexkv/transfer/compression/ans/ans_utils.py
+++ b/flexkv/transfer/compression/ans/ans_utils.py
@@ -392,7 +392,13 @@ def optimal_batch_size(
     hs = 1
     dtype = torch.bfloat16 if data_type == 0 else torch.float8_e4m3fn
 
-    shape_per_layer = (2, num_blocks, tpb, nh, hs)
+    # The calibration buffer is built K+V, so every "2" below is this kv_dim.
+    # It must also be what the kernel is told: passing a bool here used to
+    # collapse to 0, and total_chunks = layers*kv_dim*blocks went to 0 too --
+    # the calibration then timed a kernel that transferred nothing and picked
+    # a batch size from that.
+    CALIBRATION_KV_DIM = 2
+    shape_per_layer = (CALIBRATION_KV_DIM, num_blocks, tpb, nh, hs)
     gpu_cache = torch.randn(
         (num_layers,) + shape_per_layer,
         dtype=torch.bfloat16,
@@ -400,7 +406,7 @@ def optimal_batch_size(
     if dtype != torch.bfloat16:
         gpu_cache = gpu_cache.to(dtype)
     gpu_blocks = [gpu_cache[i] for i in range(num_layers)]
-    cpu_shape = (num_blocks, num_layers, 2, tpb, nh, hs)
+    cpu_shape = (num_blocks, num_layers, CALIBRATION_KV_DIM, tpb, nh, hs)
     cpu_data = torch.zeros(cpu_shape, dtype=dtype, device="cpu").pin_memory()
     gpu_ptrs = torch.tensor(
         [block.data_ptr() for block in gpu_blocks],
@@ -409,17 +415,18 @@ def optimal_batch_size(
     chunk_size = chunk_size_bytes
     gpu_kv_stride = num_blocks * tpb * nh * hs * elem
     gpu_block_stride = chunk_size
-    gpu_layer_stride = 2 * gpu_kv_stride
+    gpu_layer_stride = CALIBRATION_KV_DIM * gpu_kv_stride
     cpu_kv_stride = chunk_size
-    cpu_layer_stride = 2 * chunk_size
-    cpu_block_stride = num_layers * 2 * chunk_size
+    cpu_layer_stride = CALIBRATION_KV_DIM * chunk_size
+    cpu_block_stride = num_layers * CALIBRATION_KV_DIM * chunk_size
 
     gpu_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
     cpu_ids = torch.arange(num_blocks, dtype=torch.int64).pin_memory()
     stream = torch.cuda.Stream(device=dev)
 
     size_table = torch.zeros(
-        (num_blocks, num_layers, 2), dtype=torch.uint32).pin_memory()
+        (num_blocks, num_layers, CALIBRATION_KV_DIM),
+        dtype=torch.uint32).pin_memory()
     size_table_ptr = size_table.data_ptr()
     size_table_block_stride = size_table.stride(0)
     size_table_layer_stride = size_table.stride(1)
@@ -441,7 +448,7 @@ def optimal_batch_size(
                     ctx, gpu_ids, gpu_ptrs, gpu_kv_stride, gpu_block_stride,
                     gpu_layer_stride, cpu_ids, cpu_data, cpu_kv_stride,
                     cpu_layer_stride, cpu_block_stride, chunk_size, 0,
-                    num_layers, False, 0, size_table_ptr,
+                    num_layers, CALIBRATION_KV_DIM, 0, size_table_ptr,
                     size_table_block_stride, size_table_layer_stride)
             stream.synchronize()
 
@@ -452,7 +459,7 @@ def optimal_batch_size(
                     ctx, gpu_ids, gpu_ptrs, gpu_kv_stride, gpu_block_stride,
                     gpu_layer_stride, cpu_ids, cpu_data, cpu_kv_stride,
                     cpu_layer_stride, cpu_block_stride, chunk_size, 0,
-                    num_layers, False, 0, size_table_ptr,
+                    num_layers, CALIBRATION_KV_DIM, 0, size_table_ptr,
                     size_table_block_stride, size_table_layer_stride)
         end_evt.record(stream)
         stream.synchronize()

--- a/tests/nvcomp/nvcomp_common_utils.py
+++ b/tests/nvcomp/nvcomp_common_utils.py
@@ -6,6 +6,30 @@ DEFUALT_MHA_CONFIG = dict(num_head=8, head_dim=128)
 DEFUALT_MLA_SHAPE = dict(num_head=1, head_dim=576)
 
 
+def fp8_ans_supported() -> bool:
+    """Does the linked nvCOMP have native FP8 E4M3 ANS (>= 5.3)?
+
+    Asked by constructing the context the tests would use, because the version
+    gate lives in C++ (csrc/compression/ans/nvcomp_ans.cu:82) and is not
+    exported. An older nvCOMP is an environment limit, not a defect, so the
+    fp8 cells skip rather than fail -- the way the tp cells already skip when
+    the box has too few GPUs.
+    """
+    try:
+        from flexkv.c_ext import ANSTransferContext
+        from flexkv.transfer.compression.ans import ans_utils
+    except ImportError:
+        return False
+    chunk = 8 * 1024
+    dt = ans_utils.data_type(torch.float8_e4m3fn)
+    batch, _ = ans_utils.get_nvcomp_batch_size(chunk, data_type=dt)
+    try:
+        ANSTransferContext(batch, chunk, dt)
+    except Exception:
+        return False
+    return True
+
+
 def resolve_case(chunk_size_per_device, tp, kv_dim, num_kv_heads, dtype):
     elem = dtype.itemsize
     shape = DEFUALT_MLA_SHAPE if kv_dim == 1 else DEFUALT_MHA_CONFIG

--- a/tests/nvcomp/test_nvcomp_cpu.py
+++ b/tests/nvcomp/test_nvcomp_cpu.py
@@ -4,7 +4,7 @@ from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
 from flexkv.transfer.compression.common.strategy import NullCompressionStrategy
 from nvcomp_common_utils import (
     make_kv_cache, make_gpu_cache, compute_strides,
-    DEFUALT_MHA_CONFIG, resolve_case,
+    DEFUALT_MHA_CONFIG, resolve_case, fp8_ans_supported,
 )
 
 try:
@@ -42,6 +42,8 @@ def test_roundtrip(cpu_layout_name, dtype, tp_size, kv_dim, num_kv_heads, chunk_
         pytest.skip("nvcomp not available")
     if (kv_dim == 1) != (chunk_size_per_device == 18 * 1024):
         pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+    if dtype == torch.float8_e4m3fn and not fp8_ans_supported():
+        pytest.skip("native FP8 E4M3 ANS needs nvCOMP >= 5.3")
 
     case = resolve_case(chunk_size_per_device, tp_size, kv_dim, num_kv_heads, dtype)
 
@@ -145,6 +147,8 @@ def test_roundtrip_tp(cpu_layout_name, dtype, tp_size, kv_dim, num_kv_heads, chu
         pytest.skip("nvcomp not available")
     if (kv_dim == 1) != (chunk_size_per_device == 18 * 1024):
         pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+    if dtype == torch.float8_e4m3fn and not fp8_ans_supported():
+        pytest.skip("native FP8 E4M3 ANS needs nvCOMP >= 5.3")
     if torch.cuda.device_count() < tp_size:
         pytest.skip(f"tp_size={tp_size} needs {tp_size} GPUs, "
                     f"have {torch.cuda.device_count()}")
@@ -247,7 +251,7 @@ def test_roundtrip_tp(cpu_layout_name, dtype, tp_size, kv_dim, num_kv_heads, chu
         tg.tp_group_transfer_ans(
             block_ids, block_ids,
             cpu_kv_stride, cpu_layer_stride, cpu_block_stride, cpu_tp_stride,
-            transfer_num_cta, False, False, layer_id, num_layers, kv_dim, *st_args)
+            transfer_num_cta, False, False, layer_id, num_layers, kv_dim, num_kv_heads, *st_args)
         for g in range(tp_size):
             torch.cuda.synchronize(g)
 
@@ -269,7 +273,7 @@ def test_roundtrip_tp(cpu_layout_name, dtype, tp_size, kv_dim, num_kv_heads, chu
         tg.tp_group_transfer_ans(
             block_ids, block_ids,
             cpu_kv_stride, cpu_layer_stride, cpu_block_stride, cpu_tp_stride,
-            transfer_num_cta, True, False, layer_id, num_layers, kv_dim, *st_args)
+            transfer_num_cta, True, False, layer_id, num_layers, kv_dim, num_kv_heads, *st_args)
         for g in range(tp_size):
             torch.cuda.synchronize(g)
 

--- a/tests/nvcomp/test_nvcomp_ssd.py
+++ b/tests/nvcomp/test_nvcomp_ssd.py
@@ -10,6 +10,7 @@ from flexkv.transfer.compression.ans import ans_utils
 from nvcomp_common_utils import (
     make_gpu_cache,
     resolve_case,
+    fp8_ans_supported,
 )
 
 try:
@@ -141,6 +142,8 @@ def test_ssd_roundtrip_non_tp(
         pytest.skip("CUDA is not available")
     if (kv_dim == 1) != (chunk_size_per_device == 18 * 1024):
         pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+    if dtype == torch.float8_e4m3fn and not fp8_ans_supported():
+        pytest.skip("native FP8 E4M3 ANS needs nvCOMP >= 5.3")
 
     case = resolve_case(chunk_size_per_device, tp_size, kv_dim, num_kv_heads, dtype)
     num_heads, head_size = case["num_head"], case["head_dim"]
@@ -362,6 +365,8 @@ def test_ssd_roundtrip_tp(
         pytest.skip(f"tp_size={tp_size} needs {tp_size} GPUs")
     if (kv_dim == 1) != (chunk_size_per_device == 18 * 1024):
         pytest.skip("18KB is MLA-only; 8/16/32KB are MHA-only")
+    if dtype == torch.float8_e4m3fn and not fp8_ans_supported():
+        pytest.skip("native FP8 E4M3 ANS needs nvCOMP >= 5.3")
 
     case = resolve_case(chunk_size_per_device, tp_size, kv_dim, num_kv_heads, dtype)
     num_heads, head_size = case["num_head"], case["head_dim"]
@@ -514,6 +519,7 @@ def test_ssd_roundtrip_tp(
             0,
             num_layers,
             kv_dim,
+            num_kv_heads,
             *st_args,
         )
         for rank in range(tp_size):


### PR DESCRIPTION
2 个独立 bug，都在压缩路径上，都会让**合法**的传输被拒：

1. `csrc/compression/ans/nvcomp_ans_tp.cpp` — size-table guard 把每个`tp==1` 的 MHA 传输都判成非法。
2. `csrc/compression/ans/ans_bindings.cpp` — pybind 边界把 `kv_dim` 收缩成 bool，`kv_dim=1`（MLA）和 `kv_dim=2`（MHA）无法区分