### PR TITLE
fix(cython): stop indexing lists from the end under wraparound=False

### DIFF
--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -530,15 +530,15 @@ class TransferOpGraph:
                     else:
                         first = block_ids[:max_show].tolist()
                         last = block_ids[-max_show:].tolist()
-                        # Explicit indices, not ``[:-1]``/``[-1]``: release
-                        # builds cythonize this module with wraparound=False,
-                        # under which negative indices on a real list are not
-                        # folded to len + i.  The numpy slices above are safe
-                        # (they go through PyObject_GetItem); ``first``/``last``
-                        # are lists and are not.
-                        head = first[:len(first) - 1]
+                        # Explicit last index, not ``last[-1]``: release builds
+                        # cythonize this module with wraparound=False, under
+                        # which a negative *subscript* on a real list is not
+                        # folded to len + i -- it reads off the front and
+                        # segfaults.  Negative *slices* are unaffected (they go
+                        # through PySequence_GetSlice), so ``first[:-1]`` and
+                        # the numpy slices above are left alone.
                         tail = last[len(last) - 1]
-                        return f"{head}...{tail}] (n={block_ids.size})"
+                        return f"{first[:-1]}...{tail}] (n={block_ids.size})"
 
                 src_str = format_blocks(op.src_block_ids)
                 dst_str = format_blocks(op.dst_block_ids)

--- a/flexkv/common/transfer.py
+++ b/flexkv/common/transfer.py
@@ -530,7 +530,15 @@ class TransferOpGraph:
                     else:
                         first = block_ids[:max_show].tolist()
                         last = block_ids[-max_show:].tolist()
-                        return f"{first[:-1]}...{last[-1]}] (n={block_ids.size})"
+                        # Explicit indices, not ``[:-1]``/``[-1]``: release
+                        # builds cythonize this module with wraparound=False,
+                        # under which negative indices on a real list are not
+                        # folded to len + i.  The numpy slices above are safe
+                        # (they go through PyObject_GetItem); ``first``/``last``
+                        # are lists and are not.
+                        head = first[:len(first) - 1]
+                        tail = last[len(last) - 1]
+                        return f"{head}...{tail}] (n={block_ids.size})"
 
                 src_str = format_blocks(op.src_block_ids)
                 dst_str = format_blocks(op.dst_block_ids)

--- a/flexkv/integration/config.py
+++ b/flexkv/integration/config.py
@@ -825,7 +825,10 @@ class FlexKVConfig:
         if self.model_config.pp_size > 1:
             layers_range = mapping.pp_layers(self.model_config.num_layers)
             pp_start_layer = layers_range[0]
-            pp_end_layer = layers_range[-1] + 1
+            # Explicit last index: release builds cythonize this module with
+            # wraparound=False, so ``layers_range[-1]`` on a list reads off the
+            # front instead of folding to len - 1.
+            pp_end_layer = layers_range[len(layers_range) - 1] + 1
         else:
             pp_start_layer = 0
             pp_end_layer = self.model_config.num_layers

--- a/flexkv/kvtask.py
+++ b/flexkv/kvtask.py
@@ -199,15 +199,20 @@ class KVTaskManager:
             self.transfer_handles[0]._handle.send_config_to_remotes()
 
         if self.model_config.nnodes > 1:
-            self.transfer_handles.append(TransferManagerHandle(
+            # Bind the handle rather than reading it back with a negative
+            # index: release builds cythonize this module with
+            # wraparound=False, so ``transfer_handles[-1]`` on a list reads off
+            # the front of it instead of folding to len - 1.
+            remote_handle = TransferManagerHandle(
                 model_config,
                 cache_config,
                 mode="remote",
                 gpu_register_port=gpu_register_port,
                 master_host=self.model_config.master_host,
                 master_ports=self.model_config.master_ports,
-            ))
-            self.transfer_handles[-1]._handle.send_config_to_remotes()
+            )
+            self.transfer_handles.append(remote_handle)
+            remote_handle._handle.send_config_to_remotes()
 
         self.tasks: ExpiringDict[int, KVTask] = ExpiringDict(ttl=1800) # 30 minutes
 

--- a/flexkv/transfer/worker.py
+++ b/flexkv/transfer/worker.py
@@ -223,9 +223,13 @@ def _split_mooncake_registration_regions(
                 f"size={size}, max_mr_size={max_mr_size}"
             )
 
-    if regions[-1][0] + regions[-1][1] != base_ptr + mapped_size:
+    # Explicit last index, not ``regions[-1]``: release builds cythonize this
+    # module with wraparound=False, under which a negative index on a real
+    # list is not folded to len + i -- it reads off the front of the object.
+    last_ptr, last_size = regions[len(regions) - 1]
+    if last_ptr + last_size != base_ptr + mapped_size:
         raise ValueError("Mooncake MR split does not cover mapped extent")
-    if base_ptr + logical_size > regions[-1][0] + regions[-1][1]:
+    if base_ptr + logical_size > last_ptr + last_size:
         raise ValueError("Mooncake MR split does not cover logical KV pool")
     return regions
 


### PR DESCRIPTION
Release builds cythonize `flexkv/**/*.py` with `wraparound: False` (setup.py:443-470). Under that directive a negative index on a real list is NOT folded to `len + i` -- Cython emits a raw `PyList_GET_ITEM(o, i)`, which reads off the front of the object. The pure-Python path is unaffected, so every green test run misses this; it only ever fires in a compiled build, where it reads garbage or segfaults.

Three genuine list subscripts:

  transfer.py:597      first[:-1] / last[-1] on .tolist() results
  config.py:743        layers_range[-1] (pp_layers returns a list)
  kvtask.py:210        transfer_handles[-1] right after .append()

Left alone: the numpy/torch subscripts at cache_engine.py:3441, kvtask.py:574 and connector.py:1992 fall back to PyObject_GetItem, for which wraparound is irrelevant, and the `[-1] * n` list literals in mooncake_store_utils.py:362 / layer_eventfd.py:238 are not subscripts.